### PR TITLE
[as4630-54pe] Branch:master Fixed issue for management port eth2 change to eth0(using udev method)

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/udev/70-persistent-net.rules
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/udev/70-persistent-net.rules
@@ -1,0 +1,3 @@
+ACTION=="add", SUBSYSTEM=="net", DRIVERS=="ixgbe", KERNELS=="0000:08:00.0", NAME:="eth0"
+ACTION=="add", SUBSYSTEM=="net", DRIVERS=="ixgbe", KERNELS=="0000:06:00.1", NAME:="eth1"
+ACTION=="add", SUBSYSTEM=="net", DRIVERS=="ixgbe", KERNELS=="0000:06:00.0", NAME:="eth3"

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/restart_ixgbe.sh
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/restart_ixgbe.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+/etc/init.d/netfilter-persistent stop
+modprobe -r ixgbe
+udevadm control --reload-rules
+udevadm trigge
+modprobe ixgbe
+/etc/init.d/netfilter-persistent start
+

--- a/platform/broadcom/sonic-platform-modules-accton/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/rules
@@ -25,6 +25,7 @@ MODULE_DIRS += as5835-54x as9716-32d as9726-32d as5835-54t as7312-54xs as7315-27
 MODULE_DIR := modules
 UTILS_DIR := utils
 SERVICE_DIR := service
+UDEV_DIR := udev
 CONF_DIR := conf
 
 %:
@@ -69,9 +70,11 @@ binary-indep:
 		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} $(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
 		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} usr/local/bin; \
 		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} lib/systemd/system; \
+		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} etc/udev/rules.d; \
 		cp $(MOD_SRC_DIR)/$${mod}/$(MODULE_DIR)/*.ko debian/$(PACKAGE_PRE_NAME)-$${mod}/$(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
 		cp $(MOD_SRC_DIR)/$${mod}/$(UTILS_DIR)/* debian/$(PACKAGE_PRE_NAME)-$${mod}/usr/local/bin/; \
 		cp $(MOD_SRC_DIR)/$${mod}/$(SERVICE_DIR)/*.service debian/$(PACKAGE_PRE_NAME)-$${mod}/lib/systemd/system/; \
+		cp $(MOD_SRC_DIR)/$${mod}/$(UDEV_DIR)/* debian/$(PACKAGE_PRE_NAME)-$${mod}/etc/udev/rules.d/; \
 		$(PYTHON3) $${mod}/setup.py install --root=$(MOD_SRC_DIR)/debian/$(PACKAGE_PRE_NAME)-$${mod} --install-layout=deb; \
 	done)
 	# Resuming debhelper scripts

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as4630-54pe.postinst
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as4630-54pe.postinst
@@ -1,0 +1,2 @@
+/usr/local/bin/restart_ixgbe.sh
+


### PR DESCRIPTION
…ge to eth0(using udev method)

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Our management port is using eth2, but now need to change to using eth0.
#### How I did it
Use the method: u-dev rules to binding eth2's pci address into eth0.
#### How to verify it
After the modify, checking ifconfig RUNNING flags, means eth0 is linking.

Demo log:
root@sonic:~# ifconfig eth0
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.15.174  netmask 255.255.240.0  broadcast 192.168.15.255
        inet6 fe80::6a21:5fff:fe48:95c3  prefixlen 64  scopeid 0x20<link>
        ether 68:21:5f:48:95:c3  txqueuelen 1000  (Ethernet)
        RX packets 73  bytes 11819 (11.5 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 27  bytes 4220 (4.1 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Using udev method to manage interface: eth2 to eth0.

#### A picture of a cute animal (not mandatory but encouraged)

