### PR TITLE
parse 400g zr port config from minigraph

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -973,7 +973,8 @@ def parse_linkmeta(meta, hname):
         lower_tor_hostname = ''
         auto_negotiation = None
         macsec_enabled = False
-
+        tx_power = None
+        laser_freq = None
         properties = linkmeta.find(str(QName(ns1, "Properties")))
         for device_property in properties.findall(str(QName(ns1, "DeviceProperty"))):
             name = device_property.find(str(QName(ns1, "Name"))).text
@@ -990,6 +991,10 @@ def parse_linkmeta(meta, hname):
                 auto_negotiation = value
             elif name == "MacSecEnabled":
                 macsec_enabled = value
+            elif name == "TxPower":
+                tx_power = value
+            elif name == "Frequency":
+                laser_freq = value
 
         linkmetas[port] = {}
         if fec_disabled:
@@ -1003,6 +1008,11 @@ def parse_linkmeta(meta, hname):
             linkmetas[port]["AutoNegotiation"] = auto_negotiation
         if macsec_enabled:
             linkmetas[port]["MacSecEnabled"] = macsec_enabled
+        if tx_power:
+            linkmetas[port]["tx_power"] = tx_power
+        # Convert the freq in GHz
+        if laser_freq:
+            linkmetas[port]["laser_freq"] = int(float(laser_freq)*1000)
     return linkmetas
 
 def parse_macsec_profile(val_string):
@@ -1614,6 +1624,14 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         macsec_enabled = linkmetas.get(alias, {}).get('MacSecEnabled')
         if macsec_enabled and 'PrimaryKey' in macsec_profile:
             port['macsec'] = macsec_profile['PrimaryKey']
+
+        tx_power = linkmetas.get(alias, {}).get('tx_power')
+        if tx_power:
+            port['tx_power'] = tx_power
+
+        laser_freq = linkmetas.get(alias, {}).get('laser_freq')
+        if laser_freq:
+            port['laser_freq'] = laser_freq
 
     # set port description if parsed from deviceinfo
     for port_name in port_descriptions:

--- a/src/sonic-config-engine/tests/sample-chassis-packet-lc-graph.xml
+++ b/src/sonic-config-engine/tests/sample-chassis-packet-lc-graph.xml
@@ -233,7 +233,7 @@
           </a:DeviceProperty>
           <a:DeviceProperty>
             <a:Name>TxPower</a:Name>
-            <a:Value>7</a:Value>
+            <a:Value>7.5</a:Value>
           </a:DeviceProperty>
         </a:Properties>
         <a:Key>str2-8808-lc2-1:Eth1/1/13;ARISTA01-RH:Ethernet1/1</a:Key>

--- a/src/sonic-config-engine/tests/sample-chassis-packet-lc-graph.xml
+++ b/src/sonic-config-engine/tests/sample-chassis-packet-lc-graph.xml
@@ -222,6 +222,25 @@
       </IPNextHops>
     </DeviceDataPlaneInfo>
   </DpgDec>
+  <LinkMetadataDeclaration>
+    <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:LinkMetadata>
+        <a:Name i:nil="true"/>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>Frequency</a:Name>
+            <a:Value>131</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>TxPower</a:Name>
+            <a:Value>7</a:Value>
+          </a:DeviceProperty>
+        </a:Properties>
+        <a:Key>str2-8808-lc2-1:Eth1/1/13;ARISTA01-RH:Ethernet1/1</a:Key>
+      </a:LinkMetadata>
+    </Link>
+    <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+  </LinkMetadataDeclaration>
   <PngDec>
     <DeviceInterfaceLinks>
       <DeviceLinkBase>

--- a/src/sonic-config-engine/tests/sample-voq-graph.xml
+++ b/src/sonic-config-engine/tests/sample-voq-graph.xml
@@ -79,6 +79,20 @@
         </a:Properties>
         <a:Key>linecard-1:Ethernet1/1;ARISTA01-RH:Ethernet1/1</a:Key>
       </a:LinkMetadata>
+      <a:LinkMetadata>
+        <a:Name i:nil="true"/>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>Frequency</a:Name>
+            <a:Value>195.875</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>TxPower</a:Name>
+            <a:Value>-10</a:Value>
+          </a:DeviceProperty>
+        </a:Properties>
+        <a:Key>linecard-1:Ethernet2/1;ARISTA01-RH:Ethernet1/1</a:Key>
+       </a:LinkMetadata>
     </Link>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </LinkMetadataDeclaration>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -1020,5 +1020,5 @@ class TestCfgGen(TestCase):
         argument = "-m {} -p {} -n asic1 -v \"PORT[\'Ethernet13\']\"".format(self.packet_chassis_graph, self.packet_chassis_port_ini)
         output = self.run_script(argument)
         output_dict = utils.to_dict(output.strip())
-        self.assertEqual(output_dict['tx_power'], '7')
+        self.assertEqual(output_dict['tx_power'], '7.5')
         self.assertEqual(output_dict['laser_freq'], 131000)

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -1008,3 +1008,17 @@ class TestCfgGen(TestCase):
             utils.to_dict(output.strip()),
             utils.to_dict("{('PortChannel32.2', '192.168.1.4/24'): {}, 'PortChannel32.2': {'admin_status': 'up'}, ('PortChannel33.2', '192.168.2.4/24'): {}, 'PortChannel33.2': {'admin_status': 'up'}}")
         )
+
+    def test_minigraph_voq_400g_zr_port_config(self):
+        argument = "-j {} -m {} -p {} -v \"PORT[\'Ethernet4\']\"".format(self.macsec_profile, self.sample_graph_voq, self.voq_port_config)
+        output = self.run_script(argument)
+        output_dict = utils.to_dict(output.strip())
+        self.assertEqual(output_dict['tx_power'], '-10')
+        self.assertEqual(output_dict['laser_freq'], 195875)
+
+    def test_minigraph_packet_chassis_400g_zr_port_config(self):
+        argument = "-m {} -p {} -n asic1 -v \"PORT[\'Ethernet13\']\"".format(self.packet_chassis_graph, self.packet_chassis_port_ini)
+        output = self.run_script(argument)
+        output_dict = utils.to_dict(output.strip())
+        self.assertEqual(output_dict['tx_power'], '7')
+        self.assertEqual(output_dict['laser_freq'], 131000)


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Generate the port configuration required 400G ZR port from minigraph.

#### How I did it
Add parse logic to get `tx_power` and `laser_freq` from `LinkMetadata` section of the minigraph.
Add UT for packet-chassis and voq chassis

#### How to verify it
UT

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

