### PR TITLE
Fix vs check install login timeout issue

### DIFF
--- a/check_install.py
+++ b/check_install.py
@@ -19,6 +19,7 @@ def main():
     passwd_prompt = 'Password:'
     cmd_prompt = "{}@sonic:~\$ $".format(args.u)
     grub_selection = "The highlighted entry will be executed"
+    firsttime_prompt = '+ firsttime_exit'
 
     i = 0
     while True:
@@ -38,13 +39,17 @@ def main():
 
     # bootup sonic image
     while True:
-        i = p.expect([login_prompt, passwd_prompt, cmd_prompt])
+        i = p.expect([login_prompt, passwd_prompt, firsttime_prompt, cmd_prompt])
         if i == 0:
             # send user name
             p.sendline(args.u)
         elif i == 1:
             # send password
             p.sendline(args.P)
+        elif i == 2:
+            # fix a login timeout issue, caused by the login_prompt message mixed with the output message of the rc.local
+            time.sleep(1)
+            p.sendline()
         else:
             break
 

--- a/check_install.py
+++ b/check_install.py
@@ -19,7 +19,7 @@ def main():
     passwd_prompt = 'Password:'
     cmd_prompt = "{}@sonic:~\$ $".format(args.u)
     grub_selection = "The highlighted entry will be executed"
-    firsttime_prompt = '+ firsttime_exit'
+    firsttime_prompt = 'firsttime_exit'
 
     i = 0
     while True:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix a build not stable issue: https://github.com/sonic-net/sonic-buildimage/issues/11620
The vs vm has started successfully, but failed to wait for the message "sonic login:".

There were 55 builds failed caused by the issue in the last 30 days.

```
AzurePipelineBuildLogs
| where startTime > ago(30d)
| where type =~ "task"
| where result =~ "failed"
| where name =~ "Build sonic image"
| where content contains "Timeout exceeded"
| where content contains "re.compile('sonic login:')"
| project-away content
| extend branchName=case(reason=~"pullRequest", tostring(todynamic(parameters)['system.pullRequest.targetBranch']),
              replace("refs/heads/", "", sourceBranch))
| summarize FailedCount=dcount(buildId) by branchName

branchName	FailedCount
master	37
202012	9
202106	4
202111	2
202205	1
201911	1
```

It is caused by the login message mixed with the output message of the /etc/rc.local, one of the examples as below: (see the message rc.local[307]: **sonic**+ onie_disco_subnet=255.255.255.0 **login:** )
The check_install.py was waiting for the message "sonic login:", and Linux console was waiting for the username input (the login message has already printed in the console).
https://dev.azure.com/mssonic/build/_build/results?buildId=123294&view=logs&j=cef3d8a9-152e-5193-620b-567dc18af272&t=359769c4-8b5e-5976-a793-85da132e0a6f
```
2022-07-17T15:00:58.9198877Z [   25.493855] rc.local[307]: + onie_disco_opt53=05
2022-07-17T15:00:58.9199330Z [   25.595054] rc.local[307]: + onie_disco_router=10.0.2.2
2022-07-17T15:00:58.9199781Z [   25.699409] rc.local[307]: + onie_disco_serverid=10.0.2.2
2022-07-17T15:00:58.9200252Z [   25.789891] rc.local[307]: + onie_disco_siaddr=10.0.2.2
2022-07-17T15:00:58.9200622Z [   25.880920] 
2022-07-17T15:00:58.9200745Z 
2022-07-17T15:00:58.9201019Z Debian GNU/Linux 10 sonic ttyS0
2022-07-17T15:00:58.9201201Z 
2022-07-17T15:00:58.9201542Z rc.local[307]: sonic+ onie_disco_subnet=255.255.255.0 login: 
2022-07-17T15:00:58.9202309Z [   26.079767] rc.local[307]: + onie_exec_url=file://dev/vdb/onie-installer.bin
2022-07-17T15:00:58.9202970Z [   26.163792] rc.local[307]: + onie_firmware=auto
2022-07-17T15:00:58.9203400Z [   26.235636] rc.local[307]: + onie_grub_image_name=shimx64.efi
2022-07-17T15:00:58.9203843Z [   26.307087] rc.local[307]: + onie_initrd_tmp=/
2022-07-17T15:00:58.9204263Z [   26.397382] rc.local[307]: + onie_installer=/var/tmp/installer
2022-07-17T15:00:58.9204730Z [   26.468030] rc.local[307]: + onie_kernel_version=4.9.95
2022-07-17T15:00:58.9205156Z [   26.583260] rc.local[307]: + onie_local_parts=
```


#### How I did it
Input a newline when finished to run the script /etc/rc.local.
If entering a newline, the message "sonic login:" will prompt again.
```
sonic login: 
sonic login: 
```
The firsttime_exit is the last script printed by local.rc, see https://github.com/sonic-net/sonic-buildimage/blob/35945c9015472fb0c2feb019c6cf9dc9479c7e9e/files/image_config/platform/rc.local#L380

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

