### PR TITLE
[device/accton] Add ssd_util plugin to AS4630-54PE, AS7326-56X, AS771…

### DIFF
--- a/device/accton/x86_64-accton_as4630_54pe-r0/plugins/ssd_util.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/plugins/ssd_util.py
@@ -1,0 +1,24 @@
+# ssd_util.py
+#
+# Platform-specific SSD interface for SONiC
+##
+
+try:
+    from sonic_platform_base.sonic_ssd.ssd_generic import SsdUtil as MainSsdUtil
+except ImportError as e:
+    raise ImportError (str(e) + "- required module not found")
+
+NOT_AVAILABLE = "N/A"
+
+class SsdUtil(MainSsdUtil):
+    """Platform-specific SsdUtil class"""
+
+    def __init__(self, diskdev):
+        super(SsdUtil, self).__init__(diskdev)
+
+        # If it has no vendor tool to read SSD information,
+        # ssd_util.py will use generic SSD information
+        # for vendor SSD information.
+        if self.vendor_ssd_info == NOT_AVAILABLE:
+            self.vendor_ssd_info = self.ssd_info
+

--- a/device/accton/x86_64-accton_as7326_56x-r0/plugins/ssd_util.py
+++ b/device/accton/x86_64-accton_as7326_56x-r0/plugins/ssd_util.py
@@ -1,0 +1,24 @@
+# ssd_util.py
+#
+# Platform-specific SSD interface for SONiC
+##
+
+try:
+    from sonic_platform_base.sonic_ssd.ssd_generic import SsdUtil as MainSsdUtil
+except ImportError as e:
+    raise ImportError (str(e) + "- required module not found")
+
+NOT_AVAILABLE = "N/A"
+
+class SsdUtil(MainSsdUtil):
+    """Platform-specific SsdUtil class"""
+
+    def __init__(self, diskdev):
+        super(SsdUtil, self).__init__(diskdev)
+
+        # If it has no vendor tool to read SSD information,
+        # ssd_util.py will use generic SSD information
+        # for vendor SSD information.
+        if self.vendor_ssd_info == NOT_AVAILABLE:
+            self.vendor_ssd_info = self.ssd_info
+

--- a/device/accton/x86_64-accton_as7716_32x-r0/plugins/ssd_util.py
+++ b/device/accton/x86_64-accton_as7716_32x-r0/plugins/ssd_util.py
@@ -1,0 +1,24 @@
+# ssd_util.py
+#
+# Platform-specific SSD interface for SONiC
+##
+
+try:
+    from sonic_platform_base.sonic_ssd.ssd_generic import SsdUtil as MainSsdUtil
+except ImportError as e:
+    raise ImportError (str(e) + "- required module not found")
+
+NOT_AVAILABLE = "N/A"
+
+class SsdUtil(MainSsdUtil):
+    """Platform-specific SsdUtil class"""
+
+    def __init__(self, diskdev):
+        super(SsdUtil, self).__init__(diskdev)
+
+        # If it has no vendor tool to read SSD information,
+        # ssd_util.py will use generic SSD information
+        # for vendor SSD information.
+        if self.vendor_ssd_info == NOT_AVAILABLE:
+            self.vendor_ssd_info = self.ssd_info
+

--- a/device/accton/x86_64-accton_as7816_64x-r0/plugins/ssd_util.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/plugins/ssd_util.py
@@ -1,0 +1,24 @@
+# ssd_util.py
+#
+# Platform-specific SSD interface for SONiC
+##
+
+try:
+    from sonic_platform_base.sonic_ssd.ssd_generic import SsdUtil as MainSsdUtil
+except ImportError as e:
+    raise ImportError (str(e) + "- required module not found")
+
+NOT_AVAILABLE = "N/A"
+
+class SsdUtil(MainSsdUtil):
+    """Platform-specific SsdUtil class"""
+
+    def __init__(self, diskdev):
+        super(SsdUtil, self).__init__(diskdev)
+
+        # If it has no vendor tool to read SSD information,
+        # ssd_util.py will use generic SSD information
+        # for vendor SSD information.
+        if self.vendor_ssd_info == NOT_AVAILABLE:
+            self.vendor_ssd_info = self.ssd_info
+


### PR DESCRIPTION
…6-32X, AS7816-64X

Signed-off-by: Roger Ho <roger530_ho@edge-core.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The customer needs to show that

#### How I did it
If it has no vendor tool to read vendor SSD information then use generic SSD information.

