### PR TITLE
filter inband and recirc ports as internal ports

### DIFF
--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -15,6 +15,8 @@ FRONTEND_ASIC_SUB_ROLE = 'FrontEnd'
 BACKEND_ASIC_SUB_ROLE = 'BackEnd'
 EXTERNAL_PORT = 'Ext'
 INTERNAL_PORT = 'Int'
+INBAND_PORT = 'Inb'
+RECIRC_PORT ='Rec'
 PORT_CHANNEL_CFG_DB_TABLE = 'PORTCHANNEL'
 PORT_CFG_DB_TABLE = 'PORT'
 BGP_NEIGH_CFG_DB_TABLE = 'BGP_NEIGHBOR'
@@ -322,7 +324,7 @@ def is_port_internal(port_name, namespace=None):
 
     role = get_port_role(port_name, namespace)
 
-    if role == INTERNAL_PORT:
+    if role in [INTERNAL_PORT, INBAND_PORT, RECIRC_PORT]:
         return True
 
     return False


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently the CLI commands `show interface status` `show interface counters` and `show interface description` displays `Ethernet-IB` and `Ethernet-Rec` ports in the output. These are internal ports should only be displayed when the option `-d all` is used for the above mentioned CLI commands
#### How I did it
Add the port  roles `Inb` and `Rec` when classifing a port as internal port.
#### How to verify it
Verify the CLI output of the command  `show interface status` doesnt display the `Ethenet-IB` and `Ethernet-Rec` port when `-d all` option in not present
Before
```
admin@Ssonic:$ show interface counters
        IFACE    STATE    RX_OK      RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK     TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
-------------  -------  -------  ----------  ---------  --------  --------  --------  -------  ---------  ---------  --------  --------  --------
    Ethernet0        D        0    0.00 B/s      0.00%         0         0         0        9   0.00 B/s      0.00%         0         0         0
    Ethernet8        D        0    0.00 B/s      0.00%         0         0         0        9   0.00 B/s      0.00%         0         0         0
   Ethernet16        D        0    0.00 B/s      0.00%         0         0         0       13   0.00 B/s      0.00%         0         0         0
   Ethernet24        D        0    0.00 B/s      0.00%         0         0         0        8   0.00 B/s      0.00%         0         0         0
   Ethernet32        U   99,283  128.07 B/s      0.00%         0         0         0    3,221   1.15 B/s      0.00%         0         0         0
   Ethernet40        U   99,284  128.24 B/s      0.00%         0         0         0    3,224   1.15 B/s      0.00%         0         0         0
   Ethernet48        U   99,364  128.24 B/s      0.00%         0         0         0    3,222   1.15 B/s      0.00%         0         0         0
   Ethernet56        U   99,364  128.24 B/s      0.00%         0         0         0    3,223   1.15 B/s      0.00%         0         0         0
   Ethernet64        D        0    0.00 B/s      0.00%         0         0         0        6   0.00 B/s      0.00%         0         0         0
   Ethernet72        D        0    0.00 B/s      0.00%         0         0         0       10   0.00 B/s      0.00%         0         0         0
   Ethernet80        D        0    0.00 B/s      0.00%         0         0         0       10   0.00 B/s      0.00%         0         0         0
   Ethernet88        D        0    0.00 B/s      0.00%         0         0         0        9   0.00 B/s      0.00%         0         0         0
   Ethernet96        U    9,143   19.04 B/s      0.00%         0         0         0    3,222   1.17 B/s      0.00%         0         0         0
  Ethernet104        U   99,354  121.89 B/s      0.00%         0         0         0    3,224   1.17 B/s      0.00%         0         0         0
  Ethernet112        U   99,352  124.71 B/s      0.00%         0         0         0    3,223   1.17 B/s      0.00%         0         0         0
  Ethernet120        U    9,141   10.50 B/s      0.00%         0         0         0    3,220   1.17 B/s      0.00%         0         0         0
  Ethernet128        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet136        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
 Ethernet-IB0        U        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet-Rec0        U        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet144        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet152        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet160        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet168        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet176        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet184        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet192        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet200        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet208        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet216        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet224        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet232        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet240        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet248        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet256        U    5,855    0.67 B/s      0.00%         0         0         0   48,154  39.85 B/s      0.00%         0         0         0
  Ethernet264        U    5,853    1.00 B/s      0.00%         0         0         0   48,385  56.04 B/s      0.00%         0         0         0
  Ethernet272        U   55,215   29.45 B/s      0.00%         0         0         0   55,753  45.96 B/s      0.00%         0         0         0
  Ethernet280        U   59,847   29.45 B/s      0.00%         0         0         0   51,439  45.96 B/s      0.00%         0         0         0
 Ethernet-IB1        U        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet-Rec1        U        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
```

