### PR TITLE
[Dell] Add tenGig Ports to Dell z9100 

### DIFF
--- a/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C32/port_config.ini
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C32/port_config.ini
@@ -31,3 +31,5 @@ Ethernet112     5,6,7,8               hundredGigE1/29    29
 Ethernet116     1,2,3,4               hundredGigE1/30    30
 Ethernet120     13,14,15,16           hundredGigE1/31    31
 Ethernet124     9,10,11,12            hundredGigE1/32    32
+Ethernet128     129                   tenGigE1/33        33
+Ethernet129     131                   tenGigE1/34        34

--- a/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C32/port_config.ini
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C32/port_config.ini
@@ -1,35 +1,35 @@
-# name          lanes                 alias              index
-Ethernet0       49,50,51,52           hundredGigE1/1     1
-Ethernet4       53,54,55,56           hundredGigE1/2     2
-Ethernet8       57,58,59,60           hundredGigE1/3     3
-Ethernet12      61,62,63,64           hundredGigE1/4     4
-Ethernet16      65,66,67,68           hundredGigE1/5     5
-Ethernet20      69,70,71,72           hundredGigE1/6     6
-Ethernet24      73,74,75,76           hundredGigE1/7     7
-Ethernet28      77,78,79,80           hundredGigE1/8     8
-Ethernet32      37,38,39,40           hundredGigE1/9     9
-Ethernet36      33,34,35,36           hundredGigE1/10    10
-Ethernet40      45,46,47,48           hundredGigE1/11    11
-Ethernet44      41,42,43,44           hundredGigE1/12    12
-Ethernet48      81,82,83,84           hundredGigE1/13    13
-Ethernet52      85,86,87,88           hundredGigE1/14    14
-Ethernet56      89,90,91,92           hundredGigE1/15    15
-Ethernet60      93,94,95,96           hundredGigE1/16    16
-Ethernet64      97,98,99,100          hundredGigE1/17    17
-Ethernet68      101,102,103,104       hundredGigE1/18    18
-Ethernet72      105,106,107,108       hundredGigE1/19    19
-Ethernet76      109,110,111,112       hundredGigE1/20    20
-Ethernet80      21,22,23,24           hundredGigE1/21    21
-Ethernet84      17,18,19,20           hundredGigE1/22    22
-Ethernet88      29,30,31,32           hundredGigE1/23    23
-Ethernet92      25,26,27,28           hundredGigE1/24    24
-Ethernet96      117,118,119,120       hundredGigE1/25    25
-Ethernet100     113,114,115,116       hundredGigE1/26    26
-Ethernet104     125,126,127,128       hundredGigE1/27    27
-Ethernet108     121,122,123,124       hundredGigE1/28    28
-Ethernet112     5,6,7,8               hundredGigE1/29    29
-Ethernet116     1,2,3,4               hundredGigE1/30    30
-Ethernet120     13,14,15,16           hundredGigE1/31    31
-Ethernet124     9,10,11,12            hundredGigE1/32    32
-Ethernet128     129                   tenGigE1/33        33
-Ethernet129     131                   tenGigE1/34        34
+# name          lanes                 alias              index    speed
+Ethernet0       49,50,51,52           hundredGigE1/1     1        100000
+Ethernet4       53,54,55,56           hundredGigE1/2     2        100000
+Ethernet8       57,58,59,60           hundredGigE1/3     3        100000
+Ethernet12      61,62,63,64           hundredGigE1/4     4        100000
+Ethernet16      65,66,67,68           hundredGigE1/5     5        100000
+Ethernet20      69,70,71,72           hundredGigE1/6     6        100000
+Ethernet24      73,74,75,76           hundredGigE1/7     7        100000
+Ethernet28      77,78,79,80           hundredGigE1/8     8        100000
+Ethernet32      37,38,39,40           hundredGigE1/9     9        100000
+Ethernet36      33,34,35,36           hundredGigE1/10    10       100000
+Ethernet40      45,46,47,48           hundredGigE1/11    11       100000
+Ethernet44      41,42,43,44           hundredGigE1/12    12       100000
+Ethernet48      81,82,83,84           hundredGigE1/13    13       100000
+Ethernet52      85,86,87,88           hundredGigE1/14    14       100000
+Ethernet56      89,90,91,92           hundredGigE1/15    15       100000
+Ethernet60      93,94,95,96           hundredGigE1/16    16       100000
+Ethernet64      97,98,99,100          hundredGigE1/17    17       100000
+Ethernet68      101,102,103,104       hundredGigE1/18    18       100000
+Ethernet72      105,106,107,108       hundredGigE1/19    19       100000
+Ethernet76      109,110,111,112       hundredGigE1/20    20       100000
+Ethernet80      21,22,23,24           hundredGigE1/21    21       100000
+Ethernet84      17,18,19,20           hundredGigE1/22    22       100000
+Ethernet88      29,30,31,32           hundredGigE1/23    23       100000
+Ethernet92      25,26,27,28           hundredGigE1/24    24       100000
+Ethernet96      117,118,119,120       hundredGigE1/25    25       100000
+Ethernet100     113,114,115,116       hundredGigE1/26    26       100000
+Ethernet104     125,126,127,128       hundredGigE1/27    27       100000
+Ethernet108     121,122,123,124       hundredGigE1/28    28       100000
+Ethernet112     5,6,7,8               hundredGigE1/29    29       100000
+Ethernet116     1,2,3,4               hundredGigE1/30    30       100000
+Ethernet120     13,14,15,16           hundredGigE1/31    31       100000
+Ethernet124     9,10,11,12            hundredGigE1/32    32       100000
+Ethernet128     129                   tenGigE1/33        33       10000
+Ethernet129     131                   tenGigE1/34        34       10000

--- a/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C32/th-z9100-32x100G.config.bcm
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C32/th-z9100-32x100G.config.bcm
@@ -57,6 +57,8 @@ portmap_2=5:100
 portmap_1=1:100
 portmap_4=13:100
 portmap_3=9:100
+portmap_66=129:10
+portmap_100=131:10
 portmap_33=132:10
 portmap_67=133:10
 portmap_101=134:10
@@ -226,5 +228,7 @@ dport_map_port_2=29
 dport_map_port_1=30
 dport_map_port_4=31
 dport_map_port_3=32
+dport_map_port_66=33
+dport_map_port_100=34
 
 mmu_init_config="MSFT-TH-Tier1"


### PR DESCRIPTION
#### Why I did it
The Dell Z9100 has two ten Gig SFP ports, that are not available in the current configuration.

Note: This PR does not extend sfputil, therefore the `show interfaces transceiver presence` command will always display `Not present` for the tenGig Ports.

#### How I did it
I added the port configuration to the default sku's bcm file and extended port_config.ini. 

#### How to verify it
Generate default configuration and try out on Dell Z9100.

#### Which release branch to backport (provide reason below if selected)
Backport to 202205, thats the version where I tested it.

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
Add tenGig sfp ports to Dell Z9100


