### PR TITLE
[SAIServer] support saiserver v2 in bullseye

### DIFF
--- a/platform/broadcom/docker-saiserver-brcm/Dockerfile.j2
+++ b/platform/broadcom/docker-saiserver-brcm/Dockerfile.j2
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get -y install  \
     gdb                 \
-    libboost-atomic1.71.0
+    libboost-atomic1.74.0
 
 COPY \
 {% for deb in docker_saiserver_brcm_debs.split(' ') -%}

--- a/platform/mellanox/docker-saiserver-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-saiserver-mlnx/Dockerfile.j2
@@ -27,7 +27,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get -y install  \
     gdb                 \
-    libboost-atomic1.71.0
+    libboost-atomic1.74.0
 
 COPY \
 {% for deb in docker_saiserver_mlnx_debs.split(' ') -%}


### PR DESCRIPTION
Upgrade libboost-atomic1.71 to libboost-atomic1.74

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Upgrade libboost-atomic1.71 to libboost-atomic1.74
#### How I did it
Upgrade libboost-atomic1.71 to libboost-atomic1.74
#### How to verify it
local build with NOSTRETCH=y NOJESSIE=y NOBUSTER=y SAITHRIFT_V2=y make target/docker-saiserverv2-brcm.gz
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

