### PR TITLE
[device/quanta] Mitigation for security vulnerability

### DIFF
--- a/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/plugins/psuutil.py
+++ b/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/plugins/psuutil.py
@@ -26,7 +26,7 @@ def show_log(txt):
 def exec_cmd(cmd, show):
     logging.info('Run :'+cmd)
     try:
-        output = subprocess.run(split(cmd), universal_newlines=True, capture_output=True).stdout
+        output = subprocess.run(split(cmd), universal_newlines=True, capture_output=True, check=True).stdout
         show_log(cmd + "output:"+str(output))
     except subprocess.CalledProcessError as e:
         logging.info("Failed :"+cmd)
@@ -46,7 +46,7 @@ def log_os_system(cmd, show):
     status = 1
     output = ""
     try:
-        output = subprocess.run(split(cmd), universal_newlines=True, capture_output=True).stdout
+        output = subprocess.run(split(cmd), universal_newlines=True, capture_output=True, check=True).stdout
         my_log(cmd + "output:"+str(output))
     except subprocess.CalledProcessError as e:
         logging.info('Failed :'+cmd)

--- a/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/plugins/psuutil.py
+++ b/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/plugins/psuutil.py
@@ -48,13 +48,12 @@ def log_os_system(cmd1_args, cmd2_args, show):
     status = 1
     output = ""
     try:
-        p1 = subprocess.Popen(cmd1_args, universal_newlines=True, stdout=subprocess.PIPE)
-        p2 = subprocess.Popen(cmd2_args, universal_newlines=True, stdin=p1.stdout, stdout=subprocess.PIPE)
-        p1.stdout.close()
-        output = p2.communicate()[0]
-        if p2.returncode == 1:
-            raise subprocess.CalledProcessError(returncode=p2.returncode, cmd=cmd, output=output)
-        my_log(cmd + "output:"+str(output))
+        with subprocess.Popen(cmd1_args, universal_newlines=True, stdout=subprocess.PIPE) as p1:
+            with subprocess.Popen(cmd2_args, universal_newlines=True, stdin=p1.stdout, stdout=subprocess.PIPE) as p2:
+                output = p2.communicate()[0]
+                if p2.returncode == 1:
+                    raise subprocess.CalledProcessError(returncode=p2.returncode, cmd=cmd, output=output)
+                my_log(cmd + "output:"+str(output))
     except subprocess.CalledProcessError as e:
         logging.info('Failed :'+cmd)
         if show:
@@ -63,7 +62,7 @@ def log_os_system(cmd1_args, cmd2_args, show):
 
 
 def gpio16_exist():
-    ls = log_os_system(["ls", "/sys/class/gpio/"], ["rep", "gpio16"], 0)
+    ls = log_os_system(["ls", "/sys/class/gpio/"], ["grep", "gpio16"], 0)
     logging.info('mods:'+ls)
     if len(ls) == 0:
         return False

--- a/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/plugins/psuutil.py
+++ b/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/plugins/psuutil.py
@@ -7,6 +7,7 @@
 import os.path
 import subprocess
 import logging
+from sonic_py_common.general import check_output_pipe
 
 try:
     from sonic_psu.psu_base import PsuBase
@@ -27,7 +28,7 @@ def exec_cmd(cmd_args, out_file, show):
     logging.info('Run :'+cmd)
     try:
         with open(out_file, 'w') as f:
-            output = subprocess.run(cmd_args, stdout=f, universal_newlines=True, check=True).stdout
+            output = subprocess.check_output(cmd_args, stdout=f, universal_newlines=True)
             show_log(cmd + "output:"+str(output))
     except subprocess.CalledProcessError as e:
         logging.info("Failed :"+cmd)
@@ -48,13 +49,8 @@ def log_os_system(cmd1_args, cmd2_args, show):
     status = 1
     output = ""
     try:
-        with subprocess.Popen(cmd1_args, universal_newlines=True, stdout=subprocess.PIPE) as p1:
-            with subprocess.Popen(cmd2_args, universal_newlines=True, stdin=p1.stdout, stdout=subprocess.PIPE) as p2:
-                output = p2.communicate()[0]
-                p1.wait()
-                if p1.returncode != 0 and p2.returncode != 0:
-                    raise subprocess.CalledProcessError(returncode=p2.returncode, cmd=cmd, output=output)
-                my_log(cmd + "output:"+str(output))
+        output = check_output_pipe(cmd1_args, cmd2_args)
+        my_log(cmd + "output:"+str(output))
     except subprocess.CalledProcessError as e:
         logging.info('Failed :'+cmd)
         if show:

--- a/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/plugins/psuutil.py
+++ b/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/plugins/psuutil.py
@@ -7,6 +7,7 @@
 import os.path
 import subprocess
 import logging
+from shlex import split
 
 try:
     from sonic_psu.psu_base import PsuBase
@@ -25,7 +26,7 @@ def show_log(txt):
 def exec_cmd(cmd, show):
     logging.info('Run :'+cmd)
     try:
-        output = subprocess.check_output(cmd, shell=True, universal_newlines=True)
+        output = subprocess.run(split(cmd), universal_newlines=True, capture_output=True).stdout
         show_log(cmd + "output:"+str(output))
     except subprocess.CalledProcessError as e:
         logging.info("Failed :"+cmd)
@@ -45,7 +46,7 @@ def log_os_system(cmd, show):
     status = 1
     output = ""
     try:
-        output = subprocess.check_output(cmd, shell=True, universal_newlines=True)
+        output = subprocess.run(split(cmd), universal_newlines=True, capture_output=True).stdout
         my_log(cmd + "output:"+str(output))
     except subprocess.CalledProcessError as e:
         logging.info('Failed :'+cmd)

--- a/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/plugins/psuutil.py
+++ b/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/plugins/psuutil.py
@@ -51,7 +51,8 @@ def log_os_system(cmd1_args, cmd2_args, show):
         with subprocess.Popen(cmd1_args, universal_newlines=True, stdout=subprocess.PIPE) as p1:
             with subprocess.Popen(cmd2_args, universal_newlines=True, stdin=p1.stdout, stdout=subprocess.PIPE) as p2:
                 output = p2.communicate()[0]
-                if p2.returncode != 0:
+                p1.wait()
+                if p1.returncode != 0 and p2.returncode != 0:
                     raise subprocess.CalledProcessError(returncode=p2.returncode, cmd=cmd, output=output)
                 my_log(cmd + "output:"+str(output))
     except subprocess.CalledProcessError as e:

--- a/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/plugins/psuutil.py
+++ b/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/plugins/psuutil.py
@@ -51,7 +51,7 @@ def log_os_system(cmd1_args, cmd2_args, show):
         with subprocess.Popen(cmd1_args, universal_newlines=True, stdout=subprocess.PIPE) as p1:
             with subprocess.Popen(cmd2_args, universal_newlines=True, stdin=p1.stdout, stdout=subprocess.PIPE) as p2:
                 output = p2.communicate()[0]
-                if p2.returncode == 1:
+                if p2.returncode != 0:
                     raise subprocess.CalledProcessError(returncode=p2.returncode, cmd=cmd, output=output)
                 my_log(cmd + "output:"+str(output))
     except subprocess.CalledProcessError as e:

--- a/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/plugins/psuutil.py
+++ b/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/plugins/psuutil.py
@@ -29,7 +29,7 @@ def exec_cmd(cmd, show):
     out_file = cmd.split('>')[1].strip()
     try:
         with open(out_file, 'w') as f:
-            output = subprocess.run(split(in_cmd), universal_newlines=True, check=True).stdout
+            output = subprocess.run(split(in_cmd), stdout=f, universal_newlines=True, check=True).stdout
             show_log(cmd + "output:"+str(output))
     except subprocess.CalledProcessError as e:
         logging.info("Failed :"+cmd)

