### PR TITLE
Fix mgmt-framework rest server startup script

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/mgmt_vars.j2
+++ b/dockers/docker-sonic-mgmt-framework/mgmt_vars.j2
@@ -1,4 +1,4 @@
 {
-    "rest_server": {% if REST_SERVER is defined and "default" in RESET_SERVER.keys() %}{{ REST_SERVER['default'] }}{% else %}""{% endif %},
-    "x509" : {% if "x509" in DEVICE_METADATA.keys() %}{{ DEVICE_METADATA["x509"] }}{% else %}""{% endif %}
+    "rest_server": {% if REST_SERVER is defined and "default" in REST_SERVER.keys() %}{{ REST_SERVER['default']|json }}{% else %}""{% endif %},
+    "x509" : {% if "x509" in DEVICE_METADATA.keys() %}{{ DEVICE_METADATA["x509"]|json }}{% else %}""{% endif %}
 }

--- a/dockers/docker-sonic-mgmt-framework/rest-server.sh
+++ b/dockers/docker-sonic-mgmt-framework/rest-server.sh
@@ -11,18 +11,17 @@ fi
 
 # Read basic server settings from mgmt vars entries
 MGMT_VARS=$(sonic-cfggen -d -t $MGMT_VARS_FILE)
-MGMT_VARS=${MGMT_VARS//[\']/\"}
 
 REST_SERVER=$(echo $MGMT_VARS | jq -r '.rest_server')
 
 if [ -n "$REST_SERVER" ]; then
-    SERVER_PORT=$(echo $REST_SERVER | jq -r '.port')
-    CLIENT_AUTH=$(echo $REST_SERVER | jq -r '.client_auth')
-    LOG_LEVEL=$(echo $REST_SERVER | jq -r '.log_level')
+    SERVER_PORT=$(echo $REST_SERVER | jq -r '.port // empty')
+    CLIENT_AUTH=$(echo $REST_SERVER | jq -r '.client_auth // empty')
+    LOG_LEVEL=$(echo $REST_SERVER | jq -r '.log_level // empty')
 
-    SERVER_CRT=$(echo $REST_SERVER | jq -r '.server_crt')
-    SERVER_KEY=$(echo $REST_SERVER | jq -r '.server_key')
-    CA_CRT=$(echo $REST_SERVER | jq -r '.ca_crt')
+    SERVER_CRT=$(echo $REST_SERVER | jq -r '.server_crt // empty')
+    SERVER_KEY=$(echo $REST_SERVER | jq -r '.server_key // empty')
+    CA_CRT=$(echo $REST_SERVER | jq -r '.ca_crt // empty')
 fi
 
 if [[ -z $SERVER_CRT ]] && [[ -z $SERVER_KEY ]] && [[ -z $CA_CRT ]]; then
@@ -31,9 +30,9 @@ fi
 
 # Read certificate file paths from DEVICE_METADATA|x509 entry.
 if [ -n "$X509" ]; then
-    SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
-    SERVER_KEY=$(echo $X509 | jq -r '.server_key')
-    CA_CRT=$(echo $X509 | jq -r '.ca_crt')
+    SERVER_CRT=$(echo $X509 | jq -r '.server_crt // empty')
+    SERVER_KEY=$(echo $X509 | jq -r '.server_key // empty')
+    CA_CRT=$(echo $X509 | jq -r '.ca_crt // empty')
 fi
 
 # Create temporary server certificate if they not configured in ConfigDB

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -242,6 +242,7 @@ def _get_jinja2_env(paths):
     env.filters['unique_name'] = unique_name
     env.filters['pfx_filter'] = pfx_filter
     env.filters['ip_network'] = ip_network
+    env.filters['json'] = json.dumps
     for attr in ['ip', 'network', 'prefixlen', 'netmask', 'broadcast']:
         env.filters[attr] = partial(prefix_attr, attr)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Mgmt-framework REST startup script is broken after PR #4937. This PR misspells the table name as "RES**E**T_SERVER"; hence the user defined settings from REST_SERVER table are never loaded. **REST server always comes up with default settings.**
Also the startup script rest-server.sh does not use the `jq -r` commands correctly. With -r option, it prints a `null` value when the field requested does not exists. Startup script would have assigned a "null" value for all non-configured parameters and would have failed (if it had spelt the table name correctly in mgmt_vars.j2).

#### How I did it
Fixed mgmt_vars.j2 to load correct db entry and rest-server.sh to handle optional fields correctly.

Also introduced a new jinja filter "json" in sonic-cfggen, which formats the value using `json.dumps()` function. The mgmt_vars.j2 template uses this filter to transform db values into a syntactically correct json.

#### How to verify it
Verify REST server startup and a GET operation with following configurations:
- No REST_SERVER and x509 table entries
- With client_auth config in REST_SERVER entry
- With log_level config in REST_SERVER entry
- With certificate configs in REST_SERVER entry
- WIth all configs in REST_SERVER entry
- With certificate configs in x509 entry
- With client_auth config in REST_SERVER entry and certificate configs in x509 entry

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


