### PR TITLE
Add dependencies for eventd in bullseye and buster containers

### DIFF
--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -140,6 +140,8 @@ RUN apt-get update && apt-get install -y \
         libswitch-perl \
         libzmq5 \
         libzmq3-dev \
+        uuid-dev \
+        libboost-serialization-dev \
         jq \
         cron \
 # For quagga build

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -142,6 +142,8 @@ RUN apt-get update && apt-get install -y \
         dh-systemd \
         libzmq5 \
         libzmq3-dev \
+        uuid-dev \
+        libboost-serialization-dev \
         jq \
 # For quagga build
         libreadline-dev \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When building docker images, certain libraries are needed for libswsscommon installation such as libboost-serialization-dev and uuid-dev

#### How I did it

Added dependencies to sonic-slave-bullseye and sonic-slave-buster

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

