### PR TITLE
container_checker on supervisor should check containers based on asic presence

### DIFF
--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -20,34 +20,8 @@ import docker
 import sys
 
 import swsssdk
-from sonic_py_common import multi_asic, device_info, daemon_base
+from sonic_py_common import multi_asic, device_info
 from swsscommon import swsscommon
-
-def get_asic_presence_list():
-    """
-    @summary: This function will get the asic presence list. On Supervisor, the list includes only the asics
-              for inserted and detected fabric cards. For non-supervisor cards, e.g. line card, the list should
-              contain all supported asics by the card. The function gets the asic list from CHASSIS_ASIC_TABLE from
-              CHASSIS_STATE_DB. The function assumes that the first N asic ids (asic0 to asic(N-1)) in
-              CHASSIS_ASIC_TABLE belongs to the supervisor, where N is the max number of asics supported by the Chassis 
-    @return:  List of asics present
-    """
-    asics_list = []
-    if multi_asic.is_multi_asic():
-        if not device_info.is_supervisor():
-            # Supervisor has FRU Fabric cards. If not supervisor, all asics
-            # should be present. Add all asics, 0 - num_asics to the list.
-            asics_list = list(range(0,multi_asic.get_num_asics()))
-        else:
-            # Get asic list from CHASSIS_ASIC_TABLE
-            chassis_state_db = daemon_base.db_connect("CHASSIS_STATE_DB")
-            asic_table = swsscommon.Table(chassis_state_db, 'CHASSIS_ASIC_TABLE')
-            if asic_table:
-                asics_presence_list = list(asic_table.getKeys())
-                for asic in asics_presence_list:
-                    # asic is asid id: asic0, asic1.... asicN. Get the numeric value.
-                    asics_list.append(int(asic[4:]))
-    return asics_list
 
 def get_expected_running_containers():
     """
@@ -69,10 +43,14 @@ def get_expected_running_containers():
 
     # Get current asic presence list. For multi_asic system, multi instance containers
     # should be checked only for asics present.
-    asics_id_presence = get_asic_presence_list()
+    asics_id_presence = multi_asic.get_asic_presence_list()
 
-    # Some services, like database and bgp run all the instances irrespective of asic presence.
+    # Some services may run all the instances irrespective of asic presence.
     # Add those to exception list.
+    # database service: Currently services have dependency on all database services to
+    # be up irrespective of asic presence.
+    # bgp service: Currently bgp runs all instances. Once this is fixed to be config driven,
+    # it will be removed from exception list.
     run_all_instance_list = ['database', 'bgp']
 
     for container_name in feature_table.keys():

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -20,9 +20,34 @@ import docker
 import sys
 
 import swsssdk
-from sonic_py_common import multi_asic, device_info
+from sonic_py_common import multi_asic, device_info, daemon_base
 from swsscommon import swsscommon
 
+def get_asic_presence_list():
+    """
+    @summary: This function will get the asic presence list. On Supervisor, the list includes only the asics
+              for inserted and detected fabric cards. For non-supervisor cards, e.g. line card, the list should
+              contain all supported asics by the card. The function gets the asic list from CHASSIS_ASIC_TABLE from
+              CHASSIS_STATE_DB. The function assumes that the first N asic ids (asic0 to asic(N-1)) in
+              CHASSIS_ASIC_TABLE belongs to the supervisor, where N is the max number of asics supported by the Chassis 
+    @return:  List of asics present
+    """
+    asics_list = []
+    if multi_asic.is_multi_asic():
+        if not device_info.is_supervisor():
+            # Supervisor has FRU Fabric cards. If not supervisor, all asics
+            # should be present. Add all asics, 0 - num_asics to the list.
+            asics_list = list(range(0,multi_asic.get_num_asics()))
+        else:
+            # Get asic list from CHASSIS_ASIC_TABLE
+            chassis_state_db = daemon_base.db_connect("CHASSIS_STATE_DB")
+            asic_table = swsscommon.Table(chassis_state_db, 'CHASSIS_ASIC_TABLE')
+            if asic_table:
+                asics_presence_list = list(asic_table.getKeys())
+                for asic in asics_presence_list:
+                    # asic is asid id: asic0, asic1.... asicN. Get the numeric value.
+                    asics_list.append(int(asic[4:]))
+    return asics_list
 
 def get_expected_running_containers():
     """
