### PR TITLE
[Nokia] Update Nokia platform IXR7250E device data

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_components.template
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_components.template
@@ -1,0 +1,19 @@
+  {
+    "module": {
+      "LINE-CARD": {
+        "component": {}
+      },
+      "SUPERVISOR0": {
+        "component": {}
+      }
+    },
+    "chassis": {
+      "Nokia-IXR7250E-36x400G": {
+        "component": {
+          "FPGA2": {},
+          "FPGA1": {},
+          "BIOS": {}
+        }
+      }
+    }
+  }

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_ndk.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_ndk.json
@@ -1,8 +1,8 @@
 {
     "options": [
     {
-        "key": "sfp_init_tx_en",
-        "stringval": "yes"
+        "key": "module_direct_ipc_ue",
+        "stringval": "no"
     },
     {
         "key": "midplane_subnet",
@@ -39,6 +39,10 @@
     {
       "key": "enable_firmware_update",
       "intval": 0
+    },
+    {
+      "key": "sonic_log_level",
+      "stringval": "error"
     }
     ]
 }

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_reboot
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_reboot
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+update_reboot_cause_for_supervisor_reboot()
+{
+    DEVICE_MGR_REBOOT_FILE=/tmp/device_mgr_reboot
+    REBOOT_CAUSE_FILE=/host/reboot-cause/reboot-cause.txt
+    TMP_REBOOT_CAUSE_FILE=/tmp/tmp-reboot-cause.txt
+    if [ -f  $DEVICE_MGR_REBOOT_FILE ]; then
+        if [ -f $REBOOT_CAUSE_FILE ]; then
+            t1=`sudo grep "User: ," $REBOOT_CAUSE_FILE`
+            if [ ! -z "$t1" ]; then
+                echo $t1 | sed 's/reboot/reboot from Supervisor/g' | sed 's/User: /User: admin/g' > $TMP_REBOOT_CAUSE_FILE
+                cp $TMP_REBOOT_CAUSE_FILE $REBOOT_CAUSE_FILE
+            fi
+        fi
+    fi
+}
+
+# update the reboot_cuase file when reboot is trigger by device-mgr
+update_reboot_cause_for_supervisor_reboot
+
 systemctl stop nokia-watchdog.service
 sleep 2
 echo "w" > /dev/watchdog

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/platform.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/platform.json
@@ -7,6 +7,9 @@
             },
             {
                 "name": "FPGA1"
+            },
+            {
+                "name": "SFM-FPGA"
             }
         ],
 	"watchdog": {

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/platform_components.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/platform_components.json
@@ -1,0 +1,81 @@
+{
+    "chassis": {
+        "Nokia-IXR7250E-SUP-10": {
+            "component": {
+                "BIOS": { },
+                "FPGA1": { },
+                "SFM-FPGA": { }
+            }
+        }
+    },
+    "module": {
+      "SUPERVISOR0": {
+	    "component": {
+	    }
+      },
+      "LINE-CARD0": {
+	"component": {
+	}
+      },
+      "LINE-CARD1": {
+	"component": {
+	}
+      },
+      "LINE-CARD2": {
+	"component": {
+	}
+      },
+      "LINE-CARD3": {
+	"component": {
+	}
+      },
+      "LINE-CARD4": {
+	"component": {
+	}
+      },
+      "LINE-CARD5": {
+	"component": {
+	}
+      },
+      "LINE-CARD6": {
+	"component": {
+	}
+      },
+      "LINE-CARD7": {
+	"component": {
+	}
+      },
+      "FABRIC-CARD0": {
+	"component": {
+	}
+      },
+      "FABRIC-CARD1": {
+	"component": {
+	}
+      },
+      "FABRIC-CARD2": {
+	"component": {
+	}
+      },
+      "FABRIC-CARD3": {
+	"component": {
+	}
+      },
+      "FABRIC-CARD4": {
+	"component": {
+	}
+      },
+      "FABRIC-CARD5": {
+	"component": {
+	}
+      },
+      "FABRIC-CARD6": {
+	"component": {
+	}
+      },
+      "FABRIC-CARD7": {
+	"component": {
+	}
+      }
+   }
+}

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_ndk.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_ndk.json
@@ -27,6 +27,10 @@
     {
       "key": "enable_firmware_update",
       "intval": 0
+    },
+    {
+      "key": "sonic_log_level",
+      "stringval": "error"
     }
     ]
 }


### PR DESCRIPTION
#### Why I did it
Update Nokia platform IXR7250 platform_ndk.json files with the nokia_log_level option to  allow users to override the logging level for the Nokia NDK processes -- sr_device_mgr,  ndk-qfpga_mgr and eth_switch
#### How I did it
Modify the platform_ndk.json file with the following option. And default value is "error"
```
    {
      "key": "sonic_log_level",
      "stringval": "error"
    }
```
#### How to verify it
On running platform, verify the change by checking file /etc/opt/srlinux/startup_debug.json
```
admin@ixre-egl-board40:~$ cat /etc/opt/srlinux/startup_debug.json 
{
    "options": [
    {
        "key": "sfp_init_tx_en",
        "stringval": "yes"
    },
    {
        "key": "midplane_subnet",
        "stringval": "10.6.0.0/16"
    },
    {
        "key": "midplane_monitor",
        "stringval": "yes"
    },
    {
        "key": "monitor_action",
        "stringval": "reboot"
    },
    {
        "key": "grpc_thermal_monitor",
        "stringval": "yes"
    },
    {
        "key": "disable_vfio",
        "intval": 1
    },
    {
        "key": "sonic_bdb_mode",
        "intval": 0
    },
    { 
      "key": "update_asic_pvt",
      "intval": 10
    },
    {
      "key": "amd_pcon",
      "intval": 4
    },
    {
      "key": "enable_firmware_update",
      "intval": 0
    },
    {
      "key": "sonic_log_level",
      "stringval": "error"
    }
    ]
}
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

