### PR TITLE
[database] Fix docker-database flush_unused_database failed issue

### DIFF
--- a/dockers/docker-database/docker-database-init.sh
+++ b/dockers/docker-database/docker-database-init.sh
@@ -79,7 +79,7 @@ rm $db_cfg_file_tmp
 
 # copy dump.rdb file to each instance for restoration
 DUMPFILE=/var/lib/redis/dump.rdb
-redis_inst_list=`/usr/bin/python3 -c "import swsssdk; print(' '.join(swsssdk.SonicDBConfig.get_instancelist().keys()))"`
+redis_inst_list=`/usr/bin/python3 -c "from swsscommon import swsscommon; print(' '.join(swsscommon.SonicDBConfig.getInstanceList().keys()))"`
 for inst in $redis_inst_list
 do
     mkdir -p /var/lib/$inst

--- a/dockers/docker-database/flush_unused_database
+++ b/dockers/docker-database/flush_unused_database
@@ -11,15 +11,15 @@ while(True):
         break
     time.sleep(1)
 
-instlists = swsscommon.SonicDBConfig.get_instancelist()
+instlists = swsscommon.SonicDBConfig.getInstanceList()
 for instname, v in instlists.items():
-    insthost = v['hostname']
-    instsocket = v['unix_socket_path']
+    insthost = v.hostname
+    instsocket = v.unixSocketPath
 
-    dblists = swsscommon.SonicDBConfig.get_dblist()
+    dblists = swsscommon.SonicDBConfig.getDbList()
     for dbname in dblists:
-        dbid = swsscommon.SonicDBConfig.get_dbid(dbname)
-        dbinst = swsscommon.SonicDBConfig.get_instancename(dbname)
+        dbid = swsscommon.SonicDBConfig.getDbId(dbname)
+        dbinst = swsscommon.SonicDBConfig.getDbInst(dbname)
 
         # this DB is on current instance, skip flush
         if dbinst == instname:


### PR DESCRIPTION
#### Why I did it
Fix docker-database flush_unused_database failed issue: https://github.com/Azure/sonic-buildimage/issues/11597
When change flush_unused_database from use swsssdk to use swsscommon, get_instancelist() and get_dblist() name changed but not update.

#### How I did it
Change flush_unused_database code to use swsscommon API:
Change get_instancelist to getInstanceList.
Change get_dblist to getDbList.

#### How to verify it
Pass all E2E test.
Manually check syslog make sure error log not exist and swss, syncd, bgp service started.
Search code in Azure make sure there all similer case are fixed in this PR.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
Fix docker-database flush_unused_database failed issue: https://github.com/Azure/sonic-buildimage/issues/11597
When change flush_unused_database from use swsssdk to use swsscommon, get_instancelist() and get_dblist() name changed but not update.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

