### PR TITLE
[mux] Exit to write standby state to `active-active` ports

### DIFF
--- a/files/build_templates/mux.service.j2
+++ b/files/build_templates/mux.service.j2
@@ -14,7 +14,7 @@ ExecStartPre=/usr/local/bin/mark_dhcp_packet.py
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
-ExecStopPost=/usr/local/bin/write_standby.py
+ExecStopPost=/usr/local/bin/write_standby.py -a standby
 Restart=always
 RestartSec=30
 


### PR DESCRIPTION
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
After stopping the `mux` container, `show mux status` returns `active` for `active-active` ports, which should be in `standby` state.

#### How I did it
Let `mux` exit by calling `write_standby.py` with args to write `standby` for `active-active` ports.

#### How to verify it
Stop `mux` container and verify `active-active` ports are in `standby`.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

