### PR TITLE
[ci] Update azp reference to support transfering organization from Azure to sonic-net

### DIFF
--- a/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
+++ b/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
@@ -18,9 +18,9 @@ resources:
   repositories:
   - repository: buildimage
     type: github
-    name: Azure/sonic-buildimage
+    name: sonic-net/sonic-buildimage
     ref: master
-    endpoint: build
+    endpoint: sonic-net
 
 pool: sonicbld
 

--- a/.azure-pipelines/build-commonlib.yml
+++ b/.azure-pipelines/build-commonlib.yml
@@ -11,9 +11,9 @@ resources:
   repositories:
   - repository: buildimage
     type: github
-    name: Azure/sonic-buildimage
+    name: sonic-net/sonic-buildimage
     ref: master
-    endpoint: build
+    endpoint: sonic-net
 
 jobs:
 - template: .azure-pipelines/template-commonlib.yml@buildimage

--- a/.azure-pipelines/docker-sonic-slave-template.yml
+++ b/.azure-pipelines/docker-sonic-slave-template.yml
@@ -7,9 +7,9 @@ resources:
   repositories:
   - repository: buildimage
     type: github
-    name: Azure/sonic-buildimage
+    name: sonic-net/sonic-buildimage
     ref: master
-    endpoint: build
+    endpoint: sonic-net
 
 parameters:
 - name: arch

--- a/.azure-pipelines/official-build.yml
+++ b/.azure-pipelines/official-build.yml
@@ -16,9 +16,9 @@ resources:
   repositories:
   - repository: buildimage
     type: github
-    name: Azure/sonic-buildimage
+    name: sonic-net/sonic-buildimage
     ref: master
-    endpoint: build
+    endpoint: sonic-net
 
 trigger: none
 pr: none

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,8 +32,8 @@ resources:
     ref: refs/heads/202012
   - repository: buildimage
     type: github
-    name: Azure/sonic-buildimage
-    endpoint: build
+    name: sonic-net/sonic-buildimage
+    endpoint: sonic-net
     ref: master
 
 variables:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When transfer repo to another organization, azp reference also need change.
Change azp reference to avoid pipeline failure.
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

