### PR TITLE
[Inspur] Modify MGMT code for IPv4/IPv6

### DIFF
--- a/src/ifupdown2/Makefile
+++ b/src/ifupdown2/Makefile
@@ -12,6 +12,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	wget --no-check-certificate https://github.com/CumulusNetworks/ifupdown2/archive/$(IFUPDOWN2_VERSION).tar.gz
 	tar -z -f $(IFUPDOWN2_VERSION).tar.gz -x
 	pushd ./ifupdown2-$(IFUPDOWN2_VERSION)
+	find ../patch/ -type f -name '*.patch' -print0 | sort -z | xargs -t -0 -n 1 patch -p1 -i
 
 	# Build source and Debian packages
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)

--- a/src/ifupdown2/patch/0001-compatible-mgmt-dhcp-and-static.patch
+++ b/src/ifupdown2/patch/0001-compatible-mgmt-dhcp-and-static.patch
@@ -1,0 +1,52 @@
+diff -Nuar a/ifupdown2/addons/address.py b/ifupdown2/addons/address.py
+--- a/ifupdown2/addons/address.py  2019-07-12 16:23:18.000000000 +0800
++++ b/ifupdown2/addons/address.py  2021-12-26 00:56:25.165297691 +0800
+@@ -832,6 +832,14 @@ class address(moduleBase):
+ 
+         addr_method = ifaceobj.addr_method
+         force_reapply = False
++        module_name = self.__class__.__name__
++        ifname = ifaceobj.name
++        ifaceobjlist = [ifaceobj]
++        (addr_supported, newaddrs, newaddr_attrs) = self._inet_address_convert_to_cidr(ifaceobjlist)
++        newaddrs = utils.get_ip_objs(module_name, ifname, newaddrs)
++        user_ip4, user_ip6, newaddrs = self.order_user_configured_addrs(newaddrs)
++        if user_ip4 or user_ip6:
++            addr_method = 'static'
+         try:
+             # release any stale dhcp addresses if present
+             if (addr_method not in ["dhcp", "ppp"] and not ifupdownflags.flags.PERFMODE and
+@@ -840,13 +848,15 @@ class address(moduleBase):
+                 # any sibling iface objects, kill any stale dhclient
+                 # processes
+                 dhclientcmd = dhclient()
+-                if dhclientcmd.is_running(ifaceobj.name):
+-                    # release any dhcp leases
+-                    dhclientcmd.release(ifaceobj.name)
+-                    force_reapply = True
+-                elif dhclientcmd.is_running6(ifaceobj.name):
+-                    dhclientcmd.release6(ifaceobj.name)
+-                    force_reapply = True
++                if user_ip4:
++                    if dhclientcmd.is_running(ifaceobj.name):
++                        # release any dhcp leases
++                        dhclientcmd.release(ifaceobj.name)
++                        force_reapply = True
++                if user_ip6:
++                    if dhclientcmd.is_running6(ifaceobj.name):
++                        dhclientcmd.release6(ifaceobj.name)
++                        force_reapply = True
+         except:
+             pass
+ 
+diff -Nuar a/ifupdown2/addons/dhcp.py b/ifupdown2/addons/dhcp.py
+--- a/ifupdown2/addons/dhcp.py  2021-12-26 00:51:52.898452194 +0800
++++ b/ifupdown2/addons/dhcp.py  2021-12-26 00:56:50.265559738 +0800
+@@ -275,6 +275,7 @@ class dhcp(moduleBase):
+                 as user required state in ifaceobj. error otherwise.
+         """
+         op_handler = self._run_ops.get(operation)
++        ifaceobj.addr_method = 'dhcp'
+         if not op_handler:
+             return
+         try:

--- a/src/ifupdown2/patch/series
+++ b/src/ifupdown2/patch/series
@@ -1,0 +1,1 @@
+0001-compatible-mgmt-dhcp-and-static.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
     We can set IPv4 and IPv6 separately.
#### How I did it
     We always send the dhcp request and get the dhcp ip, when we set the static ip, we will check the ip in redis DB.
     When the static IP is found in redis DB, and then the dhcp ip will be released. 
#### How to verify it
     Set the static IP for IPv6 and DHCP ip for IPv4. And the we can check the IP.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

