### PR TITLE
[arp_update]: Set failed IPv6 neighbors to incomplete

### DIFF
--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -93,6 +93,18 @@ while /bin/true; do
         ping6_template="sed -e 's/^/timeout 0.2 ping /' -e 's/,/ -n -q -i 0 -c 1 -W 1 -I /' -e 's/$/ >\/dev\/null;/'"
         failed_ip6_neigh_cmd="ip -6 neigh show | grep -v fe80 | grep $vlan | grep -E 'FAILED|INCOMPLETE' | cut -d ' ' -f 1,3 --output-delimiter=',' | $ping6_template"
         eval `eval $failed_ip6_neigh_cmd`
+
+        # manually set any remaining FAILED/INCOMPLETE entries to permanently INCOMPLETE
+        # this prevents any remaining INCOMPLETE entries from automatically transitioning to FAILED
+        # once these entries are incomplete, any subsequent neighbor advertisement messages
+        # are able to resolve the entry
+
+        # generates the following command for each failed or incomplete IPv6 neighbor
+        # ip neigh replace <neighbor IPv6> dev <VLAN name> nud incomplete
+        neigh_replace_template="sed -e 's/^/ip neigh replace /' -e 's/,/ dev /' -e 's/$/ nud incomplete;/'" 
+        ip_neigh_replace_cmd="ip -6 neigh show | grep -v fe80 | grep Vlan1000 | grep -E 'FAILED|INCOMPLETE' | cut -d ' ' -f 1,3 --output-delimiter=',' | $neigh_replace_template"
+        eval `eval $ip_neigh_replace_cmd`
+
       fi
   done
   

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -78,6 +78,17 @@ while /bin/true; do
       eval `eval $ip6cmd`
  
       if [[ $SUBTYPE == "dualtor" ]]; then
+        # manually set any remaining FAILED/INCOMPLETE entries to permanently INCOMPLETE
+        # this prevents any remaining INCOMPLETE entries from automatically transitioning to FAILED
+        # once these entries are incomplete, any subsequent neighbor advertisement messages
+        # are able to resolve the entry
+
+        # generates the following command for each failed or incomplete IPv6 neighbor
+        # ip neigh replace <neighbor IPv6> dev <VLAN name> nud incomplete
+        neigh_replace_template="sed -e 's/^/ip neigh replace /' -e 's/,/ dev /' -e 's/$/ nud incomplete;/'" 
+        ip_neigh_replace_cmd="ip -6 neigh show | grep -v fe80 | grep Vlan1000 | grep -E 'FAILED|INCOMPLETE' | cut -d ' ' -f 1,3 --output-delimiter=',' | $neigh_replace_template"
+        eval `eval $ip_neigh_replace_cmd`
+
         # on dual ToR devices, try to resolve failed neighbor entries since
         # these entries will have tunnel routes installed, preventing normal 
         # neighbor resolution (SWSS PR #2137)
@@ -93,18 +104,6 @@ while /bin/true; do
         ping6_template="sed -e 's/^/timeout 0.2 ping /' -e 's/,/ -n -q -i 0 -c 1 -W 1 -I /' -e 's/$/ >\/dev\/null;/'"
         failed_ip6_neigh_cmd="ip -6 neigh show | grep -v fe80 | grep $vlan | grep -E 'FAILED|INCOMPLETE' | cut -d ' ' -f 1,3 --output-delimiter=',' | $ping6_template"
         eval `eval $failed_ip6_neigh_cmd`
-
-        # manually set any remaining FAILED/INCOMPLETE entries to permanently INCOMPLETE
-        # this prevents any remaining INCOMPLETE entries from automatically transitioning to FAILED
-        # once these entries are incomplete, any subsequent neighbor advertisement messages
-        # are able to resolve the entry
-
-        # generates the following command for each failed or incomplete IPv6 neighbor
-        # ip neigh replace <neighbor IPv6> dev <VLAN name> nud incomplete
-        neigh_replace_template="sed -e 's/^/ip neigh replace /' -e 's/,/ dev /' -e 's/$/ nud incomplete;/'" 
-        ip_neigh_replace_cmd="ip -6 neigh show | grep -v fe80 | grep Vlan1000 | grep -E 'FAILED|INCOMPLETE' | cut -d ' ' -f 1,3 --output-delimiter=',' | $neigh_replace_template"
-        eval `eval $ip_neigh_replace_cmd`
-
       fi
   done
   


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

If IPv6 neighbor entries become "FAILED", then any subsequent neighbor advertisement messages will not be able to resolve these entries in the neighbor cache, only a ping or other traffic being sent from the device will be able to resolve these. This means that standby ToRs may have such FAILED entries stuck in the neighbor cache for a long time.

#### How I did it

After pinging any failed IPv6 neighbor entries, set the remaining failed/incomplete entries to a permanent INCOMPLETE state. This manual setting to INCOMPLETE prevents these entries from automatically transitioning to FAILED state, and since they are now incomplete any subsequent NA messages for these neighbors is able to resolve the entry in the cache.

#### How to verify it

1. Add a failed IPv6 neighbor entry to the neighbor cache (e.g. pinging an unreachable address)
2. Run the arp_update script
3. The entry should now be incomplete

```
root@str2-7050cx3-acs-08:/# ping fc02:1000::500
PING fc02:1000::500(fc02:1000::500) 56 data bytes
^C
--- fc02:1000::500 ping statistics ---
2 packets transmitted, 0 received, 100% packet loss, time 13ms

root@str2-7050cx3-acs-08:/# ip neigh show fc02:1000::500
fc02:1000::500 dev Vlan1000  FAILED
root@str2-7050cx3-acs-08:/# arp_update
ping6: Warning: source address might be selected on device other than PortChannel101.
ping6: Warning: source address might be selected on device other than PortChannel102.
ping6: Warning: source address might be selected on device other than PortChannel103.
ping6: Warning: source address might be selected on device other than PortChannel104.
ping6: Warning: source address might be selected on device other than Vlan1000.
^C
root@str2-7050cx3-acs-08:/# ip neigh show fc02:1000::500
fc02:1000::500 dev Vlan1000  INCOMPLETE
root@str2-7050cx3-acs-08:/# sleep 10
root@str2-7050cx3-acs-08:/# ip neigh show fc02:1000::500
fc02:1000::500 dev Vlan1000  INCOMPLETE
root@str2-7050cx3-acs-08:/#
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

