### PR TITLE
[Build] Fix vstest for sonic-buildimage PR testing pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,6 +112,7 @@ stages:
 
     - script: |
         set -x
+        sudo apt-get install -y libzmq3-dev libzmq5 libboost-serialization1.71.0 uuid-dev
         sudo dpkg -i --force-confask,confnew ../libswsscommon_1.0.0_amd64.deb
         sudo dpkg -i ../python3-swsscommon_1.0.0_amd64.deb
         sudo docker load -i ../target/docker-sonic-vs.gz


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
We are seeing errors in PR testing pipeline for vstest
```
+ sudo dpkg -i --force-confask,confnew ../libswsscommon_1.0.0_amd64.deb
(Reading database ... 135502 files and directories currently installed.)
Preparing to unpack .../libswsscommon_1.0.0_amd64.deb ...
Unpacking libswsscommon (1.0.0) over (1.0.0) ...
dpkg: dependency problems prevent configuration of libswsscommon:
 libswsscommon depends on libboost-serialization1.71.0; however:
  Package libboost-serialization1.71.0 is not installed.
 libswsscommon depends on libzmq5 (>= 4.0.1+dfsg); however:
  Package libzmq5 is not installed.

dpkg: error processing package libswsscommon (--install):
 dependency problems - leaving unconfigured
Processing triggers for libc-bin (2.31-0ubuntu9.7) ...
Errors were encountered while processing:
 libswsscommon
+ sudo dpkg -i ../python3-swsscommon_1.0.0_amd64.deb
(Reading database ... 135502 files and directories currently installed.)
Preparing to unpack .../python3-swsscommon_1.0.0_amd64.deb ...
Unpacking python3-swsscommon (1.0.0) over (1.0.0) ...
dpkg: dependency problems prevent configuration of python3-swsscommon:
 python3-swsscommon depends on libswsscommon; however:
  Package libswsscommon is not configured yet.

dpkg: error processing package python3-swsscommon (--install):
 dependency problems - leaving unconfigured
Processing triggers for libc-bin (2.31-0ubuntu9.7) ...
Errors were encountered while processing:
 python3-swsscommon
```
It's because PR https://github.com/sonic-net/sonic-swss-common/pull/667 updated `swsscommon` library, which requires `libzmp5` and `libboost`. 
However, these packages are missing from test agent.

#### How I did it
Run `sudo apt-get install -y libzmq3-dev libzmq5 libboost-serialization1.71.0 uuid-dev` to install the required packages.

#### How to verify it
Verified by PR testing.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix vstest in PR testing.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

