### PR TITLE
[arping] install arping utility in the base image

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -344,6 +344,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     python3-apt             \
     traceroute              \
     iputils-ping            \
+    arping                  \
     net-tools               \
     bsdmainutils            \
     ca-certificates         \


### PR DESCRIPTION
#### Why I did it
We need to validate arp response in some cases.

#### How I did it
Install the arping tool in the base image.

#### How to verify it
This PR test.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