--- a/platform/broadcom/sonic-platform-modules-quanta/ix1b-32x/utils/quanta_ix1b_util.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix1b-32x/utils/quanta_ix1b_util.py
@@ -27,22 +27,19 @@ command:
     clean       : uninstall drivers and remove related sysfs nodes    
 """
 
-import os
 import commands
 import sys, getopt
 import logging
-import re
 import time
-from collections import namedtuple
 
 DEBUG = False
 args = []
 FORCE = 0
 i2c_prefix = '/sys/bus/i2c/devices/'
 
-if DEBUG == True:
-    print sys.argv[0]
-    print 'ARGV      :', sys.argv[1:]
+if DEBUG is True:
+    print(sys.argv[0])
+    print('ARGV      :', sys.argv[1:])
 
 def main():
     global DEBUG
@@ -56,10 +53,10 @@ def main():
                                                        'debug',
                                                        'force',
                                                           ])
-    if DEBUG == True:
-        print options
-        print args
-        print len(sys.argv)
+    if DEBUG is True:
+        print(options)
+        print(args)
+        print(len(sys.argv))
 
     for opt, arg in options:
         if opt in ('-h', '--help'):
@@ -83,12 +80,12 @@ def main():
     return 0
 
 def show_help():
-    print __doc__ % {'scriptName' : sys.argv[0].split("/")[-1]}
+    print(__doc__ % {'scriptName' : sys.argv[0].split("/")[-1]})
     sys.exit(0)
 
 def show_log(txt):
-    if DEBUG == True:
-        print "[IX1B-32X]" + txt
+    if DEBUG is True:
+        print("[IX1B-32X]" + txt)
 
     return
 
@@ -165,7 +162,7 @@ def system_install():
         status, output = exec_cmd("modprobe " + drivers[i], 1)
 
     if status:
-        print output
+        print(output)
         if FORCE == 0:
             return status
 
@@ -174,7 +171,7 @@ def system_install():
         status, output = exec_cmd(instantiate[i], 1)
 
     if status:
-        print output
+        print(output)
         if FORCE == 0:
             return status
 
@@ -184,7 +181,9 @@ def system_install():
     #QSFP for 1~32 port
     for port_number in range(1, 33):
         bus_number = port_number + 31
-        os.system("echo %d >/sys/bus/i2c/devices/%d-0050/port_name" % (port_number, bus_number))
+        file = "/sys/bus/i2c/devices/%d-0050/port_name" % bus_number
+        with open(file, 'w') as f:
+            f.write(str(port_number) + '\n')
 
     #Set system LED to green
     status, output = exec_cmd("echo 1 > /sys/class/leds/sysled_green/brightness", 1)
@@ -199,14 +198,14 @@ def system_ready():
 
 def install():
     if not device_found():
-        print "No device, installing...."
+        print("No device, installing....")
         status = system_install()
 
         if status:
             if FORCE == 0:
                 return status
     else:
-        print " ix1b driver already installed...."
+        print(" ix1b driver already installed....")
 
     return
 
@@ -215,10 +214,10 @@ def uninstall():
 
     #uninstall drivers
     for i in range(len(drivers) - 1, -1, -1):
-       status, output = exec_cmd("rmmod " + drivers[i], 1)
+        status, output = exec_cmd("rmmod " + drivers[i], 1)
 
     if status:
-        print output
+        print(output)
         if FORCE == 0:
             return status
 

--- a/platform/broadcom/sonic-platform-modules-quanta/ix1b-32x/utils/quanta_ix1b_util.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix1b-32x/utils/quanta_ix1b_util.py
@@ -37,7 +37,7 @@ args = []
 FORCE = 0
 i2c_prefix = '/sys/bus/i2c/devices/'
 
-if DEBUG is True:
+if DEBUG == True:
     print(sys.argv[0])
     print('ARGV      :', sys.argv[1:])
 

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/sonic_platform/component.py
@@ -65,7 +65,7 @@ class Component(ComponentBase):
     def _get_command_result_pipe(cmd1, cmd2):
         try:
             rc, result = getstatusoutput_noshell_pipe(cmd1, cmd2)
-            if rc != 0:
+            if rc != [0, 0]:
                 raise RuntimeError("Failed to execute command {} {}, return code {}, {}".format(cmd1, cmd2, rc, result))
 
         except OSError as e:
@@ -194,7 +194,7 @@ class ComponentPCIE(Component):
     COMPONENT_NAME = 'PCIe'
     COMPONENT_DESCRIPTION = 'ASIC PCIe Firmware'
     PCIE_QUERY_VERSION_COMMAND1 = ["bcmcmd", 'pciephy fw version']
-    PCIE_QUERY_VERSION_COMMAND2 = ["grep" 'FW version']
+    PCIE_QUERY_VERSION_COMMAND2 = ["grep", 'FW version']
 
     def __init__(self):
         super(ComponentPCIE, self).__init__()

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/sonic_platform/component.py
@@ -14,6 +14,7 @@ try:
     import subprocess
     from sonic_platform_base.component_base import ComponentBase
     from collections import namedtuple
+    from sonic_py_common.general import getstatusoutput_noshell_pipe
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -47,7 +48,7 @@ class Component(ComponentBase):
         try:
             proc = subprocess.Popen(cmdline,
                                     stdout=subprocess.PIPE,
-                                    shell=True, stderr=subprocess.STDOUT,
+                                    stderr=subprocess.STDOUT,
                                     universal_newlines=True)
             stdout = proc.communicate()[0]
             rc = proc.wait()
@@ -60,12 +61,24 @@ class Component(ComponentBase):
 
         return result
 
+    @staticmethod
+    def _get_command_result_pipe(cmd1, cmd2):
+        try:
+            rc, result = getstatusoutput_noshell_pipe(cmd1, cmd2)
+            if rc != 0:
+                raise RuntimeError("Failed to execute command {} {}, return code {}, {}".format(cmd1, cmd2, rc, result))
+
+        except OSError as e:
+            raise RuntimeError("Failed to execute command {} {} due to {}".format(cmd1, cmd2, repr(e)))
+
+        return result
+
 
 class ComponentBIOS(Component):
     COMPONENT_NAME = 'BIOS'
     COMPONENT_DESCRIPTION = 'BIOS - Basic Input/Output System'
 
-    BIOS_QUERY_VERSION_COMMAND = "dmidecode -s bios-version"
+    BIOS_QUERY_VERSION_COMMAND = ["dmidecode", "-s", "bios-version"]
 
     def __init__(self):
         super(ComponentBIOS, self).__init__()
@@ -90,7 +103,8 @@ class ComponentBIOS(Component):
 class ComponentBMC(Component):
     COMPONENT_NAME = 'BMC'
     COMPONENT_DESCRIPTION = 'BMC - Board Management Controller'
-    BMC_QUERY_VERSION_COMMAND = "ipmitool mc info | grep 'Firmware Revision'"
+    BMC_QUERY_VERSION_COMMAND1 = ["ipmitool", "mc", "info"]
+    BMC_QUERY_VERSION_COMMAND2 = ["grep", 'Firmware Revision']
 
     def __init__(self):
         super(ComponentBMC, self).__init__()
@@ -105,7 +119,7 @@ class ComponentBMC(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        bmc_ver = self._get_command_result(self.BMC_QUERY_VERSION_COMMAND)
+        bmc_ver = self._get_command_result_pipe(self.BMC_QUERY_VERSION_COMMAND1, self.BMC_QUERY_VERSION_COMMAND2)
         if not bmc_ver:
             return 'ERR'
         else:
@@ -159,7 +173,7 @@ class ComponentCPLD(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        res = self._get_command_result("ipmitool raw 0x32 0xff 0x02 {}".format(self.cplds[self.index].cmd_index))
+        res = self._get_command_result(["ipmitool", "raw", "0x32", "0xff", "0x02", str(self.cplds[self.index].cmd_index)])
         if not res:
             return 'ERR'
         else:
@@ -179,7 +193,8 @@ class ComponentCPLD(Component):
 class ComponentPCIE(Component):
     COMPONENT_NAME = 'PCIe'
     COMPONENT_DESCRIPTION = 'ASIC PCIe Firmware'
-    PCIE_QUERY_VERSION_COMMAND = "bcmcmd 'pciephy fw version' | grep 'FW version'"
+    PCIE_QUERY_VERSION_COMMAND1 = ["bcmcmd", 'pciephy fw version']
+    PCIE_QUERY_VERSION_COMMAND2 = ["grep" 'FW version']
 
     def __init__(self):
         super(ComponentPCIE, self).__init__()
@@ -194,7 +209,7 @@ class ComponentPCIE(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        version = self._get_command_result(self.PCIE_QUERY_VERSION_COMMAND)
+        version = self._get_command_result_pipe(self.PCIE_QUERY_VERSION_COMMAND1, self.PCIE_QUERY_VERSION_COMMAND2)
         if not version:
             return 'ERR'
         else:

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/sonic_platform/sfp.py
@@ -1,3 +1,13 @@
+#!/usr/bin/env python
+
+#############################################################################
+# Quanta
+#
+# Sfp contains an implementation of SONiC Platform Base API and
+# provides the sfp device status which are available in the platform
+#
+#############################################################################
+
 import time
 import subprocess
 from ctypes import create_string_buffer

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/sonic_platform/sfp.py
@@ -1,24 +1,14 @@
-#!/usr/bin/env python
-
-#############################################################################
-# Quanta
-#
-# Sfp contains an implementation of SONiC Platform Base API and
-# provides the sfp device status which are available in the platform
-#
-#############################################################################
-
-import os
 import time
+import subprocess
 from ctypes import create_string_buffer
 
 try:
-     from sonic_platform_base.sfp_base import SfpBase
-     from sonic_platform_base.sonic_sfp.sff8472 import sff8472InterfaceId
-     from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
-     from sonic_platform_base.sonic_sfp.sff8436 import sff8436InterfaceId
-     from sonic_platform_base.sonic_sfp.sff8436 import sff8436Dom
-     from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
+    from sonic_platform_base.sfp_base import SfpBase
+    from sonic_platform_base.sonic_sfp.sff8472 import sff8472InterfaceId
+    from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
+    from sonic_platform_base.sonic_sfp.sff8436 import sff8436InterfaceId
+    from sonic_platform_base.sonic_sfp.sff8436 import sff8436Dom
+    from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -163,7 +153,7 @@ class Sfp(SfpBase):
     # Path to QSFP sysfs
     PLATFORM_ROOT_PATH = "/usr/share/sonic/device"
     PMON_HWSKU_PATH = "/usr/share/sonic/hwsku"
-    HOST_CHK_CMD = "docker > /dev/null 2>&1"
+    HOST_CHK_CMD = ["docker"]
 
     PLATFORM = "x86_64-quanta_ix7_rglbmc-r0"
     HWSKU  = "Quanta-IX7-32X"
@@ -259,7 +249,7 @@ class Sfp(SfpBase):
             return 'N/A'
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/sonic_platform/sfp.py
@@ -259,7 +259,7 @@ class Sfp(SfpBase):
             return 'N/A'
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
+        return subprocess.call(self.HOST_CHK_CMD) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/utils/quanta_ix7_util.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/utils/quanta_ix7_util.py
@@ -27,7 +27,6 @@ command:
     clean       : uninstall drivers and remove related sysfs nodes
 """
 
