### PR TITLE
Revert "Update Yang for pfc_enable field (#11747)"

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/qosmaps.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/qosmaps.json
@@ -669,8 +669,8 @@
                         "pfc_to_pg_map": "map1",
                         "dscp_to_tc_map": "map1",
                         "dot1p_to_tc_map": "map1",
-                        "pfc_enable": "2,3,4,6",
-                        "pfcwd_sw_enable" : "2,3,4,6"
+                        "pfc_enable": "3,4",
+                        "pfcwd_sw_enable" : "3,4"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
@@ -82,13 +82,13 @@ module sonic-port-qos-map {
 
                 leaf pfc_enable {
                     type string {
-                        pattern "[0-7](,[0-7])*";
+                        pattern "[0-7](,[0-7])?";
                     }
                 }
 
                 leaf pfcwd_sw_enable {
                     type string {
-                        pattern "[0-7](,[0-7])*";
+                        pattern "[0-7](,[0-7])?";
                     }
                     description
                         "Specify the queue(s) on which software pfc watchdog are enabled.";


### PR DESCRIPTION
This reverts commit 53a281008a96edcc22d0536ca4357a18f071c04e.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
It breaks PR validation.
libyang_1.0.73_amd64.deb package failed to be built.
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

