### PR TITLE
[Accton] Remove unused swsssdk import from accton device code

### DIFF
--- a/device/accton/x86_64-accton_minipack-r0/plugins/led_control.py
+++ b/device/accton/x86_64-accton_minipack-r0/plugins/led_control.py
@@ -5,7 +5,6 @@
 
 try:
     from sonic_led.led_control_base import LedControlBase
-    import swsssdk
     import threading
     import os
     import logging


### PR DESCRIPTION
#### Why I did it
Update scripts in sonic-buildimage from py-swsssdk to swsscommon


#### How I did it
Remove unused swsssdk import from accton device code

#### How to verify it
Pass all E2E test case

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
Remove unused swsssdk import from accton device code

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

