### PR TITLE
Make client indentity by AME cert

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -455,7 +455,7 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install watchd
 {% if include_kubernetes == "y" %}
 # Point to kubelet to /etc/resolv.conf
 #
-echo 'KUBELET_EXTRA_ARGS="--resolv-conf=/etc/resolv.conf"' | sudo tee -a  $FILESYSTEM_ROOT/etc/default/kubelet
+echo 'KUBELET_EXTRA_ARGS="--resolv-conf=/etc/resolv.conf --cgroup-driver=cgroupfs --node-ip=::"' | sudo tee -a  $FILESYSTEM_ROOT/etc/default/kubelet
 
 # Copy Flannel conf file into sonic-templates
 #

--- a/src/sonic-ctrmgrd/ctrmgr/ctrmgrd.py
+++ b/src/sonic-ctrmgrd/ctrmgr/ctrmgrd.py
@@ -104,10 +104,12 @@ def log_debug(m):
 
 
 def log_error(m):
+    msg = "{}: {}".format(inspect.stack()[1][3], m)
     syslog.syslog(syslog.LOG_ERR, msg)
 
 
 def log_info(m):
+    msg = "{}: {}".format(inspect.stack()[1][3], m)
     syslog.syslog(syslog.LOG_INFO, msg)
 
 

--- a/src/sonic-ctrmgrd/ctrmgr/kube_commands.py
+++ b/src/sonic-ctrmgrd/ctrmgr/kube_commands.py
@@ -13,14 +13,14 @@ import sys
 import syslog
 import tempfile
 import urllib.request
-import requests
 import base64
 from urllib.parse import urlparse
-from jinja2 import Template
 
 import yaml
+import requests
 from sonic_py_common import device_info
-from swsssdk import ConfigDBConnector
+from jinja2 import Template
+from swsscommon import swsscommon
 
 KUBE_ADMIN_CONF = "/etc/sonic/kube_admin.conf"
 KUBELET_YAML = "/var/lib/kubelet/config.yaml"
@@ -270,12 +270,11 @@ users:
 
 def _get_local_ipv6():
     try:
-        config_db = ConfigDBConnector()
-        config_db.connect()
-        mgmt_ip_data = config_db.get_table('MGMT_INTERFACE')
-        for key in mgmt_ip_data.keys():
-            if key[1].find(":") >= 0:
-                return key[1].split("/")[0]
+        config_db = swsscommon.DBConnector("CONFIG_DB", 0)
+        mgmt_ip_data = swsscommon.Table(config_db, 'MGMT_INTERFACE')
+        for key in mgmt_ip_data.getKeys():
+            if key.find(":") >= 0:
+                return key.split("|")[1].split("/")[0]
         raise IOError("IPV6 not find from MGMT_INTERFACE table")
     except Exception as e:
         raise IOError(str(e))

--- a/src/sonic-ctrmgrd/ctrmgr/kube_commands.py
+++ b/src/sonic-ctrmgrd/ctrmgr/kube_commands.py
@@ -84,8 +84,7 @@ def _run_command(cmd, timeout=5):
 
 def kube_read_labels():
     """ Read current labels on node and return as dict. """
-    KUBECTL_GET_CMD = "kubectl --kubeconfig {} get nodes --show-labels |\
- grep {} | tr -s ' ' | cut -f6 -d' '"
+    KUBECTL_GET_CMD = "kubectl --kubeconfig {} get nodes {} --show-labels |tr -s ' ' | cut -f6 -d' '"
 
     labels = {}
     ret, out, _ = _run_command(KUBECTL_GET_CMD.format(

--- a/src/sonic-ctrmgrd/tests/common_test.py
+++ b/src/sonic-ctrmgrd/tests/common_test.py
@@ -9,6 +9,7 @@ import time
 CONFIG_DB_NO = 4
 STATE_DB_NO = 6
 FEATURE_TABLE = "FEATURE"
+MGMT_INTERFACE_TABLE = "MGMT_INTERFACE"
 KUBE_LABEL_TABLE = "KUBE_LABELS"
 KUBE_LABEL_SET_KEY = "SET"
 
@@ -643,8 +644,12 @@ def mock_subproc_side_effect(cmd, shell=False, stdout=None, stderr=None):
     return mock_proc(cmd, index)
 
 
-def set_kube_mock(mock_subproc):
+def set_kube_mock(mock_subproc, mock_table=None, mock_conn=None):
     mock_subproc.side_effect = mock_subproc_side_effect
+    if mock_table != None:
+        mock_table.side_effect = table_side_effect
+    if mock_conn != None:
+        mock_conn.side_effect = conn_side_effect
 
 def create_remote_ctr_config_json():
     str_conf = '\

--- a/src/sonic-ctrmgrd/tests/common_test.py
+++ b/src/sonic-ctrmgrd/tests/common_test.py
@@ -42,6 +42,7 @@ KUBE_RETURN = "kube_return"
 IMAGE_TAG = "image_tag"
 FAIL_LOCK = "fail_lock"
 DO_JOIN = "do_join"
+REQ = "req"
 
 # subproc key words
 
@@ -644,12 +645,27 @@ def mock_subproc_side_effect(cmd, shell=False, stdout=None, stderr=None):
     return mock_proc(cmd, index)
 
 
-def set_kube_mock(mock_subproc, mock_table=None, mock_conn=None):
+class mock_reqget:
+    def __init__(self):
+        self.ok = True
+
+    def json(self):
+        return current_test_data.get(REQ, "")
+
+
+def mock_reqget_side_effect(url, cert, verify=True):
+    return mock_reqget()
+
+
+def set_kube_mock(mock_subproc, mock_table=None, mock_conn=None, mock_reqget=None):
     mock_subproc.side_effect = mock_subproc_side_effect
     if mock_table != None:
         mock_table.side_effect = table_side_effect
     if mock_conn != None:
         mock_conn.side_effect = conn_side_effect
+    if mock_reqget != None:
+        mock_reqget.side_effect = mock_reqget_side_effect
+
 
 def create_remote_ctr_config_json():
     str_conf = '\

--- a/src/sonic-ctrmgrd/tests/kube_commands_test.py
+++ b/src/sonic-ctrmgrd/tests/kube_commands_test.py
@@ -128,6 +128,9 @@ none".format(KUBE_ADMIN_CONF),
                     }
                 }
             }
