### PR TITLE
[test]Fix sonic-ctrmgrd build error

### DIFF
--- a/src/sonic-ctrmgrd/tests/ctrmgr_iptables_test.py
+++ b/src/sonic-ctrmgrd/tests/ctrmgr_iptables_test.py
@@ -58,7 +58,7 @@ test_data = {
         ]
     },
     "4": {
-        "ip": "www.google.comx",
+        "ip": "www.google.notexist",
         "port": "3128",
         "pre_rules": [
             "DNAT tcp -- 20.20.0.0/0 172.16.1.1 tcp dpt:8080 to:100.127.20.21:8080",
@@ -71,7 +71,7 @@ test_data = {
         "ret": ""
     },
     "5": {
-        "ip": "www.google.comx",
+        "ip": "www.google.notexist",
         "port": "3128",
         "conf_file": "no_proxy.conf",
         "pre_rules": [


### PR DESCRIPTION
Signed-off-by: ouxiaolong <ouxiaolong@asterfusion.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Sometimes, building sonic-ctrmgrd fails like this:
```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
rootdir: /sonic/src/sonic-ctrmgrd, configfile: pytest.ini
plugins: cov-2.10.1
collected 16 items

tests/container_startup_test.py .                                        [  6%]
tests/container_test.py ......                                           [ 43%]
tests/ctrmgr_iptables_test.py F                                          [ 50%]
tests/ctrmgr_tools_test.py .                                             [ 56%]
tests/ctrmgrd_test.py ...                                                [ 75%]
tests/kube_commands_test.py ....                                         [100%]

=================================== FAILURES ===================================
_________________________ TestIPTableUpdate.test_table _________________________

self = <tests.ctrmgr_iptables_test.TestIPTableUpdate object at 0x7f1347a0f1c0>
mock_proc = <MagicMock name='run' id='139720781667488'>

    @patch("ctrmgr_iptables.subprocess.run")
    def test_table(self, mock_proc):
        global current_rules, current_tc
    
        mock_proc.side_effect = mock_subproc_run
        for i, tc in test_data.items():
            print("----- Test: {} Start ------------------".format(i))
            current_tc = tc
            current_rules = tc["pre_rules"].copy()
    
            ctrmgr_iptables.DST_IP = ""
            ctrmgr_iptables.DST_PORT = ""
            ctrmgr_iptables.DST_FILE = os.path.join(
                    os.path.dirname(os.path.realpath(__file__)),
                    tc.get("conf_file", PROXY_FILE))
            ret = ctrmgr_iptables.iptable_proxy_rule_upd(tc["ip"], tc["port"])
            if "ret" in tc:
>               assert ret == tc["ret"]
E               AssertionError: assert '159.138.20.20:3128' == ''
E                 + 159.138.20.20:3128

tests/ctrmgr_iptables_test.py:171: AssertionError
```
This is because the domain name 'www.google.comx' sometimes unexpectedly resolves to an IP(an unfixed IP).
```
ouxl@aster241:~$ nslookup 
> www.google.comx
Server:         8.8.8.8
Address:        8.8.8.8#53

Non-authoritative answer:
Name:   www.google.comx
Address: 159.138.20.20
```
#### How I did it
Change the domain name 'www.google.comx' in the file src/sonic-ctrmgrd/tests/ctrmgr_iptables_test.py to a domain name that will never be resolved an IP address .
#### How to verify it
Rebuild the module completely several times
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

