### PR TITLE
Add python-is-python3 package for bullseye base docker

### DIFF
--- a/dockers/docker-base-bullseye/Dockerfile.j2
+++ b/dockers/docker-base-bullseye/Dockerfile.j2
@@ -48,6 +48,7 @@ RUN apt-get update &&        \
         python3              \
         python3-distutils    \
         python3-pip          \
+        python-is-python3    \
         vim-tiny             \
 # Install redis-tools
         redis-tools          \


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In latest `syncd` container, it is installed bullseye, can't find command '`/usr/bin/python`'.
Some scripts such as `test_copp` still calls `/usr/bin/python` in `syncd`.
Submitted the change in #11807 for syncd docker, but it's better to add it in bullseye base docker.

#### How I did it
Install `python-is-python3` package in bullseye base docker to resolve this issue, whatever run python or python3, it will run `/usr/bin/python3`, will not cause the error of can't find command '`/usr/bin/python`' 

#### How to verify it
run `python` in syncd container.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

