### PR TITLE
[chassis] Configure midplane network on supervisor

### DIFF
--- a/device/arista/x86_64-arista_7800_sup/chassisdb.conf
+++ b/device/arista/x86_64-arista_7800_sup/chassisdb.conf
@@ -1,5 +1,6 @@
 start_chassis_db=1
 chassis_db_address=127.100.1.1
+midplane_subnet=127.100.0.0/16
 
 lag_id_start=1
 lag_id_end=128

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -170,16 +170,26 @@ function postStartAction()
            ip netns exec "$NET_NS" ip addr add 127.0.0.1/16 dev lo
            ip netns exec "$NET_NS" ip addr del 127.0.0.1/8 dev lo
 
+           slot_id=$(python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); print(platform_chassis.get_my_slot())' 2>/dev/null)
+           supervisor_slot_id=$(python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); print(platform_chassis.get_supervisor_slot())' 2>/dev/null)
+
            # Create eth1 in database instance
-           ip link add name ns-eth1"$NET_NS" link eth1-midplane type macvlan mode bridge
+           if [[ "${slot_id}" == "${supervisor_slot_id}" ]]; then
+                   ip link add name ns-eth1"$NET_NS" type veth peer name eth1@"$NET_NS"
+                   ip link set dev eth1@"$NET_NS" master br1
+                   ip link set dev eth1@"$NET_NS" up
+           else
+                   ip link add name ns-eth1"$NET_NS" link eth1-midplane type macvlan mode bridge
+           fi
+
+           # Create eth1 in database instance
            ip link set dev ns-eth1"$NET_NS" netns "$NET_NS"
            ip netns exec "$NET_NS" ip link set ns-eth1"$NET_NS" name eth1
 
            # Configure IP address and enable eth1
-           lc_slot_id=$(python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); print(platform_chassis.get_my_slot())' 2>/dev/null)
-           lc_ip_address=`echo $midplane_subnet | awk -F. '{print $1 "." $2}'`.$lc_slot_id.$(($DEV + 10))
-           lc_subnet_mask=${midplane_subnet#*/}
-           ip netns exec "$NET_NS" ip addr add $lc_ip_address/$lc_subnet_mask dev eth1
+           slot_ip_address=`echo $midplane_subnet | awk -F. '{print $1 "." $2}'`.$slot_id.$(($DEV + 10))
+           slot_subnet_mask=${midplane_subnet#*/}
+           ip netns exec "$NET_NS" ip addr add $slot_ip_address/$slot_subnet_mask dev eth1
            ip netns exec "$NET_NS" ip link set dev eth1 up
 
            # Allow localnet routing on the new interfaces if midplane is using a


### PR DESCRIPTION
#### Why I did it
Multi-asic Docker instances are created behind Docker's default bridge
which doesn't allow talking to other Docker instances that are in the
host network (like database-chassis).

On linecards, we configure midplane interfaces to let per-asic docker
containers talk to CHASSIS_DB on the supervisor through internal chassis
network.

On the supervisor we don't need to use chassis internal network, but we
still need a similar setup in order to allow fabric containers to talk
to database-chassis

#### How I did it
Reusing existing code used to setup the midplane network on a linecard,
except that we only need a pair of veth interfaces on the supervisor to allow
per-asic docker instances access to the midplane subnet.

