### PR TITLE
[lldpmgrd] Fix lldpmgrd issue where it sets the lldp system name to None

### DIFF
--- a/dockers/docker-lldp/lldpmgrd
+++ b/dockers/docker-lldp/lldpmgrd
@@ -245,10 +245,13 @@ class LldpManager(daemon_base.DaemonBase):
         if not op in ["SET", "DEL"]:
             return
         self.log_info("Device Config Opcode: {} Dict {} Key {}".format(op, device_dict, key))
-        hostname = device_dict.get("hostname")
-        if not self.hostname == hostname:
-            self.log_info("Hostname changed old {0}, new {1}".format(self.hostname, hostname))
-            self.update_hostname(hostname)
+        # only check hostname in key:localhost
+        if key == "localhost":
+            hostname = device_dict.get("hostname")
+            # check hostname is valid and not the same as before
+            if hostname and not self.hostname == hostname:
+                self.log_info("Hostname changed old {0}, new {1}".format(self.hostname, hostname))
+                self.update_hostname(hostname)
 
     def lldp_process_port_table_event(self, key, op, fvp):
         if (key != "PortInitDone") and (key != "PortConfigDone"):


### PR DESCRIPTION
[lldpmgrd] Fix lldpmgrd issue where it sets the lldp system name to None

- Only check hostname field in key DEVICE_METADATA|localhost of configDB
- If hostname does not exist, don't set lldp system name

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
lldpmgrd could set the system name to None incorrectly, which lead to peer to have wrong lldp information.

#### How I did it
Fix the lldpmgrd.

#### How to verify it
Before fix:
If loading below config:
```
{
    "DEVICE_METADATA": {
        "localhost": {
            "bgp_asn": "65100",
            "docker_routing_config_mode": "split",
            "hostname": "sonic-1",
            "hwsku": "Seastone-DX010",
            "mac": "00:e0:ec:3c:0a:16",
            "platform": "x86_64-cel_seastone-r0",
            "type": "LeafRouter"
        },
        "x509": {
            "ca_crt": "/etc/sonic/telemetry/dsmsroot.cer",
            "server_crt": "/etc/sonic/telemetry/streamingtelemetryserver.cer",
            "server_key": "/etc/sonic/telemetry/streamingtelemetryserver.key"
        }
    }
} 
```
lldp will set the system name to None, see syslog:
```
Aug 31 05:06:11.172655 lnos-x1-a-asw02 INFO lldp#lldpmgrd[32]: Device Config Opcode: SET Dict {'docker_routing_config_mode': 'split', 'hwsku': 'Seastone-DX010', 'mac': '00:e0:ec:3c:0a:16', 'platform': 'x86_64-cel_seastone-r0', 'bgp_asn': '65100', 'buffer_model': 'traditional', 'default_bgp_status': 'up', 'default_pfcwd_status': 'disable', 'hostname': 'sonic-1', 'type': 'LeafRouter'} Key localhost
Aug 31 05:06:11.172802 lnos-x1-a-asw02 INFO lldp#lldpmgrd[32]: Hostname changed old None, new sonic-1
Aug 31 05:06:11.192924 lnos-x1-a-asw02 INFO lldp#lldpmgrd[32]: Device Config Opcode: SET Dict {'ca_crt': '/etc/sonic/telemetry/dsmsroot.cer', 'server_crt': '/etc/sonic/telemetry/streamingtelemetryserver.cer', 'server_key': '/etc/sonic/telemetry/streamingtelemetryserver.key'} Key x509
Aug 31 05:06:11.192924 lnos-x1-a-asw02 INFO lldp#lldpmgrd[32]: Hostname changed old sonic-1, new None 
```

After the fix, if loading the same config:
```
Aug 31 05:53:38.686509 lnos-x1-a-asw02 INFO lldp#lldpmgrd[35]: Device Config Opcode: SET Dict {'docker_routing_config_mode': 'split', 'hwsku': 'Seastone-DX010', 'mac': '00:e0:ec:3c:0a:16', 'platform': 'x86_64-cel_seastone-r0', 'bgp_asn': '65100', 'buffer_model': 'traditional', 'default_bgp_status': 'up', 'default_pfcwd_status': 'disable', 'hostname': 'sonic-1', 'type': 'LeafRouter'} Key localhost
Aug 31 05:53:38.686509 lnos-x1-a-asw02 INFO lldp#lldpmgrd[35]: Hostname changed old None, new sonic-1
Aug 31 05:53:38.706948 lnos-x1-a-asw02 INFO lldp#lldpmgrd[35]: Device Config Opcode: SET Dict {'ca_crt': '/etc/sonic/telemetry/dsmsroot.cer', 'server_crt': '/etc/sonic/telemetry/streamingtelemetryserver.cer', 'server_key': '/etc/sonic/telemetry/streamingtelemetryserver.key'} Key x509
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

