### PR TITLE
[HLX] Enable swap for haliburton device.

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.init
@@ -11,6 +11,26 @@
 # Short-Description: Setup Haliburton board.
 ### END INIT INFO
 
+setup_swap () {
+    SWAPFILE=/host/myswapfile
+
+    if [ ! -f $SWAPFILE ]; then
+        availspace=`df -h --output=avail /host | sed '1d;s/\s//g;s/[^0-9].*//g'`
+        diff=$(( availspace - 2*$1 ))
+        if [ $diff -gt 0 ]; then
+            fallocate -l ${1}G $SWAPFILE
+            chmod 600 $SWAPFILE
+            echo "swap file created successfully"
+        else
+            echo "not enough disk space to turn on swap."
+            return
+        fi
+    fi
+    mkswap $SWAPFILE
+    swapon $SWAPFILE
+    echo "swap on successfully"
+}
+
 case "$1" in
 start)
         echo -n "Setting up board... "
@@ -73,6 +93,8 @@ start)
         echo 0 > /sys/devices/platform/e1031.smc/SFP/modabs_mask
 
         /bin/sh /usr/local/bin/platform_api_mgnt.sh init
+
+        setup_swap 2
 
         echo "done."
         ;;


### PR DESCRIPTION
Signed-off-by: Xichen Lin <lukelin0907@gmail.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Haliburton device has very little memory, and turning on swap will potentially increase the stability of the device.

#### How I did it
Turn on swap in the init file.

#### How to verify it
Modified the script and did reboot to see if things are as expected.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Turn on swap space for Haliburton device.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