After
```
admin@Ssonic:~$ show interface counters
      IFACE    STATE    RX_OK      RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK     TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
-----------  -------  -------  ----------  ---------  --------  --------  --------  -------  ---------  ---------  --------  --------  --------
  Ethernet0        D        0    0.00 B/s      0.00%         0         0         0       31   0.00 B/s      0.00%         0         0         0
  Ethernet8        D        0    0.00 B/s      0.00%         0         0         0       31   0.00 B/s      0.00%         0         0         0
 Ethernet16        D        0    0.00 B/s      0.00%         0         0         0       35   0.00 B/s      0.00%         0         0         0
 Ethernet24        D        0    0.00 B/s      0.00%         0         0         0       30   0.00 B/s      0.00%         0         0         0
 Ethernet32        U  104,850  128.24 B/s      0.00%         0         0         0    3,423   4.61 B/s      0.00%         0         0         0
 Ethernet40        U  104,850  128.78 B/s      0.00%         0         0         0    3,426   4.61 B/s      0.00%         0         0         0
 Ethernet48        U  104,937  128.78 B/s      0.00%         0         0         0    3,424   4.61 B/s      0.00%         0         0         0
 Ethernet56        U  104,938  128.64 B/s      0.00%         0         0         0    3,425   3.78 B/s      0.00%         0         0         0
 Ethernet64        D        0    0.00 B/s      0.00%         0         0         0       28   0.00 B/s      0.00%         0         0         0
 Ethernet72        D        0    0.00 B/s      0.00%         0         0         0       32   0.00 B/s      0.00%         0         0         0
 Ethernet80        D        0    0.00 B/s      0.00%         0         0         0       32   0.00 B/s      0.00%         0         0         0
 Ethernet88        D        0    0.00 B/s      0.00%         0         0         0       31   0.00 B/s      0.00%         0         0         0
 Ethernet96        U    9,652    0.78 B/s      0.00%         0         0         0    3,424   3.85 B/s      0.00%         0         0         0
Ethernet104        U  104,928  128.64 B/s      0.00%         0         0         0    3,426   3.85 B/s      0.00%         0         0         0
Ethernet112        U  104,925  128.35 B/s      0.00%         0         0         0    3,425   3.85 B/s      0.00%         0         0         0
Ethernet120        U    9,649    0.29 B/s      0.00%         0         0         0    3,422   3.85 B/s      0.00%         0         0         0
Ethernet128        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet136        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet144        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet152        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet160        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet168        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet176        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet184        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet192        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet200        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet208        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet216        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet224        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet232        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet240        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet248        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet256        U    6,036    4.91 B/s      0.00%         0         0         0   50,849  43.15 B/s      0.00%         0         0         0
Ethernet264        U    6,034    5.98 B/s      0.00%         0         0         0   51,080  56.04 B/s      0.00%         0         0         0
Ethernet272        U   55,394    0.25 B/s      0.00%         0         0         0   58,448  45.96 B/s      0.00%         0         0         0
Ethernet280        U   60,026    0.25 B/s      0.00%         0         0         0   54,134  45.96 B/s      0.00%         0         0         0
admin@Ssonic:~$ show interface counters -d all
        IFACE    STATE    RX_OK      RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK     TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
-------------  -------  -------  ----------  ---------  --------  --------  --------  -------  ---------  ---------  --------  --------  --------
    Ethernet0        D        0    0.00 B/s      0.00%         0         0         0       31   0.00 B/s      0.00%         0         0         0
    Ethernet8        D        0    0.00 B/s      0.00%         0         0         0       31   0.00 B/s      0.00%         0         0         0
   Ethernet16        D        0    0.00 B/s      0.00%         0         0         0       35   0.00 B/s      0.00%         0         0         0
   Ethernet24        D        0    0.00 B/s      0.00%         0         0         0       30   0.00 B/s      0.00%         0         0         0
   Ethernet32        U  104,855  128.09 B/s      0.00%         0         0         0    3,423   1.71 B/s      0.00%         0         0         0
   Ethernet40        U  104,855  128.29 B/s      0.00%         0         0         0    3,426   1.71 B/s      0.00%         0         0         0
   Ethernet48        U  104,942  128.29 B/s      0.00%         0         0         0    3,424   1.71 B/s      0.00%         0         0         0
   Ethernet56        U  104,942  128.29 B/s      0.00%         0         0         0    3,425   1.71 B/s      0.00%         0         0         0
   Ethernet64        D        0    0.00 B/s      0.00%         0         0         0       28   0.00 B/s      0.00%         0         0         0
   Ethernet72        D        0    0.00 B/s      0.00%         0         0         0       32   0.00 B/s      0.00%         0         0         0
   Ethernet80        D        0    0.00 B/s      0.00%         0         0         0       32   0.00 B/s      0.00%         0         0         0
   Ethernet88        D        0    0.00 B/s      0.00%         0         0         0       31   0.00 B/s      0.00%         0         0         0
   Ethernet96        U    9,652    0.35 B/s      0.00%         0         0         0    3,424   1.74 B/s      0.00%         0         0         0
  Ethernet104        U  104,932  128.29 B/s      0.00%         0         0         0    3,426   1.74 B/s      0.00%         0         0         0
  Ethernet112        U  104,929  128.16 B/s      0.00%         0         0         0    3,425   1.74 B/s      0.00%         0         0         0
  Ethernet120        U    9,649    0.13 B/s      0.00%         0         0         0    3,422   1.74 B/s      0.00%         0         0         0
  Ethernet128        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet136        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
 Ethernet-IB0        U        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet-Rec0        U        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet144        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet152        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet160        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet168        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet176        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet184        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet192        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet200        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet208        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet216        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet224        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet232        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet240        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet248        X        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
  Ethernet256        U    6,036    2.22 B/s      0.00%         0         0         0   50,851  41.98 B/s      0.00%         0         0         0
  Ethernet264        U    6,034    2.71 B/s      0.00%         0         0         0   51,082  56.04 B/s      0.00%         0         0         0
  Ethernet272        U   55,394    0.11 B/s      0.00%         0         0         0   58,450  45.96 B/s      0.00%         0         0         0
  Ethernet280        U   60,026    0.11 B/s      0.00%         0         0         0   54,136  45.96 B/s      0.00%         0         0         0
 Ethernet-IB1        U        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
Ethernet-Rec1        U        0    0.00 B/s      0.00%         0         0         0        0   0.00 B/s      0.00%         0         0         0
admin@Ssonic:~$
admin@Ssonic:~$
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

