### PR TITLE
[ci] Fix vs build issue that no space left in /tmp folder

### DIFF
--- a/.azure-pipelines/official-build.yml
+++ b/.azure-pipelines/official-build.yml
@@ -36,6 +36,8 @@ stages:
 - stage: Build
   pool: sonicbld
   variables:
+  - name: DOCKER_BUILDER_USER_MOUNT
+    value: /data/dockertmp:/tmp:rw
   - name: CACHE_MODE
     value: wcache
   - template: azure-pipelines-repd-build-variables.yml
@@ -46,3 +48,9 @@ stages:
       jobFilters: none
       ${{ if contains(variables['Build.DefinitionName'], 'cross') }}:
         qemuOrCrossBuild: true
+      preSteps:
+      - script: |
+          set -ex
+          sudo mkdir -p /data/dockertmp
+          sudo chown $(whoami):$(whoami) /data/dockertmp
+        displayName: Mount for tmp


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
VS image is getting bigger.
AZP agent OS disk is not big enough.
Use data disk to build.
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

