### PR TITLE
[bgp-cfgd] BGP allow list enhancement

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_allow_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_allow_list.py
@@ -222,7 +222,7 @@ class BGPAllowListMgr(Manager):
         :param community_value: community, which we want to use to filter prefixes
         :return: a dictionary with names
         """
-        if neighbor_type == '':
+        if not neighbor_type:
             if community_value == BGPAllowListMgr.EMPTY_COMMUNITY:
                 community_name = BGPAllowListMgr.EMPTY_COMMUNITY
             else:
@@ -673,7 +673,7 @@ class BGPAllowListMgr(Manager):
         :rm_2_call: a dictionary: key - name of a route-map, value - name of a route-map call defined for the route-map
         """
         ret = set()
-        if neighbor_type == '':
+        if not neighbor_type:
             target_allow_list_prefix = 'ALLOW_LIST_DEPLOYMENT_ID_%d_V' % deployment_id
         else:
             target_allow_list_prefix = 'ALLOW_LIST_DEPLOYMENT_ID_%d_NEIGHBOR_%s_V' % (deployment_id, neighbor_type)

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_allow_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_allow_list.py
@@ -14,8 +14,11 @@ class BGPAllowListMgr(Manager):
     ALLOW_ADDRESS_PL_NAME_TMPL = "ALLOW_ADDRESS_%d_%s"  # template for a name for the ALLOW_ADDRESS prefix-list ???
     EMPTY_COMMUNITY = "empty"
     PL_NAME_TMPL = "PL_ALLOW_LIST_DEPLOYMENT_ID_%d_COMMUNITY_%s_V%s"
+    PL_NAME_TMPL_WITH_NEIGH = "PL_ALLOW_LIST_DEPLOYMENT_ID_%d_NEIGHBOR_%s_COMMUNITY_%s_V%s"
     COMMUNITY_NAME_TMPL = "COMMUNITY_ALLOW_LIST_DEPLOYMENT_ID_%d_COMMUNITY_%s"
+    COMMUNITY_NAME_TMPL_WITH_NEIGH = "COMMUNITY_ALLOW_LIST_DEPLOYMENT_ID_%d_NEIGHBOR_%s_COMMUNITY_%s"
     RM_NAME_TMPL = "ALLOW_LIST_DEPLOYMENT_ID_%d_V%s"
+    RM_NAME_TMPL_WITH_NEIGH = "ALLOW_LIST_DEPLOYMENT_ID_%d_NEIGHBOR_%s_V%s"
     ROUTE_MAP_ENTRY_WITH_COMMUNITY_START = 10
     ROUTE_MAP_ENTRY_WITH_COMMUNITY_END = 29990
     ROUTE_MAP_ENTRY_WITHOUT_COMMUNITY_START = 30000
@@ -38,7 +41,7 @@ class BGPAllowListMgr(Manager):
             db,
             table,
         )
-        self.key_re = re.compile(r"^DEPLOYMENT_ID\|\d+\|\S+$|^DEPLOYMENT_ID\|\d+$")
+        self.key_re = re.compile(r"^DEPLOYMENT_ID\|\d+\|\S+$|^DEPLOYMENT_ID\|\d+$|^DEPLOYMENT_ID\|\d+\|\S+\|NEIGHBOR_TYPE\|\S+$|^DEPLOYMENT_ID\|\d+\|NEIGHBOR_TYPE\|\S+")
         self.enabled = self.__get_enabled()
         self.prefix_match_tag = self.__get_routemap_tag()
         self.__load_constant_lists()
@@ -55,8 +58,14 @@ class BGPAllowListMgr(Manager):
             return True
         if not self.__set_handler_validate(key, data):
             return True
-        key = key.replace("DEPLOYMENT_ID|", "")
-        deployment_id, community_value = key.split('|', 1) if '|' in key else (key, BGPAllowListMgr.EMPTY_COMMUNITY)
+        if 'NEIGHBOR_TYPE' in key:
+            keys = key.split('|NEIGHBOR_TYPE|', 1)
+            deployment_id = keys[0].replace("DEPLOYMENT_ID|", "")
+            neighbor_type, community_value = keys[1].split('|', 1) if '|' in keys[1] else (keys[1], BGPAllowListMgr.EMPTY_COMMUNITY)
+        else:
+            key = key.replace("DEPLOYMENT_ID|", "")
+            deployment_id, community_value = key.split('|', 1) if '|' in key else (key, BGPAllowListMgr.EMPTY_COMMUNITY)
+            neighbor_type = ''
         deployment_id = int(deployment_id)
         prefixes_v4 = []
         prefixes_v6 = []
