### PR TITLE
Added support for front panel port prefix regex

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -238,7 +238,8 @@ class BreakoutCfg(object):
             return hash((self.num_ports, tuple(self.supported_speed), self.num_assigned_lanes))
 
     def __init__(self, name, bmode, properties):
-        self._interface_base_id = int(name.replace(PORT_STR, ''))
+        self._name = name
+        self._front_panel_prefix, self._interface_base_id = self._parse_name_to_prefix_and_id()
         self._properties = properties
         self._lanes = properties ['lanes'].split(',')
         self._indexes = properties ['index'].split(',')
@@ -253,6 +254,12 @@ class BreakoutCfg(object):
 
         if not self._breakout_capabilities:
             raise RuntimeError("Unsupported breakout mode {}!".format(bmode))
+
+    def _parse_name_to_prefix_and_id(self):
+        match = re.match(swsscommon.FRONT_PANEL_PORT_REGEX, self._name)
+        if not match:
+            raise RuntimeError("Failed to parse front panel prefix of {}!", self._name)
+        return match.group(1), int(match.group(2))
 
     def _re_group_to_entry(self, group):
         if len(group) != BRKOUT_PATTERN_GROUPS:
@@ -300,7 +307,7 @@ class BreakoutCfg(object):
             lanes_per_port = entry.num_assigned_lanes // entry.num_ports
 
             for port in range(entry.num_ports):
-                interface_name = PORT_STR + str(self._interface_base_id + lane_id)
+                interface_name = self._front_panel_prefix + str(self._interface_base_id + lane_id)
 
                 lanes = self._lanes[lane_id:lane_id + lanes_per_port]
 

--- a/src/sonic-device-data/tests/hwsku_json_checker
+++ b/src/sonic-device-data/tests/hwsku_json_checker
@@ -8,7 +8,7 @@ import sys
 # Global variable
 PORT_ATTRIBUTES = ["default_brkout_mode"]
 OPTIONAL_PORT_ATTRIBUTES = ["fec", "autoneg", "port_type"]
-PORT_REG = "Ethernet(\d+)"
+PORT_REG = "(Ethernet)(\d+)"
 HWSKU_JSON = '*hwsku.json'
 INTF_KEY = "interfaces"
 

--- a/src/sonic-device-data/tests/platform_json_checker
+++ b/src/sonic-device-data/tests/platform_json_checker
@@ -8,7 +8,8 @@ import sys
 # Global variable
 PORT_ATTRIBUTES = ["index", "lanes", "breakout_modes"]
 ATTR_LEN = len(PORT_ATTRIBUTES)
-PORT_REG = "Ethernet(\d+)"
+# PORT_REG should be taken from scheme.h FRONT_PANEL_PORT_PREFIX_REGEX
+PORT_REG = "(Ethernet)(\d+)"
 PLATFORM_JSON = '*platform.json'
 INTF_KEY = "interfaces"
 CHASSIS_KEY = "chassis"

--- a/src/sonic-py-common/sonic_py_common/interface.py
+++ b/src/sonic-py-common/sonic_py_common/interface.py
@@ -7,8 +7,12 @@ SONiC interface types and access functions.
  "Human readable interface string":"Sonic interface prefix"
  Currently this is a static mapping, but in future could be stored as metadata in DB.
 """
+import re
+from swsscommon.swsscommon import FRONT_PANEL_PORT_PREFIX_REGEX
+
 
 SONIC_INTERFACE_PREFIXES = {
+    "FrontPanel" : FRONT_PANEL_PORT_PREFIX_REGEX,
     "Ethernet-FrontPanel": "Ethernet",
     "PortChannel": "PortChannel",
     "Vlan": "Vlan",
@@ -21,6 +25,14 @@ SONIC_INTERFACE_PREFIXES = {
 }
 
 VLAN_SUB_INTERFACE_SEPARATOR = '.'
+
+
+def front_panel_prefix_regex():
+    """
+    Retrieves the SONIC front panel interface name prefix regex.
+    """
+    return SONIC_INTERFACE_PREFIXES["FrontPanel"]
+
 
 def front_panel_prefix():
     """
@@ -79,7 +91,7 @@ def portchannel_subinterface_prefix():
 def get_interface_table_name(interface_name):
     """Get table name by interface_name prefix
     """
-    if interface_name.startswith(front_panel_prefix()):
+    if re.match(front_panel_prefix_regex(), interface_name):
         if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
             return "VLAN_SUB_INTERFACE"
         return "INTERFACE"
@@ -100,7 +112,7 @@ def get_interface_table_name(interface_name):
 def get_port_table_name(interface_name):
     """Get table name by port_name prefix
     """
-    if interface_name.startswith(front_panel_prefix()):
+    if re.match(front_panel_prefix_regex(), interface_name):
         if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
             return "VLAN_SUB_INTERFACE"
         return "PORT"


### PR DESCRIPTION
- What I did
Removed the dependency on the "Ethernet" string in the SONiC code base and added support
for extending the front panel port name pattern.

- How I did it
1. Introduced FRONT_PANEL_PORT_PREFIX_REGEX that extends the old FRONT_PANEL_PORT_PREFIX ("Ethernet")
2. Updated all the relevant usage of the "Ethernet" throughout the code base to use the new regex pattern

- How to verify it
Pass all UT and CI testing.

- Why I did it
In order to support distinguishing between different types of front panel ports in a maintainable fashion.
Specifically, we are planning to bring up a system with 'service' ports (in addition to the regular ethernet data ports) - these
are lower speed ports that used for connection to accelerators, internal loopbacks and more.

**- Related Commits and Merge Strategy**
_This is part of a group of related commits and should be merged **after https://github.com/Azure/sonic-swss-common/pull/598**._

The full merge order is:

1. swss-common - https://github.com/Azure/sonic-swss-common/pull/598
2. sonic-buildimage - https://github.com/Azure/sonic-buildimage/pull/10471
3. swsssdk - https://github.com/Azure/sonic-py-swsssdk/pull/121
4. all the rest
     [ https://github.com/Azure/sonic-utilities/pull/2127](https://github.com/Azure/sonic-utilities/pull/2127)
     [ https://github.com/Azure/sonic-snmpagent/pull/251](https://github.com/Azure/sonic-snmpagent/pull/251)
     [ https://github.com/Azure/sonic-swss/pull/2223](https://github.com/Azure/sonic-swss/pull/2223)
     [ https://github.com/Azure/sonic-platform-daemons/pull/252](https://github.com/Azure/sonic-platform-daemons/pull/252)
     [ https://github.com/Azure/sonic-platform-common/pull/274](https://github.com/Azure/sonic-platform-common/pull/274)
