### PR TITLE
[docker-wait-any] End child threads when main thread is signalled to end

### DIFF
--- a/files/image_config/misc/docker-wait-any
+++ b/files/image_config/misc/docker-wait-any
@@ -62,6 +62,7 @@ def wait_for_container(docker_client, container_name):
 
         # Signal the main thread to exit
         g_thread_exit_event.set()
+        break
 
 
 def main():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is to fix a bug in `docker-wait-any`  script which leads to Exceptions during shutdown path for services.
Reason for this error:

1. During startup some services use `docker-wait-any` as part of systemctl wait function.
2.  `docker-wait-any` creates different threads that wait as long as dependent services are running.
3. All the threads share the same `docker_client` instance which is owned by main thread.
4. When one of child threads signals main thread to exit, the child thread still continues to proceed to next iteration in the loop.
5. This creates problem when main thread starts cleaning up `docker_client` instance, but the child threads are still running and use the same `docker_client` instance.
6. This leads to NoneType error to be generated.


Error trace shows that the error is always originated during chilkd thread accessing `docker_client`, which is being freed up by main thread:

Instance 1:
```
May  4 08:25:34.249137 str-msn2700-01 INFO swss.sh[3838]: Exception in thread Thread-1:
May  4 08:25:34.250864 str-msn2700-01 INFO swss.sh[3838]: Traceback (most recent call last):
May  4 08:25:34.251987 str-msn2700-01 INFO swss.sh[3838]:   File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
May  4 08:25:34.253123 str-msn2700-01 INFO swss.sh[3838]:     self.run()
May  4 08:25:34.254245 str-msn2700-01 INFO swss.sh[3838]:   File "/usr/lib/python2.7/threading.py", line 754, in run
May  4 08:25:34.255094 str-msn2700-01 INFO swss.sh[3838]:     self.__target(*self.__args, **self.__kwargs)
May  4 08:25:34.256085 str-msn2700-01 INFO swss.sh[3838]:   File "/usr/bin/docker-wait-any", line 49, in wait_for_container
May  4 08:25:34.257340 str-msn2700-01 INFO swss.sh[3838]:     while docker_client.inspect_container(container_name)['State']['Status'] != "running":
May  4 08:25:34.258840 str-msn2700-01 INFO swss.sh[3838]:   File "/usr/local/lib/python2.7/dist-packages/docker/utils/decorators.py", line 21, in wrapped
May  4 08:25:34.259924 str-msn2700-01 INFO swss.sh[3838]:     return f(self, resource_id, *args, **kwargs)
May  4 08:25:34.261800 str-msn2700-01 INFO swss.sh[3838]:   File "/usr/local/lib/python2.7/dist-packages/docker/api/container.py", line 173, in inspect_container
May  4 08:25:34.263452 str-msn2700-01 INFO swss.sh[3838]:     self._get(self._url("/containers/{0}/json", container)), True
May  4 08:25:34.264960 str-msn2700-01 INFO swss.sh[3838]:   File "/usr/local/lib/python2.7/dist-packages/docker/client.py", line 110, in _get
May  4 08:25:34.266356 str-msn2700-01 INFO swss.sh[3838]:     return self.get(url, **self._set_request_timeout(kwargs))
May  4 08:25:34.267707 str-msn2700-01 INFO swss.sh[3838]:   File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 542, in get
May  4 08:25:34.269129 str-msn2700-01 INFO swss.sh[3838]:     return self.request('GET', url, **kwargs)
May  4 08:25:34.270841 str-msn2700-01 INFO swss.sh[3838]:   File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 515, in request
May  4 08:25:34.272377 str-msn2700-01 INFO swss.sh[3838]:     prep = self.prepare_request(req)
May  4 08:25:34.274015 str-msn2700-01 INFO swss.sh[3838]:   File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 449, in prepare_request
May  4 08:25:34.275624 str-msn2700-01 INFO swss.sh[3838]:     headers=merge_setting(request.headers, self.headers, dict_class=CaseInsensitiveDict),
May  4 08:25:34.277034 str-msn2700-01 INFO swss.sh[3838]:   File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 64, in merge_setting
May  4 08:25:34.278583 str-msn2700-01 INFO swss.sh[3838]:     isinstance(session_setting, Mapping) and
May  4 08:25:34.279902 str-msn2700-01 INFO swss.sh[3838]:   File "/usr/lib/python2.7/abc.py", line 144, in __instancecheck__
May  4 08:25:34.281770 str-msn2700-01 INFO swss.sh[3838]:     return cls.__subclasscheck__(subtype)
May  4 08:25:34.283544 str-msn2700-01 INFO swss.sh[3838]:   File "/usr/lib/python2.7/abc.py", line 171, in __subclasscheck__
May  4 08:25:34.284746 str-msn2700-01 INFO swss.sh[3838]:     cls._abc_cache.add(subclass)
May  4 08:25:34.286218 str-msn2700-01 INFO swss.sh[3838]:   File "/usr/lib/python2.7/_weakrefset.py", line 86, in add
May  4 08:25:34.291449 str-msn2700-01 INFO swss.sh[3838]:     self.data.add(ref(item, self._remove))
May  4 08:25:34.291679 str-msn2700-01 INFO swss.sh[3838]: TypeError: 'NoneType' object is not callable
```


