### PR TITLE
Upgrade docker-sonic-mgmt base image from Ubuntu18.04 to 20.04

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -1,5 +1,5 @@
 {% set prefix = DEFAULT_CONTAINER_REGISTRY %}
-FROM {{ prefix }}ubuntu:18.04
+FROM {{ prefix }}ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -21,8 +21,6 @@ RUN apt-get update && apt-get install -y build-essential \
                                          psmisc \
                                          python \
                                          python-dev \
-                                         python-scapy \
-                                         python-pip \
                                          python3-pip \
                                          python3-venv \
                                          rsyslog \
@@ -31,10 +29,16 @@ RUN apt-get update && apt-get install -y build-essential \
                                          sudo \
                                          tcpdump \
                                          telnet \
-                                         vim
+                                         vim \
+                                         python-is-python2 \
+                                         software-properties-common
+
+RUN add-apt-repository -y universe
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py \
+    && python2 get-pip.py
 
 RUN pip install setuptools==44.1.1
-RUN pip install cffi==1.10.0 \
+RUN pip install cffi==1.12.0 \
                 contextlib2==0.6.0.post1 \
                 cryptography==3.3.2 \
                 "future>=0.16.0" \
@@ -96,7 +100,7 @@ RUN pip install cffi==1.10.0 \
     && rm -f 1.0.0.tar.gz  \
     && pip install nnpy    \
     && pip install dpkt    \
-    && pip install scapy==2.4.5 --upgrade
+    && pip install scapy==2.4.5 --upgrade --ignore-installed
 
 # Install docker-ce-cli
 RUN apt-get update                  \
@@ -127,7 +131,7 @@ debs/{{ deb }}{{' '}}
 {%- endfor -%}
 debs/
 
-RUN dpkg -i \
+RUN dpkg --force-all -i \
 {% for deb in docker_sonic_mgmt_debs.split(' ') -%}
 debs/{{ deb }}{{' '}}
 {%- endfor %}
@@ -193,8 +197,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONIOENCODING=UTF-8
 
-RUN python3 -m pip install --upgrade --ignore-installed pip setuptools==58.4.0
-
+RUN python3 -m pip install --upgrade --ignore-installed pip setuptools==58.4.0 wheel==0.33.6
 RUN python3 -m pip install setuptools-rust \
                             aiohttp \
                             defusedxml \
@@ -237,7 +240,6 @@ RUN python3 -m pip install setuptools-rust \
                             tabulate \
                             textfsm==1.1.2 \
                             virtualenv \
-                            wheel==0.33.6 \
                             pysubnettree \
                             nnpy \
                             dpkt \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In order to support Python3 migration of docker-sonic-mgmt, the docker base image should be upgrade first.

#### How I did it
Modify docker build file(docker-sonic-mgmt/Dockerfile.j2):
1. Update base image from ubuntu18.04 to ubuntu20.04
2. Fix necessary dependencies.

#### How to verify it
Randomly select supported testbed, manually run a few tests and all pass:
fib/test_fib.py
vxlan/test_vxlan_decap.py
fdb/test_fdb.py
decap/test_decap.py
pfcwd/test_pfcwd_all_port_storm.py
acl/null_route/test_null_route_helper.py 
acl/test_acl.py
vlan/test_vlan.py
platform_tests/test_reboot.py
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[None-xoff_1]

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update docker-sonic-mgmt/Dockerfile.j2. After upgrade, Py2 is 2.7.18, Py3 is 3.8.10, Ubuntu is 20.04.

