### PR TITLE
[Mellanox] Support UID LED in platform API

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -75,6 +75,9 @@ class Chassis(ChassisBase):
     # System status LED
     _led = None
 
+    # System UID LED
+    _led_uid = None
+
     def __init__(self):
         super(Chassis, self).__init__()
 
@@ -622,8 +625,10 @@ class Chassis(ChassisBase):
 
     def initizalize_system_led(self):
         if not Chassis._led:
-            from .led import SystemLed
+            from .led import SystemLed, \
+                SystemUidLed
             Chassis._led = SystemLed()
+            Chassis._led_uid = SystemUidLed()
 
     def set_status_led(self, color):
         """
@@ -649,6 +654,31 @@ class Chassis(ChassisBase):
         """
         self.initizalize_system_led()
         return None if not Chassis._led else Chassis._led.get_status()
+
+    def set_uid_led(self, color):
+        """
+        Sets the state of the system UID LED
+
+        Args:
+            color: A string representing the color with which to set the
+                   system UID LED
+
+        Returns:
+            bool: True if system LED state is set successfully, False if not
+        """
+        self.initizalize_system_led()
+        return False if not Chassis._led_uid else Chassis._led_uid.set_status(color)
+
+    def get_uid_led(self):
+        """
+        Gets the state of the system UID LED
+
+        Returns:
+            A string, one of the valid LED color strings which could be vendor
+            specified.
+        """
+        self.initizalize_system_led()
+        return None if not Chassis._led_uid else Chassis._led_uid.get_status()
 
     def get_watchdog(self):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
@@ -28,10 +28,12 @@ class Led(object):
     STATUS_LED_COLOR_GREEN = 'green'
     STATUS_LED_COLOR_RED = 'red'
     STATUS_LED_COLOR_ORANGE = 'orange'
+    STATUS_LED_COLOR_BLUE = 'blue'
     STATUS_LED_COLOR_OFF = 'off'
     STATUS_LED_COLOR_GREEN_BLINK = 'green_blink'
     STATUS_LED_COLOR_RED_BLINK = 'red_blink'
     STATUS_LED_COLOR_ORANGE_BLINK = 'orange_blink'
+    STATUS_LED_COLOR_BLUE_BLINK = 'blue_blink'
 
     LED_ON = '255'
     LED_OFF = '0'
@@ -47,7 +49,8 @@ class Led(object):
         'red': 'red',
         'amber': 'red',
         'orange': 'red',
-        'green': 'green'
+        'green': 'green',
+        'blue': 'blue'
     }
 
     LED_PATH = "/var/run/hw-management/led/"
@@ -271,6 +274,12 @@ class SystemLed(Led):
     def __init__(self):
         super().__init__()
         self._led_id = 'status'
+
+
+class SystemUidLed(Led):
+    def __init__(self):
+        super().__init__()
+        self._led_id = 'uid'
 
 
 class SharedLed(object):


### PR DESCRIPTION
Signed-off-by: David Xia <daxia@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
As a LED indicator to help user to find switch location in the lab, UID LED is a useful LED in Mellanox switch.
#### How I did it
I add a new member _led_uid in Mellanox/Chassis.py, and extend Mellanox/led.py to support blue color.
Relevant platform-common PR https://github.com/sonic-net/sonic-platform-common/pull/369
#### How to verify it
Add unit test cases in test.py, and do manual test including turn-on/off/show uid led.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

