### PR TITLE
[syncd.sh] 'sxdkernel start' => 'sxdkernel restart'

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -24,7 +24,7 @@ function startplatform() {
         debug "Starting Firmware update procedure"
         /usr/bin/mst start --with_i2cdev
         /usr/bin/mlnx-fw-upgrade.sh
-        /etc/init.d/sxdkernel start
+        /etc/init.d/sxdkernel restart
         debug "Firmware update procedure ended"
     fi
 


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Change ```sxdkernel start``` to ```sxdkernel restart```. If ```syncd``` service crashes in ```ExecStartPre``` systemd will not call ```ExecStop``` and thus will not call ```sxdkernel stop```. Use of ```sxdkernel restart``` is more robust in terms of guarantees to restore the system after unexpected crashes.

#### How I did it

Changed ```syncd.sh```

#### How to verify it

Run regression.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

