### PR TITLE
[Arista] Add emmc quirks in boot0 to improve reliability

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -623,6 +623,7 @@ write_platform_specific_cmdline() {
     if in_array "$platform" "crow" "magpie"; then
         cmdline_add amd_iommu=off
         cmdline_add modprobe.blacklist=snd_hda_intel,hdaudio
+        cmdline_add sdhci.append_quirks2=0x40
         read_system_eeprom
     fi
     if in_array "$platform" "woodpecker"; then
@@ -653,7 +654,6 @@ write_platform_specific_cmdline() {
     fi
 
     cmdline_add "varlog_size=$varlog_size"
-
     cmdline_add "sonic.mode=$sonic_mode"
 }
 
@@ -670,6 +670,9 @@ write_image_specific_cmdline() {
 
     # disable unified cgroup hierarchy to workaround dockerd limitation
     cmdline_add systemd.unified_cgroup_hierarchy=0
+
+    # increase kernel log buffer size
+    cmdline_add log_buf_len=1M
 
     # verbosity
     cmdline_add quiet


### PR DESCRIPTION
#### Why I did it
Fix some unreliability seen on emmc device with some AMD CPUs

#### How I did it
Added a kernel parameter to add quirks to
It depends on a sonic-linux-kernel change to work properly but will be a no-op without it.
The quirk added is `SDHCI_QUIRK2_BROKEN_HS200` used to downgrade the link speed for the eMMC.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
Add emmc quirks for Upperlake
