### PR TITLE
[system health daemon] Support PSU power threshold checking

### DIFF
--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -239,6 +239,18 @@ class HardwareChecker(HealthChecker):
                                                                                                                voltage_min_th,
                                                                                                                voltage_max_th))
                         continue
+
+            if not self._ignore_check(config.ignore_devices, 'psu', name, 'power_threshold'):
+                power_overload = data_dict.get('power_overload', None)
+                if power_overload == 'True':
+                    try:
+                        power = data_dict['power']
+                        power_critical_threshold = data_dict['power_critical_threshold']
+                        self.set_object_not_ok('PSU', name, 'power of {} ({}w) exceeds threshold ({}w)'.format(name, power, power_critical_threshold))
+                    except KeyError:
+                        self.set_object_not_ok('PSU', name, 'power of {} exceeds threshold but power or power_critical_threshold does not invalid'.format(name))
+                    continue
+
             self.set_object_ok('PSU', name)
 
     def reset(self):

--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -248,7 +248,7 @@ class HardwareChecker(HealthChecker):
                         power_critical_threshold = data_dict['power_critical_threshold']
                         self.set_object_not_ok('PSU', name, 'power of {} ({}w) exceeds threshold ({}w)'.format(name, power, power_critical_threshold))
                     except KeyError:
-                        self.set_object_not_ok('PSU', name, 'power of {} exceeds threshold but power or power_critical_threshold does not invalid'.format(name))
+                        self.set_object_not_ok('PSU', name, 'power of {} exceeds threshold but power or power_critical_threshold is not invalid'.format(name))
                     continue
 
             self.set_object_ok('PSU', name)

--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -248,7 +248,7 @@ class HardwareChecker(HealthChecker):
                         power_critical_threshold = data_dict['power_critical_threshold']
                         self.set_object_not_ok('PSU', name, 'power of {} ({}w) exceeds threshold ({}w)'.format(name, power, power_critical_threshold))
                     except KeyError:
-                        self.set_object_not_ok('PSU', name, 'power of {} exceeds threshold but power or power_critical_threshold is not invalid'.format(name))
+                        self.set_object_not_ok('PSU', name, 'power of {} exceeds threshold but power or power_critical_threshold is invalid'.format(name))
                     continue
 
             self.set_object_ok('PSU', name)

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -374,7 +374,7 @@ def test_hardware_checker():
             'power_overload': 'True',
             'power': '101.0',
             'power_critical_threshold': '100.0',
-            'power_threshold': '90.0'
+            'power_warning_threshold': '90.0'
         },
         'PSU_INFO|PSU 7': {
             'presence': 'True',

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -362,6 +362,30 @@ def test_hardware_checker():
             'voltage': '10',
             'voltage_min_threshold': '12',
             'voltage_max_threshold': '15',
+        },
+        'PSU_INFO|PSU 6': {
+            'presence': 'True',
+            'status': 'True',
+            'temp': '55',
+            'temp_threshold': '100',
+            'voltage': '10',
+            'voltage_min_threshold': '12',
+            'voltage_max_threshold': '15',
+            'power_overload': 'True',
+            'power': '101.0',
+            'power_critical_threshold': '100.0',
+            'power_threshold': '90.0'
+        },
+        'PSU_INFO|PSU 7': {
+            'presence': 'True',
+            'status': 'True',
+            'temp': '55',
+            'temp_threshold': '100',
+            'voltage': '10',
+            'voltage_min_threshold': '12',
+            'voltage_max_threshold': '15',
+            'power_overload': 'True',
+            'power': '101.0'
         }
     })
 
@@ -399,6 +423,12 @@ def test_hardware_checker():
 
     assert 'PSU 5' in checker._info
     assert checker._info['PSU 5'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
+
+    assert 'PSU 6' in checker._info
+    assert checker._info['PSU 6'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
+
+    assert 'PSU 7' in checker._info
+    assert checker._info['PSU 7'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
 
 
 def test_config():

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -374,7 +374,7 @@ def test_hardware_checker():
             'power_overload': 'True',
             'power': '101.0',
             'power_critical_threshold': '100.0',
-            'power_warning_threshold': '90.0'
+            'power_warning_suppress_threshold': '90.0'
         },
         'PSU_INFO|PSU 7': {
             'presence': 'True',

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -368,7 +368,7 @@ def test_hardware_checker():
             'status': 'True',
             'temp': '55',
             'temp_threshold': '100',
-            'voltage': '10',
+            'voltage': '12',
             'voltage_min_threshold': '12',
             'voltage_max_threshold': '15',
             'power_overload': 'True',
@@ -381,7 +381,7 @@ def test_hardware_checker():
             'status': 'True',
             'temp': '55',
             'temp_threshold': '100',
-            'voltage': '10',
+            'voltage': '12',
             'voltage_min_threshold': '12',
             'voltage_max_threshold': '15',
             'power_overload': 'True',
@@ -425,10 +425,12 @@ def test_hardware_checker():
     assert checker._info['PSU 5'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
 
     assert 'PSU 6' in checker._info
+    assert checker._info['PSU 6'][HealthChecker.INFO_FIELD_OBJECT_MSG] == 'power of PSU 6 (101.0w) exceeds threshold (100.0w)'
     assert checker._info['PSU 6'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
 
     assert 'PSU 7' in checker._info
     assert checker._info['PSU 7'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
+    assert checker._info['PSU 7'][HealthChecker.INFO_FIELD_OBJECT_MSG] == 'power of PSU 7 exceeds threshold but power or power_critical_threshold does not invalid'
 
 
 def test_config():

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -430,7 +430,7 @@ def test_hardware_checker():
 
     assert 'PSU 7' in checker._info
     assert checker._info['PSU 7'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
-    assert checker._info['PSU 7'][HealthChecker.INFO_FIELD_OBJECT_MSG] == 'power of PSU 7 exceeds threshold but power or power_critical_threshold does not invalid'
+    assert checker._info['PSU 7'][HealthChecker.INFO_FIELD_OBJECT_MSG] == 'power of PSU 7 exceeds threshold but power or power_critical_threshold is invalid'
 
 
 def test_config():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Support PSU power threshold checking in the system health daemon.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

The system health daemon will check whether PSU's `power_overload` is `True` and treat it as not health if it is.

#### How to verify it

Unit test and regression test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

