### PR TITLE
Update the  DNX SAI to 7.1.0.0-7

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,5 +1,5 @@
 LIBSAIBCM_XGS_VERSION = 7.1.0.0-8
-LIBSAIBCM_DNX_VERSION = 7.1.0.0-1
+LIBSAIBCM_DNX_VERSION = 7.1.0.0-7
 LIBSAIBCM_BRANCH_NAME = REL_7.0
 LIBSAIBCM_XGS_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/bcmsai/$(LIBSAIBCM_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)"
 LIBSAIBCM_DNX_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/bcmsai/$(LIBSAIBCM_BRANCH_NAME)/$(LIBSAIBCM_DNX_VERSION)"


### PR DESCRIPTION
#### Why I did it
Update the DNX SAI to 7.1.0.0-7. This debian will not have macsec support enabled.

#### How I did it

#### How to verify it
Validated with the JR2 and J2C+ based boards, with interfaces up, traffic ok. Validated a few sonic-mgmt tests as well.

```

admin@str2--lc1-1:~$ show int status
     Interface                            Lanes    Speed    MTU    FEC          Alias            Vlan    Oper    Admin                                             Type    Asym PFC
--------------  -------------------------------  -------  -----  -----  -------------  --------------  ------  -------  -----------------------------------------------  ----------
     Ethernet0          72,73,74,75,76,77,78,79     400G   9100    N/A      Ethernet0          routed    down     down  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet1          80,81,82,83,84,85,86,87     400G   9100    N/A      Ethernet1          routed    down     down                                              N/A         off
     Ethernet2          88,89,90,91,92,93,94,95     400G   9100    N/A      Ethernet2          routed    down     down                                              N/A         off
     Ethernet3      96,97,98,99,100,101,102,103     400G   9100    N/A      Ethernet3          routed    down     down                                              N/A         off
     Ethernet4  104,105,106,107,108,109,110,111     400G   9100    N/A      Ethernet4  PortChannel102      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet5  112,113,114,115,116,117,118,119     400G   9100    N/A      Ethernet5  PortChannel102      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet6  120,121,122,123,124,125,126,127     400G   9100    N/A      Ethernet6          routed    down     down                                              N/A         off
     Ethernet7  128,129,130,131,132,133,134,135     400G   9100    N/A      Ethernet7          routed    down     down                                              N/A         off
     Ethernet8  136,137,138,139,140,141,142,143     400G   9100    N/A      Ethernet8          routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet9          64,65,66,67,68,69,70,71     400G   9100    N/A      Ethernet9          routed    down     down                                              N/A         off
    Ethernet10          56,57,58,59,60,61,62,63     400G   9100    N/A     Ethernet10          routed    down     down                                              N/A         off
    Ethernet11          48,49,50,51,52,53,54,55     400G   9100    N/A     Ethernet11          routed    down     down                                              N/A         off
    Ethernet12          40,41,42,43,44,45,46,47     400G   9100    N/A     Ethernet12          routed    down     down                                              N/A         off
    Ethernet13          32,33,34,35,36,37,38,39     400G   9100    N/A     Ethernet13          routed    down     down                                              N/A         off
    Ethernet14          24,25,26,27,28,29,30,31     400G   9100    N/A     Ethernet14          routed    down     down                                              N/A         off
    Ethernet15          16,17,18,19,20,21,22,23     400G   9100    N/A     Ethernet15          routed    down     down                                              N/A         off
    Ethernet16            8,9,10,11,12,13,14,15     400G   9100    N/A     Ethernet16          routed    down     down                                              N/A         off
    Ethernet17                  0,1,2,3,4,5,6,7     400G   9100    N/A     Ethernet17          routed    down     down                                              N/A         off
    Ethernet18          72,73,74,75,76,77,78,79     400G   9100    N/A     Ethernet18          routed    down     down                                              N/A         off
    Ethernet19          80,81,82,83,84,85,86,87     400G   9100    N/A     Ethernet19          routed    down     down                                              N/A         off
    Ethernet20          88,89,90,91,92,93,94,95     400G   9100    N/A     Ethernet20          routed    down     down                                              N/A         off
    Ethernet21      96,97,98,99,100,101,102,103     400G   9100    N/A     Ethernet21          routed    down     down                                              N/A         off
    Ethernet22  104,105,106,107,108,109,110,111     400G   9100    N/A     Ethernet22          routed    down     down                                              N/A         off
    Ethernet23  112,113,114,115,116,117,118,119     400G   9100    N/A     Ethernet23          routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet24  120,121,122,123,124,125,126,127     400G   9100    N/A     Ethernet24          routed    down     down                                              N/A         off
    Ethernet25  128,129,130,131,132,133,134,135     400G   9100    N/A     Ethernet25          routed    down     down                                              N/A         off
    Ethernet26  136,137,138,139,140,141,142,143     400G   9100    N/A     Ethernet26  PortChannel106      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet27          64,65,66,67,68,69,70,71     400G   9100    N/A     Ethernet27  PortChannel106      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet28          56,57,58,59,60,61,62,63     400G   9100    N/A     Ethernet28          routed    down     down                                              N/A         off
    Ethernet29          48,49,50,51,52,53,54,55     400G   9100    N/A     Ethernet29          routed    down     down                                              N/A         off
    Ethernet30          40,41,42,43,44,45,46,47     400G   9100    N/A     Ethernet30          routed    down     down                                              N/A         off
    Ethernet31          32,33,34,35,36,37,38,39     400G   9100    N/A     Ethernet31          routed    down     down                                              N/A         off
    Ethernet32          24,25,26,27,28,29,30,31     400G   9100    N/A     Ethernet32          routed    down     down                                              N/A         off
    Ethernet33          16,17,18,19,20,21,22,23     400G   9100    N/A     Ethernet33          routed    down     down                                              N/A         off
    Ethernet34            8,9,10,11,12,13,14,15     400G   9100    N/A     Ethernet34          routed    down     down                                              N/A         off
    Ethernet35                  0,1,2,3,4,5,6,7     400G   9100    N/A     Ethernet35          routed    down     down                                              N/A         off
  Ethernet-IB0                              115      10G   9100    N/A   Ethernet-IB0          routed      up       up                                              N/A         off
  Ethernet-IB1                              115      10G   9100    N/A   Ethernet-IB1          routed      up       up                                              N/A         off
 Ethernet-Rec0                              116      10G   9100    N/A  Ethernet-Rec0          routed      up       up                                              N/A         off
 Ethernet-Rec1                              116      10G   9100    N/A  Ethernet-Rec1          routed      up       up                                              N/A         off
PortChannel102                              N/A     800G   9100    N/A            N/A          routed      up       up                                              N/A         N/A
PortChannel106                              N/A     800G   9100    N/A            N/A          routed      up       up                                              N/A         N/A

root@str2--lc1-1:/# dpkg -l | grep saibcm
libsaibcm                  7.1.0.0-7                   amd64        Switch Abstraction Interface sdk based on Broadcom SAI
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

