### PR TITLE
[Mellanox] add PSU input voltage and current

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -196,6 +196,8 @@ class Psu(FixedPsu):
     PSU_CURRENT = "power/psu{}_curr"
     PSU_POWER = "power/psu{}_power"
     PSU_VPD = "eeprom/psu{}_vpd"
+    PSU_CURRENT_IN = "power/psu{}_curr_in"
+    PSU_VOLT_IN = "power/psu{}_volt_in"
 
     shared_led = None
 
@@ -207,7 +209,10 @@ class Psu(FixedPsu):
         self._psu_voltage_max = None
         self._psu_voltage_capability = None
 
+        self.psu_voltage_in = os.path.join(PSU_PATH, self.PSU_VOLT_IN.format(self.index))
+
         self.psu_current = os.path.join(PSU_PATH, self.PSU_CURRENT.format(self.index))
+        self.psu_current_in = os.path.join(PSU_PATH, self.PSU_CURRENT_IN.format(self.index))
         self.psu_power = os.path.join(PSU_PATH, self.PSU_POWER.format(self.index))
         self.psu_power_max = self.psu_power + "_max"
         self.psu_presence = os.path.join(PSU_PATH, "thermal/psu{}_status".format(self.index))
@@ -457,6 +462,30 @@ class Psu(FixedPsu):
         else:
             return None
 
+    def get_input_voltage(self):
+        """
+        Retrieves current PSU voltage input
+
+        Returns:
+            A float number, the input voltage in volts, 
+            e.g. 12.1 
+        """
+        if self.get_powergood_status():
+            voltage = utils.read_int_from_file(self.psu_voltage_in, log_func=logger.log_info)
+            return float(voltage) / 1000
+        return None
+
+    def get_input_current(self):
+        """
+        Retrieves the input current draw of the power supply
+
+        Returns:
+            A float number, the electric current in amperes, e.g 15.4
+        """
+        if self.get_powergood_status():
+            amperes = utils.read_int_from_file(self.psu_current_in, log_func=logger.log_info)
+            return float(amperes) / 1000
+        return None
 
 class InvalidPsuVolWA:
     """This class is created as a workaround for a known hardware issue that the PSU voltage threshold could be a 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -190,7 +190,25 @@ class FixedPsu(PsuBase):
         """
         return None
 
-     
+    def get_input_voltage(self):
+        """
+        Retrieves current PSU voltage input
+
+        Returns:
+            A float number, the input voltage in volts, 
+            e.g. 12.1 
+        """
+        return None
+
+    def get_input_current(self):
+        """
+        Retrieves the input current draw of the power supply
+
+        Returns:
+            A float number, the electric current in amperes, e.g 15.4
+        """
+        return None
+
 class Psu(FixedPsu):
     """Platform-specific Psu class"""
     PSU_CURRENT = "power/psu{}_curr"

--- a/platform/mellanox/mlnx-platform-api/tests/test_psu.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_psu.py
@@ -49,6 +49,8 @@ class TestPsu:
         assert psu.is_replaceable() is False
         assert psu.get_temperature() is None
         assert psu.get_temperature_high_threshold() is None
+        assert psu.get_input_voltage() is None
+        assert psu.get_input_current() is None
 
     @mock.patch('os.path.exists', mock.MagicMock(return_value=True))
     def test_psu(self):
@@ -64,7 +66,9 @@ class TestPsu:
             psu.psu_current: 20345,
             psu.psu_power: 30456,
             psu.psu_temp: 40567,
-            psu.psu_temp_threshold: 50678
+            psu.psu_temp_threshold: 50678,
+            psu.psu_voltage_in: 102345,
+            psu.psu_current_in: 676,
         }
 
         def mock_read_int_from_file(file_path, **kwargs):
@@ -85,6 +89,8 @@ class TestPsu:
         assert psu.get_power() is None
         assert psu.get_temperature() is None
         assert psu.get_temperature_high_threshold() is None
+        assert psu.get_input_voltage() is None
+        assert psu.get_input_current() is None
 
         mock_sysfs_content[psu.psu_oper_status] = 1
         assert psu.get_voltage() == 10.234
@@ -94,6 +100,8 @@ class TestPsu:
         assert psu.get_power() == 0.030456
         assert psu.get_temperature() == 40.567
         assert psu.get_temperature_high_threshold() == 50.678
+        assert psu.get_input_voltage() == 102.345
+        assert psu.get_input_current() == 0.676
 
         assert psu.get_position_in_parent() == 1
         assert psu.is_replaceable() is True


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Depends on https://github.com/sonic-net/sonic-platform-common/pull/295 and https://github.com/sonic-net/sonic-platform-daemons/pull/276

#### Why I did it

Add PSU input voltage and input current to mlnx platform api.

#### How I did it

Implement 2 function of getting the psu voltage and psu current input:
Get the values from "power/psu{}_curr_in" , "power/psu{}_volt_in"

#### How to verify it

Manual test.
Run sonic-mgmt regression

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
![2081428662](https://user-images.githubusercontent.com/33719090/180210118-a5df8987-1146-4a4a-8b0d-00f5d93a7fb3.jpg)

