### PR TITLE
[pmon] Add ping package to pmon docker

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -25,7 +25,8 @@ RUN apt-get update &&   \
         i2c-tools       \
         psmisc          \
         python3-jsonschema \
-        libpci3
+        libpci3         \
+        iputils-ping
 
 # On Arista devices, the sonic_platform wheel is not installed in the container.
 # Instead, the installation directory is mounted from the host OS. However, this method


### PR DESCRIPTION
#### Why I did it
ping command is not working inside PMON docker (bullseye)
Use case: chassisd checks for module reachability inside PMON for "show chassis modules midplane-status" CLI, and on Cisco chassis, this uses ping command to check network reachability

#### How I did it
Add iputils-ping package in pmon dockerfile

#### How to verify it
Run ping command inside PMON container

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
[pmon] Add ping package to pmon docker

#### A picture of a cute animal (not mandatory but encouraged)
![pexels-pixabay-162140](https://user-images.githubusercontent.com/98349131/181342899-82564f2e-ba76-4bd7-b8a6-397089f20071.jpeg)


