### PR TITLE
Z9432F kernel dependency of platform module

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/debian/control
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/control
@@ -57,7 +57,7 @@ Description: kernel modules for platform devices such as fan, led, sfp
 
 Package: platform-modules-z9432f
 Architecture: amd64
-Depends: linux-image-5.10.0-8-2-amd64-unsigned
+Depends: linux-image-5.10.0-12-2-amd64-unsigned
 Description: kernel modules for platform devices such as fan, led, sfp
 
 Package: platform-modules-n3248pxe


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Z9432F Update the kernel dependency of platform module

#### How I did it
Modified the kernel version to current latest 5.10.0-12-2

#### How to verify it
[Z9432F_log.txt](https://github.com/sonic-net/sonic-buildimage/files/9472971/Z9432F_log.txt)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

