### PR TITLE
Add python-is-python3 package for broadcom syncd docker container

### DIFF
--- a/platform/broadcom/docker-syncd-brcm-dnx/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm-dnx/Dockerfile.j2
@@ -23,7 +23,8 @@ debs/
 RUN apt-get install -yf kmod
 
 ## BRCM uses ethtool to set host interface speed
-RUN apt-get install -y ethtool
+RUN apt-get install -y ethtool \
+    python-is-python3
 
 COPY ["files/dsserve", "files/bcmcmd", "start.sh", "start_led.sh", "bcmsh", "/usr/bin/"]
 RUN chmod +x /usr/bin/dsserve /usr/bin/bcmcmd

--- a/platform/broadcom/docker-syncd-brcm/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm/Dockerfile.j2
@@ -23,7 +23,8 @@ debs/
 RUN apt-get install -yf kmod
 
 ## BRCM uses ethtool to set host interface speed
-RUN apt-get install -y ethtool
+RUN apt-get install -y ethtool \
+    python-is-python3
 
 COPY ["files/dsserve", "files/bcmcmd", "start.sh", "start_led.sh", "bcmsh", "/usr/bin/"]
 RUN chmod +x /usr/bin/dsserve /usr/bin/bcmcmd


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In latest `syncd` container, it is installed bullseye, can't find command '`/usr/bin/python`'.
Some scripts such as `test_copp` still calls `/usr/bin/python` in `syncd`.

#### How I did it
Install `python-is-python3` package to resolve this issue, whatever run python or python3, it will both run `/usr/bin/python3`, will not cause the error of can't find command '`/usr/bin/python`' 
#### How to verify it
run `python` in syncd container.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

