### PR TITLE
[docker-fpm-frr]: Add unified-split mode to routing config

### DIFF
--- a/dockers/docker-fpm-frr/docker_init.sh
+++ b/dockers/docker-fpm-frr/docker_init.sh
@@ -69,6 +69,9 @@ if [ -z "$CONFIG_TYPE" ] || [ "$CONFIG_TYPE" == "separated" ]; then
 elif [ "$CONFIG_TYPE" == "split" ]; then
     echo "no service integrated-vtysh-config" > /etc/frr/vtysh.conf
     rm -f /etc/frr/frr.conf
+elif [ "$CONFIG_TYPE" == "split-unified" ]; then
+    echo "service integrated-vtysh-config" > /etc/frr/vtysh.conf
+    rm -f /etc/frr/bgpd.conf /etc/frr/zebra.conf /etc/frr/staticd.conf
 elif [ "$CONFIG_TYPE" == "unified" ]; then
     CFGGEN_PARAMS=" \
         -d \

--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -152,7 +152,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=bgpd:running
 
-{% if DEVICE_METADATA.localhost.docker_routing_config_mode is defined and DEVICE_METADATA.localhost.docker_routing_config_mode == "unified" %}
+{% if DEVICE_METADATA.localhost.docker_routing_config_mode is defined and (DEVICE_METADATA.localhost.docker_routing_config_mode == "unified" or DEVICE_METADATA.localhost.docker_routing_config_mode == "split-unified") %}
 [program:vtysh_b]
 command=/usr/bin/vtysh -b
 priority=6

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -49,8 +49,13 @@ module sonic-device_metadata {
                 }
 
                 leaf docker_routing_config_mode {
+                    description "This leaf allows different configuration modes for FRR:
+                                - separated: FRR config generated from ConfigDB, each FRR daemon has its own config file
+                                - unified: FRR config generated from ConfigDB, single FRR config file
+                                - split: FRR config not generated from ConfigDB, each FRR daemon has its own config file
+                                - split-unified: FRR config not generated from ConfigDB, single FRR config file";
                     type string {
-                        pattern "unified|split|separated";
+                        pattern "separated|unified|split|split-unified";
                     }
                     default "unified";
                 }


### PR DESCRIPTION
#### Why I did it
The values for config_db "docker_routing_config_mode" are:
- separated: FRR config generated from ConfigDB, each FRR daemon has its own config file
- unified: FRR config generated from ConfigDB, single FRR config file
- split: FRR config not generated from ConfigDB, each FRR daemon has its own config file
This commit adds:
- split-unified: FRR config not generated from ConfigDB, single FRR config file

#### How I did it
In docker_init.sh, when split-unified is used, the FRR configs are not generated
from ConfigDB. What's more, "service integrated-vtysh-config" is configured in vtysh.conf.

#### How to verify it
FRR config not overwritten when FRR container starts.

#### Which release branch to backport (provide reason below if selected)

- [] 201811
- [] 201911
- [] 202006
- [] 202012
- [] 202106
- [] 202111
- [] 202205

#### Description for the changelog
Add a "split-unified" option to "docker_routing_config_mode"

#### Link to config_db schema for YANG module changes
https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#device-metadata


