### PR TITLE
[Edge-core][AS5812-54X] fixes : Inconsistent use of tabs and spaces in …

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54x/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54x/classes/fanutil.py
@@ -135,7 +135,7 @@ class FanUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             self.logger.debug('GET. unable to close file. device_path:%s', device_path)
             return None
@@ -166,7 +166,7 @@ class FanUtil(object):
         val_file.write(content)
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             self.logger.debug('GET. unable to close file. device_path:%s', device_path)
             return None

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54x/classes/thermalutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54x/classes/thermalutil.py
@@ -84,7 +84,7 @@ class ThermalUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             self.logger.debug('GET. unable to close file. device_path:%s', device_path)
             return None


### PR DESCRIPTION
Signed-off-by: Roger Ho <roger530_ho@edge-core.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To startup as5812-platform-monitor.service fail.

Debug:
admin@sonic:~$ /usr/local/bin/accton_as5812_monitor.py
Traceback (most recent call last):
  File "/usr/local/bin/accton_as5812_monitor.py", line 33, in <module>
    from as5812_54x.fanutil import FanUtil
  File "/usr/lib/python3/dist-packages/as5812_54x/fanutil.py", line 138
    val_file.close()
TabError: inconsistent use of tabs and spaces in indentation

#### How I did it
Replace tab with space

#### How to verify it
admin@sonic:~$ systemctl status as5812-platform-monitor.service
● as5812-platform-monitor.service - Accton AS5812-54X Platform Monitoring service
     Loaded: loaded (/lib/systemd/system/as5812-platform-monitor.service; enabled; vendor preset: enabled)
     Active: active (running) since Thu 2022-08-18 01:07:37 UTC; 2h 10min ago
    Process: 25347 ExecStartPre=/usr/local/bin/accton_as5812_util.py install (code=exited, status=0/SUCCESS)
   Main PID: 25357 (python)
      Tasks: 1 (limit: 9477)
     Memory: 7.5M
     CGroup: /system.slice/as5812-platform-monitor.service
             └─25357 python /usr/local/bin/accton_as5812_monitor.py

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111
--> customer requirement
- [x] 202205
--> customer requirement

#### Description for the changelog
Replace tab with space
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
N/A
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

