### PR TITLE
Adding support for get/set low power mode for QSFPs in PDDF common APIs

### DIFF
--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
@@ -204,10 +204,10 @@ class PddfSfp(SfpOptoeBase):
                     lpmode = super().get_lpmode()
                 elif xcvr_id == 0x11 or xcvr_id == 0x0d or xcvr_id == 0x0c:
                     # QSFP28, QSFP+, QSFP
-                    val = self.read_eeprom(QSFP_PWR_CTRL_ADDR, 1)
-                    if val is not None:
-                        if (ord(val) & 0x3) == 0x3:
-                            lpmode = True
+                    power_set = self.get_power_set()
+                    power_override = self.get_power_override()
+                    # By default the lpmode pin is pulled high as mentioned in the sff community
+                    return power_set if power_override else True
 
         return lpmode
 
@@ -341,12 +341,10 @@ class PddfSfp(SfpOptoeBase):
                     status = super().set_lpmode(lpmode)
                 elif xcvr_id == 0x11 or xcvr_id == 0x0d or xcvr_id == 0x0c:
                     # QSFP28, QSFP+, QSFP
-                    val = self.read_eeprom(QSFP_PWR_CTRL_ADDR, 1)
-                    if val is not None:
-                        val = ord(val) & 0xf0
-                        val |= 0x3 if lpmode else 0xd
-                        buf = bytearray([val])
-                        status = self.write_eeprom(QSFP_PWR_CTRL_ADDR, 1, buf)
+                    if lpmode is True:
+                        self.set_power_override(True, True)
+                    else:
+                        self.set_power_override(True, False)
 
         return status
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Issue#11785

Unable to get/set low power mode for QSFP28 and QSFP+

Platforms which use PDDF have common PDDF platform APIs. Since sfp_refactor framework takes care of only CMIS transceivers and platform APIs are supposed to take care of the low power mode for QSFPs.

#### How I did it
Modified pddf_sfp.py to include get/set APIs for lpmode in case of QSFP

#### How to verify it

> sfputil show lpmode
> sfputil lpmode on/off <>

LOGS:

```
>>> platform_chassis.get_sfp(55).set_lpmode(True)

True

>>> 

>>> platform_chassis.get_sfp(55).get_lpmode()

True

>>> platform_chassis.get_sfp(55).set_lpmode(False)

True

>>> 

>>> platform_chassis.get_sfp(55).get_lpmode()

False
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