@@ -41,7 +66,15 @@ def get_expected_running_containers():
 
     expected_running_containers = set()
     always_running_containers = set()
-    
+
+    # Get current asic presence list. For multi_asic system, multi instance containers
+    # should be checked only for asics present.
+    asics_id_presence = get_asic_presence_list()
+
+    # Some services, like database and bgp run all the instances irrespective of asic presence.
+    # Add those to exception list.
+    run_all_instance_list = ['database', 'bgp']
+
     for container_name in feature_table.keys():
         if feature_table[container_name]["state"] not in ["disabled", "always_disabled"]:
             if multi_asic.is_multi_asic():
@@ -50,7 +83,8 @@ def get_expected_running_containers():
                 if feature_table[container_name]["has_per_asic_scope"] == "True":
                     num_asics = multi_asic.get_num_asics()
                     for asic_id in range(num_asics):
-                        expected_running_containers.add(container_name + str(asic_id))
+                        if asic_id in asics_id_presence or container_name in run_all_instance_list:
+                            expected_running_containers.add(container_name + str(asic_id))
             else:
                 expected_running_containers.add(container_name)
         if feature_table[container_name]["state"] == 'always_enabled':
@@ -60,9 +94,11 @@ def get_expected_running_containers():
                 if feature_table[container_name]["has_per_asic_scope"] == "True":
                     num_asics = multi_asic.get_num_asics()
                     for asic_id in range(num_asics):
-                        always_running_containers.add(container_name + str(asic_id))
+                        if asic_id in asics_id_presence or container_name in run_all_instance_list:
+                            always_running_containers.add(container_name + str(asic_id))
             else:
                 always_running_containers.add(container_name)
+
     if device_info.is_supervisor():
         always_running_containers.add("database-chassis")
     return expected_running_containers, always_running_containers

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -4,6 +4,7 @@ import subprocess
 
 from natsort import natsorted
 from swsscommon import swsscommon
+from sonic_py_common import daemon_base
 
 from .device_info import CONTAINER_PLATFORM_PATH
 from .device_info import HOST_DEVICE_PATH
@@ -25,7 +26,8 @@ BGP_INTERNAL_NEIGH_CFG_DB_TABLE = 'BGP_INTERNAL_NEIGHBOR'
 NEIGH_DEVICE_METADATA_CFG_DB_TABLE = 'DEVICE_NEIGHBOR_METADATA'
 DEFAULT_NAMESPACE = ''
 PORT_ROLE = 'role'
-
+CHASSIS_STATE_DB='CHASSIS_STATE_DB'
+CHASSIS_ASIC_INFO_TABLE='CHASSIS_ASIC_TABLE'
 
 # Dictionary to cache config_db connection handle per namespace
 # to prevent duplicate connections from being opened
@@ -480,3 +482,31 @@ def validate_namespace(namespace):
         return True
     else:
         return False