-import os
 import subprocess
 import sys, getopt
 import logging
@@ -38,7 +37,7 @@ args = []
 FORCE = 0
 i2c_prefix = '/sys/bus/i2c/devices/'
 
-if DEBUG == True:
+if DEBUG is True:
     print(sys.argv[0])
     print('ARGV      :', sys.argv[1:])
 
@@ -54,7 +53,7 @@ def main():
                                                        'debug',
                                                        'force',
                                                           ])
-    if DEBUG == True:
+    if DEBUG is True:
         print(options)
         print(args)
         print(len(sys.argv))
@@ -84,7 +83,7 @@ def show_help():
     sys.exit(0)
 
 def show_log(txt):
-    if DEBUG == True:
+    if DEBUG is True:
         print("[IX7-32X]" + txt)
     return
 
@@ -204,7 +203,9 @@ def system_install():
     #QSFP for 1~32 port
     for port_number in range(1, 33):
         bus_number = port_number + 16
-        os.system("echo %d >/sys/bus/i2c/devices/%d-0050/port_name" % (port_number, bus_number))
+        file = "/sys/bus/i2c/devices/%d-0050/port_name" % bus_number
+        with open(file, 'w') as f:
+            f.write(str(port_number) + '\n')
     return
 
 

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/utils/quanta_ix7_util.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/utils/quanta_ix7_util.py
@@ -37,7 +37,7 @@ args = []
 FORCE = 0
 i2c_prefix = '/sys/bus/i2c/devices/'
 
-if DEBUG is True:
+if DEBUG == True:
     print(sys.argv[0])
     print('ARGV      :', sys.argv[1:])
 

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/sonic_platform/component.py
@@ -65,7 +65,7 @@ class Component(ComponentBase):
     def _get_command_result_pipe(cmd1, cmd2):
         try:
             rc, result = getstatusoutput_noshell_pipe(cmd1, cmd2)
-            if rc != 0:
+            if rc != [0, 0]:
                 raise RuntimeError("Failed to execute command {} {}, return code {}, {}".format(cmd1, cmd2, rc, result))
 
         except OSError as e:

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/sonic_platform/component.py
@@ -14,6 +14,7 @@ try:
     import subprocess
     from sonic_platform_base.component_base import ComponentBase
     from collections import namedtuple
+    from sonic_py_common.general import getstatusoutput_noshell_pipe
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -47,7 +48,7 @@ class Component(ComponentBase):
         try:
             proc = subprocess.Popen(cmdline,
                                     stdout=subprocess.PIPE,
-                                    shell=True, stderr=subprocess.STDOUT,
+                                    stderr=subprocess.STDOUT,
                                     universal_newlines=True)
             stdout = proc.communicate()[0]
             rc = proc.wait()
@@ -60,12 +61,24 @@ class Component(ComponentBase):
 
         return result
 
+    @staticmethod
+    def _get_command_result_pipe(cmd1, cmd2):
+        try:
+            rc, result = getstatusoutput_noshell_pipe(cmd1, cmd2)
+            if rc != 0:
+                raise RuntimeError("Failed to execute command {} {}, return code {}, {}".format(cmd1, cmd2, rc, result))
+
+        except OSError as e:
+            raise RuntimeError("Failed to execute command {} {} due to {}".format(cmd1, cmd2, repr(e)))
+
+        return result
+
 
 class ComponentBIOS(Component):
     COMPONENT_NAME = 'BIOS'
     COMPONENT_DESCRIPTION = 'BIOS - Basic Input/Output System'
 
-    BIOS_QUERY_VERSION_COMMAND = "dmidecode -s bios-version"
+    BIOS_QUERY_VERSION_COMMAND = ["dmidecode", "-s", "bios-version"]
 
     def __init__(self):
         super(ComponentBIOS, self).__init__()
@@ -90,7 +103,8 @@ class ComponentBIOS(Component):
 class ComponentBMC(Component):
     COMPONENT_NAME = 'BMC'
     COMPONENT_DESCRIPTION = 'BMC - Board Management Controller'
-    BMC_QUERY_VERSION_COMMAND = "ipmitool mc info | grep 'Firmware Revision'"
+    BMC_QUERY_VERSION_COMMAND1 = ["ipmitool", "mc", "info"]
+    BMC_QUERY_VERSION_COMMAND2 = ["grep", 'Firmware Revision']
 
     def __init__(self):
         super(ComponentBMC, self).__init__()
