### PR TITLE
[docker-sonic-vs]: generate full config db based on mounted config_db

### DIFF
--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -52,6 +52,8 @@ cp /etc/default/sonic-db/database_config.json /var/run/redis/sonic-db/
 supervisorctl start redis-server
 
 /usr/bin/configdb-load.sh
+[ -f /var/sonic/config_db.json ] && config load -y /var/sonic/config_db.json
+config save -y
 
 supervisorctl start syncd
 
@@ -78,6 +80,8 @@ supervisorctl start vlanmgrd
 supervisorctl start zebra
 
 supervisorctl start staticd
+
+supervisorctl start bgpd
 
 supervisorctl start buffermgrd
 

--- a/platform/vs/tests/bgp/test_invalid_nexthop.py
+++ b/platform/vs/tests/bgp/test_invalid_nexthop.py
@@ -8,7 +8,7 @@ import pytest
 def test_InvalidNexthop(dvs, testlog):
 
     dvs.copy_file("/etc/frr/", "bgp/files/invalid_nexthop/bgpd.conf")
-    dvs.runcmd("supervisorctl start bgpd")
+    dvs.runcmd("supervisorctl restart bgpd")
     dvs.runcmd("ip addr add fc00::1/126 dev Ethernet0")
     dvs.runcmd("config interface startup Ethernet0")
 

--- a/platform/vs/tests/bgp/test_no_export.py
+++ b/platform/vs/tests/bgp/test_no_export.py
@@ -7,8 +7,8 @@ import json
 def test_bounce(dvs, testlog):
     dvs.servers[0].runcmd("pkill -f exabgp")
     dvs.copy_file("/etc/frr/", "bgp/files/no_export/bgpd.conf")
-    dvs.runcmd("supervisorctl start bgpd")
-    dvs.runcmd("ip addr add 10.0.0.0/31 dev Ethernet0") 
+    dvs.runcmd("supervisorctl restart bgpd")
+    dvs.runcmd("ip addr add 10.0.0.0/31 dev Ethernet0")
     dvs.runcmd("config interface startup Ethernet0")
 
     dvs.runcmd("ip addr add 10.0.0.2/31 dev Ethernet4")
@@ -30,7 +30,7 @@ def test_bounce(dvs, testlog):
     (exit_code, sum_res) =  dvs.runcmd(["vtysh", "-c", "show ip bgp sum"])
     (exit_code, all_route) = dvs.runcmd(["vtysh", "-c", "show ip bgp"])
     (exit_code, announce_route) = dvs.runcmd(["vtysh", "-c", "show ip bgp neighbors 10.0.0.3 advertised-routes"])
- 
+
     p1.terminate()
     p1 = p1.wait()
 


### PR DESCRIPTION
/var/sonic/config_db.json is mounted config db. if this file exists,
then generate full config_db based on the mounted config db

also start bgpd by default

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
This is needed for using sonic as neighbor switch in sonic-mgmt testbed

**- How I did it**
/var/sonic/config_db.json is mounted config db. if this file exists,
then generate full config_db based on the mounted config db

also start bgpd by default

**- How to verify it**
build vs docker and test
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
