### PR TITLE
[SAI-PTF]Fix bug in shell for startig saiserver, skip re-create of the profile

### DIFF
--- a/platform/broadcom/docker-saiserver-brcm/start.sh
+++ b/platform/broadcom/docker-saiserver-brcm/start.sh
@@ -37,7 +37,14 @@ generate_profile()
 rm -f /var/run/rsyslogd.pid
 
 supervisorctl start rsyslogd
-
+#skip the profile creation if it already exists.
+#In warm boot test, we need to add more configuration for warm restart.
+#This profile should not be reset when start the saiserver docker.
+if [ ! -f "/etc/sai.d/sai.profile" ]; then
+ generate_profile
+else
+ echo "Profile already exists, skip profile creation!"
+fi
 generate_profile
 start_bcm
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fix bug when saiserver docker start, the start.sh will recreate the sai
profile, this will cause the warmboot configuration resets.

#### How I did it
Add a condition for checking the saiserver start shell. if the profile
already exists, then skip it.

#### How to verify it
Test it in dut with the warmboot test 
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

