### PR TITLE
[macsec]: Add MACsec clear CLI support

### DIFF
--- a/dockers/docker-macsec/cli/clear/plugins/clear_macsec_counter.py
+++ b/dockers/docker-macsec/cli/clear/plugins/clear_macsec_counter.py
@@ -3,7 +3,7 @@ import click
 
 import show.plugins.macsec as show_macsec
 import utilities_common.cli as clicommon
-
+from sonic_py_common import multi_asic
 
 @click.group(cls=clicommon.AliasedGroup)
 def macsec():
@@ -19,13 +19,14 @@ def macsec_clear_counters(clean_cache):
     """
 
     if clean_cache:
-        os.remove(show_macsec.CACHE_FILE)
-        print("Clean cache {}".format(show_macsec.CACHE_FILE))
+        for namespace in multi_asic.get_namespace_list():
+            if os.path.isfile(show_macsec.CACHE_FILE.format(namespace)):
+                os.remove(show_macsec.CACHE_FILE.format(namespace))
+            print("Cleaned cache")
         return
 
-    clicommon.run_command("show macsec --dump-file {}".format(show_macsec.CACHE_FILE))
+    clicommon.run_command("show macsec --dump-file")
     print("Clear MACsec counters")
-
 
 def register(cli):
     cli.add_command(macsec_clear_counters)

--- a/dockers/docker-macsec/cli/clear/plugins/clear_macsec_counter.py
+++ b/dockers/docker-macsec/cli/clear/plugins/clear_macsec_counter.py
@@ -11,9 +11,12 @@ def macsec():
 
 
 @macsec.command('macsec')
-@click.option('--clean-cache', type=bool, required=False, default=False)
+@click.option('--clean-cache', type=bool, required=False, default=False, help="If the option of clean cache is true, next show commands will show the raw counters which based on the service booted instead of the last clear command.")
 def macsec_clear_counters(clean_cache):
-    """ Clear MACsec counts """
+    """ 
+        Clear MACsec counts.
+        This clear command will generated a cache for next show commands which will base on this cache as the zero baseline to show the increment of counters.
+    """
 
     if clean_cache:
         os.remove(show_macsec.CACHE_FILE)

--- a/dockers/docker-macsec/cli/clear/plugins/clear_macsec_counter.py
+++ b/dockers/docker-macsec/cli/clear/plugins/clear_macsec_counter.py
@@ -1,0 +1,32 @@
+import os
+import click
+
+import show.plugins.macsec as show_macsec
+import utilities_common.cli as clicommon
+
+
+@click.group(cls=clicommon.AliasedGroup)
+def macsec():
+    pass
+
+
+@macsec.command('macsec')
+@click.option('--clean-cache', type=bool, required=False, default=False)
+def macsec_clear_counters(clean_cache):
+    """ Clear MACsec counts """
+
+    if clean_cache:
+        os.remove(show_macsec.CACHE_FILE)
+        print("Clean cache {}".format(show_macsec.CACHE_FILE))
+        return
+
+    clicommon.run_command("show macsec --dump-file {}".format(show_macsec.CACHE_FILE))
+    print("Clear MACsec counters")
+
+
+def register(cli):
+    cli.add_command(macsec_clear_counters)
+
+
+if __name__ == '__main__':
+    macsec_clear_counters(None)

--- a/dockers/docker-macsec/cli/show/plugins/show_macsec.py
+++ b/dockers/docker-macsec/cli/show/plugins/show_macsec.py
@@ -237,9 +237,17 @@ class MacsecContext(object):
         for interface_name in natsorted(interface_names):
             objs += create_macsec_objs(interface_name)
 
-        cache = {}
+        cache = {"objs":[]}
+
         if os.path.isfile(CACHE_FILE):
-            cache = pickle.load(open(CACHE_FILE, "rb"))
+            with open(CACHE_FILE, "rb") as f:
+                while True:
+                    try:
+                        data = pickle.load(f)
+                        cache['time'] = data['time']
+                        cache['objs'] += data['objs']
+                    except EOFError:
+                        break
 
         if dump_file is None:
             if cache and cache["time"] and objs:
@@ -253,6 +261,7 @@ class MacsecContext(object):
                 "objs": objs
             }
             pickle.dump(dump_obj, dump_file)
+            dump_file.flush()
 
 
 def register(cli):

--- a/dockers/docker-macsec/cli/show/plugins/show_macsec.py
+++ b/dockers/docker-macsec/cli/show/plugins/show_macsec.py
@@ -1,12 +1,19 @@
 import typing
 from natsort import natsorted
+import datetime
+import pickle
+import os
+import copy
 
 import click
 from tabulate import tabulate
 
 import utilities_common.multi_asic as multi_asic_util
 from swsscommon.swsscommon import CounterTable, MacsecCounter
+from utilities_common.cli import UserCache
 
+CACHE_MANAGER = UserCache(app_name="macsec")
+CACHE_FILE = os.path.join(CACHE_MANAGER.get_directory(), "macsecstats")
 
 DB_CONNECTOR = None
 COUNTER_TABLE = None
@@ -15,12 +22,12 @@ COUNTER_TABLE = None
 class MACsecAppMeta(object):
     def __init__(self, *args) -> None:
         SEPARATOR = DB_CONNECTOR.get_db_separator(DB_CONNECTOR.APPL_DB)
-        key = self.__class__.get_appl_table_name() + SEPARATOR + \
+        self.key = self.__class__.get_appl_table_name() + SEPARATOR + \
             SEPARATOR.join(args)
         self.meta = DB_CONNECTOR.get_all(
-            DB_CONNECTOR.APPL_DB, key)
+            DB_CONNECTOR.APPL_DB, self.key)
         if len(self.meta) == 0:
-            raise ValueError("No such MACsecAppMeta: {}".format(key))
+            raise ValueError("No such MACsecAppMeta: {}".format(self.key))
         for k, v in self.meta.items():
             setattr(self, k, v)
 
@@ -39,10 +46,15 @@ class MACsecSA(MACsecAppMeta, MACsecCounters):
         MACsecAppMeta.__init__(self, port_name, sci, an)
         MACsecCounters.__init__(self, port_name, sci, an)
 
-    def dump_str(self) -> str:
+    def dump_str(self, cache = None) -> str:
         buffer = self.get_header()
         meta = sorted(self.meta.items(), key=lambda x: x[0])
-        counters = sorted(self.counters.items(), key=lambda x: x[0])
+        counters = copy.deepcopy(self.counters)
+        if cache:
+            for k, v in counters.items():
+                if k in cache.counters:
+                    counters[k] = int(counters[k]) - int(cache.counters[k])
+        counters = sorted(counters.items(), key=lambda x: x[0])
         buffer += tabulate(meta + counters)
         buffer = "\n".join(["\t\t" + line for line in buffer.splitlines()])
         return buffer
@@ -87,7 +99,7 @@ class MACsecIngressSC(MACsecSC):
     def get_appl_table_name(cls) -> str:
         return "MACSEC_INGRESS_SC_TABLE"
 
-    def dump_str(self) -> str:
+    def dump_str(self, cache = None) -> str:
         buffer = self.get_header()
         buffer = "\n".join(["\t" + line for line in buffer.splitlines()])
         return buffer
@@ -104,7 +116,7 @@ class MACsecEgressSC(MACsecSC):
     def get_appl_table_name(cls) -> str:
         return "MACSEC_EGRESS_SC_TABLE"
 
-    def dump_str(self) -> str:
+    def dump_str(self, cache = None) -> str:
         buffer = self.get_header()
         buffer += tabulate(sorted(self.meta.items(), key=lambda x: x[0]))
         buffer = "\n".join(["\t" + line for line in buffer.splitlines()])
@@ -123,7 +135,7 @@ class MACsecPort(MACsecAppMeta):
     def get_appl_table_name(cls) -> str:
         return "MACSEC_PORT_TABLE"
 
-    def dump_str(self) -> str:
+    def dump_str(self, cache = None) -> str:
         buffer = self.get_header()
         buffer += tabulate(sorted(self.meta.items(), key=lambda x: x[0]))
         return buffer
@@ -148,6 +160,7 @@ def create_macsec_obj(key: str) -> MACsecAppMeta:
         raise TypeError("Unknown MACsec object type")
     except ValueError as e:
         return None
+
 
 def create_macsec_objs(interface_name: str) -> typing.List[MACsecAppMeta]:
     objs = []
@@ -179,11 +192,25 @@ def create_macsec_objs(interface_name: str) -> typing.List[MACsecAppMeta]:
     return objs
 
 
+def cache_find(cache: dict, target: MACsecAppMeta) -> MACsecAppMeta:
+    if not cache or not cache["objs"]:
+        return None
+    for obj in cache["objs"]:
+        if type(obj) == type(target) and obj.key == target.key:
+            # MACsec SA may be refreshed by a cycle that use the same key
+            # So, use the SA as the identifier
+            if isinstance(obj, MACsecSA) and obj.sak != target.sak:
+                continue
+            return obj
+    return None
+
+
 @click.command()
 @click.argument('interface_name', required=False)
+@click.option('--dump-file', type=click.File('wb'), required=False, default=None)
 @multi_asic_util.multi_asic_click_options
-def macsec(interface_name, namespace, display):
-    MacsecContext(namespace, display).show(interface_name)
+def macsec(interface_name, dump_file, namespace, display):
+    MacsecContext(namespace, display).show(interface_name, dump_file)
 
 
 class MacsecContext(object):
@@ -194,7 +221,7 @@ class MacsecContext(object):
             display_option, namespace_option)
 
     @multi_asic_util.run_on_multi_asic
-    def show(self, interface_name):
+    def show(self, interface_name, dump_file):
         global DB_CONNECTOR
         global COUNTER_TABLE
         DB_CONNECTOR = self.db
@@ -205,12 +232,27 @@ class MacsecContext(object):
             if interface_name not in interface_names:
                 return
             interface_names = [interface_name]
-
         objs = []
+
         for interface_name in natsorted(interface_names):
             objs += create_macsec_objs(interface_name)
-        for obj in objs:
-            print(obj.dump_str())
+
+        cache = {}
+        if os.path.isfile(CACHE_FILE):
+            cache = pickle.load(open(CACHE_FILE, "rb"))
+
+        if dump_file is None:
+            if cache and cache["time"] and objs:
+                print("Last cached time was {}".format(cache["time"]))
+            for obj in objs:
+                cache_obj = cache_find(cache, obj)
+                print(obj.dump_str(cache_obj))
+        else:
+            dump_obj = {
+                "time": datetime.datetime.now(),
+                "objs": objs
+            }
+            pickle.dump(dump_obj, dump_file)
 
 
 def register(cli):

--- a/rules/docker-macsec.mk
+++ b/rules/docker-macsec.mk
@@ -44,5 +44,6 @@ $(DOCKER_MACSEC)_RUN_OPT += -v /host/warmboot:/var/warmboot
 
 $(DOCKER_MACSEC)_CLI_CONFIG_PLUGIN = /cli/config/plugins/macsec.py
 $(DOCKER_MACSEC)_CLI_SHOW_PLUGIN = /cli/show/plugins/show_macsec.py
+$(DOCKER_MACSEC)_CLI_CLEAR_PLUGIN = /cli/clear/plugins/clear_macsec_counter.py
 
 $(DOCKER_MACSEC)_FILES += $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To support clear MACsec counters by `sonic-clear macsec`

#### How I did it
Add macsec sub-command in sonic-clear to cache the current macsec stats, and in the `show macsec` command to check the cache and return the diff with cache file.

#### How to verify it

```

admin@vlab-02:~$ show macsec  Ethernet0
MACsec port(Ethernet0)
---------------------  -----------
cipher_suite           GCM-AES-128
enable                 true
enable_encrypt         true
enable_protect         true
enable_replay_protect  false
replay_window          0
send_sci               true
---------------------  -----------
        MACsec Egress SC (52540067daa70001)
        -----------  -
        encoding_an  0
        -----------  -
                MACsec Egress SA (0)
                -------------------------------------  --------------------------------
                auth_key                               9DDD4C69220A1FA9B6763F229B75CB6F
                next_pn                                1
                sak                                    BA86574D054FCF48B9CD7CF54F21304A
                salt                                   000000000000000000000000
                ssci                                   0
                SAI_MACSEC_SA_ATTR_CURRENT_XPN         52
                SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED    0
                SAI_MACSEC_SA_STAT_OCTETS_PROTECTED    0
                SAI_MACSEC_SA_STAT_OUT_PKTS_ENCRYPTED  0
                SAI_MACSEC_SA_STAT_OUT_PKTS_PROTECTED  0
                -------------------------------------  --------------------------------
        MACsec Ingress SC (525400d4fd3f0001)
                MACsec Ingress SA (0)
                ---------------------------------------  --------------------------------
                active                                   true
                auth_key                                 9DDD4C69220A1FA9B6763F229B75CB6F
                lowest_acceptable_pn                     1
                sak                                      BA86574D054FCF48B9CD7CF54F21304A
                salt                                     000000000000000000000000
                ssci                                     0
                SAI_MACSEC_SA_ATTR_CURRENT_XPN           56
                SAI_MACSEC_SA_STAT_IN_PKTS_DELAYED       0
                SAI_MACSEC_SA_STAT_IN_PKTS_INVALID       0
                SAI_MACSEC_SA_STAT_IN_PKTS_LATE          0
                SAI_MACSEC_SA_STAT_IN_PKTS_NOT_USING_SA  0
                SAI_MACSEC_SA_STAT_IN_PKTS_NOT_VALID     0
                SAI_MACSEC_SA_STAT_IN_PKTS_OK            0
                SAI_MACSEC_SA_STAT_IN_PKTS_UNCHECKED     0
                SAI_MACSEC_SA_STAT_IN_PKTS_UNUSED_SA     0
                SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED      0
                SAI_MACSEC_SA_STAT_OCTETS_PROTECTED      0
                ---------------------------------------  --------------------------------

admin@vlab-02:~$ sonic-clear macsec
Clear MACsec counters

admin@vlab-02:~$ show macsec  Ethernet0
MACsec port(Ethernet0)
---------------------  -----------
cipher_suite           GCM-AES-128
enable                 true
enable_encrypt         true
enable_protect         true
enable_replay_protect  false
replay_window          0
send_sci               true
---------------------  -----------
        MACsec Egress SC (52540067daa70001)
        -----------  -
        encoding_an  0
        -----------  -
                MACsec Egress SA (0)
                -------------------------------------  --------------------------------
                auth_key                               9DDD4C69220A1FA9B6763F229B75CB6F
                next_pn                                1
                sak                                    BA86574D054FCF48B9CD7CF54F21304A
                salt                                   000000000000000000000000
                ssci                                   0
                SAI_MACSEC_SA_ATTR_CURRENT_XPN         52
                SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED    0
                SAI_MACSEC_SA_STAT_OCTETS_PROTECTED    0
                SAI_MACSEC_SA_STAT_OUT_PKTS_ENCRYPTED  0
                SAI_MACSEC_SA_STAT_OUT_PKTS_PROTECTED  0
                -------------------------------------  --------------------------------
        MACsec Ingress SC (525400d4fd3f0001)
                MACsec Ingress SA (0)
                ---------------------------------------  --------------------------------
                active                                   true
                auth_key                                 9DDD4C69220A1FA9B6763F229B75CB6F
                lowest_acceptable_pn                     1
                sak                                      BA86574D054FCF48B9CD7CF54F21304A
                salt                                     000000000000000000000000
                ssci                                     0
                SAI_MACSEC_SA_ATTR_CURRENT_XPN           0 <---this counters was cleared.
                SAI_MACSEC_SA_STAT_IN_PKTS_DELAYED       0
                SAI_MACSEC_SA_STAT_IN_PKTS_INVALID       0
                SAI_MACSEC_SA_STAT_IN_PKTS_LATE          0
                SAI_MACSEC_SA_STAT_IN_PKTS_NOT_USING_SA  0
                SAI_MACSEC_SA_STAT_IN_PKTS_NOT_VALID     0
                SAI_MACSEC_SA_STAT_IN_PKTS_OK            0
                SAI_MACSEC_SA_STAT_IN_PKTS_UNCHECKED     0
                SAI_MACSEC_SA_STAT_IN_PKTS_UNUSED_SA     0
                SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED      0
                SAI_MACSEC_SA_STAT_OCTETS_PROTECTED      0
                ---------------------------------------  --------------------------------

```


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

