### PR TITLE
[gbsyncd] Add mount directory /var/warmboot in docker gbsyncd

### DIFF
--- a/platform/components/docker-gbsyncd-broncos.mk
+++ b/platform/components/docker-gbsyncd-broncos.mk
@@ -30,6 +30,7 @@ $(DOCKER_GBSYNCD_BRONCOS)_CONTAINER_NAME = gbsyncd
 $(DOCKER_GBSYNCD_BRONCOS)_RUN_OPT += --privileged -t
 $(DOCKER_GBSYNCD_BRONCOS)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_GBSYNCD_BRONCOS)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_GBSYNCD_BRONCOS)_RUN_OPT += -v /host/warmboot:/var/warmboot
 
 SONIC_ONLINE_DEBS += $(LIBSAI_BRONCOS)
 

--- a/platform/template/docker-gbsyncd-base.mk
+++ b/platform/template/docker-gbsyncd-base.mk
@@ -27,3 +27,4 @@ $(DOCKER_GBSYNCD_BASE)_CONTAINER_NAME = gbsyncd
 $(DOCKER_GBSYNCD_BASE)_RUN_OPT += --privileged -t
 $(DOCKER_GBSYNCD_BASE)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_GBSYNCD_BASE)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_GBSYNCD_BASE)_RUN_OPT += -v /host/warmboot:/var/warmboot


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The directory `/var/warmboot` as top directory for warmboot feature is also needed in docker gbsyncd. Some vendor SAI might save data under it. Without it, the SAI init/creation API failure has happened on PikeZ platform.

#### How I did it
Mount host directory /host/warmboot as /var/warmboot in docker gbsyncd, which is same as what it has done on docker syncd.

#### How to verify it
The directory /var/warmboot exists in docker gbsyncd.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