@@ -65,7 +74,7 @@ class BGPAllowListMgr(Manager):
         if "prefixes_v6" in data:
             prefixes_v6 = str(data['prefixes_v6']).split(",")
         default_action_community = self.__get_default_action_community(data)
-        self.__update_policy(deployment_id, community_value, prefixes_v4, prefixes_v6, default_action_community)
+        self.__update_policy(deployment_id, community_value, prefixes_v4, prefixes_v6, default_action_community, neighbor_type)
         return True
 
     def __set_handler_validate(self, key, data):
@@ -85,13 +94,13 @@ class BGPAllowListMgr(Manager):
         prefixes_v6 = []
         if "prefixes_v4" in data:
             prefixes_v4 = str(data["prefixes_v4"]).split(",")
-            if not all(TemplateFabric.is_ipv4(prefix) for prefix in prefixes_v4):
+            if not all(TemplateFabric.is_ipv4(re.split('ge|le', prefix)[0]) for prefix in prefixes_v4):
                 arguments = "prefixes_v4", str(data["prefixes_v4"])
                 log_err("BGPAllowListMgr::Received BGP ALLOWED 'SET' message with invalid input[%s]:'%s'" % arguments)
                 return False
         if "prefixes_v6" in data:
             prefixes_v6 = str(data["prefixes_v6"]).split(",")
-            if not all(TemplateFabric.is_ipv6(prefix) for prefix in prefixes_v6):
+            if not all(TemplateFabric.is_ipv6(re.split('ge|le', prefix)[0]) for prefix in prefixes_v6):
                 arguments = "prefixes_v6", str(data["prefixes_v6"])
                 log_err("BGPAllowListMgr::Received BGP ALLOWED 'SET' message with invalid input[%s]:'%s'" % arguments)
                 return False
@@ -113,10 +122,18 @@ class BGPAllowListMgr(Manager):
             return
         if not self.__del_handler_validate(key):
             return
-        key = key.replace('DEPLOYMENT_ID|', '')
-        deployment_id, community = key.split('|', 1) if '|' in key else (key, BGPAllowListMgr.EMPTY_COMMUNITY)
+
+        if 'NEIGHBOR_TYPE' in key:
+            keys = key.split('|NEIGHBOR_TYPE|', 1)
+            deployment_id = keys[0].replace("DEPLOYMENT_ID|", "")
+            neighbor_type, community_value = keys[1].split('|', 1) if '|' in keys[1] else (keys[1], BGPAllowListMgr.EMPTY_COMMUNITY)
+        else:
+            key = key.replace("DEPLOYMENT_ID|", "")
+            deployment_id, community_value = key.split('|', 1) if '|' in key else (key, BGPAllowListMgr.EMPTY_COMMUNITY)
+            neighbor_type = ''
+
         deployment_id = int(deployment_id)
-        self.__remove_policy(deployment_id, community)
+        self.__remove_policy(deployment_id, community_value, neighbor_type)
 
     def __del_handler_validate(self, key):
         """
@@ -129,7 +146,7 @@ class BGPAllowListMgr(Manager):
             return False
         return True
 
-    def __update_policy(self, deployment_id, community_value, prefixes_v4, prefixes_v6, default_action):
+    def __update_policy(self, deployment_id, community_value, prefixes_v4, prefixes_v6, default_action, neighbor_type):
         """
         Update "allow list" policy with parameters
         :param deployment_id: deployment id which policy will be changed
