### PR TITLE
Increase LAG Ids to 1024

### DIFF
--- a/device/arista/x86_64-arista_7800_sup/chassisdb.conf
+++ b/device/arista/x86_64-arista_7800_sup/chassisdb.conf
@@ -2,4 +2,4 @@ start_chassis_db=1
 chassis_db_address=127.100.1.1
 
 lag_id_start=1
-lag_id_end=128
+lag_id_end=1024


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Today at most 128 LAGs are supported. This is not sufficient if there are many LAGs with just few ports.

#### How I did it
Increase LAG Ids to 1024 for DNX device.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

