### PR TITLE
[Centec] Replace swsssdk with swsscommon in centec devices.

### DIFF
--- a/device/centec/x86_64-centec_e582_48x2q4z-r0/plugins/led_control.py
+++ b/device/centec/x86_64-centec_e582_48x2q4z-r0/plugins/led_control.py
@@ -5,7 +5,6 @@
 
 try:
     from sonic_led.led_control_base import LedControlBase
-    import swsssdk
     import threading
     import os
     import logging

--- a/device/centec/x86_64-centec_e582_48x6q-r0/plugins/led_control.py
+++ b/device/centec/x86_64-centec_e582_48x6q-r0/plugins/led_control.py
@@ -5,7 +5,6 @@
 
 try:
     from sonic_led.led_control_base import LedControlBase
-    import swsssdk
     import threading
     import os
     import logging

--- a/platform/centec/sonic-platform-modules-e582/48x2q4z/scripts/48x2q4z_platform_monitor.py
+++ b/platform/centec/sonic-platform-modules-e582/48x2q4z/scripts/48x2q4z_platform_monitor.py
@@ -15,7 +15,7 @@ try:
     import logging
     import struct
     import syslog
-    import swsssdk
+    from swsscommon import swsscommon
     from socket import *
     from select import *
 except ImportError, e:
@@ -96,7 +96,7 @@ class PlatformMonitor:
             aligned_last_byte = format(int(int(str(last_byte), 16) + 1), '02x')
             mac_addr = mac_addr[:-2] + aligned_last_byte
             DBG_PRINT("start connect swss config-db to set device mac-address")
-            swss = swsssdk.SonicV2Connector()
+            swss = swsscommon.SonicV2Connector()
             swss.connect(swss.CONFIG_DB)
             swss.set(swss.CONFIG_DB, "DEVICE_METADATA|localhost", 'mac', mac_addr)
             mac_addr = swss.get(swss.CONFIG_DB, "DEVICE_METADATA|localhost", 'mac')

--- a/platform/centec/sonic-platform-modules-e582/48x6q/scripts/48x6q_platform_monitor.py
+++ b/platform/centec/sonic-platform-modules-e582/48x6q/scripts/48x6q_platform_monitor.py
@@ -15,7 +15,7 @@ try:
     import logging
     import struct
     import syslog
-    import swsssdk
+    from swsscommon import swsscommon
     from socket import *
     from select import *
 except ImportError, e:
@@ -96,7 +96,7 @@ class PlatformMonitor:
             aligned_last_byte = format(int(int(str(last_byte), 16) + 1), '02x')
             mac_addr = mac_addr[:-2] + aligned_last_byte
             DBG_PRINT("start connect swss config-db to set device mac-address")
-            swss = swsssdk.SonicV2Connector()
+            swss = swsscommon.SonicV2Connector()
             swss.connect(swss.CONFIG_DB)
             swss.set(swss.CONFIG_DB, "DEVICE_METADATA|localhost", 'mac', mac_addr)
             mac_addr = swss.get(swss.CONFIG_DB, "DEVICE_METADATA|localhost", 'mac')


### PR DESCRIPTION

#### Why I did it
Update scripts in sonic-buildimage from py-swsssdk to swsscommon

#### How I did it
Replace swsssdk with swsscommon in centec devices.

#### How to verify it
Pass all E2E test case

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
Replace swsssdk with swsscommon in centec devices.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

