### PR TITLE
[Nokia] Update Nokia platform IXR7250E device data

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_ndk.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_ndk.json
@@ -39,6 +39,10 @@
     {
       "key": "enable_firmware_update",
       "intval": 0
+    },
+    {
+      "key": "sonic_log_level",
+      "stringval": "error"
     }
     ]
 }

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_ndk.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_ndk.json
@@ -27,6 +27,10 @@
     {
       "key": "enable_firmware_update",
       "intval": 0
+    },
+    {
+      "key": "sonic_log_level",
+      "stringval": "error"
     }
     ]
 }


### PR DESCRIPTION
Signed-off-by: mlok <marty.lok@nokia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Update Nokia platform IXR7250 platform_ndk.json files with the nokia_log_level option to allow users to override the logging level for the Nokia NDK processes -- sr_device_mgr, ndk-qfpga_mgr and eth_switch

#### How I did it
Modify the platform_ndk.json file with the following option. And default value is "error"

#### How to verify it
On running platform, verify the change by checking file /etc/opt/srlinux/startup_debug.json

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

