### PR TITLE
[updategraph]: Create factory default configuration if graph dhcp not available

### DIFF
--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -48,7 +48,7 @@ if [ "$src" = "dhcp" ]; then
     done
 
     if [ "`cat /tmp/dhcp_graph_url`" = "N/A" ]; then
-        echo "No graph_url option in DHCP response. Skipping graph update and generating an factory default configuration."
+        echo "No graph_url option in DHCP response. Skipping graph update and generating a factory default configuration."
         PLATFORM=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
         if [ -f /etc/sonic/minigraph.xml ]; then
             sonic-cfggen -H -m /etc/sonic/minigraph.xml --preset empty > /tmp/device_meta.json

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -48,13 +48,13 @@ if [ "$src" = "dhcp" ]; then
     done
 
     if [ "`cat /tmp/dhcp_graph_url`" = "N/A" ]; then
-        echo "No graph_url option in DHCP response. Skipping graph update and generating an empty configuration."
+        echo "No graph_url option in DHCP response. Skipping graph update and generating an factory default configuration."
         PLATFORM=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
         if [ -f /etc/sonic/minigraph.xml ]; then
             sonic-cfggen -H -m /etc/sonic/minigraph.xml --preset empty > /tmp/device_meta.json
         else
             PRESET=(`head -n 1 /usr/share/sonic/device/$PLATFORM/default_sku`)
-            sonic-cfggen -H -k ${PRESET[0]} --preset empty > /tmp/device_meta.json
+            sonic-cfggen -H -k ${PRESET[0]} --preset ${PRESET[1]} > /tmp/device_meta.json
         fi
         if [ -f /etc/sonic/init_cfg.json ]; then
             sonic-cfggen -j /tmp/device_meta.json -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Factory default configuration should be set if no external configuration source available.
From config-setup design 
https://github.com/Azure/sonic-buildimage/blob/a04da0456bb4af2c38a8021227230b371be81943/files/image_config/config-setup/config-setup#L231
SONiC will generate factory default configuration if graph service not enabled.
The graph service suppose was designed to generate an empty configuration when graph service not available, this could make some troubles like: https://github.com/Azure/sonic-buildimage/issues/9201

#### How I did it
Use platform PRESET value to generate a default configuration instead of generate empty config. 

#### How to verify it

- [ ] To be verify on Nokia 7215 platform

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use platform preset to generate default configuration when dhcp graph service is not available 

#### A picture of a cute animal (not mandatory but encouraged)
![image](https://user-images.githubusercontent.com/6898708/151129726-9061ffbf-00db-4f4f-95ae-f70dbf53189c.png)