+        },
+        common_test.REQ: {
+            "data": {"ca.crt": "test"}
         }
     },
     1: {
@@ -158,6 +161,9 @@ none".format(KUBE_ADMIN_CONF),
                     }
                 }
             }
+        },
+        common_test.REQ: {
+            "data": {"ca.crt": "test"}
         }
     },
     2: {
@@ -321,12 +327,13 @@ clusters:\n\
                     json.dumps(labels, indent=4)))
                 assert False
 
-    @patch("ctrmgr_tools.swsscommon.DBConnector")
-    @patch("ctrmgr_tools.swsscommon.Table")
+    @patch("kube_commands.requests.get")
+    @patch("kube_commands.swsscommon.DBConnector")
+    @patch("kube_commands.swsscommon.Table")
     @patch("kube_commands.subprocess.Popen")
-    def test_join(self, mock_subproc, mock_table, mock_conn):
+    def test_join(self, mock_subproc, mock_table, mock_conn, mock_reqget):
         self.init()
-        common_test.set_kube_mock(mock_subproc, mock_table, mock_conn)
+        common_test.set_kube_mock(mock_subproc, mock_table, mock_conn, mock_reqget)
 
         for (i, ct_data) in join_test_data.items():
             lock_file = ""

--- a/src/sonic-ctrmgrd/tests/kube_commands_test.py
+++ b/src/sonic-ctrmgrd/tests/kube_commands_test.py
@@ -27,8 +27,7 @@ read_labels_test_data = {
         common_test.DESCR: "read labels",
         common_test.RETVAL: 0,
         common_test.PROC_CMD: ["\
-kubectl --kubeconfig {} get nodes --show-labels |\
- grep none | tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF)],
+kubectl --kubeconfig {} get nodes none --show-labels |tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF)],
         common_test.PROC_OUT: ["foo=bar,hello=world"],
         common_test.POST: {
             "foo": "bar",
@@ -41,8 +40,7 @@ kubectl --kubeconfig {} get nodes --show-labels |\
         common_test.TRIGGER_THROW: True,
         common_test.RETVAL: -1,
         common_test.PROC_CMD: ["\
-kubectl --kubeconfig {} get nodes --show-labels |\
- grep none | tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF)],
+kubectl --kubeconfig {} get nodes none --show-labels |tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF)],
         common_test.POST: {
         },
         common_test.PROC_KILLED: 1
@@ -51,8 +49,7 @@ kubectl --kubeconfig {} get nodes --show-labels |\
         common_test.DESCR: "read labels fail",
         common_test.RETVAL: -1,
         common_test.PROC_CMD: ["\
-kubectl --kubeconfig {} get nodes --show-labels |\
- grep none | tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF)],
+kubectl --kubeconfig {} get nodes none --show-labels |tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF)],
         common_test.PROC_OUT: [""],
         common_test.PROC_ERR: ["command failed"],
         common_test.POST: {
@@ -67,8 +64,7 @@ write_labels_test_data = {
         common_test.RETVAL: 0,
         common_test.ARGS: { "foo": "bar", "hello": "World!", "test": "ok" },
         common_test.PROC_CMD: [
-"kubectl --kubeconfig {} get nodes --show-labels |\
- grep none | tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF),
+"kubectl --kubeconfig {} get nodes none --show-labels |tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF),
 "kubectl --kubeconfig {} label --overwrite nodes none hello-".format(
     KUBE_ADMIN_CONF),
 "kubectl --kubeconfig {} label --overwrite nodes none hello=World! test=ok".format(
@@ -81,8 +77,7 @@ write_labels_test_data = {
         common_test.RETVAL: 0,
         common_test.ARGS: { "foo": "bar", "hello": "world" },
         common_test.PROC_CMD: [
-"kubectl --kubeconfig {} get nodes --show-labels |\
- grep none | tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF)
+"kubectl --kubeconfig {} get nodes none --show-labels |tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF)
  ],
         common_test.PROC_OUT: ["foo=bar,hello=world"]
     },
@@ -92,8 +87,7 @@ write_labels_test_data = {
         common_test.ARGS: { "any": "thing" },
         common_test.RETVAL: -1,
         common_test.PROC_CMD: [
-"kubectl --kubeconfig {} get nodes --show-labels |\
- grep none | tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF)
+"kubectl --kubeconfig {} get nodes none --show-labels |tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF)
 ],
         common_test.PROC_ERR: ["read failed"]
     }


### PR DESCRIPTION
Signed-off-by: Yun Li <yunli1@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Need to change sonic current k8s worker code to make sonic join current k8s cluster with local AME cert 
#### How I did it
Generate client identity by sonic local AME cert
#### How to verify it
File path is /etc/sonic/kube_admin.conf
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

