### PR TITLE
[BFN] Canceling PSU platform API calls on SIGTERM

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/component.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/component.py
@@ -6,6 +6,7 @@ try:
     import json
     from collections import OrderedDict
     from sonic_py_common import device_info
+    from platform_utils import limit_execution_time
 
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -24,6 +25,7 @@ def get_bios_version():
     except subprocess.CalledProcessError as e:
         raise RuntimeError("Failed to get BIOS version")
 
+@limit_execution_time(1)
 def get_bmc_version():
     """
     Retrieves the firmware version of the BMC

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/platform_utils.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/platform_utils.py
@@ -3,6 +3,8 @@
 try:
     import os
     import subprocess
+    import signal
+    from functools import wraps
 
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -20,3 +22,24 @@ def file_create(path, mode=None):
         run_cmd(['touch', path])
     if (mode is not None):    
         run_cmd(['chmod', mode, path])
+
+def cancel_on_sigterm(func):
+    """
+    Wrapper for a function which has to be cancel on SIGTERM
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        def handler(sig, frame):
+            if sigterm_handler:
+                sigterm_handler(sig, frame)
+            raise Exception("Canceling {}() execution...".format(func.__name__))
+
+        sigterm_handler = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGTERM, handler)
+        result = None
+        try:
+            result = func(*args, **kwargs)
+        finally:
+            signal.signal(signal.SIGTERM, sigterm_handler)
+        return result
+    return wrapper

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/platform_utils.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/platform_utils.py
@@ -10,6 +10,12 @@ except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 def file_create(path, mode=None):
+    """
+    Ensure that file is created with the appropriate permissions
+    Args:
+        path: full path of a file
+        mode: file permission in octal representation  
+    """
     def run_cmd(cmd):
         if os.geteuid() != 0:
             cmd.insert(0, 'sudo')
@@ -20,7 +26,7 @@ def file_create(path, mode=None):
         run_cmd(['mkdir', '-p', file_path])
     if not os.path.isfile(path):
         run_cmd(['touch', path])
-    if (mode is not None):    
+    if (mode is not None):
         run_cmd(['chmod', mode, path])
 
 def cancel_on_sigterm(func):
@@ -43,3 +49,32 @@ def cancel_on_sigterm(func):
             signal.signal(signal.SIGTERM, sigterm_handler)
         return result
     return wrapper
+
+def limit_execution_time(execution_time_secs: int):
+    """
+    Wrapper for a function whose execution time must be limited
+    Args:
+        execution_time_secs: maximum execution time in seconds,
+        after which the function execution will be stopped
+    """
+    def wrapper(func):
+        @wraps(func)
+        def execution_func(*args, **kwargs):
+            def handler(sig, frame):
+                if sigalrm_handler:
+                    sigalrm_handler(sig, frame)
+                raise Exception("Canceling {}() execution...".format(func.__name__))
+
+            sigalrm_handler = signal.getsignal(signal.SIGALRM)
+            signal.signal(signal.SIGALRM, handler)
+            signal.alarm(execution_time_secs)
+            result = None
+            try:
+                result = func(*args, **kwargs)
+            finally:
+                signal.alarm(0)
+
+            return result
+        return execution_func
+    return wrapper
+


### PR DESCRIPTION
Signed-off-by: Andriy Kokhan <andriyx.kokhan@intel.com>
Co-authored-by: Taras Keryk <tarasx.keryk@intel.com>

#### Why I did it
Sometime, SIGTERM processing by psud takes more then default 10sec (please see stopwaitsecs in http://supervisord.org/configuration.html).

Due to this, the following two testcases may fail:
```
test_pmon_psud_stop_and_start_status
test_pmon_psud_term_and_start_status
```

Also, limited `get_bmc_version()` execution time to 1 sec.

#### How I did it
Introduced two levels of SIGTERM handlers:
1. The PSU class level `signal_handler()` that executes a default handler (`psud` SIGTERM handler) and avoids subsequent `psu_info_get()` executions.
2. The `cancel_on_sigterm()` decorator that executes class level `signal_handler()` and raises an exception to cancel current `psu_info_get()` execution.

#### How to verify it
Run SONiC CTs:
```
test_pmon_psud_stop_and_start_status
test_pmon_psud_term_and_start_status
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111