Instance 2:
```
Apr 25 16:02:11.122539 str-dcfx-t0-1-04 INFO swss.sh[4575]: Exception in thread Thread-1:
Apr 25 16:02:11.123217 str-dcfx-t0-1-04 INFO swss.sh[4575]: Traceback (most recent call last):
Apr 25 16:02:11.123788 str-dcfx-t0-1-04 INFO swss.sh[4575]:   File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
Apr 25 16:02:11.124292 str-dcfx-t0-1-04 INFO swss.sh[4575]:     self.run()
Apr 25 16:02:11.124792 str-dcfx-t0-1-04 INFO swss.sh[4575]:   File "/usr/lib/python2.7/threading.py", line 754, in run
Apr 25 16:02:11.125278 str-dcfx-t0-1-04 INFO swss.sh[4575]:     self.__target(*self.__args, **self.__kwargs)
Apr 25 16:02:11.125782 str-dcfx-t0-1-04 INFO swss.sh[4575]:   File "/usr/bin/docker-wait-any", line 49, in wait_for_container
Apr 25 16:02:11.126274 str-dcfx-t0-1-04 INFO swss.sh[4575]:     while docker_client.inspect_container(container_name)['State']['Status'] != "running":
Apr 25 16:02:11.126759 str-dcfx-t0-1-04 INFO swss.sh[4575]:   File "/usr/local/lib/python2.7/dist-packages/docker/utils/decorators.py", line 21, in wrapped
Apr 25 16:02:11.127247 str-dcfx-t0-1-04 INFO swss.sh[4575]:     return f(self, resource_id, *args, **kwargs)
Apr 25 16:02:11.129110 str-dcfx-t0-1-04 INFO swss.sh[4575]:   File "/usr/local/lib/python2.7/dist-packages/docker/api/container.py", line 173, in inspect_container
Apr 25 16:02:11.130943 str-dcfx-t0-1-04 INFO swss.sh[4575]:     self._get(self._url("/containers/{0}/json", container)), True
Apr 25 16:02:11.133140 str-dcfx-t0-1-04 INFO swss.sh[4575]:   File "/usr/local/lib/python2.7/dist-packages/docker/client.py", line 120, in _url
Apr 25 16:02:11.136573 str-dcfx-t0-1-04 INFO swss.sh[4575]:     if not isinstance(arg, six.string_types):
Apr 25 16:02:11.138394 str-dcfx-t0-1-04 INFO swss.sh[4575]: AttributeError: 'NoneType' object has no attribute 'string_types'
```

Instance 3:
```
Apr 25 16:38:26.009619 str-dcfx-t0-1-04 INFO swss.sh[4594]: Exception in thread Thread-1:
Apr 25 16:38:26.010321 str-dcfx-t0-1-04 INFO swss.sh[4594]: Traceback (most recent call last):
Apr 25 16:38:26.010878 str-dcfx-t0-1-04 INFO swss.sh[4594]:   File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
Apr 25 16:38:26.011440 str-dcfx-t0-1-04 INFO swss.sh[4594]:     self.run()
Apr 25 16:38:26.011946 str-dcfx-t0-1-04 INFO swss.sh[4594]:   File "/usr/lib/python2.7/threading.py", line 754, in run
Apr 25 16:38:26.012469 str-dcfx-t0-1-04 INFO swss.sh[4594]:     self.__target(*self.__args, **self.__kwargs)
Apr 25 16:38:26.012982 str-dcfx-t0-1-04 INFO swss.sh[4594]:   File "/usr/bin/docker-wait-any", line 49, in wait_for_container
Apr 25 16:38:26.013479 str-dcfx-t0-1-04 INFO swss.sh[4594]:     while docker_client.inspect_container(container_name)['State']['Status'] != "running":
Apr 25 16:38:26.014010 str-dcfx-t0-1-04 INFO swss.sh[4594]:   File "/usr/local/lib/python2.7/dist-packages/docker/utils/decorators.py", line 21, in wrapped
Apr 25 16:38:26.014526 str-dcfx-t0-1-04 INFO swss.sh[4594]:     return f(self, resource_id, *args, **kwargs)
Apr 25 16:38:26.015021 str-dcfx-t0-1-04 INFO swss.sh[4594]:   File "/usr/local/lib/python2.7/dist-packages/docker/api/container.py", line 173, in inspect_container
Apr 25 16:38:26.017533 str-dcfx-t0-1-04 INFO swss.sh[4594]:     self._get(self._url("/containers/{0}/json", container)), True
Apr 25 16:38:26.020224 str-dcfx-t0-1-04 INFO swss.sh[4594]:   File "/usr/local/lib/python2.7/dist-packages/docker/client.py", line 120, in _url
Apr 25 16:38:26.023942 str-dcfx-t0-1-04 INFO swss.sh[4594]:     if not isinstance(arg, six.string_types):
Apr 25 16:38:26.027494 str-dcfx-t0-1-04 INFO swss.sh[4594]: AttributeError: 'NoneType' object has no attribute 'string_types'
```
#### How I did it

Child thread should break out of infinite loop after signaling main thread to unblock and exit.

#### How to verify it
Tried multiple times on physical testbed and issue is not seen with this fix,

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

