### PR TITLE
[rsyslog/rsyslog.d]: Rsyslogd config to reduce disk writes.

### DIFF
--- a/files/image_config/rsyslog/rsyslog.d/00-sonic.conf
+++ b/files/image_config/rsyslog/rsyslog.d/00-sonic.conf
@@ -13,12 +13,12 @@ if re_match($programname, "bgp[0-9]*#bgpd") then {
 ## Teamd rules
 
 if $programname contains "teamd_" then {
-    /var/log/teamd.log
+    action(type="omfile" file="/var/log/teamd.log" flushOnTXEnd="off" asyncWriting="on" flushInterval="5" ioBufferSize="64k")
     stop
 }
 
 ## telemetry rules
-if $msg startswith  " telemetry" or ($msg startswith  " dialout" )then {
-    /var/log/telemetry.log
+if (($msg startswith  " telemetry") or ($msg startswith  " dialout" )) then {
+    action(type="omfile" file="/var/log/telemetry.log" flushOnTXEnd="off" asyncWriting="on" flushInterval="5" ioBufferSize="64k")
     stop
 }

--- a/files/image_config/rsyslog/rsyslog.d/99-default.conf
+++ b/files/image_config/rsyslog/rsyslog.d/99-default.conf
@@ -4,9 +4,13 @@
 
 # Log all facilities to /var/log/syslog except cron, auth
 # and authpriv. They are noisy - log them to their own files
-*.*;cron,auth,authpriv.none     -/var/log/syslog
-auth,authpriv.*                 /var/log/auth.log
-cron.*                          /var/log/cron.log
+if (($syslogfacility-text == "auth") or ($syslogfacility-text == "authpriv")) then {
+        action(type="omfile" file="/var/log/auth.log" flushOnTXEnd="off" asyncWriting="on" flushInterval="5" ioBufferSize="64k")
+} else if (($syslogfacility-text == "cron")) then {
+        action(type="omfile" file="/var/log/cron.log" flushOnTXEnd="off" asyncWriting="on" flushInterval="5" ioBufferSize="64k")
+} else {
+        action(type="omfile" file="/var/log/syslog"   flushOnTXEnd="off" asyncWriting="on" flushInterval="5" ioBufferSize="64k")
+}
 
 #
 # Emergencies are sent to everybody logged in.

--- a/files/image_config/rsyslog/rsyslog.d/99-default.conf
+++ b/files/image_config/rsyslog/rsyslog.d/99-default.conf
@@ -5,11 +5,11 @@
 # Log all facilities to /var/log/syslog except cron, auth
 # and authpriv. They are noisy - log them to their own files
 if (($syslogfacility-text == "auth") or ($syslogfacility-text == "authpriv")) then {
-        action(type="omfile" file="/var/log/auth.log" flushOnTXEnd="off" asyncWriting="on" flushInterval="5" ioBufferSize="64k")
+    action(type="omfile" file="/var/log/auth.log" flushOnTXEnd="off" asyncWriting="on" flushInterval="5" ioBufferSize="64k")
 } else if (($syslogfacility-text == "cron")) then {
-        action(type="omfile" file="/var/log/cron.log" flushOnTXEnd="off" asyncWriting="on" flushInterval="5" ioBufferSize="64k")
+    action(type="omfile" file="/var/log/cron.log" flushOnTXEnd="off" asyncWriting="on" flushInterval="5" ioBufferSize="64k")
 } else {
-        action(type="omfile" file="/var/log/syslog"   flushOnTXEnd="off" asyncWriting="on" flushInterval="5" ioBufferSize="64k")
+    action(type="omfile" file="/var/log/syslog"   flushOnTXEnd="off" asyncWriting="on" flushInterval="5" ioBufferSize="64k")
 }
 
 #


### PR DESCRIPTION
Changes:
-- Added action queue config for teamd, telemetry,
   auth, cron and syslog to reduce disk writes.

Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
[rsyslog/rsyslog.d]: Rsyslogd config to reduce disk writes.

See detailed explanation and testing at:
https://github.com/praveen-li/equilibrium/blob/main/rsyslog/rsyslog_config.md

#### How I did it

-- Added action queue config for teamd, telemetry,
   auth, cron and syslog to reduce disk writes.

#### How to verify it

See detailed explanation and testing at:
https://github.com/praveen-li/equilibrium/blob/main/rsyslog/rsyslog_config.md


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

