### PR TITLE
[PikeZ] Correct port index in Arista-720DT-48S/phy24_config.json

### DIFF
--- a/device/arista/x86_64-arista_720dt_48s/Arista-720DT-48S/phy24_config.json
+++ b/device/arista/x86_64-arista_720dt_48s/Arista-720DT-48S/phy24_config.json
@@ -14,7 +14,7 @@
   ],
   "ports": [
     {
-      "index": 22,
+      "index": 23,
       "mdio_addr": "",
       "system_speed": 1000,
       "system_fec": "none",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Port index 22 is associated with phy23_config.json, then same port index 22 in phy24_config.json may cause gearbox port creation error. Port Ethernet22 maps to index 23. 

The related error messages:
```
Aug 12 01:59:09.077562 bjw-pikez-112 NOTICE swss#orchagent: :- initGearboxPort: BOX: port_id:0x1000000000018 index:23 alias:Ethernet22
Aug 12 01:59:09.077562 bjw-pikez-112 NOTICE swss#orchagent: :- initGearboxPort: BOX: Gearbox port Ethernet22 assigned phyOid 0x1621010000000016
Aug 12 01:59:09.078782 bjw-pikez-112 ERR swss#orchagent: :- meta_generic_validation_create: SAI_PORT_ATTR_SPEED:SAI_ATTR_VALUE_TYPE_UINT32 attribute is mandatory but not passed in attr list
Aug 12 01:59:09.078782 bjw-pikez-112 ERR swss#orchagent: :- initGearboxPort: BOX: Failed to create Gearbox system-side port for alias:Ethernet22 port_id:0x1000000000018 index:23 status:-14
Aug 12 01:59:09.078782 bjw-pikez-112 ERR swss#orchagent: :- handleSaiCreateStatus: Encountered failure in create operation, exiting orchagent, SAI API: SAI_API_PORT, status: SAI_STATUS_MANDATORY_ATTRIBUTE_MISSING
```

#### How I did it
Correct port index from 22 to 23 in phy24_config.json.

#### How to verify it
Gearbox port Ethernet22 is created successfully.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

