### PR TITLE
[Arista] Implement ssd_util plugin

### DIFF
--- a/device/arista/x86_64-arista_common/plugins/ssd_util.py
+++ b/device/arista/x86_64-arista_common/plugins/ssd_util.py
@@ -1,0 +1,5 @@
+# pylint: disable=unused-import
+try:
+   from arista.utils.sonic_ssd import SsdUtil
+except ImportError:
+   from sonic_platform_base.sonic_ssd.ssd_generic import SsdUtil


### PR DESCRIPTION
#### Why I did it

Some Arista products do not have an SSD but use an eMMC instead.
The SsdUtil plugin is therefore extended to support both.

#### How I did it

Implemented `ssd_util.py` platform plugin loaded by `ssdutil`.
This plugin fallback to the default SONiC implementation if the arista one can't be found.

#### How to verify it

Run `show platform ssdhealth` on a product with an eMMC

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Implement ssd_util plugin for Arista products
