### PR TITLE
[telemetry] Limit resource usage of ST and disable OOM killer

### DIFF
--- a/rules/docker-telemetry.mk
+++ b/rules/docker-telemetry.mk
@@ -29,6 +29,9 @@ endif
 
 $(DOCKER_TELEMETRY)_CONTAINER_NAME = telemetry
 $(DOCKER_TELEMETRY)_RUN_OPT += --privileged -t
+$(DOCKER_TELEMETRY)_RUN_OPT += --memory 450m
+$(DOCKER_TELEMETRY)_RUN_OPT += --cpus 0.3
+$(DOCKER_TELEMETRY)_RUN_OPT += --oom-kill-disable
 $(DOCKER_TELEMETRY)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_TELEMETRY)_RUN_OPT += -v /usr/share/sonic/scripts:/usr/share/sonic/scripts:ro
 $(DOCKER_TELEMETRY)_RUN_OPT += -v /var/run/dbus:/var/run/dbus:rw


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Recently we observed the occurrence of memory spike in streaming telemetry due to the issues of gNMI client side. As such, we put a hard limitation on memory usage. At the same time, the OOM killer will be disabled in streaming telemetry container since OOM killer will panicked the kernel if OOM did happen.

In other words, if OOM occurs in streaming telemetry, we will depend on the Monit to catch this issue and restart the streaming telemetry container. So we have another open PR (https://github.com/Azure/sonic-buildimage/pull/10008) to do this change on Monit scripts.

#### How I did it
I added several runtime parameters to limit the memory and CPU usage, also disabled the OOM killer in streaming telemetry.

#### How to verify it
I verified this change on DuT `str-msn27000-20`.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ x] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

