### PR TITLE
[201911][Mellanox] Collect MST dump before syncd restart on shutdown notification

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -290,7 +290,6 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     sysfsutils              \
     squashfs-tools          \
     grub2-common            \
-    linux-tools             \
     rsyslog                 \
     ethtool                 \
     screen                  \

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -290,6 +290,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     sysfsutils              \
     squashfs-tools          \
     grub2-common            \
+    linux-tools             \
     rsyslog                 \
     ethtool                 \
     screen                  \

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -138,13 +138,10 @@ wait() {
 
 collect_mst() {
     debug "Collecting MST dump before syncd restart"
-    IRGDBSERVER=/usr/local/bin/ir-gdbserver
     TMPDIR=/tmp/mlnxdump
     MSTDIR=$TMPDIR/mstdump
     DUMPDIR=/var/dump/mstdump
-    IRGDBDIR=$TMPDIR/ir-gdb
     mkdir -p $MSTDIR
-    mkdir -p $IRGDBDIR
     if ! mst status -v &> $MSTDIR/mststatus; then
         debug "mst status command returned error"
     else
@@ -156,10 +153,6 @@ collect_mst() {
                 break
             fi
         done
-        if [ -f $IRGDBSERVER ]; then
-            debug "collecting ir-gdbserver dump"
-            $IRGDBSERVER -d /dev/mst/mt*_pci_cr0 -c $IRGDBDIR/core
-        fi
     fi
     mkdir -p $DUMPDIR
     TARFILE=mstdump_`date +%Y%m%d_%H%M%S`.tar

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -136,6 +136,25 @@ wait() {
     /usr/bin/${SERVICE}.sh wait $DEV
 }
 
+collect_mst() {
+    debug "Collecting MST dump before syncd restart"
+    MSTDIR=/tmp/mstdump
+    DUMPDIR=/var/dump/mstdump
+    mkdir -p $MSTDIR
+    local mst_dump_filename="$MSTDIR/mstdump"
+    local max_dump_count="3"
+    for i in $(seq 1 $max_dump_count); do
+        ${CMD_PREFIX}/usr/bin/mstdump /dev/mst/mt*conf0 > "${mst_dump_filename}${i}"
+    done
+    mkdir -p $DUMPDIR
+    TARFILE=mstdump_`date +%Y%m%d_%H%M%S`
+    tar -C $MSTDIR -cf $DUMPDIR/$TARFILE  .
+    gzip -f $DUMPDIR/$TARFILE
+    rm -rf $MSTDIR
+    # Maintaining the recent 3 files and removing the rest
+    ls -1td $DUMPDIR/* | tail -n +4 | xargs rm -rf
+}
+
 stop() {
     debug "Stopping ${SERVICE}$DEV service..."
 
@@ -155,6 +174,12 @@ stop() {
         debug "Stopped pmon service"
     fi
 
+    if [[ x$sonic_asic_platform == x"mellanox" ]]; then
+        # In case of SAI failure the last line of sairedis.rec would contain switch_shutdown_request
+        if tail -1 /var/log/swss/sairedis.rec | grep -q switch_shutdown_request; then
+            collect_mst
+        fi
+    fi
     if [[ x$sonic_asic_platform != x"mellanox" ]] || [[ x$TYPE != x"cold" ]]; then
         debug "${TYPE} shutdown syncd process ..."
         /usr/bin/docker exec -i syncd$DEV /usr/bin/syncd_request_shutdown --${TYPE}

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -145,7 +145,7 @@ collect_mst() {
     IRGDBDIR=$TMPDIR/ir-gdb
     mkdir -p $MSTDIR
     mkdir -p $IRGDBDIR
-    if ! mst status -v > $MSTDIR/mststatus; then
+    if ! mst status -v &> $MSTDIR/mststatus; then
         debug "mst status command returned error"
     else
         local mst_dump_filename="$MSTDIR/mstdump"
@@ -165,6 +165,7 @@ collect_mst() {
     TARFILE=mstdump_`date +%Y%m%d_%H%M%S`.tar
     tar -C $TMPDIR -cf $DUMPDIR/$TARFILE  .
     gzip -f $DUMPDIR/$TARFILE
+    debug "MST dump created $DUMPDIR/$TARFILE.gz"
     rm -rf $TMPDIR
     # Maintaining the recent 3 files and removing the rest
     ls -1td $DUMPDIR/* | tail -n +4 | xargs rm -rf


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Collecting MST dump before syncd restart on shutdown notification during a SAI failure

Dump can be found under:
```
root@sonic:/home/admin# ls -l /var/dump/mstdump/
total 10684
-rw-r--r-- 1 root root 5460332 Aug 15 18:41 mstdump_20220815_184143.tar.gz
-rw-r--r-- 1 root root 5473253 Aug 15 21:46 mstdump_20220815_214642.tar.gz

root@sonic:/home/admin# tar -xvzf /var/dump/mstdump/mstdump_20220815_214642.tar.gz
├── ir-gdb
│   └── core
└── mstdump
    ├── mstdump1
    ├── mstdump2
    ├── mstdump3
    └── mststatus
```



#### How I did it

Checked for shutdown notification log in sairedis and used it to determine whether the shutdown is normal or due to SAI failure

#### How to verify it

Simulated a SAI failure event and verified it. Verified it also on different reboots and config reload scenarios the dump is not generated

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

