### PR TITLE
[Yang] Update Yang for `pfc_enable` and `pfcwd_sw_enable` fields

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/qosmaps.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/qosmaps.json
@@ -669,8 +669,8 @@
                         "pfc_to_pg_map": "map1",
                         "dscp_to_tc_map": "map1",
                         "dot1p_to_tc_map": "map1",
-                        "pfc_enable": "3,4",
-                        "pfcwd_sw_enable" : "3,4"
+                        "pfc_enable": "2,3,4,6",
+                        "pfcwd_sw_enable" : "2,3,4,6"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
@@ -82,13 +82,13 @@ module sonic-port-qos-map {
 
                 leaf pfc_enable {
                     type string {
-                        pattern "[0-7](,[0-7])?";
+                        pattern "[0-7](,[0-7])*";
                     }
                 }
 
                 leaf pfcwd_sw_enable {
                     type string {
-                        pattern "[0-7](,[0-7])?";
+                        pattern "[0-7](,[0-7])*";
                     }
                     description
                         "Specify the queue(s) on which software pfc watchdog are enabled.";


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR is to update Yang model for  `pfc_enable` and `pfcwd_sw_enable` fields to support more than 2 queues, like `2,3,4,6`.
Before this change, the regex `"[0-7](,[0-7])?"` accepts only no more than 2 queues.

#### How I did it
Update the regex pattern for `pfc_enable` and `pfcwd_sw_enable`, from `"[0-7](,[0-7])?"` to `"[0-7](,[0-7])*`

#### How to verify it
The change is verified by UT. The test input is updated to cover the change.
```
collected 3 items                                                                                                                                                                                     

tests/test_sonic_yang_models.py ..                                                                                                                                                              [ 66%]
tests/yang_model_tests/test_yang_model.py .                                                                                                                                                     [100%]

====================================================================================== 3 passed in 2.55 seconds =======================================================================================
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update Yang model for  `pfc_enable` and `pfcwd_sw_enable` fields to support more than 2 queues, like `2,3,4,6`.
#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