@@ -139,12 +156,13 @@ class BGPAllowListMgr(Manager):
         :param default_action: the default action for the policy. should be either 'permit' or 'deny'
         """
         # update all related entries with the information
-        info = deployment_id, community_value, str(prefixes_v4), str(prefixes_v6)
+        info = deployment_id, community_value, str(prefixes_v4), str(prefixes_v6), neighbor_type
         msg = "BGPAllowListMgr::Updating 'Allow list' policy."
         msg += " deployment_id '%s'. community: '%s'"
         msg += " prefix_v4 '%s'. prefix_v6: '%s'"
+        msg += " neighbor_type %s"
         log_info(msg % info)
-        names = self.__generate_names(deployment_id, community_value)
+        names = self.__generate_names(deployment_id, community_value, neighbor_type)
         self.cfg_mgr.update()
         cmds = []
         cmds += self.__update_prefix_list(self.V4, names['pl_v4'], prefixes_v4)
@@ -156,14 +174,14 @@ class BGPAllowListMgr(Manager):
         cmds += self.__update_default_route_map_entry(names['rm_v6'], default_action)
         if cmds:
             self.cfg_mgr.push_list(cmds)
-            peer_groups = self.__find_peer_group_by_deployment_id(deployment_id)
+            peer_groups = self.__find_peer_group(deployment_id, neighbor_type)
             self.cfg_mgr.restart_peer_groups(peer_groups)
             log_debug("BGPAllowListMgr::__update_policy. The peers configuration scheduled for updates")
         else:
             log_debug("BGPAllowListMgr::__update_policy. Nothing to update")
         log_info("BGPAllowListMgr::Done")
 
-    def __remove_policy(self, deployment_id, community_value):
+    def __remove_policy(self, deployment_id, community_value, neighbor_type):
         """
         Remove "allow list" policy for given deployment_id and community_value
         :param deployment_id: deployment id which policy will be removed
@@ -177,7 +195,7 @@ class BGPAllowListMgr(Manager):
         log_info(msg % info)
 
         default_action = self.__get_default_action_community()
-        names = self.__generate_names(deployment_id, community_value)
+        names = self.__generate_names(deployment_id, community_value, neighbor_type)
         self.cfg_mgr.update()
         cmds = []
         cmds += self.__remove_allow_route_map_entry(self.V4, names['pl_v4'], names['community'], names['rm_v4'])
@@ -189,7 +207,7 @@ class BGPAllowListMgr(Manager):
         cmds += self.__update_default_route_map_entry(names['rm_v6'], default_action)
         if cmds:
             self.cfg_mgr.push_list(cmds)
-            peer_groups = self.__find_peer_group_by_deployment_id(deployment_id)
+            peer_groups = self.__find_peer_group(deployment_id, neighbor_type)
             self.cfg_mgr.restart_peer_groups(peer_groups)
             log_debug("BGPAllowListMgr::__remove_policy. 'Allow list' policy was scheduled for removal")
         else:
@@ -197,26 +215,42 @@ class BGPAllowListMgr(Manager):
         log_info('BGPAllowListMgr::Done')
 
     @staticmethod
-    def __generate_names(deployment_id, community_value):
+    def __generate_names(deployment_id, community_value, neighbor_type):
         """
         Generate prefix-list names for a given peer_ip and community value
         :param deployment_id: deployment_id for which we're going to filter prefixes
         :param community_value: community, which we want to use to filter prefixes
         :return: a dictionary with names
         """
-        if community_value == BGPAllowListMgr.EMPTY_COMMUNITY:
-            community_name = BGPAllowListMgr.EMPTY_COMMUNITY
+        if neighbor_type == '':
+            if community_value == BGPAllowListMgr.EMPTY_COMMUNITY:
+                community_name = BGPAllowListMgr.EMPTY_COMMUNITY
+            else:
+                community_name = BGPAllowListMgr.COMMUNITY_NAME_TMPL % (deployment_id, community_value)
+            names = {
+                "pl_v4": BGPAllowListMgr.PL_NAME_TMPL % (deployment_id, community_value, '4'),
+                "pl_v6": BGPAllowListMgr.PL_NAME_TMPL % (deployment_id, community_value, '6'),
+                "rm_v4": BGPAllowListMgr.RM_NAME_TMPL % (deployment_id, '4'),
+                "rm_v6": BGPAllowListMgr.RM_NAME_TMPL % (deployment_id, '6'),
+                "community": community_name,
+                'neigh_type': neighbor_type,
+            }
+            arguments = deployment_id, community_value, str(names)
+            log_debug("BGPAllowListMgr::__generate_names. deployment_id: %d, community: %s. names: %s" % arguments)
         else:
