### PR TITLE
[chassis][supervisor] show system-health summary fails on the supervisor card

### DIFF
--- a/src/system-health/health_checker/service_checker.py
+++ b/src/system-health/health_checker/service_checker.py
@@ -127,11 +127,11 @@ class ServiceChecker(HealthChecker):
                         self.bad_containers.add(container)
                         logger.log_error('Invalid syntax in critical_processes file of {}'.format(container))
                     continue
-
-                identifier_key = match.group(2).strip()
-                identifier_value = match.group(3).strip()
-                if identifier_key == "program" and identifier_value:
-                    critical_process_list.append(identifier_value)
+                if match.group(1) is not None:
+                    identifier_key = match.group(2).strip()
+                    identifier_value = match.group(3).strip()
+                    if identifier_key == "program" and identifier_value:
+                        critical_process_list.append(identifier_value)
 
         return critical_process_list
 


### PR DESCRIPTION
#### Why I did it
Fix the command "sudo show system-health summary" shows the following error on the supervisor card.  Fixes #10630

#### How I did it
This issue is caused by the function get_critical_process_list_from_file() that is not able to handle the empty line in the file critical_processes.  On supervisor card,  the critical_processes file under swss which is derived from the critical_processes.j2 file and contains empty lines.  Added code the check the the re.match result is None, don't continue to process it  

#### How to verify it
1)  boot the image on supervisor card,  issue command "sudo show system-health summary".  The output should be shown as below:
```
admin@supervisor:~$ sudo show system-health summary 
System status summary

  System status LED  green
  Services:
    Status: OK
  Hardware:
    Status: OK
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

