### PR TITLE
[202012] [Celestica/Seastone2] Install sonic_platform

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-seastone2.install
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-seastone2.install
@@ -1,4 +1,5 @@
 seastone2/cfg/seastone2-modules.conf etc/modules-load.d
 seastone2/systemd/platform-modules-seastone2.service lib/systemd/system
 seastone2/modules/sonic_platform-1.0-py2-none-any.whl usr/share/sonic/device/x86_64-cel_seastone_2-r0
+seastone2/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-cel_seastone_2-r0
 services/platform_api/platform_api_mgnt.sh usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-cel/services/platform_api/platform_api_mgnt.sh
+++ b/platform/broadcom/sonic-platform-modules-cel/services/platform_api/platform_api_mgnt.sh
@@ -10,7 +10,7 @@ PY3_PACK=$DEVICE/$PLATFORM/sonic_platform-1.0-py3-none-any.whl
 install() {
     # Install python2.7 sonic-platform package
     if [ -e $PY2_PACK ]; then
-        pip install $PY2_PACK
+        pip2 install $PY2_PACK
     fi
 
     # Install python3 sonic-platform package


### PR DESCRIPTION
#### Why I did it

This is part of fixing https://github.com/Azure/sonic-buildimage/issues/8212.
This changes fixes installation of `sonic_platform` to be installed for both python2 and python3.
Right now neither is installed.

#### How I did it

Looked at the error messages when booting a clean Seastone2 as well as the packaging files.

#### How to verify it

Verify that `sonic_platform` is installed.

```
(vrf:mgmt)bluecmd@ixp-kg-sw1:~$ python2 -c 'import sonic_platform'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named sonic_platform
(vrf:mgmt)bluecmd@ixp-kg-sw1:~$ python3 -c 'import sonic_platform'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'sonic_platform'
```

After:

```
(vrf:mgmt)bluecmd@ixp-kg-sw1:~$ python2 -c 'import sonic_platform'
(vrf:mgmt)bluecmd@ixp-kg-sw1:~$ python3 -c 'import sonic_platform'
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog

cel/seastone2: install `sonic_platform`

#### A picture of a cute animal (not mandatory but encouraged)

![image](https://user-images.githubusercontent.com/149442/149661074-ddb5578b-9859-4570-808c-f0e781824f76.png)
