### PR TITLE
[AlphaNetworks] Replace swsssdk with swsscommon in alphanetworks devices

### DIFF
--- a/device/alphanetworks/x86_64-alphanetworks_snh60a0_320fv2-r0/plugins/led_control.py
+++ b/device/alphanetworks/x86_64-alphanetworks_snh60a0_320fv2-r0/plugins/led_control.py
@@ -3,7 +3,7 @@
 
 # try:
 #     from sonic_led.led_control_base import LedControlBase
-#     import swsssdk
+#     from swsscommon import swsscommon
 # except ImportError as e:
 #     raise ImportError (str(e) + " - required module not found")
 
@@ -181,7 +181,7 @@ class LedControl(LedControlBase):
 
         sonic_port_num = int(port_name[len(self.SONIC_PORT_NAME_PREFIX):])
 
-        swss = swsssdk.SonicV2Connector()
+        swss = swsscommon.SonicV2Connector()
         swss.connect(swss.APPL_DB)
 
         lanes = swss.get(

--- a/device/alphanetworks/x86_64-alphanetworks_snh60b0_640f-r0/plugins/led_control.py
+++ b/device/alphanetworks/x86_64-alphanetworks_snh60b0_640f-r0/plugins/led_control.py
@@ -5,7 +5,7 @@
 
 # try:
 #     from sonic_led.led_control_base import LedControlBase
-#     import swsssdk
+#     from swsscommon import swsscommon
 # except ImportError as e:
 #     raise ImportError (str(e) + " - required module not found")
 
@@ -148,7 +148,7 @@ class LedControl(LedControlBase):
 
         sonic_port_num = int(port_name[len(self.SONIC_PORT_NAME_PREFIX):])
 
-        swss = swsssdk.SonicV2Connector()
+        swss = swsscommon.SonicV2Connector()
         swss.connect(swss.APPL_DB)
 
         lanes = swss.get(


### PR DESCRIPTION

#### Why I did it
Update scripts in sonic-buildimage from py-swsssdk to swsscommon

#### How I did it
Replace swsssdk with swsscommon in alphanetworks devices code.

#### How to verify it
Pass all E2E test case

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
Replace swsssdk with swsscommon in alphanetworks devices code.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

