### PR TITLE
[Saiserver] Support sai_ptf in syncd

### DIFF
--- a/platform/broadcom/docker-syncd-brcm-rpc.mk
+++ b/platform/broadcom/docker-syncd-brcm-rpc.mk
@@ -3,6 +3,15 @@
 DOCKER_SYNCD_BRCM_RPC = docker-syncd-brcm-rpc.gz
 $(DOCKER_SYNCD_BRCM_RPC)_PATH = $(PLATFORM_PATH)/docker-syncd-brcm-rpc
 $(DOCKER_SYNCD_BRCM_RPC)_DEPENDS += $(SYNCD_RPC) $(LIBTHRIFT) $(PTF)
+
+#Support two different versions of thrift
+ifeq ($(SAITHRIFT_V2),y)
+$(DOCKER_SYNCD_BRCM_RPC)_DEPENDS += $(SYNCD_RPC) $(LIBTHRIFT_0_13_0) $(LIBTHRIFT_DEV_0_13_0) $(PYTHON3_THRIFT_0_13_0) $(THRIFT_COMPILER_0_13_0) $(PTF)
+else
+$(DOCKER_SYNCD_BRCM_RPC)_DEPENDS += $(SYNCD_RPC) $(LIBTHRIFT) $(PTF)
+endif
+
+
 ifeq ($(INSTALL_DEBUG_TOOLS), y)
 $(DOCKER_SYNCD_BRCM_RPC)_DEPENDS += $(SYNCD_RPC_DBG) \
                                     $(LIBSWSSCOMMON_DBG) \

--- a/platform/broadcom/docker-syncd-brcm-rpc/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm-rpc/Dockerfile.j2
@@ -25,6 +25,7 @@ RUN apt-get update \
     cmake               \
     libqt5core5a        \
     libqt5network5      \
+    gdb                 \
     libboost-atomic1.71.0
 
 RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \

--- a/rules/syncd.mk
+++ b/rules/syncd.mk
@@ -17,7 +17,13 @@ $(SYNCD_RPC)_RDEPENDS += $(LIBSAIREDIS) $(LIBSAIMETADATA)
 $(eval $(call add_derived_package,$(SYNCD),$(SYNCD_RPC)))
 
 # Inject libthrift build dependency for RPC build
-$(SYNCD)_DEPENDS += $(LIBSWSSCOMMON_DEV) $(LIBTHRIFT_DEV)
+# Support two different versions of thrift
+ifeq ($(SAITHRIFT_V2),y)
+$(SYNCD)_DEPENDS += $(LIBTHRIFT_DEV_0_13_0)
+else
+$(SYNCD)_DEPENDS += $(LIBTHRIFT_DEV)
+endif
+$(SYNCD)_DEPENDS += $(LIBSWSSCOMMON_DEV)
 $(SYNCD)_DPKG_TARGET = binary-syncd-rpc
 endif
 


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In order to make the comparison with SONiC default config environment, we need to init the saiserver within a complete sonic environment.
In order to do that we need to make syncd compatiable with new SAI-PTF with thrift.0.13 (in 202012)

#### How I did it
depends on the build variable, set the syncd dependents.

#### How to verify it
Test done:
Test the syncd-rpc container within DUT.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

