### PR TITLE
Add gearbox taps to vs gearbox_config.json

### DIFF
--- a/device/virtual/x86_64-kvm_x86_64-r0/brcm_gearbox_vs/gearbox_config.json
+++ b/device/virtual/x86_64-kvm_x86_64-r0/brcm_gearbox_vs/gearbox_config.json
@@ -20,7 +20,17 @@
       "index": 0,
       "phy_id" : 1,
       "system_lanes": [200,201],
-      "line_lanes": [206]
+      "line_lanes": [206],
+      "system_tx_fir_pre2": [1,1],
+      "system_tx_fir_pre1": [-5,-5],
+      "system_tx_fir_main": [14,14],
+      "system_tx_fir_post1": [0,0],
+      "system_tx_fir_post2": [0,0],
+      "line_tx_fir_pre2": [0],
+      "line_tx_fir_pre1": [-1],
+      "line_tx_fir_main": [13],
+      "line_tx_fir_post1": [-5],
+      "line_tx_fir_post2": [0]
     },
     {
       "name": "Ethernet4",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For the change to support gearbox taps by gearbox_config.json (https://github.com/Azure/sonic-swss/pull/2158), I need to add tests to sonic-swss/tests/test_gearbox.py to satisfy the test coverage of the change. The existing code in test_gearbox.py has already used brcm_gearbox_vs and here is to add some gearbox tap value to its gearbox_config.json, for the added tests in sonic-swss/tests/test_gearbox.py.

#### How I did it

#### How to verify it
This change itself will not affect existing code.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