@@ -105,7 +119,7 @@ class ComponentBMC(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        bmc_ver = self._get_command_result(self.BMC_QUERY_VERSION_COMMAND)
+        bmc_ver = self._get_command_result_pipe(self.BMC_QUERY_VERSION_COMMAND1, self.BMC_QUERY_VERSION_COMMAND2)
         if not bmc_ver:
             return 'ERR'
         else:
@@ -158,9 +172,9 @@ class ComponentCPLD(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        self._get_command_result("ipmitool raw 0x30 0xe0 0xd0 0x01 0x01")
-        res = self._get_command_result("ipmitool raw 0x32 0xff 0x02 {}".format(self.cplds[self.index].cmd_index))
-        self._get_command_result("ipmitool raw 0x30 0xe0 0xd0 0x01 0x00")
+        self._get_command_result(["ipmitool", "raw", "0x30", "0xe0", "0xd0", "0x01", "0x01"])
+        res = self._get_command_result(["ipmitool", "raw", "0x32", "0xff", "0x02", str(self.cplds[self.index].cmd_index)])
+        self._get_command_result(["ipmitool", "raw", "0x30", "0xe0", "0xd0", "0x01", "0x00"])
         if not res:
             return 'ERR'
         else:
@@ -180,7 +194,8 @@ class ComponentCPLD(Component):
 class ComponentPCIE(Component):
     COMPONENT_NAME = 'PCIe'
     COMPONENT_DESCRIPTION = 'ASIC PCIe Firmware'
-    PCIE_QUERY_VERSION_COMMAND = "bcmcmd 'pciephy fw version' | grep 'FW version'"
+    PCIE_QUERY_VERSION_COMMAND1 = ["bcmcmd", 'pciephy fw version']
+    PCIE_QUERY_VERSION_COMMAND2 = ["grep", 'FW version']
 
     def __init__(self):
         super(ComponentPCIE, self).__init__()
@@ -195,7 +210,7 @@ class ComponentPCIE(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        version = self._get_command_result(self.PCIE_QUERY_VERSION_COMMAND)
+        version = self._get_command_result_pipe(self.PCIE_QUERY_VERSION_COMMAND1, self.PCIE_QUERY_VERSION_COMMAND2)
         if not version:
             return 'ERR'
         else:

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/sonic_platform/sfp.py
@@ -259,7 +259,7 @@ class Sfp(SfpBase):
             return 'N/A'
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
+        return subprocess.call(self.HOST_CHK_CMD) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/sonic_platform/sfp.py
@@ -8,17 +8,17 @@
 #
 #############################################################################
 
-import os
 import time
+import subprocess
 from ctypes import create_string_buffer
 
 try:
-     from sonic_platform_base.sfp_base import SfpBase
-     from sonic_platform_base.sonic_sfp.sff8472 import sff8472InterfaceId
-     from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
-     from sonic_platform_base.sonic_sfp.sff8436 import sff8436InterfaceId
-     from sonic_platform_base.sonic_sfp.sff8436 import sff8436Dom
-     from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
+    from sonic_platform_base.sfp_base import SfpBase
+    from sonic_platform_base.sonic_sfp.sff8472 import sff8472InterfaceId
+    from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
+    from sonic_platform_base.sonic_sfp.sff8436 import sff8436InterfaceId
+    from sonic_platform_base.sonic_sfp.sff8436 import sff8436Dom
+    from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -163,7 +163,7 @@ class Sfp(SfpBase):
     # Path to QSFP sysfs
     PLATFORM_ROOT_PATH = "/usr/share/sonic/device"
     PMON_HWSKU_PATH = "/usr/share/sonic/hwsku"
-    HOST_CHK_CMD = "docker > /dev/null 2>&1"
+    HOST_CHK_CMD = ["docker"]
 
     PLATFORM = "x86_64-quanta_ix7_bwde-r0"
     HWSKU  = "Quanta-IX7-BWDE-32X"
@@ -259,7 +259,7 @@ class Sfp(SfpBase):
             return 'N/A'
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/utils/quanta_ix7_bwde_util.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/utils/quanta_ix7_bwde_util.py
@@ -37,7 +37,7 @@ args = []
 FORCE = 0
 i2c_prefix = '/sys/bus/i2c/devices/'
 
-if DEBUG is True:
+if DEBUG == True:
     print(sys.argv[0])
     print('ARGV      :', sys.argv[1:])
 

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/utils/quanta_ix7_bwde_util.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/utils/quanta_ix7_bwde_util.py
@@ -27,7 +27,6 @@ command:
     clean       : uninstall drivers and remove related sysfs nodes
 """
 
-import os
 import subprocess
 import sys, getopt
 import logging
@@ -38,7 +37,7 @@ args = []
 FORCE = 0
 i2c_prefix = '/sys/bus/i2c/devices/'
 
-if DEBUG == True:
+if DEBUG is True:
     print(sys.argv[0])
     print('ARGV      :', sys.argv[1:])
 
@@ -54,7 +53,7 @@ def main():
                                                        'debug',
                                                        'force',
                                                           ])
-    if DEBUG == True:
+    if DEBUG is True:
         print(options)
         print(args)
         print(len(sys.argv))
@@ -84,7 +83,7 @@ def show_help():
     sys.exit(0)
 
 def show_log(txt):
-    if DEBUG == True:
+    if DEBUG is True:
         print("[IX7-BWDE-32X]"+txt)
     return
 
@@ -203,7 +202,9 @@ def system_install():
     #QSFP for 1~32 port
     for port_number in range(1, 33):
         bus_number = port_number + 12
-        os.system("echo %d >/sys/bus/i2c/devices/%d-0050/port_name" % (port_number, bus_number))
+        file = "/sys/bus/i2c/devices/%d-0050/port_name" % bus_number
+        with open(file, 'w') as f:
+            f.write(str(port_number) + '\n')
 
     status, output = exec_cmd("pip3 install  /usr/share/sonic/device/x86_64-quanta_ix7_bwde-r0/sonic_platform-1.0-py3-none-any.whl",1)
     if status:

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/sonic_platform/component.py
@@ -14,6 +14,7 @@ try:
     import subprocess
     from sonic_platform_base.component_base import ComponentBase
     from collections import namedtuple
+    from sonic_py_common.general import getstatusoutput_noshell_pipe
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -47,7 +48,7 @@ class Component(ComponentBase):
         try:
             proc = subprocess.Popen(cmdline,
                                     stdout=subprocess.PIPE,
-                                    shell=True, stderr=subprocess.STDOUT,
+                                    stderr=subprocess.STDOUT,
                                     universal_newlines=True)
             stdout = proc.communicate()[0]
             rc = proc.wait()
@@ -60,12 +61,24 @@ class Component(ComponentBase):
 
         return result
 
+    @staticmethod
+    def _get_command_result_pipe(cmd1, cmd2):
+        try:
+            rc, result = getstatusoutput_noshell_pipe(cmd1, cmd2)
+            if rc != 0:
+                raise RuntimeError("Failed to execute command {} {}, return code {}, {}".format(cmd1, cmd2, rc, result))
+
+        except OSError as e:
+            raise RuntimeError("Failed to execute command {} {} due to {}".format(cmd1, cmd2, repr(e)))
+
+        return result
+
 
 class ComponentBIOS(Component):
     COMPONENT_NAME = 'BIOS'
     COMPONENT_DESCRIPTION = 'BIOS - Basic Input/Output System'
 
-    BIOS_QUERY_VERSION_COMMAND = "dmidecode -s bios-version"
+    BIOS_QUERY_VERSION_COMMAND = ["dmidecode", "-s", "bios-version"]
 
     def __init__(self):
         super(ComponentBIOS, self).__init__()
@@ -90,7 +103,8 @@ class ComponentBIOS(Component):
 class ComponentBMC(Component):
     COMPONENT_NAME = 'BMC'
     COMPONENT_DESCRIPTION = 'BMC - Board Management Controller'
-    BMC_QUERY_VERSION_COMMAND = "ipmitool mc info | grep 'Firmware Revision'"
+    BMC_QUERY_VERSION_COMMAND1 = ["ipmitool", "mc", "info"]
+    BMC_QUERY_VERSION_COMMAND2 = ["grep", 'Firmware Revision']
 
     def __init__(self):
         super(ComponentBMC, self).__init__()
@@ -105,7 +119,7 @@ class ComponentBMC(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        bmc_ver = self._get_command_result(self.BMC_QUERY_VERSION_COMMAND)
+        bmc_ver = self._get_command_result_pipe(self.BMC_QUERY_VERSION_COMMAND1, self.BMC_QUERY_VERSION_COMMAND2)
         if not bmc_ver:
             return 'ERR'
         else:
@@ -160,7 +174,7 @@ class ComponentCPLD(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        res = self._get_command_result("ipmitool raw 0x32 0xff 0x02 {}".format(self.cplds[self.index].cmd_index))
+        res = self._get_command_result(["ipmitool", "raw", "0x32", "0xff", "0x02", str(self.cplds[self.index].cmd_index)])
         if not res:
             return 'ERR'
         else:
@@ -180,7 +194,8 @@ class ComponentCPLD(Component):
 class ComponentPCIE(Component):
     COMPONENT_NAME = 'PCIe'
     COMPONENT_DESCRIPTION = 'ASIC PCIe Firmware'
-    PCIE_QUERY_VERSION_COMMAND = "bcmcmd 'pciephy fw version' | grep 'FW version'"
+    PCIE_QUERY_VERSION_COMMAND1 = ["bcmcmd", 'pciephy fw version']
+    PCIE_QUERY_VERSION_COMMAND2 = ["grep", 'FW version']
 
     def __init__(self):
         super(ComponentPCIE, self).__init__()
@@ -195,7 +210,7 @@ class ComponentPCIE(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        version = self._get_command_result(self.PCIE_QUERY_VERSION_COMMAND)
+        version = self._get_command_result_pipe(self.PCIE_QUERY_VERSION_COMMAND1, self.PCIE_QUERY_VERSION_COMMAND2)
         if not version:
             return 'ERR'
         else:

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/sonic_platform/component.py
@@ -65,7 +65,7 @@ class Component(ComponentBase):
     def _get_command_result_pipe(cmd1, cmd2):
         try:
             rc, result = getstatusoutput_noshell_pipe(cmd1, cmd2)
-            if rc != 0:
+            if rc != [0, 0]:
                 raise RuntimeError("Failed to execute command {} {}, return code {}, {}".format(cmd1, cmd2, rc, result))
 
         except OSError as e:

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/sonic_platform/sfp.py
@@ -281,7 +281,7 @@ class Sfp(SfpBase):
             return 'N/A'
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
+        return subprocess.call(self.HOST_CHK_CMD) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/sonic_platform/sfp.py
@@ -8,17 +8,17 @@
 #
 #############################################################################
 
-import os
 import time
+import subprocess
 from ctypes import create_string_buffer
 
 try:
-     from sonic_platform_base.sfp_base import SfpBase
-     from sonic_platform_base.sonic_sfp.sff8472 import sff8472InterfaceId
-     from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
-     from sonic_platform_base.sonic_sfp.sff8436 import sff8436InterfaceId
-     from sonic_platform_base.sonic_sfp.sff8436 import sff8436Dom
-     from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
+    from sonic_platform_base.sfp_base import SfpBase
+    from sonic_platform_base.sonic_sfp.sff8472 import sff8472InterfaceId
+    from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
+    from sonic_platform_base.sonic_sfp.sff8436 import sff8436InterfaceId
+    from sonic_platform_base.sonic_sfp.sff8436 import sff8436Dom
+    from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -163,7 +163,7 @@ class Sfp(SfpBase):
     # Path to QSFP sysfs
     PLATFORM_ROOT_PATH = "/usr/share/sonic/device"
     PMON_HWSKU_PATH = "/usr/share/sonic/hwsku"
-    HOST_CHK_CMD = "docker > /dev/null 2>&1"
+    HOST_CHK_CMD = ["docker"]
 
     PLATFORM = "x86_64-quanta_ix8_rglbmc-r0"
     HWSKU  = "Quanta-IX8-56X"
@@ -281,7 +281,7 @@ class Sfp(SfpBase):
             return 'N/A'
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/utils/quanta_ix8_util.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/utils/quanta_ix8_util.py
@@ -37,7 +37,7 @@ args = []
 FORCE = 0
 i2c_prefix = '/sys/bus/i2c/devices/'
 
-if DEBUG is True:
+if DEBUG == True:
     print(sys.argv[0])
     print('ARGV      :', sys.argv[1:])
 

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/utils/quanta_ix8_util.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/utils/quanta_ix8_util.py
@@ -27,7 +27,6 @@ command:
     clean       : uninstall drivers and remove related sysfs nodes
 """
 
-import os
 import subprocess
 import sys, getopt
 import logging
@@ -38,7 +37,7 @@ args = []
 FORCE = 0
 i2c_prefix = '/sys/bus/i2c/devices/'
 
-if DEBUG == True:
+if DEBUG is True:
     print(sys.argv[0])
     print('ARGV      :', sys.argv[1:])
 
@@ -54,7 +53,7 @@ def main():
                                                        'debug',
                                                        'force',
                                                           ])
-    if DEBUG == True:
+    if DEBUG is True:
         print(options)
         print(args)
         print(len(sys.argv))
@@ -84,7 +83,7 @@ def show_help():
     sys.exit(0)
 
 def show_log(txt):
-    if DEBUG == True:
+    if DEBUG is True:
         print("[IX8-56X]" + txt)
     return
 
@@ -301,7 +300,9 @@ def system_install():
     #QSFP for 1~56 port
     for port_number in range(1, 57):
         bus_number = port_number + 16
-        os.system("echo %d >/sys/bus/i2c/devices/%d-0050/port_name" % (port_number, bus_number))
+        file = "/sys/bus/i2c/devices/%d-0050/port_name" % bus_number
+        with open(file, 'w') as f:
+            f.write(str(port_number) + '\n')
 
     status, output = exec_cmd("pip3 install  /usr/share/sonic/device/x86_64-quanta_ix8_rglbmc-r0/sonic_platform-1.0-py3-none-any.whl",1)
     if status:

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/sonic_platform/component.py
@@ -65,7 +65,7 @@ class Component(ComponentBase):
     def _get_command_result_pipe(cmd1, cmd2):
         try:
             rc, result = getstatusoutput_noshell_pipe(cmd1, cmd2)
-            if rc != 0:
+            if rc != [0, 0]:
                 raise RuntimeError("Failed to execute command {} {}, return code {}, {}".format(cmd1, cmd2, rc, result))
 
         except OSError as e:

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/sonic_platform/component.py
@@ -14,6 +14,7 @@ try:
     import subprocess
     from sonic_platform_base.component_base import ComponentBase
     from collections import namedtuple
+    from sonic_py_common.general import getstatusoutput_noshell_pipe
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -47,7 +48,7 @@ class Component(ComponentBase):
         try:
             proc = subprocess.Popen(cmdline,
                                     stdout=subprocess.PIPE,
-                                    shell=True, stderr=subprocess.STDOUT,
+                                    stderr=subprocess.STDOUT,
                                     universal_newlines=True)
             stdout = proc.communicate()[0]
             rc = proc.wait()
@@ -60,12 +61,24 @@ class Component(ComponentBase):
 
         return result
 
+    @staticmethod
+    def _get_command_result_pipe(cmd1, cmd2):
+        try:
+            rc, result = getstatusoutput_noshell_pipe(cmd1, cmd2)
+            if rc != 0:
+                raise RuntimeError("Failed to execute command {} {}, return code {}, {}".format(cmd1, cmd2, rc, result))
+
+        except OSError as e:
+            raise RuntimeError("Failed to execute command {} {} due to {}".format(cmd1, cmd2, repr(e)))
+
+        return result
+
 
 class ComponentBIOS(Component):
     COMPONENT_NAME = 'BIOS'
     COMPONENT_DESCRIPTION = 'BIOS - Basic Input/Output System'
 
-    BIOS_QUERY_VERSION_COMMAND = "dmidecode -s bios-version"
+    BIOS_QUERY_VERSION_COMMAND = ["dmidecode", "-s", "bios-version"]
 
     def __init__(self):
         super(ComponentBIOS, self).__init__()
@@ -90,7 +103,8 @@ class ComponentBIOS(Component):
 class ComponentBMC(Component):
     COMPONENT_NAME = 'BMC'
     COMPONENT_DESCRIPTION = 'BMC - Board Management Controller'
-    BMC_QUERY_VERSION_COMMAND = "ipmitool mc info | grep 'Firmware Revision'"
+    BMC_QUERY_VERSION_COMMAND1 = ["ipmitool", "mc", "info"]
+    BMC_QUERY_VERSION_COMMAND2 = ["grep", 'Firmware Revision']
 
     def __init__(self):
         super(ComponentBMC, self).__init__()
@@ -105,7 +119,7 @@ class ComponentBMC(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        bmc_ver = self._get_command_result(self.BMC_QUERY_VERSION_COMMAND)
+        bmc_ver = self._get_command_result_pipe(self.BMC_QUERY_VERSION_COMMAND1, self.BMC_QUERY_VERSION_COMMAND2)
         if not bmc_ver:
             return 'ERR'
         else:
@@ -159,9 +173,9 @@ class ComponentCPLD(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        self._get_command_result("ipmitool raw 0x30 0xe0 0xd0 0x01 0x01")
-        res = self._get_command_result("ipmitool raw 0x32 0xff 0x02 {}".format(self.cplds[self.index].cmd_index))
-        self._get_command_result("ipmitool raw 0x30 0xe0 0xd0 0x01 0x00")
+        self._get_command_result(["ipmitool", "raw", "0x30", "0xe0", "0xd0", "0x01", "0x01"])
+        res = self._get_command_result(["ipmitool", "raw", "0x32", "0xff", "0x02", str(self.cplds[self.index].cmd_index)])
+        self._get_command_result(["ipmitool", "raw", "0x30", "0xe0", "0xd0", "0x01", "0x00"])
         if not res:
             return 'ERR'
         else:
@@ -181,7 +195,8 @@ class ComponentCPLD(Component):
 class ComponentPCIE(Component):
     COMPONENT_NAME = 'PCIe'
     COMPONENT_DESCRIPTION = 'ASIC PCIe Firmware'
-    PCIE_QUERY_VERSION_COMMAND = "bcmcmd 'pciephy fw version' | grep 'FW version'"
+    PCIE_QUERY_VERSION_COMMAND1 = ["bcmcmd", 'pciephy fw version']
+    PCIE_QUERY_VERSION_COMMAND2 = ["grep", 'FW version']
 
     def __init__(self):
         super(ComponentPCIE, self).__init__()
@@ -196,7 +211,7 @@ class ComponentPCIE(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        version = self._get_command_result(self.PCIE_QUERY_VERSION_COMMAND)
+        version = self._get_command_result_pipe(self.PCIE_QUERY_VERSION_COMMAND1, self.PCIE_QUERY_VERSION_COMMAND2)
         if not version:
             return 'ERR'
         else:

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/sonic_platform/sfp.py
@@ -281,7 +281,7 @@ class Sfp(SfpBase):
             return 'N/A'
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
+        return subprocess.call(self.HOST_CHK_CMD) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/sonic_platform/sfp.py
@@ -8,17 +8,17 @@
 #
 #############################################################################
 
-import os
 import time
+import subprocess
 from ctypes import create_string_buffer
 
 try:
-     from sonic_platform_base.sfp_base import SfpBase
-     from sonic_platform_base.sonic_sfp.sff8472 import sff8472InterfaceId
-     from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
-     from sonic_platform_base.sonic_sfp.sff8436 import sff8436InterfaceId
-     from sonic_platform_base.sonic_sfp.sff8436 import sff8436Dom
-     from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
+    from sonic_platform_base.sfp_base import SfpBase
+    from sonic_platform_base.sonic_sfp.sff8472 import sff8472InterfaceId
+    from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
+    from sonic_platform_base.sonic_sfp.sff8436 import sff8436InterfaceId
+    from sonic_platform_base.sonic_sfp.sff8436 import sff8436Dom
+    from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -163,7 +163,7 @@ class Sfp(SfpBase):
     # Path to QSFP sysfs
     PLATFORM_ROOT_PATH = "/usr/share/sonic/device"
     PMON_HWSKU_PATH = "/usr/share/sonic/hwsku"
-    HOST_CHK_CMD = "docker > /dev/null 2>&1"
+    HOST_CHK_CMD = ["docker"]
 
     PLATFORM = "x86_64-quanta_ix8a_bwde-r0"
     HWSKU  = "Quanta-IX8A-BWDE-56X"
@@ -281,7 +281,7 @@ class Sfp(SfpBase):
             return 'N/A'
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/utils/quanta_ix8a_bwde_util.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/utils/quanta_ix8a_bwde_util.py
@@ -27,7 +27,6 @@ command:
     clean       : uninstall drivers and remove related sysfs nodes
 """
 
-import os
 import subprocess
 import sys, getopt
 import logging
@@ -38,7 +37,7 @@ args = []
 FORCE = 0
 i2c_prefix = '/sys/bus/i2c/devices/'
 
-if DEBUG == True:
+if DEBUG is True:
     print(sys.argv[0])
     print('ARGV      :', sys.argv[1:])
 
@@ -54,7 +53,7 @@ def main():
                                                        'debug',
                                                        'force',
                                                           ])
-    if DEBUG == True:
+    if DEBUG is True:
         print(options)
         print(args)
         print(len(sys.argv))
@@ -84,7 +83,7 @@ def show_help():
     sys.exit(0)
 
 def show_log(txt):
-    if DEBUG == True:
+    if DEBUG is True:
         print("[IX8A-BWDE-56X]" + txt)
     return
 
@@ -301,7 +300,9 @@ def system_install():
     #QSFP for 1~56 port
     for port_number in range(1, 57):
         bus_number = port_number + 12
-        os.system("echo %d >/sys/bus/i2c/devices/%d-0050/port_name" % (port_number, bus_number))
+        file = "/sys/bus/i2c/devices/%d-0050/port_name" % bus_number
+        with open(file, 'w') as f:
+            f.write(str(port_number) + '\n')
 
     #Enable front-ports LED decoding
     exec_cmd('echo 1 > /sys/class/cpld-led/CPLDLED-1/led_decode', 1)

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/utils/quanta_ix8a_bwde_util.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/utils/quanta_ix8a_bwde_util.py
@@ -37,7 +37,7 @@ args = []
 FORCE = 0
 i2c_prefix = '/sys/bus/i2c/devices/'
 
-if DEBUG is True:
+if DEBUG == True:
     print(sys.argv[0])
     print('ARGV      :', sys.argv[1:])
 

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/sonic_platform/component.py
@@ -65,7 +65,7 @@ class Component(ComponentBase):
     def _get_command_result_pipe(cmd1, cmd2):
         try:
             rc, result = getstatusoutput_noshell_pipe(cmd1, cmd2)
-            if rc != 0:
+            if rc != [0, 0]:
                 raise RuntimeError("Failed to execute command {} {}, return code {}, {}".format(cmd1, cmd2, rc, result))
 
         except OSError as e:

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/sonic_platform/component.py
@@ -14,6 +14,7 @@ try:
     import subprocess
     from sonic_platform_base.component_base import ComponentBase
     from collections import namedtuple
+    from sonic_py_common.general import getstatusoutput_noshell_pipe
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -47,7 +48,7 @@ class Component(ComponentBase):
         try:
             proc = subprocess.Popen(cmdline,
                                     stdout=subprocess.PIPE,
-                                    shell=True, stderr=subprocess.STDOUT,
+                                    stderr=subprocess.STDOUT,
                                     universal_newlines=True)
             stdout = proc.communicate()[0]
             rc = proc.wait()
@@ -60,12 +61,24 @@ class Component(ComponentBase):
 
         return result
 
+    @staticmethod
+    def _get_command_result_pipe(cmd1, cmd2):
+        try:
+            rc, result = getstatusoutput_noshell_pipe(cmd1, cmd2)
+            if rc != 0:
+                raise RuntimeError("Failed to execute command {} {}, return code {}, {}".format(cmd1, cmd2, rc, result))
+
+        except OSError as e:
+            raise RuntimeError("Failed to execute command {} {} due to {}".format(cmd1, cmd2, repr(e)))
+
+        return result
+
 
 class ComponentBIOS(Component):
     COMPONENT_NAME = 'BIOS'
     COMPONENT_DESCRIPTION = 'BIOS - Basic Input/Output System'
 
-    BIOS_QUERY_VERSION_COMMAND = "dmidecode -s bios-version"
+    BIOS_QUERY_VERSION_COMMAND = ["dmidecode", "-s", "bios-version"]
 
     def __init__(self):
         super(ComponentBIOS, self).__init__()
@@ -90,7 +103,8 @@ class ComponentBIOS(Component):
 class ComponentBMC(Component):
     COMPONENT_NAME = 'BMC'
     COMPONENT_DESCRIPTION = 'BMC - Board Management Controller'
-    BMC_QUERY_VERSION_COMMAND = "ipmitool mc info | grep 'Firmware Revision'"
+    BMC_QUERY_VERSION_COMMAND1 = ["ipmitool", "mc", "info"]
+    BMC_QUERY_VERSION_COMMAND2 = ["grep", 'Firmware Revision']
 
     def __init__(self):
         super(ComponentBMC, self).__init__()
@@ -105,7 +119,7 @@ class ComponentBMC(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        bmc_ver = self._get_command_result(self.BMC_QUERY_VERSION_COMMAND)
+        bmc_ver = self._get_command_result_pipe(self.BMC_QUERY_VERSION_COMMAND1, self.BMC_QUERY_VERSION_COMMAND2)
         if not bmc_ver:
             return 'ERR'
         else:
@@ -158,10 +172,10 @@ class ComponentCPLD(Component):
 
         Returns:
             A string containing the firmware version of the component
-        """
-        self._get_command_result("ipmitool raw 0x30 0xe0 0xd0 0x01 0x01")
-        res = self._get_command_result("ipmitool raw 0x32 0xff 0x02 {}".format(self.cplds[self.index].cmd_index))
-        self._get_command_result("ipmitool raw 0x30 0xe0 0xd0 0x01 0x00")
+        """  
+        self._get_command_result(["ipmitool", "raw", "0x30", "0xe0", "0xd0", "0x01", "0x01"])
+        res = self._get_command_result(["ipmitool", "raw", "0x32", "0xff", "0x02", str(self.cplds[self.index].cmd_index)])
+        self._get_command_result(["ipmitool", "raw", "0x30", "0xe0", "0xd0", "0x01", "0x00"])
         if not res:
             return 'ERR'
         else:
@@ -181,7 +195,8 @@ class ComponentCPLD(Component):
 class ComponentPCIE(Component):
     COMPONENT_NAME = 'PCIe'
     COMPONENT_DESCRIPTION = 'ASIC PCIe Firmware'
-    PCIE_QUERY_VERSION_COMMAND = "bcmcmd 'pciephy fw version' | grep 'FW version'"
+    PCIE_QUERY_VERSION_COMMAND1 = ["bcmcmd", 'pciephy fw version']
+    PCIE_QUERY_VERSION_COMMAND2 = ["grep", 'FW version']
 
     def __init__(self):
         super(ComponentPCIE, self).__init__()
@@ -196,7 +211,7 @@ class ComponentPCIE(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        version = self._get_command_result(self.PCIE_QUERY_VERSION_COMMAND)
+        version = self._get_command_result_pipe(self.PCIE_QUERY_VERSION_COMMAND1, self.PCIE_QUERY_VERSION_COMMAND2)
         if not version:
             return 'ERR'
         else:

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/sonic_platform/sfp.py
@@ -281,7 +281,7 @@ class Sfp(SfpBase):
             return 'N/A'
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
+        return subprocess.call(self.HOST_CHK_CMD) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/sonic_platform/sfp.py
@@ -8,17 +8,17 @@
 #
 #############################################################################
 
-import os
+import subprocess
 import time
 from ctypes import create_string_buffer
 
 try:
-     from sonic_platform_base.sfp_base import SfpBase
-     from sonic_platform_base.sonic_sfp.sff8472 import sff8472InterfaceId
-     from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
-     from sonic_platform_base.sonic_sfp.sff8436 import sff8436InterfaceId
-     from sonic_platform_base.sonic_sfp.sff8436 import sff8436Dom
-     from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
+    from sonic_platform_base.sfp_base import SfpBase
+    from sonic_platform_base.sonic_sfp.sff8472 import sff8472InterfaceId
+    from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
+    from sonic_platform_base.sonic_sfp.sff8436 import sff8436InterfaceId
+    from sonic_platform_base.sonic_sfp.sff8436 import sff8436Dom
+    from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -281,7 +281,7 @@ class Sfp(SfpBase):
             return 'N/A'
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/utils/quanta_ix8c_util.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/utils/quanta_ix8c_util.py
@@ -37,7 +37,7 @@ args = []
 FORCE = 0
 i2c_prefix = '/sys/bus/i2c/devices/'
 
-if DEBUG is True:
+if DEBUG == True:
     print(sys.argv[0])
     print('ARGV      :', sys.argv[1:])
 

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/utils/quanta_ix8c_util.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/utils/quanta_ix8c_util.py
@@ -27,7 +27,6 @@ command:
     clean       : uninstall drivers and remove related sysfs nodes
 """
 
-import os
 import subprocess
 import sys, getopt
 import logging
@@ -38,7 +37,7 @@ args = []
 FORCE = 0
 i2c_prefix = '/sys/bus/i2c/devices/'
 
-if DEBUG == True:
+if DEBUG is True:
     print(sys.argv[0])
     print('ARGV      :', sys.argv[1:])
 
@@ -54,7 +53,7 @@ def main():
                                                        'debug',
                                                        'force',
                                                           ])
-    if DEBUG == True:
+    if DEBUG is True:
         print(options)
         print(args)
         print(len(sys.argv))
@@ -84,7 +83,7 @@ def show_help():
     sys.exit(0)
 
 def show_log(txt):
-    if DEBUG == True:
+    if DEBUG is True:
         print("[IX8C-56X]" + txt)
     return
 
@@ -297,7 +296,9 @@ def system_install():
     #QSFP for 1~56 port
     for port_number in range(1, 57):
         bus_number = port_number + 12
-        os.system("echo %d >/sys/bus/i2c/devices/%d-0050/port_name" % (port_number, bus_number))
+        file = "/sys/bus/i2c/devices/%d-0050/port_name" % bus_number
+        with open(file, 'w') as f:
+            f.write(str(port_number) + '\n')
 
     return
 

--- a/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/sonic_platform/component.py
@@ -65,7 +65,7 @@ class Component(ComponentBase):
     def _get_command_result_pipe(cmd1, cmd2):
         try:
             rc, result = getstatusoutput_noshell_pipe(cmd1, cmd2)
-            if rc != 0:
+            if rc != [0, 0]:
                 raise RuntimeError("Failed to execute command {} {}, return code {}, {}".format(cmd1, cmd2, rc, result))
 
         except OSError as e:

--- a/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/sonic_platform/component.py
@@ -14,6 +14,7 @@ try:
     import subprocess
     from sonic_platform_base.component_base import ComponentBase
     from collections import namedtuple
+    from sonic_py_common.general import getstatusoutput_noshell_pipe
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -47,7 +48,7 @@ class Component(ComponentBase):
         try:
             proc = subprocess.Popen(cmdline,
                                     stdout=subprocess.PIPE,
-                                    shell=True, stderr=subprocess.STDOUT,
+                                    stderr=subprocess.STDOUT,
                                     universal_newlines=True)
             stdout = proc.communicate()[0]
             rc = proc.wait()
@@ -60,12 +61,24 @@ class Component(ComponentBase):
 
         return result
 
+    @staticmethod
+    def _get_command_result_pipe(cmd1, cmd2):
+        try:
+            rc, result = getstatusoutput_noshell_pipe(cmd1, cmd2)
+            if rc != 0:
+                raise RuntimeError("Failed to execute command {} {}, return code {}, {}".format(cmd1, cmd2, rc, result))
+
+        except OSError as e:
+            raise RuntimeError("Failed to execute command {} {} due to {}".format(cmd1, cmd2, repr(e)))
+
+        return result
+
 
 class ComponentBIOS(Component):
     COMPONENT_NAME = 'BIOS'
     COMPONENT_DESCRIPTION = 'BIOS - Basic Input/Output System'
 
-    BIOS_QUERY_VERSION_COMMAND = "dmidecode -s bios-version"
+    BIOS_QUERY_VERSION_COMMAND = ["dmidecode", "-s", "bios-version"]
 
     def __init__(self):
         super(ComponentBIOS, self).__init__()
@@ -90,7 +103,8 @@ class ComponentBIOS(Component):
 class ComponentBMC(Component):
     COMPONENT_NAME = 'BMC'
     COMPONENT_DESCRIPTION = 'BMC - Board Management Controller'
-    BMC_QUERY_VERSION_COMMAND = "ipmitool mc info | grep 'Firmware Revision'"
+    BMC_QUERY_VERSION_COMMAND1 = ["ipmitool", "mc", "info"]
+    BMC_QUERY_VERSION_COMMAND2 = ["grep", 'Firmware Revision']
 
     def __init__(self):
         super(ComponentBMC, self).__init__()
@@ -105,7 +119,7 @@ class ComponentBMC(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        bmc_ver = self._get_command_result(self.BMC_QUERY_VERSION_COMMAND)
+        bmc_ver = self._get_command_result_pipe(self.BMC_QUERY_VERSION_COMMAND1, self.BMC_QUERY_VERSION_COMMAND2)
         if not bmc_ver:
             return 'ERR'
         else:
@@ -158,9 +172,9 @@ class ComponentCPLD(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        self._get_command_result("ipmitool raw 0x30 0xe0 0xd0 0x01 0x01")
-        res = self._get_command_result("ipmitool raw 0x32 0xff 0x02 {}".format(self.cplds[self.index].cmd_index))
-        self._get_command_result("ipmitool raw 0x30 0xe0 0xd0 0x01 0x00")
+        self._get_command_result(["ipmitool", "raw", "0x30", "0xe0", "0xd0", "0x01", "0x01"])
+        res = self._get_command_result(["ipmitool", "raw", "0x32", "0xff", "0x02", str(self.cplds[self.index].cmd_index)])
+        self._get_command_result(["ipmitool", "raw", "0x30", "0xe0", "0xd0", "0x01", "0x00"])
         if not res:
             return 'ERR'
         else:
@@ -180,7 +194,8 @@ class ComponentCPLD(Component):
 class ComponentPCIE(Component):
     COMPONENT_NAME = 'PCIe'
     COMPONENT_DESCRIPTION = 'ASIC PCIe Firmware'
-    PCIE_QUERY_VERSION_COMMAND = "bcmcmd 'pciephy fw version' | grep 'FW version'"
+    PCIE_QUERY_VERSION_COMMAND1 = ["bcmcmd", 'pciephy fw version']
+    PCIE_QUERY_VERSION_COMMAND2 = ["grep", 'FW version']
 
     def __init__(self):
         super(ComponentPCIE, self).__init__()
@@ -195,7 +210,7 @@ class ComponentPCIE(Component):
         Returns:
             A string containing the firmware version of the component
         """
-        version = self._get_command_result(self.PCIE_QUERY_VERSION_COMMAND)
+        version = self._get_command_result_pipe(self.PCIE_QUERY_VERSION_COMMAND1, self.PCIE_QUERY_VERSION_COMMAND2)
         if not version:
             return 'ERR'
         else:

--- a/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/sonic_platform/sfp.py
@@ -354,7 +354,7 @@ class Sfp(SfpBase):
             return 'N/A'
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
+        return subprocess.call(self.HOST_CHK_CMD) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/sonic_platform/sfp.py
@@ -8,21 +8,21 @@
 #
 #############################################################################
 
-import os
 import time
+import subprocess
 from ctypes import create_string_buffer
 
 try:
-     from sonic_platform_base.sfp_base import SfpBase
-     from sonic_platform_base.sonic_sfp.sff8472 import sff8472InterfaceId
-     from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
-     from sonic_platform_base.sonic_sfp.sff8436 import sff8436InterfaceId
-     from sonic_platform_base.sonic_sfp.sff8436 import sff8436Dom
-     from sonic_platform_base.sonic_sfp.inf8628 import inf8628InterfaceId
-     from sonic_platform_base.sonic_sfp.qsfp_dd import qsfp_dd_InterfaceId
-     from sonic_platform_base.sonic_sfp.qsfp_dd import qsfp_dd_Dom
-     from sonic_py_common.logger import Logger
-     from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
+    from sonic_platform_base.sfp_base import SfpBase
+    from sonic_platform_base.sonic_sfp.sff8472 import sff8472InterfaceId
+    from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
+    from sonic_platform_base.sonic_sfp.sff8436 import sff8436InterfaceId
+    from sonic_platform_base.sonic_sfp.sff8436 import sff8436Dom
+    from sonic_platform_base.sonic_sfp.inf8628 import inf8628InterfaceId
+    from sonic_platform_base.sonic_sfp.qsfp_dd import qsfp_dd_InterfaceId
+    from sonic_platform_base.sonic_sfp.qsfp_dd import qsfp_dd_Dom
+    from sonic_py_common.logger import Logger
+    from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
@@ -354,7 +354,7 @@ class Sfp(SfpBase):
             return 'N/A'
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/utils/quanta_ix9_util.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/utils/quanta_ix9_util.py
@@ -27,7 +27,6 @@ command:
     clean       : uninstall drivers and remove related sysfs nodes
 """
 
-import os
 import subprocess
 import sys, getopt
 import logging
@@ -38,7 +37,7 @@ args = []
 FORCE = 0
 i2c_prefix = '/sys/bus/i2c/devices/'
 
-if DEBUG == True:
+if DEBUG is True:
     print(sys.argv[0])
     print('ARGV      :', sys.argv[1:])
 
@@ -54,7 +53,7 @@ def main():
                                                        'debug',
                                                        'force',
                                                           ])
-    if DEBUG == True:
+    if DEBUG is True:
         print(options)
         print(args)
         print(len(sys.argv))
@@ -84,7 +83,7 @@ def show_help():
     sys.exit(0)
 
 def show_log(txt):
-    if DEBUG == True:
+    if DEBUG is True:
         print("[IX9-32X]" + txt)
     return
 
@@ -237,7 +236,9 @@ def system_install():
     #QSFPDD for 1~32 port
     for port_number in range(1, 33):
         bus_number = port_number + 12
-        os.system("echo %d >/sys/bus/i2c/devices/%d-0050/port_name" % (port_number, bus_number))
+        file = "/sys/bus/i2c/devices/%d-0050/port_name" % bus_number
+        with open(file, 'w') as f:
+            f.write(str(port_number) + '\n')
 
     return
 

--- a/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/utils/quanta_ix9_util.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/utils/quanta_ix9_util.py
@@ -37,7 +37,7 @@ args = []
 FORCE = 0
 i2c_prefix = '/sys/bus/i2c/devices/'
 
-if DEBUG is True:
+if DEBUG == True:
     print(sys.argv[0])
     print('ARGV      :', sys.argv[1:])
 


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Dependency: [https://github.com/sonic-net/sonic-buildimage/pull/12065](https://github.com/sonic-net/sonic-buildimage/pull/12065)
#### Why I did it
`shell=True` is dangerous because this call will spawn the command using a shell process
`os` - not secure against maliciously constructed input and dangerous if used to evaluate dynamic content.
#### How I did it
`os` - use with `subprocess`
Use `shell=False` with shell features
- redirection: [https://stackoverflow.com/questions/4965159/how-to-redirect-output-with-subprocess-in-python/6482200#6482200?newreg=53afb91b3ebd47c5930be627fcdf2930](https://stackoverflow.com/questions/4965159/how-to-redirect-output-with-subprocess-in-python/6482200#6482200?newreg=53afb91b3ebd47c5930be627fcdf2930)
- `|` operator: [https://docs.python.org/2/library/subprocess.html#replacing-shell-pipeline](https://docs.python.org/2/library/subprocess.html#replacing-shell-pipeline)

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

