### PR TITLE
Replace strtok in systemd-sonic-generator

### DIFF
--- a/src/systemd-sonic-generator/systemd-sonic-generator.c
+++ b/src/systemd-sonic-generator/systemd-sonic-generator.c
@@ -517,8 +517,7 @@ int get_num_of_asic() {
     char *line = NULL;
     char* token;
     char* platform;
-    char* saveptr1;
-    char* saveptr2;
+    char* saveptr;
     size_t len = 0;
     ssize_t nread;
     bool ans;
@@ -537,8 +536,8 @@ int get_num_of_asic() {
     while ((nread = getline(&line, &len, fp)) != -1) {
         if ((strstr(line, "onie_platform") != NULL) ||
             (strstr(line, "aboot_platform") != NULL)) {
-            token = strtok_r(line, "=", &saveptr1);
-            platform = strtok_r(NULL, "=", &saveptr1);
+            token = strtok_r(line, "=", &saveptr);
+            platform = strtok_r(NULL, "=", &saveptr);
             strip_trailing_newline(platform);
             break;
         }
@@ -550,8 +549,8 @@ int get_num_of_asic() {
         if (fp != NULL) {
             while ((nread = getline(&line, &len, fp)) != -1) {
                 if (strstr(line, "NUM_ASIC") != NULL) {
-                    token = strtok_r(line, "=", &saveptr2);
-                    str_num_asic = strtok_r(NULL, "=", &saveptr2);
+                    token = strtok_r(line, "=", &saveptr);
+                    str_num_asic = strtok_r(NULL, "=", &saveptr);
                     strip_trailing_newline(str_num_asic);
                     if (str_num_asic != NULL){
                         sscanf(str_num_asic, "%d",&num_asic);

--- a/src/systemd-sonic-generator/systemd-sonic-generator.c
+++ b/src/systemd-sonic-generator/systemd-sonic-generator.c
@@ -121,6 +121,7 @@ static int get_install_targets_from_line(char* target_string, char* install_type
     ***/
     char* token;
     char* target;
+    char* saveptr;
     char final_target[PATH_MAX];
     int num_targets = 0;
 
@@ -135,8 +136,8 @@ static int get_install_targets_from_line(char* target_string, char* install_type
         strip_trailing_newline(target);
 
         if (strstr(target, "%") != NULL) {
-            char* prefix = strtok(target, ".");
-            char* suffix = strtok(NULL, ".");
+            char* prefix = strtok_r(target, ".", &saveptr);
+            char* suffix = strtok_r(NULL, ".", &saveptr);
             int prefix_len = strlen(prefix);
 
             strncpy(final_target, prefix, prefix_len - 2);
@@ -516,6 +517,8 @@ int get_num_of_asic() {
     char *line = NULL;
     char* token;
     char* platform;
+    char* saveptr1;
+    char* saveptr2;
     size_t len = 0;
     ssize_t nread;
     bool ans;
@@ -534,8 +537,8 @@ int get_num_of_asic() {
     while ((nread = getline(&line, &len, fp)) != -1) {
         if ((strstr(line, "onie_platform") != NULL) ||
             (strstr(line, "aboot_platform") != NULL)) {
-            token = strtok(line, "=");
-            platform = strtok(NULL, "=");
+            token = strtok_r(line, "=", &saveptr1);
+            platform = strtok_r(NULL, "=", &saveptr1);
             strip_trailing_newline(platform);
             break;
         }
@@ -547,8 +550,8 @@ int get_num_of_asic() {
         if (fp != NULL) {
             while ((nread = getline(&line, &len, fp)) != -1) {
                 if (strstr(line, "NUM_ASIC") != NULL) {
-                    token = strtok(line, "=");
-                    str_num_asic = strtok(NULL, "=");
+                    token = strtok_r(line, "=", &saveptr2);
+                    str_num_asic = strtok_r(NULL, "=", &saveptr2);
                     strip_trailing_newline(str_num_asic);
                     if (str_num_asic != NULL){
                         sscanf(str_num_asic, "%d",&num_asic);
@@ -571,6 +574,7 @@ int ssg_main(int argc, char **argv) {
     char* unit_instance;
     char* prefix;
     char* suffix;
+    char* saveptr;
     int num_unit_files;
     int num_targets;
     int r;
@@ -589,8 +593,8 @@ int ssg_main(int argc, char **argv) {
     for (int i = 0; i < num_unit_files; i++) {
         unit_instance = strdup(unit_files[i]);
         if ((num_asics == 1) && strstr(unit_instance, "@") != NULL) {
-            prefix = strtok(unit_instance, "@");
-            suffix = strtok(NULL, "@");
+            prefix = strtok_r(unit_instance, "@", &saveptr);
+            suffix = strtok_r(NULL, "@", &saveptr);
 
             strcpy(unit_instance, prefix);
             strcat(unit_instance, suffix);


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Replace unsafe functions to safe functions
#### How I did it
Replace `strtok()` by `strtok_r()`
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