#### How to verify it
admin@sonic:~$ sudo show platform ssdhealth --vendor
Device Model : TS32XBTMM1600
Health       : N/A
Temperature  : 100C
smartctl 6.6 2017-11-05 r4594 [x86_64-linux-5.10.0-8-2-amd64] (local build)
Copyright (C) 2002-17, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Device Model:     TS32XBTMM1600
Serial Number:    F051970047
Firmware Version: O0918B
User Capacity:    32,017,047,552 bytes [32.0 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
Device is:        Not in smartctl database [for details use: -P showall]
ATA Version is:   ACS-2 (minor revision not indicated)
SATA Version is:  SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Wed Sep 13 14:43:26 2023 UTC
SMART support is: Available - device has SMART capability.
SMART support is: Enabled

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

General SMART Values:
Offline data collection status:  (0x00) Offline data collection activity
                                        was never started.
                                        Auto Offline Data Collection: Disabled.
Self-test execution status:      (   0) The previous self-test routine completed
                                        without error or no self-test has ever
                                        been run.
Total time to complete Offline
data collection:                (    0) seconds.
Offline data collection
capabilities:                    (0x71) SMART execute Offline immediate.
                                        No Auto Offline data collection support.
                                        Suspend Offline collection upon new
                                        command.
                                        No Offline surface scan supported.
                                        Self-test supported.
                                        Conveyance Self-test supported.
                                        Selective Self-test supported.
SMART capabilities:            (0x0002) Does not save SMART data before
                                        entering power-saving mode.
                                        Supports SMART auto save timer.
Error logging capability:        (0x01) Error logging supported.
                                        General Purpose Logging supported.
Short self-test routine
recommended polling time:        (   1) minutes.
Extended self-test routine
recommended polling time:        (   1) minutes.
Conveyance self-test routine
recommended polling time:        (   1) minutes.

SMART Attributes Data Structure revision number: 1
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  1 Raw_Read_Error_Rate     0x0000   100   100   000    Old_age   Offline      -       0
  5 Reallocated_Sector_Ct   0x0000   100   100   000    Old_age   Offline      -       0
  9 Power_On_Hours          0x0000   100   100   000    Old_age   Offline      -       203
 12 Power_Cycle_Count       0x0000   100   100   000    Old_age   Offline      -       1239
160 Unknown_Attribute       0x0000   100   100   000    Old_age   Offline      -       0
161 Unknown_Attribute       0x0000   100   100   000    Old_age   Offline      -       50
163 Unknown_Attribute       0x0000   100   100   000    Old_age   Offline      -       18
164 Unknown_Attribute       0x0000   100   100   000    Old_age   Offline      -       67908
165 Unknown_Attribute       0x0000   100   100   000    Old_age   Offline      -       127
166 Unknown_Attribute       0x0000   100   100   000    Old_age   Offline      -       23
167 Unknown_Attribute       0x0000   100   100   000    Old_age   Offline      -       66
168 Unknown_Attribute       0x0000   100   100   000    Old_age   Offline      -       3000
169 Unknown_Attribute       0x0000   100   100   000    Old_age   Offline      -       98
175 Program_Fail_Count_Chip 0x0000   100   100   000    Old_age   Offline      -       0
176 Erase_Fail_Count_Chip   0x0000   100   100   000    Old_age   Offline      -       0
177 Wear_Leveling_Count     0x0000   100   100   050    Old_age   Offline      -       33
178 Used_Rsvd_Blk_Cnt_Chip  0x0000   100   100   000    Old_age   Offline      -       0
181 Program_Fail_Cnt_Total  0x0000   100   100   000    Old_age   Offline      -       0
182 Erase_Fail_Count_Total  0x0000   100   100   000    Old_age   Offline      -       0
192 Power-Off_Retract_Count 0x0000   100   100   000    Old_age   Offline      -       25
194 Temperature_Celsius     0x0000   100   100   000    Old_age   Offline      -       32
195 Hardware_ECC_Recovered  0x0000   100   100   000    Old_age   Offline      -       436
196 Reallocated_Event_Count 0x0000   100   100   016    Old_age   Offline      -       0
197 Current_Pending_Sector  0x0000   100   100   000    Old_age   Offline      -       0
198 Offline_Uncorrectable   0x0000   100   100   000    Old_age   Offline      -       0
199 UDMA_CRC_Error_Count    0x0000   100   100   050    Old_age   Offline      -       1
232 Available_Reservd_Space 0x0000   100   100   000    Old_age   Offline      -       100
241 Total_LBAs_Written      0x0000   100   100   000    Old_age   Offline      -       37044
242 Total_LBAs_Read         0x0000   100   100   000    Old_age   Offline      -       22440
245 Unknown_Attribute       0x0000   100   100   000    Old_age   Offline      -       67908

SMART Error Log Version: 1
No Errors Logged

SMART Self-test log structure revision number 1
No self-tests have been logged.  [To run self-tests, use: smartctl -t]

SMART Selective self-test log data structure revision number 1
 SPAN  MIN_LBA  MAX_LBA  CURRENT_TEST_STATUS
    1        0        0  Not_testing
    2        0        0  Not_testing
    3        0        0  Not_testing
    4        0        0  Not_testing
    5        0        0  Not_testing
    6        0    65535  Read_scanning was never started
Selective self-test flags (0x0):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 0 minute delay.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x ] 202111
   customer use this branch.
- [x ] 202205
   customer use this branch.
#### Description for the changelog
Add ssd_util.py to AS4630-54PE, AS7326-56X, AS7716-32X, AS7816-64X
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
N/A
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

