### PR TITLE
[ifupdown2]:Patch ifupdown2 (#9630)

### DIFF
--- a/src/ifupdown2/patch/0003-Fix-the-return-value-of-utils._execute_subprocess-me.patch
+++ b/src/ifupdown2/patch/0003-Fix-the-return-value-of-utils._execute_subprocess-me.patch
@@ -1,0 +1,21 @@
+Fix the return value of utils._execute_subprocess method for empty strings
+---
+ ifupdown2/ifupdown/utils.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ifupdown2/ifupdown/utils.py b/ifupdown2/ifupdown/utils.py
+index d638fe9..0c5d8ce 100644
+--- a/ifupdown2/ifupdown/utils.py
++++ b/ifupdown2/ifupdown/utils.py
+@@ -380,7 +380,7 @@ class utils():
+         finally:
+             utils.disable_subprocess_signal_forwarding(signal.SIGINT)
+ 
+-        cmd_output_string = cmd_output.decode() if cmd_output else cmd_output
++        cmd_output_string = cmd_output.decode() if cmd_output is not None else cmd_output
+ 
+         if cmd_returncode != 0:
+             raise Exception(cls._format_error(cmd,
+-- 
+2.14.1
+

--- a/src/ifupdown2/patch/series
+++ b/src/ifupdown2/patch/series
@@ -1,2 +1,3 @@
 0001-fix-broadcast-addr-encoding.patch
 0002-disable-checks-when-using-no-wait.patch
+0003-Fix-the-return-value-of-utils._execute_subprocess-me.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Patch bug in ifupdown2 package which may cause dhclient not to run properly.
#### How I did it
Backport ifupdown2 patch https://github.com/CumulusNetworks/ifupdown2/pull/242 on ifupdown2 v3.0.0-1
It fixes the return value of the utils._execute_subprocess() method in case the subprocess output is empty.
#### How to verify it
Run the flow described in issue #9630
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix issue that may cause dhclient not to run properly.
#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

