### PR TITLE
[build] Fix version dependency issue about libnetsnmptrapd40:amd64

### DIFF
--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -275,6 +275,8 @@ RUN apt-get update && apt-get install -y \
         python3-parse \
 # For snmpd
         libnetsnmptrapd40=5.9+dfsg-3+b1 \
+        libsnmp40=5.9+dfsg-3+b1 \
+        libsnmp-dev=5.9+dfsg-3+b1 \
         default-libmysqlclient-dev \
         libssl-dev \
         libperl-dev \

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -274,6 +274,7 @@ RUN apt-get update && apt-get install -y \
         python3-pytest-cov \
         python3-parse \
 # For snmpd
+        libnetsnmptrapd40=5.9+dfsg-3+b1 \
         default-libmysqlclient-dev \
         libssl-dev \
         libperl-dev \

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -276,7 +276,6 @@ RUN apt-get update && apt-get install -y \
 # For snmpd
         libnetsnmptrapd40=5.9+dfsg-3+b1 \
         libsnmp40=5.9+dfsg-3+b1 \
-        libsnmp-dev=5.9+dfsg-3+b1 \
         default-libmysqlclient-dev \
         libssl-dev \
         libperl-dev \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix package dependency issue.
libsnmp-dev depends on libnetsnmptrapd40:amd64=5.9+dfsg-3+b1
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

