### PR TITLE
[swss] Adding conditional for bgp when on multi ASIC platform

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -9,6 +9,8 @@ LOCKFILE="/tmp/swss-syncd-lock$DEV"
 NAMESPACE_PREFIX="asic"
 ETC_SONIC_PATH="/etc/sonic/"
 
+# DEPENDENT initially contains namespace independent services
+# namespace specific services are added later in this script.
 DEPENDENT="radv"
 MULTI_INST_DEPENDENT="teamd"
 

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -9,7 +9,7 @@ LOCKFILE="/tmp/swss-syncd-lock$DEV"
 NAMESPACE_PREFIX="asic"
 ETC_SONIC_PATH="/etc/sonic/"
 
-DEPENDENT="radv bgp"
+DEPENDENT="radv"
 MULTI_INST_DEPENDENT="teamd"
 
 . /usr/local/bin/asic_status.sh
@@ -309,9 +309,11 @@ function check_peer_gbsyncd()
 if [ "$DEV" ]; then
     NET_NS="$NAMESPACE_PREFIX$DEV" #name of the network namespace
     SONIC_DB_CLI="sonic-db-cli -n $NET_NS"
+    DEPENDENT+=" bgp@${DEV}"
 else
     NET_NS=""
     SONIC_DB_CLI="sonic-db-cli"
+    DEPENDENT+=" bgp"
 fi
 
 check_peer_gbsyncd


### PR DESCRIPTION
bgp should be a per-asic service, and runs for each namespace on
multi-asic platforms. However, putting bgp in MULTI_INST_DEPENDENT
causes swss to be restarted as well as bgp. this is causing issues after #11000

Issue: https://github.com/sonic-net/sonic-buildimage/issues/11653

This fix:
- removes bgp from dependents list
- adds a conditional that either adds bgp, or bgp@$DEV to separate
between single and multi-asic platforms

Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