-            community_name = BGPAllowListMgr.COMMUNITY_NAME_TMPL % (deployment_id, community_value)
-        names = {
-            "pl_v4": BGPAllowListMgr.PL_NAME_TMPL % (deployment_id, community_value, '4'),
-            "pl_v6": BGPAllowListMgr.PL_NAME_TMPL % (deployment_id, community_value, '6'),
-            "rm_v4": BGPAllowListMgr.RM_NAME_TMPL % (deployment_id, '4'),
-            "rm_v6": BGPAllowListMgr.RM_NAME_TMPL % (deployment_id, '6'),
-            "community": community_name,
-        }
-        arguments = deployment_id, community_value, str(names)
-        log_debug("BGPAllowListMgr::__generate_names. deployment_id: %d, community: %s. names: %s" % arguments)
+            if community_value == BGPAllowListMgr.EMPTY_COMMUNITY:
+                community_name = BGPAllowListMgr.EMPTY_COMMUNITY
+            else:
+                community_name = BGPAllowListMgr.COMMUNITY_NAME_TMPL_WITH_NEIGH % (deployment_id, neighbor_type, community_value)
+            names = {
+                "pl_v4": BGPAllowListMgr.PL_NAME_TMPL_WITH_NEIGH % (deployment_id, neighbor_type, community_value, '4'),
+                "pl_v6": BGPAllowListMgr.PL_NAME_TMPL_WITH_NEIGH % (deployment_id, neighbor_type, community_value, '6'),
+                "rm_v4": BGPAllowListMgr.RM_NAME_TMPL_WITH_NEIGH % (deployment_id, neighbor_type, '4'),
+                "rm_v6": BGPAllowListMgr.RM_NAME_TMPL_WITH_NEIGH % (deployment_id, neighbor_type, '6'),
+                "community": community_name,
+            }
+            arguments = deployment_id, neighbor_type, community_value, str(names)
+            log_debug("BGPAllowListMgr::__generate_names. deployment_id: %d, neighbor_type: %s, community: %s. names: %s" % arguments)
         return names
 
     def __update_prefix_list(self, af, pl_name, allow_list):
@@ -630,7 +664,7 @@ class BGPAllowListMgr(Manager):
         return prefix_match_tag
 
     @staticmethod
-    def __get_peer_group_to_restart(deployment_id, pg_2_rm, rm_2_call):
+    def __get_peer_group_to_restart(deployment_id, pg_2_rm, rm_2_call, neighbor_type):
         """
         Get peer_groups which are assigned to deployment_id
         :deployment_id: deployment_id number
@@ -639,14 +673,17 @@ class BGPAllowListMgr(Manager):
         :rm_2_call: a dictionary: key - name of a route-map, value - name of a route-map call defined for the route-map
         """
         ret = set()
-        target_allow_list_prefix = 'ALLOW_LIST_DEPLOYMENT_ID_%d_V' % deployment_id
+        if neighbor_type == '':
+            target_allow_list_prefix = 'ALLOW_LIST_DEPLOYMENT_ID_%d_V' % deployment_id
+        else:
+            target_allow_list_prefix = 'ALLOW_LIST_DEPLOYMENT_ID_%d_NEIGHBOR_%s_V' % (deployment_id, neighbor_type)
         for peer_group, route_map in pg_2_rm.items():
             if route_map in rm_2_call:
                 if rm_2_call[route_map].startswith(target_allow_list_prefix):
                     ret.add(peer_group)
         return list(ret)
 
