### PR TITLE
[AS9716-32d] Fix i2c_psu drv bug when plug out PSU

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/modules/accton_i2c_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/modules/accton_i2c_psu.c
@@ -526,6 +526,7 @@ static struct accton_i2c_psu_data *accton_i2c_psu_update_device(struct device *d
             if (status < 0) {
                 dev_dbg(&client->dev, "reg %d, err %d\n",
                         regs_byte[i].reg, status);
+                *(regs_byte[i].value) = 0;
             }
             else {
                 *(regs_byte[i].value) = status;
@@ -539,6 +540,7 @@ static struct accton_i2c_psu_data *accton_i2c_psu_update_device(struct device *d
             if (status < 0) {
                 dev_dbg(&client->dev, "reg %d, err %d\n",
                         regs_word[i].reg, status);
+                *(regs_word[i].value) = 0;
             }
             else {
                 *(regs_word[i].value) = status;
@@ -546,33 +548,33 @@ static struct accton_i2c_psu_data *accton_i2c_psu_update_device(struct device *d
             
         }
         /* Read mfr_id */
-		status = accton_i2c_psu_read_block_data(client, PMBUS_REGISTER_MFR_ID, data->mfr_id,
-										 ARRAY_SIZE(data->mfr_id));
-		if (status < 0) {
-			dev_dbg(&client->dev, "reg %d, err %d\n", PMBUS_REGISTER_MFR_ID, status);
-			goto exit;
-		}		
-		/* Read mfr_model */		
-		status = accton_i2c_psu_read_block_data(client, PMBUS_REGISTER_MFR_MODEL, data->mfr_model,
-										 ARRAY_SIZE(data->mfr_model));
-		if (status < 0) {
-			dev_dbg(&client->dev, "reg %d, err %d\n", PMBUS_REGISTER_MFR_MODEL, status);
-			goto exit;
-		}
+        status = accton_i2c_psu_read_block_data(client, PMBUS_REGISTER_MFR_ID, data->mfr_id,
+                                                 ARRAY_SIZE(data->mfr_id));
+        if (status < 0) {
+            dev_dbg(&client->dev, "reg %d, err %d\n", PMBUS_REGISTER_MFR_ID, status);
+            goto exit;
+        }		
+        /* Read mfr_model */		
+        status = accton_i2c_psu_read_block_data(client, PMBUS_REGISTER_MFR_MODEL, data->mfr_model,
+                                                 ARRAY_SIZE(data->mfr_model));
+        if (status < 0) {
+            dev_dbg(&client->dev, "reg %d, err %d\n", PMBUS_REGISTER_MFR_MODEL, status);
+            goto exit;
+        }
         /* Read mfr_revsion */		
-		status = accton_i2c_psu_read_block_data(client, PMBUS_REGISTER_MFR_REVISION, data->mfr_revsion,
-										 ARRAY_SIZE(data->mfr_revsion));
-		if (status < 0) {
-			dev_dbg(&client->dev, "reg %d, err %d\n", PMBUS_REGISTER_MFR_REVISION, status);
-			goto exit;
-		}
-		/* Read mfr_serial */
-		status = accton_i2c_psu_read_block_data(client, PMBUS_REGISTER_MFR_SERIAL, data->mfr_serial,
-										 ARRAY_SIZE(data->mfr_serial));
-		if (status < 0) {
-			dev_dbg(&client->dev, "reg %d, err %d\n", PMBUS_REGISTER_MFR_SERIAL, status);
-			goto exit;
-		}
+        status = accton_i2c_psu_read_block_data(client, PMBUS_REGISTER_MFR_REVISION, data->mfr_revsion,
+                                                ARRAY_SIZE(data->mfr_revsion));
+        if (status < 0) {
+            dev_dbg(&client->dev, "reg %d, err %d\n", PMBUS_REGISTER_MFR_REVISION, status);
+            goto exit;
+        }
+        /* Read mfr_serial */
+        status = accton_i2c_psu_read_block_data(client, PMBUS_REGISTER_MFR_SERIAL, data->mfr_serial,
+                                                ARRAY_SIZE(data->mfr_serial));
+        if (status < 0) {
+            dev_dbg(&client->dev, "reg %d, err %d\n", PMBUS_REGISTER_MFR_SERIAL, status);
+            goto exit;
+        }
         
         data->last_updated = jiffies;
         data->valid = 1;


### PR DESCRIPTION
Signed-off-by: Jostar Yang <jostar_yang@accton.com.tw>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When plug out power, psu temp sysfs still keep original value.  But psu_temp should be zero, when psu is removed.
#### How I did it
Set all psu data to 0 when i2c access fail. 
#### How to verify it
Test sensors cmd,
Plug out one power, log is as below.
acbel_fsh082-i2c-10-59
Adapter: i2c-1-mux (chan_id 1)
PSU 2 Voltage:      +0.00 V
PSU 2 Fan:            0 RPM
PSU 2 Temperature:   +0.0 C
PSU 2 Power:         0.00 W
PSU 2 Current:      +0.00 A

acbel_fsh082-i2c-9-58
Adapter: i2c-1-mux (chan_id 0)
PSU 1 Voltage:     +12.03 V
PSU 1 Fan:         13696 RPM
PSU 1 Temperature:  +29.0 C
PSU 1 Power:       220.00 W
PSU 1 Current:     +18.12 A

When two power were inserted, log is as below.

acbel_fsh082-i2c-10-59
Adapter: i2c-1-mux (chan_id 1)
PSU 2 Voltage:     +12.04 V
PSU 2 Fan:         13696 RPM
PSU 2 Temperature:  +28.0 C
PSU 2 Power:        79.00 W
PSU 2 Current:      +6.57 A

lm75-i2c-18-4c
Adapter: i2c-1-mux (chan_id 1)
OCXO Temperature:  +34.0 C  (high = +80.0 C, hyst = +75.0 C)

acbel_fsh082-i2c-9-58
Adapter: i2c-1-mux (chan_id 0)
PSU 1 Voltage:     +12.17 V
PSU 1 Fan:         13696 RPM
PSU 1 Temperature:  +30.0 C
PSU 1 Power:       143.00 W
PSU 1 Current:     +11.88 A

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
--> The issue happen on 202012 branch, so please merge to the BR.
- [x] 202106
--> The issue happen on 202106 branch, so please merge to the BR.
#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

