### PR TITLE
[Arista] Fix extraction of platform.tar.gz in secureboot

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -401,9 +401,14 @@ extract_image() {
 extract_image_secureboot() {
     info "Extracting necessary swi content"
     # NOTE: boot/ is not used by the boot process but only extracted for kdump
-    unzip -oq "$swipath" 'boot/*' platform/firsttime .imagehash -d "$image_path"
+    unzip -oq "$swipath" 'boot/*' .imagehash -d "$image_path"
 
-    info "Installing image as $installer_image_path"
+    ## Extract platform.tar.gz
+    info "Extracting platform.tar.gz"
+    mkdir -p "$image_path/platform"
+    unzip -oqp "$swipath" "platform.tar.gz" | tar xzf - -C "$image_path/platform" $TAR_EXTRA_OPTION
+
+    info "Installing swi under $installer_image_path"
     mv "$swipath" "$installer_image_path"
     chmod a+r "$installer_image_path"
     swipath="$installer_image_path"


### PR DESCRIPTION
#### Why I did it

A recent change modified the `platform` folder of the image into a tarball `platform.tar.gz`
The `boot0` script was modified for regular boot but not secureboot.
This means that the `platform/firstime` does not get created and `rc.local` therefore skips initial configuration.

#### How I did it

Updated the secureboot image extraction logic to properly handle `platform.tar.gz`

#### How to verify it

Boot the image on a secureboot enabled product and make sure that `rc.local` enters the firstime codepath.
Also verify that `/host/image-XXX/platform` exists.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix extraction of platform.tar.gz in secureboot