### PR TITLE
[swss.sh/syncd.sh] Trap only on EXIT

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -38,7 +38,7 @@ function lock_service_state_change()
 
     exec {LOCKFD}>${LOCKFILE}
     /usr/bin/flock -x ${LOCKFD}
-    trap "/usr/bin/flock -u ${LOCKFD}" 0 2 3 15
+    trap "/usr/bin/flock -u ${LOCKFD}" EXIT
 
     debug "Locked ${LOCKFILE} (${LOCKFD}) from ${SERVICE}$DEV service"
 }

--- a/files/scripts/syncd_common.sh
+++ b/files/scripts/syncd_common.sh
@@ -3,11 +3,11 @@
 #
 # common functions used by "syncd" scipts (syncd.sh, gbsyncd.sh, etc..)
 # scripts using this must provide implementations of the following functions:
-# 
+#
 # startplatform
 # waitplatform
 # stopplatform1 and stopplatform2
-# 
+#
 # For examples of these, see gbsyncd.sh and syncd.sh.
 #
 
@@ -25,7 +25,7 @@ function lock_service_state_change()
 
     exec {LOCKFD}>${LOCKFILE}
     /usr/bin/flock -x ${LOCKFD}
-    trap "/usr/bin/flock -u ${LOCKFD}" 0 2 3 15
+    trap "/usr/bin/flock -u ${LOCKFD}" EXIT
 
     debug "Locked ${LOCKFILE} (${LOCKFD}) from ${SERVICE}$DEV service"
 }


### PR DESCRIPTION
When using trap on SIGTERM the script will not react to the SIGTERM signal sent while a child is executing.
I.e, the following script does not react on SIGTERM sent to it if it is
waiting for sleep to finish:

```
#!/bin/bash
trap "echo Handled SIGTERM" 0 2 3 15

echo "Before sleep"
sleep inf
echo "After sleep"
```

On SIGTERM sent to the followig script:

```
+ trap 'echo Handled SIGTERM' 15
+ echo Before sleep
Before sleep
+ sleep inf

Terminated
++ echo Handled SIGTERM
Handled SIGTERM
+ echo After sleep
After sleep
```

"echo After sleep" shouldn't be printed, the script has to exit.

Instead, trap only on EXIT which covers also a scenario with exit on
SIGINT, SIGTERM.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When NVIDIA switch is first booting FW upgrade process starts, if user does ```ztp disable -y``` during that process, which calls ```config reload -y -f``` all services will be terminated, including syncd and running FW upgrade process, however, it is observed that syncd.sh does not terminate but continues loading kernel drivers. This will cause an issue on next syncd start leading to switch init failure.

#### How I did it

Changed the signal for trap.

#### How to verify it

Boot NVIDIA switch first time, do "ztp disable -y", verify after some time all services are started and running.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

