### PR TITLE
[202012][swss] Only run tunnel packet handler on dualtor devices

### DIFF
--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -74,7 +74,7 @@ RUN apt-get purge -y          \
 
 COPY ["files/arp_update", "/usr/bin"]
 COPY ["arp_update.conf", "files/arp_update_vars.j2", "/usr/share/sonic/templates/"]
-COPY ["ndppd.conf", "/usr/share/sonic/templates/"]
+COPY ["ndppd.conf", "tunnel_packet_handler.conf", "/usr/share/sonic/templates/"]
 COPY ["enable_counters.py", "tunnel_packet_handler.py", "/usr/bin/"]
 COPY ["docker-init.sh", "orchagent.sh", "swssconfig.sh", "buffermgrd.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]

--- a/dockers/docker-orchagent/docker-init.sh
+++ b/dockers/docker-orchagent/docker-init.sh
@@ -13,6 +13,7 @@ CFGGEN_PARAMS=" \
     -t /usr/share/sonic/templates/wait_for_link.sh.j2,/usr/bin/wait_for_link.sh \
 "
 VLAN=$(sonic-cfggen $CFGGEN_PARAMS)
+SUBTYPE=$(sonic-cfggen -d -v "DEVICE_METADATA['localhost']['subtype']")
 
 chmod +x /usr/bin/wait_for_link.sh
 
@@ -25,6 +26,10 @@ fi
 if [ "$VLAN" != "" ]; then
     cp /usr/share/sonic/templates/arp_update.conf /etc/supervisor/conf.d/
     cp /usr/share/sonic/templates/ndppd.conf /etc/supervisor/conf.d/
+fi
+
+if [ "$SUBTYPE" == "DualToR" ]; then
+    cp /usr/share/sonic/templates/tunnel_packet_handler.conf /etc/supervisor/conf.d/
 fi
 
 exec /usr/local/bin/supervisord

--- a/dockers/docker-orchagent/supervisord.conf
+++ b/dockers/docker-orchagent/supervisord.conf
@@ -205,13 +205,3 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=swssconfig:exited
-
-[program:tunnel_packet_handler]
-command=/usr/bin/tunnel_packet_handler.py
-priority=12
-autostart=false
-autorestart=unexpected
-stdout_logfile=syslog
-stderr_logfile=syslog
-dependent_startup=true
-dependent_startup_wait_for=swssconfig:exited

--- a/dockers/docker-orchagent/tunnel_packet_handler.conf
+++ b/dockers/docker-orchagent/tunnel_packet_handler.conf
@@ -1,0 +1,9 @@
+[program:tunnel_packet_handler]
+command=/usr/bin/tunnel_packet_handler.py
+priority=12
+autostart=false
+autorestart=unexpected
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=swssconfig:exited


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Tunnel packet handler running on non dualtor devices generates error logs

#### How I did it
At SWSS docker init time, check the device subtype and enable tunnel packet handler only if it is dualtor

#### How to verify it
- Apply changes to dualtor device, verify that tunnel packet handler is running after restarting swss
- Apply changes to non dualtor device, verify that tunnel packet handler is not running and does not show in `supervisorctl status` after restarting swss (verified on both T0 and T1 devices)
- The SWSS docker built from this PR has been validated on both dualtor and non-dualtor devices

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

