### PR TITLE
[arp_update]: Resolve failed neighbors on dualtor

### DIFF
--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -77,6 +77,21 @@ while /bin/true; do
       eval `eval $ip6cmd`
   done
 
+  DBNEIGH=$(sonic-db-cli APPL_DB keys NEIGH_TABLE*)
+  TUNNEL_ENTRY=$(sonic-db-cli CONFIG_DB keys "TUNNEL|*")
+  if [[ ! -z $TUNNEL_ENTRY ]]; then
+    for neigh in $DBNEIGH; do
+        MAC=$(sonic-db-cli APPL_DB hgetall $neigh | cut -d '{' -f 2 | cut -d ',' -f 1 | cut -d ' ' -f 2 | cut -d "'" -f 2)
+        if [[ $MAC == "00:00:00:00:00:00" ]]; then
+            intf="$( cut -d ':' -f 2 <<< "$neigh" )"
+            ip="$( cut -d ':' -f 3- <<< "$neigh" )"
+            pingcmd="timeout 0.2 ping -I $intf -n -q -i 0 -c 1 -W 1 $ip >/dev/null"
+            eval $pingcmd
+            logger "arp_update: resolving failed neighbor entry, pinging ${ip} on ${intf}"
+        fi
+    done
+  fi
+
   # sleep here before handling the mismatch as it is not required during startup
   sleep 300
 

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -54,6 +54,7 @@ while /bin/true; do
   done
 
   VLAN=$(echo $ARP_UPDATE_VARS | jq -r '.vlan')
+  SUBTYPE=$(sonic-db-cli CONFIG_DB hget 'DEVICE_METADATA|localhost' 'subtype' | tr '[:upper:]' '[:lower:]')
   for vlan in $VLAN; do
       # generate a list of arping commands:
       #   arping -q -w 0 -c 1 -i <VLAN interface> <IP 1>;
@@ -75,26 +76,26 @@ while /bin/true; do
       ndisc6cmd="sed -e 's/^/ndisc6 -q -w 0 -1 /' -e 's/$/;/'"
       ip6cmd="ip -6 neigh show | grep -v fe80 | grep $vlan | cut -d ' ' -f 1,3 | $ndisc6cmd"
       eval `eval $ip6cmd`
-  done
+ 
+      if [[ $SUBTYPE == "dualtor" ]]; then
+        # on dual ToR devices, try to resolve failed neighbor entries since
+        # these entries will have tunnel routes installed, preventing normal 
+        # neighbor resolution (SWSS PR #2137)
 
-  # on dual ToR devices, try to resolve failed neighbor entries since
-  # these entries will have tunnel routes installed, preventing normal 
-  # neighbor resolution
-  KERNEL_NEIGHBORS=$(ip -4 neigh show | grep Vlan | cut -d ' ' -f 1,3,6 --output-delimiter=','; \
-                     ip -6 neigh show | grep -v fe80 | grep Vlan | cut -d ' ' -f 1,3,5 --output-delimiter=',')
-  TUNNEL_ENTRY=$(sonic-db-cli CONFIG_DB keys "TUNNEL|*")
-  if [[ ! -z $TUNNEL_ENTRY ]]; then
-    for neigh in $KERNEL_NEIGHBORS; do
-        STATE=$(cut -d ',' -f 3 <<< $neigh)
-        if [[ $STATE == "FAILED" ]] || [[ $STATE == "INCOMPLETE" ]]; then
-            intf=$(cut -d ',' -f 2 <<< $neigh)
-            ip=$(cut -d ',' -f 1 <<< $neigh)
-            pingcmd="timeout 0.2 ping -I $intf -n -q -i 0 -c 1 -W 1 $ip >/dev/null"
-            eval $pingcmd
-            logger "arp_update: resolving failed neighbor entry, pinging ${ip} on ${intf}"
-        fi
-    done
-  fi
+        # since ndisc6 is a userland process, the above ndisc6 commands are 
+        # insufficient to update the kernel neighbor table for failed entries
+
+        # we don't need to do this for ipv4 neighbors since arping is able to
+        # update the kernel neighbor table
+
+        # generates the following command for each failed or incomplete IPv6 neighbor
+        # timeout 0.2 ping <neighbor IPv6> -n -q -i 0 -c 1 -W 1 -I <VLAN name> >/dev/null
+        ping6_template="sed -e 's/^/timeout 0.2 ping /' -e 's/,/ -n -q -i 0 -c 1 -W 1 -I /' -e 's/$/ >\/dev\/null;/'"
+        failed_ip6_neigh_cmd="ip -6 neigh show | grep -v fe80 | grep $vlan | grep -E 'FAILED|INCOMPLETE' | cut -d ' ' -f 1,3 --output-delimiter=',' | $ping6_template"
+        eval `eval $failed_ip6_neigh_cmd`
+      fi
+  done
+  
 
   # sleep here before handling the mismatch as it is not required during startup
   sleep 300

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -77,14 +77,18 @@ while /bin/true; do
       eval `eval $ip6cmd`
   done
 
-  DBNEIGH=$(sonic-db-cli APPL_DB keys NEIGH_TABLE*)
+  # on dual ToR devices, try to resolve failed neighbor entries since
+  # these entries will have tunnel routes installed, preventing normal 
+  # neighbor resolution
+  KERNEL_NEIGHBORS=$(ip -4 neigh show | grep Vlan | cut -d ' ' -f 1,3,6 --output-delimiter=','; \
+                     ip -6 neigh show | grep -v fe80 | grep Vlan | cut -d ' ' -f 1,3,5 --output-delimiter=',')
   TUNNEL_ENTRY=$(sonic-db-cli CONFIG_DB keys "TUNNEL|*")
   if [[ ! -z $TUNNEL_ENTRY ]]; then
-    for neigh in $DBNEIGH; do
-        MAC=$(sonic-db-cli APPL_DB hgetall $neigh | cut -d '{' -f 2 | cut -d ',' -f 1 | cut -d ' ' -f 2 | cut -d "'" -f 2)
-        if [[ $MAC == "00:00:00:00:00:00" ]]; then
-            intf="$( cut -d ':' -f 2 <<< "$neigh" )"
-            ip="$( cut -d ':' -f 3- <<< "$neigh" )"
+    for neigh in $KERNEL_NEIGHBORS; do
+        STATE=$(cut -d ',' -f 3 <<< $neigh)
+        if [[ $STATE == "FAILED" ]] || [[ $STATE == "INCOMPLETE" ]]; then
+            intf=$(cut -d ',' -f 2 <<< $neigh)
+            ip=$(cut -d ',' -f 1 <<< $neigh)
             pingcmd="timeout 0.2 ping -I $intf -n -q -i 0 -c 1 -W 1 $ip >/dev/null"
             eval $pingcmd
             logger "arp_update: resolving failed neighbor entry, pinging ${ip} on ${intf}"


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

There is a separate PR to bring this change into the 202012 branch https://github.com/sonic-net/sonic-buildimage/pull/11641

#### Why I did it
On dual ToR devices, failed neighbor entries result in tunnel routes being added to the peer switch by orchagent. These tunnel routes prevent the neighbor entries from being resolved if the neighbor ever becomes responsive again. 

#### How I did it
In arp_update, check for FAILED or INCOMPLETE kernel neighbor entries and manually ping them to try and resolve the neighbor

#### How to verify it
Run sonic-mgmt test dualtor/test_orchagent_active_tor_downstream.py::test_active_tor_remove_neighbor_downstream_active[ipv6] (requires changes in this PR to pass: https://github.com/sonic-net/sonic-mgmt/pull/6071)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