+
+def get_asic_presence_list():
+    """
+    @summary: This function will get the asic presence list. On Supervisor, the list includes only the asics
+              for inserted and detected fabric cards. For non-supervisor cards, e.g. line card, the list should
+              contain all supported asics by the card. The function gets the asic list from CHASSIS_ASIC_TABLE from
+              CHASSIS_STATE_DB. The function assumes that the first N asic ids (asic0 to asic(N-1)) in
+              CHASSIS_ASIC_TABLE belongs to the supervisor, where N is the max number of asics supported by the Chassis 
+    @return:  List of asics present
+    """
+    asics_list = []
+    if is_multi_asic():
+        if not is_supervisor():
+            # This is not supervisor, all asics should be present. Assuming that asics
+            # are not removable entity on Line Cards. Add all asics, 0 - num_asics to the list.
+            asics_list = list(range(0,get_num_asics()))
+        else:
+            # This is supervisor card. Some fabric cards may not be inserted.
+            # Get asic list from CHASSIS_ASIC_TABLE which lists only the asics
+            # present based on Fabric card detection by the platform.
+            db = daemon_base.db_connect(CHASSIS_STATE_DB)
+            asic_table = swsscommon.Table(db,CHASSIS_ASIC_INFO_TABLE)
+            if asic_table:
+                asics_presence_list = list(asic_table.getKeys())
+                for asic in asics_presence_list:
+                    # asic is asid id: asic0, asic1.... asicN. Get the numeric value.
+                    asics_list.append(int(asic[4:]))
+    return asics_list

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -4,7 +4,6 @@ import subprocess
 
 from natsort import natsorted
 from swsscommon import swsscommon
-from sonic_py_common import daemon_base
 
 from .device_info import CONTAINER_PLATFORM_PATH
 from .device_info import HOST_DEVICE_PATH

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -508,5 +508,5 @@ def get_asic_presence_list():
                 asics_presence_list = list(asic_table.getKeys())
                 for asic in asics_presence_list:
                     # asic is asid id: asic0, asic1.... asicN. Get the numeric value.
-                    asics_list.append(int(asic[4:]))
+                    asics_list.append(int(get_asic_id_from_name(asic)))
     return asics_list

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -497,13 +497,13 @@ def get_asic_presence_list():
         if not is_supervisor():
             # This is not supervisor, all asics should be present. Assuming that asics
             # are not removable entity on Line Cards. Add all asics, 0 - num_asics to the list.
-            asics_list = list(range(0,get_num_asics()))
+            asics_list = list(range(0, get_num_asics()))
         else:
             # This is supervisor card. Some fabric cards may not be inserted.
             # Get asic list from CHASSIS_ASIC_TABLE which lists only the asics
             # present based on Fabric card detection by the platform.
-            db = daemon_base.db_connect(CHASSIS_STATE_DB)
-            asic_table = swsscommon.Table(db,CHASSIS_ASIC_INFO_TABLE)
+            db = swsscommon.DBConnector(CHASSIS_STATE_DB, 0, True)
+            asic_table = swsscommon.Table(db, CHASSIS_ASIC_INFO_TABLE)
             if asic_table:
                 asics_presence_list = list(asic_table.getKeys())
                 for asic in asics_presence_list:


### PR DESCRIPTION
Signed-off-by: anamehra anamehra@cisco.com

    On Supervisor/RP card, some application containers may not run if
    the asic is not present due to a missing Fabric card. The container checker
    should skip those container instances.
    Container instances which run only if asic present: swss, syncd, lldp,
    teamd
    Exception: All instances of database and bgp containers run irrespective
    of asic presence.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
On a supervisor card in a chassis, syncd/teamd/swss/lldp etc dockers are created for each Switch Fabric card. However, not all chassis would have all the switch fabric cards present. In this case, only dockers for Switch Fabrics present would be created.

The monit 'container_checker' fails in this scenario as it is expecting dockers for all Switch Fabrics (based on NUM_ASIC defined in asic.conf file).

https://github.com/Azure/sonic-buildimage/issues/8520#issuecomment-1137541344

#### How I did it
Get the aisc presence list from CHASSIS_ASIC_TABLE on CHASSIS_STATE_DB. Use this list to check for state of the dockers expected to be up.

#### How to verify it
1. Bringup Supervisor card with one or more missing fabric cards. Check for 'monit' process logs in syslogs. monit process should not report failure due to missing dockers for the asics on the fabric cards which are not present.
2. execute 'container_checker'. The command should not report failure due to missing dockers for the asics on the fabric cards which are not present.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
container_checker on supervisor should check containers based on asic presence

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

