### PR TITLE
[Mellanox] Fix issue: set lpmode by platform API does not work

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -53,6 +53,8 @@ try:
         SX_PORT_MODULE_STATUS_UNPLUGGED = 2
         SX_PORT_MODULE_STATUS_PLUGGED_WITH_ERROR = 3
         SX_PORT_MODULE_STATUS_PLUGGED_DISABLED = 4
+        SX_PORT_ADMIN_STATUS_UP = True
+        SX_PORT_ADMIN_STATUS_DOWN = False
 except KeyError:
     pass
 
@@ -571,7 +573,7 @@ class SFP(NvidiaSFPCommon):
     @classmethod
     def is_port_admin_status_up(cls, sdk_handle, log_port):
         _, admin_state = cls._fetch_port_status(sdk_handle, log_port);
-        admin_state == SX_PORT_ADMIN_STATUS_UP
+        return admin_state == SX_PORT_ADMIN_STATUS_UP
 
 
     @classmethod

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -111,3 +111,11 @@ class TestSfp:
         sfp = SFP(0)
         assert output_sfp.y_cable_part_number == sfp.read_eeprom(offset, 16).decode()
         MlxregManager.read_mlxred_eeprom.assert_called_with(132, 4, 16)
+
+    @mock.patch('sonic_platform.sfp.SFP._fetch_port_status')
+    def test_is_port_admin_status_up(self, mock_port_status):
+        mock_port_status.return_value = (0, True)
+        assert SFP.is_port_admin_status_up(None, None)
+
+        mock_port_status.return_value = (0, False)
+        assert not SFP.is_port_admin_status_up(None, None)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix issue: set lpmode by platform API does not work

#### How I did it

Fix miss return value in code

#### How to verify it

Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

