### PR TITLE
Add new Redis database PROFILE_DB

### DIFF
--- a/dockers/docker-database/database_config.json.j2
+++ b/dockers/docker-database/database_config.json.j2
@@ -93,6 +93,11 @@
             "id" : 14,
             "separator": ":",
             "instance" : "redis"
+        },
+        "STATIC_CONFIG_DB" : {
+            "id" : 15,
+            "separator": ":",
+            "instance" : "redis"
         }
     },
     "VERSION" : "1.0"

--- a/dockers/docker-database/database_config.json.j2
+++ b/dockers/docker-database/database_config.json.j2
@@ -94,7 +94,7 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "STATIC_CONFIG_DB" : {
+        "PROFILE_DB" : {
             "id" : 15,
             "separator": ":",
             "instance" : "redis"

--- a/dockers/docker-database/database_config.json.j2
+++ b/dockers/docker-database/database_config.json.j2
@@ -96,7 +96,7 @@
         },
         "PROFILE_DB" : {
             "id" : 15,
-            "separator": ":",
+            "separator": "|",
             "instance" : "redis"
         }
     },

--- a/platform/vs/docker-sonic-vs/database_config.json
+++ b/platform/vs/docker-sonic-vs/database_config.json
@@ -82,6 +82,11 @@
             "id" : 14,
             "separator": ":",
             "instance" : "redis"
+        },
+        "STATIC_CONFIG_DB" : {
+            "id" : 15,
+            "separator": ":",
+            "instance" : "redis"
         }
     },
     "VERSION" : "1.0"

--- a/platform/vs/docker-sonic-vs/database_config.json
+++ b/platform/vs/docker-sonic-vs/database_config.json
@@ -83,7 +83,7 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "STATIC_CONFIG_DB" : {
+        "PROFILE_DB" : {
             "id" : 15,
             "separator": ":",
             "instance" : "redis"


### PR DESCRIPTION
Add new Redis database PROFILE_DB

#### Why I did it
Add new PROFILE_DB so profile in J2 template will render to this DB.
Also, swss-common will change to read profile from this new DB.
This will simplify reboot handling logic.

#### How I did it
Add PROFILE_DB config in database_config.j2 and database_config.json.

#### How to verify it
Pass all E2E test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
Add new Redis database PROFILE_DB

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

