### PR TITLE
Replace unsafe functions in iccpd

### DIFF
--- a/src/iccpd/src/cmd_option.c
+++ b/src/iccpd/src/cmd_option.c
@@ -86,6 +86,7 @@ static void cmd_option_register(struct CmdOptionParser* parser, char* syntax, ch
     char* param = NULL;
     char* desc_copy = NULL;
     char* token = NULL;
+    char* saveptr;
 
     if (parser == NULL)
         return;
@@ -94,11 +95,11 @@ static void cmd_option_register(struct CmdOptionParser* parser, char* syntax, ch
 
     snprintf(buf, OPTION_MAX_LEN - 1, "%s", syntax);
 
-    if ((token = strtok(buf, " ")) == NULL)
+    if ((token = strtok_r(buf, " ", &saveptr)) == NULL)
         return;
 
     opt_name = strdup(token);
-    if ((token = strtok(NULL, " ")) != NULL)
+    if ((token = strtok_r(NULL, " ", &saveptr)) != NULL)
         param = strdup(token);
     desc_copy = strdup(desc);
     if ((opt = cmd_option_find(parser, opt_name)) != NULL)

--- a/src/iccpd/src/cmd_option.c
+++ b/src/iccpd/src/cmd_option.c
@@ -80,7 +80,7 @@ struct CmdOption* cmd_option_add(struct CmdOptionParser* parser, char* opt_name)
 
 static void cmd_option_register(struct CmdOptionParser* parser, char* syntax, char* desc)
 {
-    char buf[OPTION_MAX_LEN];
+    char buf[OPTION_MAX_LEN] = {0};
     struct CmdOption* opt = NULL;
     char* opt_name = NULL;
     char* param = NULL;
@@ -92,7 +92,6 @@ static void cmd_option_register(struct CmdOptionParser* parser, char* syntax, ch
     if (syntax == NULL)
         return;
 
-    memset(buf, 0, OPTION_MAX_LEN);
     snprintf(buf, OPTION_MAX_LEN - 1, "%s", syntax);
 
     if ((token = strtok(buf, " ")) == NULL)

--- a/src/iccpd/src/iccp_ifm.c
+++ b/src/iccpd/src/iccp_ifm.c
@@ -128,7 +128,7 @@ static void do_arp_learn_from_kernel(struct ndmsg *ndm, struct rtattr *tb[], int
     uint16_t vlan_id = 0;
     struct VLAN_ID vlan_key = { 0 };
 
-    char buf[MAX_BUFSIZE];
+    char buf[MAX_BUFSIZE] = { 0 };
     size_t msg_len = 0;
 
     struct LocalInterface *lif_po = NULL, *arp_lif = NULL;
@@ -144,7 +144,6 @@ static void do_arp_learn_from_kernel(struct ndmsg *ndm, struct rtattr *tb[], int
         return;
 
     /* create ARP msg*/
-    memset(buf, 0, MAX_BUFSIZE);
     msg_len = sizeof(struct ARPMsg);
     arp_msg = (struct ARPMsg *)&buf;
     arp_msg->op_type = NEIGH_SYNC_LIF;
@@ -388,7 +387,7 @@ static void do_ndisc_learn_from_kernel(struct ndmsg *ndm, struct rtattr *tb[], i
     uint16_t vlan_id = 0;
     struct VLAN_ID vlan_key = { 0 };
 
-    char buf[MAX_BUFSIZE];
+    char buf[MAX_BUFSIZE] = { 0 };
     size_t msg_len = 0;
     char addr_null[16] = { 0 };
 
@@ -406,7 +405,6 @@ static void do_ndisc_learn_from_kernel(struct ndmsg *ndm, struct rtattr *tb[], i
         return;
 
     /* create NDISC msg */
-    memset(buf, 0, MAX_BUFSIZE);
     msg_len = sizeof(struct NDISCMsg);
     ndisc_msg = (struct NDISCMsg *)&buf;
     ndisc_msg->op_type = NEIGH_SYNC_LIF;
@@ -815,7 +813,7 @@ void do_arp_update_from_reply_packet(unsigned int ifindex, unsigned int addr, ui
     uint16_t vlan_id = 0;
     struct VLAN_ID vlan_key = { 0 };
 
-    char buf[MAX_BUFSIZE];
+    char buf[MAX_BUFSIZE] = { 0 };
     size_t msg_len = 0;
 
     struct LocalInterface *lif_po = NULL, *arp_lif = NULL;
@@ -830,7 +828,6 @@ void do_arp_update_from_reply_packet(unsigned int ifindex, unsigned int addr, ui
         return;
 
     /* create ARP msg*/
-    memset(buf, 0, MAX_BUFSIZE);
     msg_len = sizeof(struct ARPMsg);
     arp_msg = (struct ARPMsg*)&buf;
     arp_msg->op_type = NEIGH_SYNC_LIF;
@@ -1033,7 +1030,7 @@ void do_ndisc_update_from_reply_packet(unsigned int ifindex, char *ipv6_addr, ui
     struct LocalInterface *peer_link_if = NULL;
     int is_link_local = 0;
 
-    char buf[MAX_BUFSIZE];
+    char buf[MAX_BUFSIZE] = { 0 };
     size_t msg_len = 0;
     char addr_null[16] = { 0 };
     uint16_t vlan_id = 0;
@@ -1053,7 +1050,6 @@ void do_ndisc_update_from_reply_packet(unsigned int ifindex, char *ipv6_addr, ui
     sprintf(mac_str, "%02x:%02x:%02x:%02x:%02x:%02x", mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
 
     /* create Ndisc msg */
-    memset(buf, 0, MAX_BUFSIZE);
     msg_len = sizeof(struct NDISCMsg);
     ndisc_msg = (struct NDISCMsg *)&buf;
     ndisc_msg->op_type = NEIGH_SYNC_LIF;

--- a/src/iccpd/src/iccp_main.c
+++ b/src/iccpd/src/iccp_main.c
@@ -143,7 +143,7 @@ static int iccpd_signal_init(struct System* sys)
     int fds[2];
     int err;
     sigset_t ss;
-    struct sigaction sa;
+    struct sigaction sa = { 0 };
     struct epoll_event event;
 
     err = pipe(fds);
@@ -171,7 +171,6 @@ static int iccpd_signal_init(struct System* sys)
         goto close_pipe;
     }
 
-    memset(&sa, 0, sizeof(sa));
     sa.sa_handler = iccpd_signal_handler;
     sigemptyset(&sa.sa_mask);
     sa.sa_flags = SA_RESTART;

--- a/src/iccpd/src/iccp_netlink.c
+++ b/src/iccpd/src/iccp_netlink.c
@@ -570,9 +570,10 @@ static int iccp_netlink_set_portchannel_iff_flag(
 {
     int rv, ret_rv = 0;
     char* token;
+    char* saveptr;
     struct LocalInterface* member_if;
     char *tmp_member_buf = NULL;
-
+    
     if (!lif_po)
         return MCLAG_ERROR;
 
@@ -590,7 +591,7 @@ static int iccp_netlink_set_portchannel_iff_flag(
             lif_po->portchannel_member_buf);
     }
     /* Port-channel members are stored as comma separated strings */
-    token = strtok(tmp_member_buf, ",");
+    token = strtok_r(tmp_member_buf, ",", &saveptr);
     while (token != NULL)
     {
         member_if = local_if_find_by_name(token);
@@ -614,7 +615,7 @@ static int iccp_netlink_set_portchannel_iff_flag(
                 "Can't find member %s:%s, if_up(%d), location %d",
                 lif_po->name, token, is_iff_up, location);
         }
-        token = strtok(NULL, ",");
+        token = strtok_r(NULL, ",", &saveptr);
     }
     if (tmp_member_buf)
         free(tmp_member_buf);

--- a/src/iccpd/src/iccp_netlink.c
+++ b/src/iccpd/src/iccp_netlink.c
@@ -461,7 +461,7 @@ void iccp_set_interface_ipadd_mac(struct LocalInterface *lif, char * mac_addr )
 {
     struct IccpSyncdHDr * msg_hdr;
     mclag_sub_option_hdr_t * sub_msg;
-    char msg_buf[4096];
+    char msg_buf[4096] = { 0 };
     struct System *sys;
 
     int src_len = 0, dst_len = 0;
@@ -469,8 +469,6 @@ void iccp_set_interface_ipadd_mac(struct LocalInterface *lif, char * mac_addr )
     sys = system_get_instance();
     if (sys == NULL)
         return;
-
-    memset(msg_buf, 0, 4095);
 
     msg_hdr = (struct IccpSyncdHDr *)msg_buf;
     msg_hdr->ver = 1;
@@ -1942,13 +1940,11 @@ int iccp_receive_ndisc_packet_handler(struct System *sys)
     struct nd_msg *ndmsg = NULL;
     struct nd_opt_hdr *nd_opt = NULL;
     struct in6_addr target;
-    uint8_t mac_addr[ETHER_ADDR_LEN];
+    uint8_t mac_addr[ETHER_ADDR_LEN] = { 0 };
     int8_t *opt = NULL;
     int opt_len = 0, l = 0;
     int len;
     struct CSM* csm = NULL;
-
-    memset(mac_addr, 0, ETHER_ADDR_LEN);
 
     /* Fill in message and iovec. */
     msg.msg_name = (void *)(&from);
@@ -2375,9 +2371,9 @@ void recover_vlan_if_mac_on_standby(struct LocalInterface* lif_vlan, int dir, ui
     struct CSM *csm = NULL;
     struct System* sys = NULL;
     uint8_t null_mac[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    char macaddr[64];
-    char remote_macaddr[64];
-    uint8_t system_mac[ETHER_ADDR_LEN];
+    char macaddr[64] = { 0 };
+    char remote_macaddr[64] = { 0 };
+    uint8_t system_mac[ETHER_ADDR_LEN] = { 0 };
     int ret = 0;
     int vid = 0;
 
@@ -2404,9 +2400,6 @@ void recover_vlan_if_mac_on_standby(struct LocalInterface* lif_vlan, int dir, ui
 
     sscanf (lif_vlan->name, "Vlan%d", &vid);
 
-    memset(macaddr, 0, 64);
-    memset(remote_macaddr, 0, 64);
-    memset(system_mac, 0, ETHER_ADDR_LEN);
     ICCPD_LOG_DEBUG(__FUNCTION__, " ifname %s, l3_proto %d, dir %d\n",
             lif_vlan->name, lif_vlan->is_l3_proto_enabled, dir);
     if (lif_vlan->is_l3_proto_enabled == true)

--- a/src/iccpd/src/mclagdctl/mclagdctl.c
+++ b/src/iccpd/src/mclagdctl/mclagdctl.c
@@ -164,7 +164,7 @@ static struct command_type command_types[] =
 
 int mclagdctl_sock_connect()
 {
-    struct sockaddr_un addr;
+    struct sockaddr_un addr = { 0 };
     int addrlen = 0;
     int ret = 0;
 
@@ -181,7 +181,6 @@ int mclagdctl_sock_connect()
         return MCLAG_ERROR;
     }
 
-    memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
     snprintf(addr.sun_path, sizeof(addr.sun_path) - 1, "%s", mclagdctl_sock_path);
     addrlen = sizeof(addr.sun_family) + strlen(mclagdctl_sock_path);


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Replace unsafe functions in iccpd
#### How I did it
Replace `memset()` by zero initialization
Replace `strtok()` by `strtok_r()`
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

