### PR TITLE
[202012] Fix CVE-2017-1000487 security alert

### DIFF
--- a/src/thrift_0_13_0/Makefile
+++ b/src/thrift_0_13_0/Makefile
@@ -26,6 +26,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	patch -p1 < ../patch/0001-Remove-unneeded-packages.patch
 	patch -p1 < ../patch/0002-Remove-minimist-packages.patch
 	patch -p1 < ../patch/0003-Remove-underscore-packages.patch
+	patch -p1 < ../patch/0002-cve-2017-1000487.patch
 	DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -d -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 	popd
 

--- a/src/thrift_0_13_0/patch/0002-cve-2017-1000487.patch
+++ b/src/thrift_0_13_0/patch/0002-cve-2017-1000487.patch
@@ -1,0 +1,1 @@
+../../thrift/patch/0002-cve-2017-1000487.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix CVE-2017-1000487 alert in thrift 0.14.1.
See https://nvd.nist.gov/vuln/detail/CVE-2017-1000487

#### How I did it
Change the version of org.codehaus.plexus:plexus-utils from 3.0.14 to 3.0.16.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

