### PR TITLE
Modify buffers_defaults.j2 to fit file definition of BUFFER_QUEUE for x86_64-accton_wedge100bf_65x-r0

### DIFF
--- a/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/buffers_defaults_t0.j2
+++ b/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/buffers_defaults_t0.j2
@@ -63,21 +63,17 @@
     },
 {%- endmacro %}
 
-{%- macro generate_pg_profils(port_names) %}
-    "BUFFER_PG": {
-        "{{ port_names }}|3-4": {
-            "profile" : "ingress_lossless_profile"
-        }
-    },
-{%- endmacro %}
-
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
-        "{{ port_names }}|3-4": {
-            "profile" : "egress_lossless_profile"
-        },
-        "{{ port_names }}|0-1": {
+{% for port in port_names.split(',') %}
+        "{{ port }}|0-2": {
             "profile" : "q_lossy_profile"
-        }
+        },
+{% endfor %}
+{% for port in port_names.split(',') %}
+        "{{ port }}|3-4": {
+            "profile" : "egress_lossless_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
     }
 {%- endmacro %}

--- a/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/buffers_defaults_t1.j2
+++ b/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/buffers_defaults_t1.j2
@@ -63,21 +63,17 @@
     },
 {%- endmacro %}
 
-{%- macro generate_pg_profils(port_names) %}
-    "BUFFER_PG": {
-        "{{ port_names }}|3-4": {
-            "profile" : "ingress_lossless_profile"
-        }
-    },
-{%- endmacro %}
-
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
-        "{{ port_names }}|3-4": {
-            "profile" : "egress_lossless_profile"
-        },
-        "{{ port_names }}|0-1": {
+{% for port in port_names.split(',') %}
+        "{{ port }}|0-2": {
             "profile" : "q_lossy_profile"
-        }
+        },
+{% endfor %}
+{% for port in port_names.split(',') %}
+        "{{ port }}|3-4": {
+            "profile" : "egress_lossless_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
     }
 {%- endmacro %}


### PR DESCRIPTION
#### Why I did it
In order to let generic_config_updater works in these devices.

#### How I did it
Modify buffers_defaults.j2 to fit file definition of `BUFFER_QUEUE` in yang files.
* devices:
  * x86_64-accton_wedge100bf_65x-r0
* yang files:
  * src/sonic-yang-models/yang-models/sonic-buffer-queue.yang


* Before modified:
  ```
  "BUFFER_QUEUE": {
          "Ethernet8,Ethernet16|0-1": {
              "profile": "q_lossy_profile"
          },
          "Ethernet8,Ethernet16|3-4": {
              "profile": "egress_lossless_profile"
          }
  }
  ```
* After modified:
  ```
  "BUFFER_QUEUE": {
          "Ethernet8|0-1": {
              "profile": "q_lossy_profile"
          },
          "Ethernet8|3-4": {
              "profile": "egress_lossless_profile"
          },
          "Ethernet16|0-1": {
              "profile": "q_lossy_profile"
          },
          "Ethernet16|3-4": {
              "profile": "egress_lossless_profile"
          }
  }
  ```

Signed-off-by: MuLin <mulin_huang@edge-core.com>