### PR TITLE
Update cisco-8000 submodule to v0.112

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202012-v0.111
+ref=202012-v0.112


### PR DESCRIPTION
Update cisco-8000 submodule to v0.112

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