-    def __find_peer_group_by_deployment_id(self, deployment_id):
+    def __find_peer_group(self, deployment_id, neighbor_type):
         """
         Deduce peer-group names which are connected to devices with requested deployment_id
         :param deployment_id: deployment_id number
@@ -656,7 +693,7 @@ class BGPAllowListMgr(Manager):
         peer_groups = self.__extract_peer_group_names()
         pg_2_rm = self.__get_peer_group_to_route_map(peer_groups)
         rm_2_call = self.__get_route_map_calls(set(pg_2_rm.values()))
-        ret = self.__get_peer_group_to_restart(deployment_id, pg_2_rm, rm_2_call)
+        ret = self.__get_peer_group_to_restart(deployment_id, pg_2_rm, rm_2_call, neighbor_type)
         return list(ret)
 
     def __get_enabled(self):
@@ -706,11 +743,14 @@ class BGPAllowListMgr(Manager):
         res = []
         prefix_mask_default = 32 if af == self.V4 else 128
         for prefix in allow_list:
-            prefix_mask = int(prefix.split("/")[1])
-            if prefix_mask == prefix_mask_default:
+            if 'le' in prefix or 'ge' in prefix:
                 res.append("permit %s" % prefix)
             else:
-                res.append("permit %s le %d" % (prefix, prefix_mask_default))
+                prefix_mask = int(prefix.split("/")[1])
+                if prefix_mask == prefix_mask_default:
+                    res.append("permit %s" % prefix)
+                else:
+                    res.append("permit %s le %d" % (prefix, prefix_mask_default))
         return res
 
     def __af_to_family(self, af):

--- a/src/sonic-bgpcfgd/tests/test_allow_list.py
+++ b/src/sonic-bgpcfgd/tests/test_allow_list.py
@@ -866,6 +866,131 @@ def test_set_handler_no_community_update_prefixes_remove():
         ]
     )
 
+def test_set_handler_with_neighbor_type():
+    set_del_test(
+        "SET",
+        ("DEPLOYMENT_ID|5|NEIGHBOR_TYPE|OpticalLonghaulTerminal", {
+            "prefixes_v4": "10.62.64.0/22 ge 30,"\
+                           "10.1.44.0/23 ge 30,"\
+                           "10.17.92.0/23 ge 30,"\
+                           "10.73.92.0/23 ge 30,"\
+                           "10.26.170.0/24 ge 30,"\
+                           "10.26.171.0/24 ge 30,"\
+                           "10.26.255.0/24 ge 30",
+            "prefixes_v6": "fc01:20::/64",
+        }),
+        [
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V4 seq 10 deny 0.0.0.0/0 le 17',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V4 seq 20 permit 20.20.30.0/24 le 32',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V4 seq 30 permit 40.50.0.0/16 le 32',
+            'ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V6 seq 10 deny ::/0 le 59',
+            'ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V6 seq 20 deny ::/0 ge 65',
+            'ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V6 seq 30 permit fc01:20::/64 le 128',
+            'ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V6 seq 40 permit fc01:30::/64 le 128',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_V4 permit 30000',
+            ' match ip address prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V4',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_V6 permit 30000',
+            ' match ipv6 address prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V6',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_V4 permit 65535',
+            ' set community 123:123 additive',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_V6 permit 65535',
+            ' set community 123:123 additive',
+            ""
+        ],
+        [
+            'no ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V4',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V4 seq 10 deny 0.0.0.0/0 le 17',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V4 seq 20 permit 10.62.64.0/22 ge 30',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V4 seq 30 permit 10.1.44.0/23 ge 30',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V4 seq 40 permit 10.17.92.0/23 ge 30',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V4 seq 50 permit 10.73.92.0/23 ge 30',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V4 seq 60 permit 10.26.170.0/24 ge 30',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V4 seq 70 permit 10.26.171.0/24 ge 30',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V4 seq 80 permit 10.26.255.0/24 ge 30',
+            'no ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V6',
+            'ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V6 seq 10 deny ::/0 le 59',
+            'ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V6 seq 20 deny ::/0 ge 65',
+            'ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_empty_V6 seq 30 permit fc01:20::/64 le 128',
+        ]
+    )
+
+def test_set_handler_with_neighbor_type_and_community():
+    set_del_test(
+        "SET",
+        ("DEPLOYMENT_ID|5|NEIGHBOR_TYPE|OpticalLonghaulTerminal|1010:2020", {
+            "prefixes_v4": "10.62.64.0/22 ge 30,"\
+                           "10.1.44.0/23 ge 30,"\
+                           "10.17.92.0/23 ge 30,"\
+                           "10.73.92.0/23 ge 30,"\
+                           "10.26.170.0/24 ge 30,"\
+                           "10.26.171.0/24 ge 30,"\
+                           "10.26.255.0/24 ge 30",
+            "prefixes_v6": "fc01:20::/64",
+        }),
+        [
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V4 seq 10 deny 0.0.0.0/0 le 17',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V4 seq 20 permit 20.20.30.0/24 le 32',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V4 seq 30 permit 40.50.0.0/16 le 32',
+            'ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V6 seq 10 deny ::/0 le 59',
+            'ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V6 seq 20 deny ::/0 ge 65',
+            'ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V6 seq 30 permit fc01:20::/64 le 128',
+            'ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V6 seq 40 permit fc01:30::/64 le 128',
+            'bgp community-list standard COMMUNITY_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020 permit 1010:2020',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_V4 permit 10',
+            ' match ip address prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V4',
+            ' match community COMMUNITY_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_V6 permit 10',
+            ' match ipv6 address prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V6',
+            ' match community COMMUNITY_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_V4 permit 65535',
+            ' set community 123:123 additive',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_V6 permit 65535',
+            ' set community 123:123 additive',
+            ""
+        ],
+        [
+            'no ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V4',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V4 seq 10 deny 0.0.0.0/0 le 17',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V4 seq 20 permit 10.62.64.0/22 ge 30',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V4 seq 30 permit 10.1.44.0/23 ge 30',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V4 seq 40 permit 10.17.92.0/23 ge 30',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V4 seq 50 permit 10.73.92.0/23 ge 30',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V4 seq 60 permit 10.26.170.0/24 ge 30',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V4 seq 70 permit 10.26.171.0/24 ge 30',
+            'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V4 seq 80 permit 10.26.255.0/24 ge 30',
+            'no ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V6',
+            'ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V6 seq 10 deny ::/0 le 59',
+            'ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V6 seq 20 deny ::/0 ge 65',
+            'ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_COMMUNITY_1010:2020_V6 seq 30 permit fc01:20::/64 le 128',
+        ]
+    )
+
+def test_del_handler_with_neighbor_type_community_no_data():
+    set_del_test(
+        "DEL",
+        ("DEPLOYMENT_ID|5|NEIGHBOR_TYPE|OpticalLonghaulTerminal|1010:2020",),
+        [
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_V4 permit 65535',
+            ' set community 123:123 additive',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_V6 permit 65535',
+            ' set community 123:123 additive'
+        ],
+        []
+    )
+
+def test_del_handler_with_neighbor_type_no_data():
+    set_del_test(
+        "DEL",
+        ("DEPLOYMENT_ID|5|NEIGHBOR_TYPE|OpticalLonghaulTerminal",),
+        [
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_V4 permit 65535',
+            ' set community 123:123 additive',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_NEIGHBOR_OpticalLonghaulTerminal_V6 permit 65535',
+            ' set community 123:123 additive'
+        ],
+        []
+    )
+
 @patch.dict("sys.modules", swsscommon=swsscommon_module_mock)
 def test___set_handler_validate():
     from bgpcfgd.managers_allow_list import BGPAllowListMgr
@@ -894,7 +1019,7 @@ def test___set_handler_validate():
     })
 
 @patch.dict("sys.modules", swsscommon=swsscommon_module_mock)
-def test___find_peer_group_by_deployment_id():
+def test___find_peer_group():
     from bgpcfgd.managers_allow_list import BGPAllowListMgr
     cfg_mgr = MagicMock()
     cfg_mgr.update.return_value = None
@@ -984,7 +1109,7 @@ def test___find_peer_group_by_deployment_id():
         'constants': global_constants,
     }
     mgr = BGPAllowListMgr(common_objs, "CONFIG_DB", "BGP_ALLOWED_PREFIXES")
-    values = mgr._BGPAllowListMgr__find_peer_group_by_deployment_id(0)
+    values = mgr._BGPAllowListMgr__find_peer_group(0, '')
     assert set(values) == {'PEER_V4_INT', 'PEER_V6_INT', 'PEER_V6', 'PEER_V4'}
 
 @patch.dict("sys.modules", swsscommon=swsscommon_module_mock)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
2 things are missing in current allow-prefix list implementation. 
1. In some usecase, need to tell the BGP neighbor and have different allow-prefix list for different neighbors, which is not supported.
2. for the prefix list, can't support flexible le and ge.

#### How I did it
To enhance the bgp allow-prefix list feature to have:
1. To include the neighbor type info for the allow-prefix list. 
2. To support flexible le and ge length for allow-prefix list. 
#### How to verify it
4 new unit test cases are added in this PR to cover changes. 
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
Yang model changes would be implemented by another PR.
#### A picture of a cute animal (not mandatory but encouraged)

