### PR TITLE
DellEMC: Z9332f - Graceful platform reboot

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9332f.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9332f.install
@@ -4,7 +4,11 @@ z9332f/scripts/sensors usr/bin
 z9332f/cfg/z9332f-modules.conf etc/modules-load.d
 z9332f/systemd/platform-modules-z9332f.service etc/systemd/system
 z9332f/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
-common/platform_reboot usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
+z9332f/scripts/platform_reboot_override usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
+z9332f/scripts/override.conf /etc/systemd/system/systemd-reboot.service.d
+z9332f/scripts/fast-reboot_plugin usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
+z9332f/scripts/soft-reboot_plugin usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
+z9332f/scripts/warm-reboot_plugin usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
 common/pcisysfs.py usr/bin
 common/io_rd_wr.py usr/local/bin
 common/fw-updater usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/scripts/fast-reboot_plugin
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/scripts/fast-reboot_plugin
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+ONIE_PATH="/mnt/onie-boot"
+
+# Unmount ONIE partition if mounted
+if grep -qs ${ONIE_PATH} /proc/mounts; then
+    umount ${ONIE_PATH}
+fi

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/scripts/override.conf
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/scripts/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0/platform_reboot_override

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/scripts/platform_reboot_override
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/scripts/platform_reboot_override
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+import os
+import struct
+
+PORT_RES = '/dev/port'
+
+
+def portio_reg_write(resource, offset, val):
+    fd = os.open(resource, os.O_RDWR)
+    if(fd < 0):
+        print('file open failed %s' % resource)
+        return
+    if(os.lseek(fd, offset, os.SEEK_SET) != offset):
+        print('lseek failed on %s' % resource)
+        return
+    ret = os.write(fd, struct.pack('B', val))
+    if(ret != 1):
+        print('write failed %d' % ret)
+        return
+    os.close(fd)
+
+if __name__ == "__main__":
+    portio_reg_write(PORT_RES, 0xcf9, 0xe)

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/scripts/soft-reboot_plugin
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/scripts/soft-reboot_plugin
@@ -1,0 +1,1 @@
+fast-reboot_plugin

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/scripts/warm-reboot_plugin
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/scripts/warm-reboot_plugin
@@ -1,0 +1,1 @@
+fast-reboot_plugin


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

- To gracefully unmount filesystems and stop containers while performing a cold reboot.
- Unmount ONIE-BOOT if mounted during fast/soft/warm reboot

#### How I did it

- Override systemd-reboot service to perform a cold reboot.
- Unmount ONIE-BOOT if mounted using fast/soft/warm-reboot plugins.

#### How to verify it

On reboot, verify that the container stop and filesystem unmount services have completed execution before the platform reboot. 

Logs: [UT_Logs.txt](https://github.com/Azure/sonic-buildimage/files/8252901/UT_Logs.txt)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

DellEMC: Z9332f - Graceful platform reboot

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

