### PR TITLE
[Arista] Add new SWI attribute required by Aboot for secureboot

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -191,6 +191,7 @@ elif [ "$IMAGE_TYPE" = "aboot" ]; then
     zip -g $ABOOT_BOOT_IMAGE .imagehash
     rm .imagehash
     echo "SWI_VERSION=42.0.0" > version
+    echo "BUILD_DATE=$(date -d "${build_date}" -u +%Y%m%dT%H%M%SZ)" >> version
     echo "SWI_MAX_HWEPOCH=2" >> version
     echo "SWI_VARIANT=US" >> version
     zip -g $OUTPUT_ABOOT_IMAGE version


### PR DESCRIPTION
#### Why I did it

Newer versions of Aboot will expect this `BUILD_DATE=` attribute to exist and contain valid data.
It is only use for the `secureboot` feature and does not impact regular boot.

#### How I did it

Added the new attribute declaration in `build_image.sh`

#### How to verify it

Build a SWI and boot it on a secureboot enabled product with the latest Aboot version.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add new SWI attribute required by Aboot for secureboot