### PR TITLE
[mux] skip mux operations during warm shutdown

### DIFF
--- a/files/build_templates/per_namespace/bgp.service.j2
+++ b/files/build_templates/per_namespace/bgp.service.j2
@@ -15,7 +15,7 @@ User={{ sonicadmin_user }}
 ExecStartPre=/usr/local/bin/{{docker_container_name}}.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/local/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-ExecStopPost=/usr/local/bin/write_standby.py
+ExecStopPost=/usr/local/bin/write_standby.py --shutdown bgp
 
 RestartSec=30
 

--- a/files/scripts/write_standby.py
+++ b/files/scripts/write_standby.py
@@ -20,13 +20,14 @@ class MuxStateWriter(object):
     Class used to write standby mux state to APP DB
     """
 
-    def __init__(self, activeactive, activestandby):
+    def __init__(self, activeactive, activestandby, shutdown_module):
         self.config_db_connector = None
         self.appl_db_connector = None
         self.state_db_connector = None
         self.asic_db_connector = None
         self.default_active_active_state = activeactive
         self.default_active_standby_state = activestandby
+        self.shutdown_module = shutdown_module
 
     @property
     def config_db(self):
@@ -97,7 +98,15 @@ class MuxStateWriter(object):
         tbl = Table(self.state_db, 'WARM_RESTART_ENABLE_TABLE')
         (status, value) = tbl.hget('system', 'enable')
 
-        return status and value == 'true' 
+        if status and value == 'true':
+            return True
+
+        if self.shutdown_module:
+            (status, value) = tbl.hget(self.shutdown_module, 'enable')
+            if status and value == 'true':
+                return True
+
+        return False
 
     def get_all_mux_intfs_modes(self):
         """
@@ -178,12 +187,12 @@ if __name__ == '__main__':
     parser.add_argument('-s', '--active_standby',
                         help='state: intial state for "auto" and/or "manual" config in active-standby mode, default "standby"',
                         type=str, required=False, default='standby')
-    parser.add_argument('--shutdown', help='write mux state after shutdown other services, supported: mux',
-                        type=str, required=False, choices=['mux'])
+    parser.add_argument('--shutdown', help='write mux state after shutdown other services, supported: mux, bgp',
+                        type=str, required=False, choices=['mux', 'bgp'], default=None)
     args = parser.parse_args()
     active_active_state = args.active_active
     active_standby_state = args.active_standby
-    if args.shutdown == 'mux':
+    if args.shutdown in ['mux', 'bgp']:
         active_active_state = "standby"
-    mux_writer = MuxStateWriter(activeactive=active_active_state, activestandby=active_standby_state)
+    mux_writer = MuxStateWriter(activeactive=active_active_state, activestandby=active_standby_state, shutdown_module=args.shutdown)
     mux_writer.apply_mux_config()

--- a/files/scripts/write_standby.py
+++ b/files/scripts/write_standby.py
@@ -28,6 +28,7 @@ class MuxStateWriter(object):
         self.default_active_active_state = activeactive
         self.default_active_standby_state = activestandby
         self.shutdown_module = shutdown_module
+        self.is_shutdwon = (self.shutdown_module != None)
 
     @property
     def config_db(self):
@@ -162,7 +163,7 @@ class MuxStateWriter(object):
             # If not running on a dual ToR system, take no action
             return
 
-        if self.is_warmrestart:
+        if self.is_warmrestart and self.is_shutdwon:
             # If in warmrestart context, take no action
             logger.log_warning("Skip setting mux state due to ongoing warmrestart.")
             return


### PR DESCRIPTION
#### Why I did it
MuX related operations are not warm reboot ready previously.

#### How I did it
- Enhance write_standby.py script to skip actions during warm shutdown.
- Expand the support to BGP service.
- MuX support was added by a previous PR.
- Addressed a bug: the action should not be skipped during warm recovery.

#### How to verify it
Run test on device with following settings and validate behavior is expected:
- warm reboot/restart is not enabled.
- system level warm reboot is enabled.
- bgp warm restart was enabled.
- mux warm restart was enabled.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
