### PR TITLE
[Arista] Enable AN for Ethernet24-47 on 720DT-48S

### DIFF
--- a/device/arista/x86_64-arista_720dt_48s/Arista-720DT-48S/hwsku.json
+++ b/device/arista/x86_64-arista_720dt_48s/Arista-720DT-48S/hwsku.json
@@ -98,98 +98,122 @@
         },
         "Ethernet24": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet25": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet26": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet27": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet28": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet29": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet30": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet31": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet32": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet33": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet34": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet35": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet36": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet37": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet38": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet39": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet40": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet41": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet42": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet43": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet44": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet45": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet46": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet47": {
             "default_brkout_mode": "1x1G",
+            "autoneg": "on",
             "port_type": "RJ45"
         },
         "Ethernet48": {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes link training issue seen on 720DT-48S running SONiC image using SAI 7.1.7.1 that causes orchagent to crash

#### How I did it
Update hwsku.json to set autoneg to "on" for Ethernet24-47.

#### How to verify it
Verified on 720DT-48S platform that orchagent does not exit, all links are up.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

