### PR TITLE
[Edge-core][AS5812-54X] Support 'show platform firmware updates'

### DIFF
--- a/device/accton/x86_64-accton_as5812_54x-r0/platform_components.json
+++ b/device/accton/x86_64-accton_as5812_54x-r0/platform_components.json
@@ -1,0 +1,12 @@
+{
+    "chassis": {
+        "5812-54X-O-AC-F": {
+            "component": {
+                "CPLD1": { },
+                "CPLD2": { },
+                "CPLD3": { },
+                "BIOS": { }                
+            }
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Roger Ho <roger530_ho@edge-core.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The command shows an error message.
 
admin@sonic:~$ show platform firmware updates
Error: [Errno 2] No such file or directory: '/usr/share/sonic/device/x86_64-accton_as5812_54x-r0/platform_components.json'. Aborting...
Aborted!

#### How I did it
Add platform_components.json

#### How to verify it
admin@sonic:~$ show platform firmware updates
Info: Firmware updates are not available.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111
--> customer requirement
- [x] 202205
--> customer requirement
#### Description for the changelog
Add platform_components.json to device/barefoot/x86_64-accton_as9516_32d-r0/
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
N/A
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

