### PR TITLE
[device/accton] Replace os.system and remove subprocess with shell=True

### DIFF
--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/chassis.py
@@ -8,6 +8,7 @@
 
 import os
 import sys
+import subprocess
 
 try:
     from sonic_platform_base.chassis_base import ChassisBase
@@ -27,7 +28,7 @@ HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
 PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
-HOST_CHK_CMD = "which systemctl > /dev/null 2>&1"
+HOST_CHK_CMD = ["which", "systemctl"]
 SYSLED_FNODE = "/sys/class/leds/diag/brightness"
 SYSLED_MODES = {
     "0" : "STATUS_LED_COLOR_OFF",
@@ -97,7 +98,7 @@ class Chassis(ChassisBase):
 
 
     def __is_host(self):
-        return os.system(HOST_CHK_CMD) == 0
+        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/chassis.py
@@ -97,7 +97,7 @@ class Chassis(ChassisBase):
 
 
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD).returncode == 0
+        return subprocess.call(HOST_CHK_CMD) == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/chassis.py
@@ -6,7 +6,6 @@
 #
 #############################################################################
 
-import os
 import sys
 import subprocess
 
@@ -98,7 +97,7 @@ class Chassis(ChassisBase):
 
 
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(HOST_CHK_CMD).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/component.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/component.py
@@ -6,8 +6,6 @@
 #
 #############################################################################
 
-import subprocess
-
 
 try:
     from sonic_platform_base.component_base import ComponentBase

--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/component.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/component.py
@@ -6,7 +6,6 @@
 #
 #############################################################################
 
-import shlex
 import subprocess
 
 
@@ -37,22 +36,6 @@ class Component(ComponentBase):
         ComponentBase.__init__(self)
         self.index = component_index
         self.name = self.get_name()
-
-    def __run_command(self, command):
-        # Run bash command and print output to stdout
-        try:
-            process = subprocess.Popen(
-                shlex.split(command), stdout=subprocess.PIPE)
-            while True:
-                output = process.stdout.readline()
-                if output == '' and process.poll() is not None:
-                    break
-            rc = process.poll()
-            if rc != 0:
-                return False
-        except Exception:
-            return False
-        return True
 
     def __get_bios_version(self):
         # Retrieves the BIOS firmware version

--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/helper.py
@@ -4,7 +4,7 @@ import subprocess
 from mmap import *
 from sonic_py_common import device_info
 
-HOST_CHK_CMD = "docker > /dev/null 2>&1"
+HOST_CHK_CMD = ["docker"]
 EMPTY_STRING = ""
 
 
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return os.system(HOST_CHK_CMD) == 0
+        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def pci_get_value(self, resource, offset):
         status = True
@@ -28,26 +28,6 @@ class APIHelper():
         except Exception:
             status = False
         return status, result
-
-    def run_command(self, cmd):
-        status = True
-        result = ""
-        try:
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-        except Exception:
-            status = False
-        return status, result
-
-    def run_interactive_command(self, cmd):
-        try:
-            os.system(cmd)
-        except Exception:
-            return False
-        return True
 
     def read_txt_file(self, file_path):
         try:
@@ -66,52 +46,3 @@ class APIHelper():
             return False
         return True
 
-    def ipmi_raw(self, netfn, cmd):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool raw {} {}".format(str(netfn), str(cmd))
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result
-
-    def ipmi_fru_id(self, id, key=None):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool fru print {}".format(str(
-                id)) if not key else "ipmitool fru print {0} | grep '{1}' ".format(str(id), str(key))
-
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result
-
-    def ipmi_set_ss_thres(self, id, threshold_key, value):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool sensor thresh '{}' {} {}".format(str(id), str(threshold_key), str(value))
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result

--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/helper.py
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(HOST_CHK_CMD).returncode == 0
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/helper.py
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.run(HOST_CHK_CMD).returncode == 0
+        return subprocess.call(HOST_CHK_CMD) == 0
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/sfp.py
@@ -6,10 +6,9 @@
 #
 #############################################################################
 
-import os
 import time
 import sys
-
+import subprocess
 from ctypes import create_string_buffer
 
 try:
@@ -30,7 +29,7 @@ class Sfp(SfpOptoeBase):
     # Path to sysfs
     PLATFORM_ROOT_PATH = "/usr/share/sonic/device"
     PMON_HWSKU_PATH = "/usr/share/sonic/hwsku"
-    HOST_CHK_CMD = "which systemctl > /dev/null 2>&1"
+    HOST_CHK_CMD = ["which", "systemctl"]
         
     PLATFORM = "x86_64-accton_as4630_54pe-r0"
     HWSKU = "Accton-AS4630-54PE"
@@ -60,7 +59,7 @@ class Sfp(SfpOptoeBase):
         return self.port_to_eeprom_mapping[self.port_num]
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.run(self.HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/sfp.py
@@ -59,7 +59,7 @@ class Sfp(SfpOptoeBase):
         return self.port_to_eeprom_mapping[self.port_num]
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
+        return subprocess.call(self.HOST_CHK_CMD) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/sfp.py
@@ -59,7 +59,7 @@ class Sfp(SfpOptoeBase):
         return self.port_to_eeprom_mapping[self.port_num]
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/chassis.py
@@ -6,7 +6,7 @@
 #
 #############################################################################
 
-import os
+import subprocess
 
 try:
     from sonic_platform_base.chassis_base import ChassisBase
@@ -26,7 +26,7 @@ HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
 PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
-HOST_CHK_CMD = "docker > /dev/null 2>&1"
+HOST_CHK_CMD = ["docker"]
 SYSLED_FNODE = "/sys/class/leds/diag/brightness"
 SYSLED_MODES = {
     "0" : "STATUS_LED_COLOR_OFF",
@@ -95,7 +95,7 @@ class Chassis(ChassisBase):
 
 
     def __is_host(self):
-        return os.system(HOST_CHK_CMD) == 0
+        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/chassis.py
@@ -95,7 +95,7 @@ class Chassis(ChassisBase):
 
 
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(HOST_CHK_CMD).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/chassis.py
@@ -95,7 +95,7 @@ class Chassis(ChassisBase):
 
 
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD).returncode == 0
+        return subprocess.call(HOST_CHK_CMD) == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/component.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/component.py
@@ -6,9 +6,6 @@
 #
 #############################################################################
 
-import shlex
-import subprocess
-
 
 try:
     from sonic_platform_base.component_base import ComponentBase
@@ -37,22 +34,6 @@ class Component(ComponentBase):
         ComponentBase.__init__(self)
         self.index = component_index
         self.name = self.get_name()        
-
-    def __run_command(self, command):
-        # Run bash command and print output to stdout
-        try:
-            process = subprocess.Popen(
-                shlex.split(command), stdout=subprocess.PIPE)
-            while True:
-                output = process.stdout.readline()
-                if output == '' and process.poll() is not None:
-                    break
-            rc = process.poll()
-            if rc != 0:
-                return False
-        except Exception:
-            return False
-        return True
 
     def __get_bios_version(self):
         # Retrieves the BIOS firmware version

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/helper.py
@@ -4,7 +4,7 @@ import subprocess
 from mmap import *
 from sonic_py_common import device_info
 
-HOST_CHK_CMD = "docker > /dev/null 2>&1"
+HOST_CHK_CMD = ["docker"]
 EMPTY_STRING = ""
 
 
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return os.system(HOST_CHK_CMD) == 0
+        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def pci_get_value(self, resource, offset):
         status = True
@@ -28,26 +28,6 @@ class APIHelper():
         except Exception:
             status = False
         return status, result
-
-    def run_command(self, cmd):
-        status = True
-        result = ""
-        try:
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-        except Exception:
-            status = False
-        return status, result
-
-    def run_interactive_command(self, cmd):
-        try:
-            os.system(cmd)
-        except Exception:
-            return False
-        return True
 
     def read_txt_file(self, file_path):
         try:
@@ -66,52 +46,3 @@ class APIHelper():
             return False
         return True
 
-    def ipmi_raw(self, netfn, cmd):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool raw {} {}".format(str(netfn), str(cmd))
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result
-
-    def ipmi_fru_id(self, id, key=None):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool fru print {}".format(str(
-                id)) if not key else "ipmitool fru print {0} | grep '{1}' ".format(str(id), str(key))
-
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result
-
-    def ipmi_set_ss_thres(self, id, threshold_key, value):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool sensor thresh '{}' {} {}".format(str(id), str(threshold_key), str(value))
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/helper.py
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(HOST_CHK_CMD).returncode == 0
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/helper.py
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.run(HOST_CHK_CMD).returncode == 0
+        return subprocess.call(HOST_CHK_CMD) == 0
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/sfp.py
@@ -192,7 +192,7 @@ class Sfp(SfpBase):
         return True
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD, stdout=None, stderr=None) == 0
+        return subprocess.run(self.HOST_CHK_CMD) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/sfp.py
@@ -8,10 +8,9 @@
 #
 #############################################################################
 
-import os
 import time
 import sys
-
+import subprocess
 from ctypes import create_string_buffer
 
 try:
@@ -127,7 +126,7 @@ class Sfp(SfpBase):
     # Path to sysfs
     PLATFORM_ROOT_PATH = "/usr/share/sonic/device"
     PMON_HWSKU_PATH = "/usr/share/sonic/hwsku"
-    HOST_CHK_CMD = "docker > /dev/null 2>&1"
+    HOST_CHK_CMD = ["docker"]
 
     PLATFORM = "x86_64-accton_as4630_54te-r0"
     HWSKU = "Accton-AS4630-54TE"
@@ -193,7 +192,7 @@ class Sfp(SfpBase):
         return True
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.run(self.HOST_CHK_CMD, stdout=None, stderr=None) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/sfp.py
@@ -192,7 +192,7 @@ class Sfp(SfpBase):
         return True
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD) == 0
+        return subprocess.call(self.HOST_CHK_CMD) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/chassis.py
@@ -98,7 +98,7 @@ class Chassis(ChassisBase):
     
 
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(HOST_CHK_CMD).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/chassis.py
@@ -98,7 +98,7 @@ class Chassis(ChassisBase):
     
 
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD).returncode == 0
+        return subprocess.call(HOST_CHK_CMD) == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/chassis.py
@@ -6,8 +6,8 @@
 #
 #############################################################################
 
-import os
 import sys
+import subprocess
 
 try:
     from sonic_platform_base.chassis_base import ChassisBase
@@ -28,7 +28,7 @@ HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
 PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
-HOST_CHK_CMD = "which systemctl > /dev/null 2>&1"
+HOST_CHK_CMD = ["which", "systemctl"]
 SYSLED_FNODE= "/sys/class/leds/as5835_54x_led::diag/brightness"
 
 SYSLED_MODES = {
@@ -98,7 +98,7 @@ class Chassis(ChassisBase):
     
 
     def __is_host(self):
-        return os.system(HOST_CHK_CMD) == 0
+        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/component.py
+++ b/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/component.py
@@ -6,10 +6,6 @@
 #
 #############################################################################
 
-import shlex
-import subprocess
-
-
 try:
     from sonic_platform_base.component_base import ComponentBase
     from .helper import APIHelper
@@ -43,23 +39,6 @@ class Component(ComponentBase):
         ComponentBase.__init__(self)
         self.index = component_index
         self.name = self.get_name()
-
-
-    def __run_command(self, command):
-        # Run bash command and print output to stdout
-        try:
-            process = subprocess.Popen(
-                shlex.split(command), stdout=subprocess.PIPE)
-            while True:
-                output = process.stdout.readline()
-                if output == '' and process.poll() is not None:
-                    break
-            rc = process.poll()
-            if rc != 0:
-                return False
-        except Exception:
-            return False
-        return True
 
     def __get_bios_version(self):
         # Retrieves the BIOS firmware version

--- a/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/helper.py
@@ -4,7 +4,7 @@ import subprocess
 from mmap import *
 from sonic_py_common import device_info
 
-HOST_CHK_CMD = "docker > /dev/null 2>&1"
+HOST_CHK_CMD = ["docker"]
 EMPTY_STRING = ""
 
 
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return os.system(HOST_CHK_CMD) == 0
+        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def pci_get_value(self, resource, offset):
         status = True
@@ -28,26 +28,6 @@ class APIHelper():
         except Exception:
             status = False
         return status, result
-
-    def run_command(self, cmd):
-        status = True
-        result = ""
-        try:
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-        except Exception:
-            status = False
-        return status, result
-
-    def run_interactive_command(self, cmd):
-        try:
-            os.system(cmd)
-        except Exception:
-            return False
-        return True
 
     def read_txt_file(self, file_path):
         try:
@@ -66,52 +46,3 @@ class APIHelper():
             return False
         return True
 
-    def ipmi_raw(self, netfn, cmd):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool raw {} {}".format(str(netfn), str(cmd))
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result
-
-    def ipmi_fru_id(self, id, key=None):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool fru print {}".format(str(
-                id)) if not key else "ipmitool fru print {0} | grep '{1}' ".format(str(id), str(key))
-
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result
-
-    def ipmi_set_ss_thres(self, id, threshold_key, value):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool sensor thresh '{}' {} {}".format(str(id), str(threshold_key), str(value))
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result

--- a/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/helper.py
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(HOST_CHK_CMD).returncode == 0
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/helper.py
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.run(HOST_CHK_CMD).returncode == 0
+        return subprocess.call(HOST_CHK_CMD) == 0
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/sfp.py
@@ -6,10 +6,9 @@
 #
 #############################################################################
 
-import os
 import time
 import sys
-
+import subprocess
 from ctypes import create_string_buffer
 
 try:
@@ -31,7 +30,7 @@ class Sfp(SfpOptoeBase):
     # Path to sysfs
     PLATFORM_ROOT_PATH = "/usr/share/sonic/device"
     PMON_HWSKU_PATH = "/usr/share/sonic/hwsku"
-    HOST_CHK_CMD = "which systemctl > /dev/null 2>&1"
+    HOST_CHK_CMD = ["which", "systemctl"]
         
     PLATFORM = "x86_64-accton_as5835_54x-r0"
     HWSKU = "Accton-AS5835-54X"
@@ -121,7 +120,7 @@ class Sfp(SfpOptoeBase):
 
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess(self.HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/sfp.py
@@ -120,7 +120,7 @@ class Sfp(SfpOptoeBase):
 
 
     def __is_host(self):
-        return subprocess(self.HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess(self.HOST_CHK_CMD).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/chassis.py
@@ -5,12 +5,7 @@
 #
 #############################################################################
 try:
-    import sys
-    import re
-    import os
     import subprocess
-    import json
-    import syslog
     from sonic_platform_base.chassis_base import ChassisBase
     from sonic_py_common.logger import Logger
     from sonic_platform.fan import Fan
@@ -36,7 +31,7 @@ PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
 COMPONENT_NAME_LIST = ["BIOS"]
-HOST_CHK_CMD = "docker > /dev/null 2>&1"
+HOST_CHK_CMD = ["docker"]
 
 
 class Chassis(ChassisBase):
@@ -71,7 +66,7 @@ class Chassis(ChassisBase):
         logger.log_info("Chassis loaded successfully")
 
     def __is_host(self):
-        return os.system(HOST_CHK_CMD) == 0
+        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/chassis.py
@@ -66,7 +66,7 @@ class Chassis(ChassisBase):
         logger.log_info("Chassis loaded successfully")
 
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(HOST_CHK_CMD).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/chassis.py
@@ -66,7 +66,7 @@ class Chassis(ChassisBase):
         logger.log_info("Chassis loaded successfully")
 
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD).returncode == 0
+        return subprocess.call(HOST_CHK_CMD) == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/component.py
+++ b/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/component.py
@@ -3,10 +3,7 @@
 # provides the components firmware management function
 #############################################################################
 
-import json
 import os.path
-import shutil
-import shlex
 import subprocess
 
 try:
@@ -29,8 +26,7 @@ class Component(DeviceBase):
     def __run_command(self, command):
         # Run bash command and print output to stdout
         try:
-            process = subprocess.Popen(
-                shlex.split(command), universal_newlines=True, stdout=subprocess.PIPE)
+            process = subprocess.Popen(command, universal_newlines=True, stdout=subprocess.PIPE)
             while True:
                 output = process.stdout.readline()
                 if output == '' and process.poll() is not None:

--- a/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/sfp.py
@@ -3,10 +3,8 @@
 # provides the sfp device status which are available in the platform
 #############################################################################
 try:
-    import os
     import time
     import subprocess
-    import syslog
     from ctypes import create_string_buffer
     from sonic_platform_base.sfp_base import SfpBase
     from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
@@ -173,7 +171,7 @@ class Sfp(SfpBase):
 
     PLATFORM_ROOT_PATH = '/usr/share/sonic/device'
     PMON_HWSKU_PATH = '/usr/share/sonic/hwsku'
-    HOST_CHK_CMD = "docker > /dev/null 2>&1"
+    HOST_CHK_CMD = ["docker"]
 
     PLATFORM = "x86_64-accton_as7116_54x-r0"
     HWSKU = "Accton-AS7116-54X-R0"
@@ -233,7 +231,7 @@ class Sfp(SfpBase):
         return ""
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.run(self.HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/sfp.py
@@ -231,7 +231,7 @@ class Sfp(SfpBase):
         return ""
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/sfp.py
@@ -231,7 +231,7 @@ class Sfp(SfpBase):
         return ""
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
+        return subprocess.call(self.HOST_CHK_CMD) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/chassis.py
@@ -87,7 +87,7 @@ class Chassis(ChassisBase):
     
     
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD).returncode == 0
+        return subprocess.call(HOST_CHK_CMD) == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/chassis.py
@@ -6,7 +6,7 @@
 #
 #############################################################################
 
-import os
+import subprocess
 
 try:
     from sonic_platform_base.chassis_base import ChassisBase
@@ -24,7 +24,7 @@ HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
 PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
-HOST_CHK_CMD = "docker > /dev/null 2>&1"
+HOST_CHK_CMD = ["docker"]
 
 
 class Chassis(ChassisBase):
@@ -87,7 +87,7 @@ class Chassis(ChassisBase):
     
     
     def __is_host(self):
-        return os.system(HOST_CHK_CMD) == 0
+        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/chassis.py
@@ -87,7 +87,7 @@ class Chassis(ChassisBase):
     
     
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(HOST_CHK_CMD).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/component.py
+++ b/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/component.py
@@ -6,8 +6,6 @@
 #
 #############################################################################
 
-import shlex
-import subprocess
 
 try:
     from sonic_platform_base.component_base import ComponentBase
@@ -42,22 +40,6 @@ class Component(ComponentBase):
         ComponentBase.__init__(self)
         self.index = component_index
         self.name = self.get_name()
-
-    def __run_command(self, command):
-        # Run bash command and print output to stdout
-        try:
-            process = subprocess.Popen(
-                shlex.split(command), stdout=subprocess.PIPE)
-            while True:
-                output = process.stdout.readline()
-                if output == '' and process.poll() is not None:
-                    break
-            rc = process.poll()
-            if rc != 0:
-                return False
-        except Exception:
-            return False
-        return True
 
     def __get_bios_version(self):
         # Retrieves the BIOS firmware version

--- a/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/helper.py
@@ -4,7 +4,7 @@ import subprocess
 from mmap import *
 from sonic_py_common import device_info
 
-HOST_CHK_CMD = "docker > /dev/null 2>&1"
+HOST_CHK_CMD = ["docker"]
 EMPTY_STRING = ""
 
 
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return os.system(HOST_CHK_CMD) == 0
+        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def pci_get_value(self, resource, offset):
         status = True
@@ -28,26 +28,6 @@ class APIHelper():
         except Exception:
             status = False
         return status, result
-
-    def run_command(self, cmd):
-        status = True
-        result = ""
-        try:
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-        except Exception:
-            status = False
-        return status, result
-
-    def run_interactive_command(self, cmd):
-        try:
-            os.system(cmd)
-        except Exception:
-            return False
-        return True
 
     def read_txt_file(self, file_path):
         try:
@@ -66,52 +46,3 @@ class APIHelper():
             return False
         return True
 
-    def ipmi_raw(self, netfn, cmd):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool raw {} {}".format(str(netfn), str(cmd))
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result
-
-    def ipmi_fru_id(self, id, key=None):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool fru print {}".format(str(
-                id)) if not key else "ipmitool fru print {0} | grep '{1}' ".format(str(id), str(key))
-
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result
-
-    def ipmi_set_ss_thres(self, id, threshold_key, value):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool sensor thresh '{}' {} {}".format(str(id), str(threshold_key), str(value))
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result

--- a/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/helper.py
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(HOST_CHK_CMD).returncode == 0
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/helper.py
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.run(HOST_CHK_CMD).returncode == 0
+        return subprocess.call(HOST_CHK_CMD) == 0
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/sfp.py
@@ -255,7 +255,7 @@ class Sfp(SfpBase):
         return True
     
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/sfp.py
@@ -255,7 +255,7 @@ class Sfp(SfpBase):
         return True
     
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
+        return subprocess.call(self.HOST_CHK_CMD) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/sfp.py
@@ -6,10 +6,9 @@
 #
 #############################################################################
 
-import os
 import time
 import sys
-
+import subprocess
 from ctypes import create_string_buffer
 
 try:
@@ -125,7 +124,7 @@ class Sfp(SfpBase):
     # Path to sysfs
     PLATFORM_ROOT_PATH = "/usr/share/sonic/device"
     PMON_HWSKU_PATH = "/usr/share/sonic/hwsku"
-    HOST_CHK_CMD = "docker > /dev/null 2>&1"
+    HOST_CHK_CMD = ["docker"]
         
     PLATFORM = "x86_64-accton_as7312_54x-r0"
     HWSKU = "Accton-AS7312-54X"
@@ -256,7 +255,7 @@ class Sfp(SfpBase):
         return True
     
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.run(self.HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as7326_56x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as7326_56x-r0/sonic_platform/chassis.py
@@ -93,7 +93,7 @@ class Chassis(ChassisBase):
         self._watchdog = Watchdog()
 
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD).returncode == 0
+        return subprocess.call(HOST_CHK_CMD) == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as7326_56x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as7326_56x-r0/sonic_platform/chassis.py
@@ -93,7 +93,7 @@ class Chassis(ChassisBase):
         self._watchdog = Watchdog()
 
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(HOST_CHK_CMD).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as7326_56x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as7326_56x-r0/sonic_platform/chassis.py
@@ -6,8 +6,8 @@
 #
 #############################################################################
 
-import os
 import sys
+import subprocess
 
 try:
     from sonic_platform_base.chassis_base import ChassisBase
@@ -27,7 +27,7 @@ HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
 PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
-HOST_CHK_CMD = "which systemctl > /dev/null 2>&1"
+HOST_CHK_CMD = ["which", "systemctl"]
 SYSLED_FNODE= "/sys/class/leds/accton_as7326_56x_led::diag/brightness"
 SYSLED_MODES = {
     "0" : "STATUS_LED_COLOR_OFF",
@@ -93,7 +93,7 @@ class Chassis(ChassisBase):
         self._watchdog = Watchdog()
 
     def __is_host(self):
-        return os.system(HOST_CHK_CMD) == 0
+        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as7326_56x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as7326_56x-r0/sonic_platform/sfp.py
@@ -143,7 +143,7 @@ class Sfp(SfpOptoeBase):
         return True
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as7326_56x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as7326_56x-r0/sonic_platform/sfp.py
@@ -143,7 +143,7 @@ class Sfp(SfpOptoeBase):
         return True
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
+        return subprocess.call(self.HOST_CHK_CMD) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as7326_56x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as7326_56x-r0/sonic_platform/sfp.py
@@ -6,10 +6,9 @@
 #
 #############################################################################
 
-import os
 import time
 import sys
-
+import subprocess
 from ctypes import create_string_buffer
 
 try:
@@ -40,7 +39,7 @@ class Sfp(SfpOptoeBase):
     # Path to sysfs
     PLATFORM_ROOT_PATH = "/usr/share/sonic/device"
     PMON_HWSKU_PATH = "/usr/share/sonic/hwsku"
-    HOST_CHK_CMD = "which systemctl > /dev/null 2>&1"
+    HOST_CHK_CMD = ["which", "systemctl"]
 
     PLATFORM = "x86_64-accton_as7326_56x-r0"
     HWSKU = "Accton-AS7326-56X"
@@ -144,7 +143,7 @@ class Sfp(SfpOptoeBase):
         return True
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.run(self.HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/chassis.py
@@ -96,7 +96,7 @@ class Chassis(ChassisBase):
     
 
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(HOST_CHK_CMD).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/chassis.py
@@ -6,8 +6,8 @@
 #
 #############################################################################
 
-import os
 import sys
+import subprocess
 
 try:
     from sonic_platform_base.chassis_base import ChassisBase
@@ -26,7 +26,7 @@ HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
 PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
-HOST_CHK_CMD = "which systemctl > /dev/null 2>&1"
+HOST_CHK_CMD = ["which", "systemctl"]
 SYSLED_FNODE = "/sys/class/leds/as7816_64x_led::diag/brightness"
 SYSLED_MODES = {
     "0" : "STATUS_LED_COLOR_OFF",
@@ -96,7 +96,7 @@ class Chassis(ChassisBase):
     
 
     def __is_host(self):
-        return os.system(HOST_CHK_CMD) == 0
+        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/chassis.py
@@ -96,7 +96,7 @@ class Chassis(ChassisBase):
     
 
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD).returncode == 0
+        return subprocess.call(HOST_CHK_CMD) == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/component.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/component.py
@@ -6,8 +6,6 @@
 #
 #############################################################################
 
-import shlex
-import subprocess
 
 try:
     from sonic_platform_base.component_base import ComponentBase
@@ -42,22 +40,6 @@ class Component(ComponentBase):
         ComponentBase.__init__(self)
         self.index = component_index
         self.name = self.get_name()
-
-    def __run_command(self, command):
-        # Run bash command and print output to stdout
-        try:
-            process = subprocess.Popen(
-                shlex.split(command), stdout=subprocess.PIPE)
-            while True:
-                output = process.stdout.readline()
-                if output == '' and process.poll() is not None:
-                    break
-            rc = process.poll()
-            if rc != 0:
-                return False
-        except Exception:
-            return False
-        return True
 
     def __get_bios_version(self):
         # Retrieves the BIOS firmware version

--- a/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/helper.py
@@ -4,7 +4,7 @@ import subprocess
 from mmap import *
 from sonic_py_common import device_info
 
-HOST_CHK_CMD = "docker > /dev/null 2>&1"
+HOST_CHK_CMD = ["docker"]
 EMPTY_STRING = ""
 
 
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return os.system(HOST_CHK_CMD) == 0
+        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def pci_get_value(self, resource, offset):
         status = True
@@ -28,26 +28,6 @@ class APIHelper():
         except Exception:
             status = False
         return status, result
-
-    def run_command(self, cmd):
-        status = True
-        result = ""
-        try:
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-        except Exception:
-            status = False
-        return status, result
-
-    def run_interactive_command(self, cmd):
-        try:
-            os.system(cmd)
-        except Exception:
-            return False
-        return True
 
     def read_txt_file(self, file_path):
         try:
@@ -66,52 +46,3 @@ class APIHelper():
             return False
         return True
 
-    def ipmi_raw(self, netfn, cmd):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool raw {} {}".format(str(netfn), str(cmd))
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result
-
-    def ipmi_fru_id(self, id, key=None):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool fru print {}".format(str(
-                id)) if not key else "ipmitool fru print {0} | grep '{1}' ".format(str(id), str(key))
-
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result
-
-    def ipmi_set_ss_thres(self, id, threshold_key, value):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool sensor thresh '{}' {} {}".format(str(id), str(threshold_key), str(value))
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result

--- a/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/helper.py
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(HOST_CHK_CMD).returncode == 0
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/helper.py
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.run(HOST_CHK_CMD).returncode == 0
+        return subprocess.call(HOST_CHK_CMD) == 0
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/sfp.py
@@ -6,10 +6,9 @@
 #
 #############################################################################
 
-import os
 import time
 import sys
-
+import subprocess
 from ctypes import create_string_buffer
 
 try:
@@ -31,7 +30,7 @@ class Sfp(SfpOptoeBase):
     # Path to sysfs
     PLATFORM_ROOT_PATH = "/usr/share/sonic/device"
     PMON_HWSKU_PATH = "/usr/share/sonic/hwsku"
-    HOST_CHK_CMD = "which systemctl > /dev/null 2>&1"
+    HOST_CHK_CMD = ["which", "systemctl"]
         
     PLATFORM = "x86_64-accton_as7816_64x-r0"
     HWSKU = "Accton-AS7816-64X"
@@ -119,7 +118,7 @@ class Sfp(SfpOptoeBase):
         return self.port_to_eeprom_mapping[self.port_num]
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.run(self.HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/sfp.py
@@ -118,7 +118,7 @@ class Sfp(SfpOptoeBase):
         return self.port_to_eeprom_mapping[self.port_num]
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
+        return subprocess.call(self.HOST_CHK_CMD) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/sfp.py
@@ -118,7 +118,7 @@ class Sfp(SfpOptoeBase):
         return self.port_to_eeprom_mapping[self.port_num]
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/chassis.py
@@ -96,7 +96,7 @@ class Chassis(ChassisBase):
 
 
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(HOST_CHK_CMD).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/chassis.py
@@ -96,7 +96,7 @@ class Chassis(ChassisBase):
 
 
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD).returncode == 0
+        return subprocess.call(HOST_CHK_CMD) == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/chassis.py
@@ -6,7 +6,7 @@
 #
 #############################################################################
 
-import os
+import subprocess
 
 try:
     from sonic_platform_base.chassis_base import ChassisBase
@@ -28,7 +28,7 @@ HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
 PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
-HOST_CHK_CMD = "docker > /dev/null 2>&1"
+HOST_CHK_CMD = ["docker"]
 
 
 class Chassis(ChassisBase):
@@ -96,7 +96,7 @@ class Chassis(ChassisBase):
 
 
     def __is_host(self):
-        return os.system(HOST_CHK_CMD) == 0
+        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/component.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/component.py
@@ -6,9 +6,6 @@
 #
 #############################################################################
 
-import shlex
-import subprocess
-
 
 try:
     from sonic_platform_base.component_base import ComponentBase
@@ -37,22 +34,6 @@ class Component(ComponentBase):
         ComponentBase.__init__(self)
         self.index = component_index
         self.name = self.get_name()        
-
-    def __run_command(self, command):
-        # Run bash command and print output to stdout
-        try:
-            process = subprocess.Popen(
-                shlex.split(command), stdout=subprocess.PIPE)
-            while True:
-                output = process.stdout.readline()
-                if output == '' and process.poll() is not None:
-                    break
-            rc = process.poll()
-            if rc != 0:
-                return False
-        except Exception:
-            return False
-        return True
 
     def __get_bios_version(self):
         # Retrieves the BIOS firmware version

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/helper.py
@@ -4,7 +4,7 @@ import subprocess
 from mmap import *
 from sonic_py_common import device_info
 
-HOST_CHK_CMD = "docker > /dev/null 2>&1"
+HOST_CHK_CMD = ["docker"]
 EMPTY_STRING = ""
 
 
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return os.system(HOST_CHK_CMD) == 0
+        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def pci_get_value(self, resource, offset):
         status = True
@@ -28,26 +28,6 @@ class APIHelper():
         except Exception:
             status = False
         return status, result
-
-    def run_command(self, cmd):
-        status = True
-        result = ""
-        try:
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-        except Exception:
-            status = False
-        return status, result
-
-    def run_interactive_command(self, cmd):
-        try:
-            os.system(cmd)
-        except Exception:
-            return False
-        return True
 
     def read_txt_file(self, file_path):
         try:
@@ -66,52 +46,3 @@ class APIHelper():
             return False
         return True
 
-    def ipmi_raw(self, netfn, cmd):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool raw {} {}".format(str(netfn), str(cmd))
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result
-
-    def ipmi_fru_id(self, id, key=None):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool fru print {}".format(str(
-                id)) if not key else "ipmitool fru print {0} | grep '{1}' ".format(str(id), str(key))
-
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result
-
-    def ipmi_set_ss_thres(self, id, threshold_key, value):
-        status = True
-        result = ""
-        try:
-            cmd = "ipmitool sensor thresh '{}' {} {}".format(str(id), str(threshold_key), str(value))
-            p = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            raw_data, err = p.communicate()
-            if err == '':
-                result = raw_data.strip()
-            else:
-                status = False
-        except Exception:
-            status = False
-        return status, result

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/helper.py
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.run(HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(HOST_CHK_CMD).returncode == 0
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/helper.py
@@ -14,7 +14,7 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.run(HOST_CHK_CMD).returncode == 0
+        return subprocess.call(HOST_CHK_CMD) == 0
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/sfp.py
@@ -309,7 +309,7 @@ class Sfp(SfpBase):
         return True
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
+        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/sfp.py
@@ -309,7 +309,7 @@ class Sfp(SfpBase):
         return True
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
+        return subprocess.call(self.HOST_CHK_CMD) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/sfp.py
@@ -6,11 +6,10 @@
 #
 #############################################################################
 
-import os
 import sys
 import time
 import struct
-
+import subprocess
 from ctypes import create_string_buffer
 
 try:
@@ -272,7 +271,7 @@ I2C_EEPROM_PATH = '/sys/bus/i2c/devices/{0}-0050/eeprom'
 
 class Sfp(SfpBase):
     """Platform-specific Sfp class"""
-    HOST_CHK_CMD = "docker > /dev/null 2>&1"
+    HOST_CHK_CMD = ["docker"]
     PLATFORM = "x86_64-accton_as9726_32d-r0"
     HWSKU = "Accton-AS9726-32D"
 
@@ -310,7 +309,7 @@ class Sfp(SfpBase):
         return True
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.run(self.HOST_CHK_CMD, stdout=None, stderr=None).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/sonic_platform/component.py
@@ -8,8 +8,8 @@
 #############################################################################
 
 try:
-    import subprocess
     from sonic_platform_base.component_base import ComponentBase
+    from sonic_py_common.general import getstatusoutput_noshell
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -67,8 +67,8 @@ class Component(ComponentBase):
         if self.name == "BIOS":
             fw_version = self.__get_bios_version()
         elif "CPLD" in self.name:
-            cmd = "i2cget -f -y {0} {1} 0x1".format(self.cpld_mapping[self.index][0], self.cpld_mapping[self.index][1])
-            status, value = subprocess.getstatusoutput(cmd)
+            cmd = ["i2cget", "-f", "-y", self.cpld_mapping[self.index][0], self.cpld_mapping[self.index][1], "0x1"]
+            status, value = getstatusoutput_noshell(cmd)
             if not status:
                 fw_version = value.rstrip()
 

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_monitor.py
@@ -26,9 +26,9 @@ try:
     import logging.config
     import logging.handlers
     import time
-    import subprocess
     from as4630_54pe.fanutil import FanUtil
     from as4630_54pe.thermalutil import ThermalUtil
+    from sonic_py_common.general import getstatusoutput_noshell
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
 
@@ -198,9 +198,9 @@ class device_monitor(object):
         if temp[0] >= 70000: #LM75-48    
             #critical case*/
             logging.critical('Alarm-Critical for temperature critical is detected, reset DUT')
-            cmd_str="i2cset -y -f 3 0x60 0x4 0xE4"
+            cmd_str = ["i2cset", "-y", "-f", "3", "0x60", "0x4", "0xE4"]
             time.sleep(2);
-            status, output = subprocess.getstatusoutput(cmd_str)
+            status, output = getstatusoutput_noshell(cmd_str)
                 
         #logging.debug('ori_state=%d, current_state=%d, temp_val=%d\n\n',ori_state, fan_policy_state, temp_val)
         

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_pddf_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_pddf_monitor.py
@@ -28,6 +28,7 @@ try:
     import logging.handlers
     import time
     from sonic_platform import platform
+    from sonic_py_common.general import getstatusoutput_noshell
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
 
@@ -209,10 +210,12 @@ class device_monitor(object):
             # Critical: Either all the fans are faulty or they are removed, shutdown the system
             logging.critical('Alarm for all fan faulty/absent is detected')
             logging.critical("Alarm for all fan faulty/absent is detected, reset DUT")
-            cmd_str = "i2cset -y -f 3 0x60 0x4 0xE4"
+            cmd_str = ["i2cset", "-y", "-f", "3", "0x60", "0x4", "0xE4"]
             time.sleep(2)
-            subprocess.getstatusoutput('sync; sync; sync')
-            subprocess.getstatusoutput(cmd_str)
+            getstatusoutput_noshell('sync')
+            getstatusoutput_noshell('sync')
+            getstatusoutput_noshell('sync')
+            getstatusoutput_noshell(cmd_str)
         elif sum(fan_fail_list) != 0:
             # Set the 100% speed only for first fan failure detection
             logging.warning('Fan_{} failed, set remaining fan speed to 100%'.format(
@@ -235,7 +238,7 @@ class device_monitor(object):
             as4630_54pe_set_fan_speed(new_duty_cycle)
             if test_temp == 1:
                 time.sleep(3)
-                status, output = subprocess.getstatusoutput('pddf_fanutil getspeed')
+                status, output = getstatusoutput_noshell(['pddf_fanutil', 'getspeed'])
                 logging.debug('\n%s\n', output)
 
         if temp[0] >= 70000:  # LM77-48
@@ -252,10 +255,12 @@ class device_monitor(object):
             if status:
                 logging.warning('Reboot cause file not updated. {}'.format(output))
 
-            cmd_str = "i2cset -y -f 3 0x60 0x4 0xE4"
-            subprocess.getstatusoutput('sync; sync; sync')
+            cmd_str = ["i2cset", "-y", "-f", "3", "0x60", "0x4", "0xE4"]
+            getstatusoutput_noshell('sync')
+            getstatusoutput_noshell('sync')
+            getstatusoutput_noshell('sync')
             time.sleep(3)
-            subprocess.getstatusoutput(cmd_str)
+            getstatusoutput_noshell(cmd_str)
 
         logging.debug('ori_state=%d, current_state=%d, temp_val=%d\n\n', ori_state, fan_policy_state, temp_val)
 

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/pddf_switch_svc.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/pddf_switch_svc.py
@@ -2,111 +2,111 @@
 # Script to stop and start the respective platforms default services. 
 # This will be used while switching the pddf->non-pddf mode and vice versa
 
-import commands
+from sonic_py_common.general import getstatusoutput_noshell
 
 def check_pddf_support():
     return True
 
 def stop_platform_svc():
-    status, output = commands.getstatusoutput("systemctl disable as4630-54pe-platform-monitor-fan.service")
+    status, output = getstatusoutput_noshell(["systemctl", "disable", "as4630-54pe-platform-monitor-fan.service"])
     if status:
-        print "Disable as4630-54pe-platform-monitor-fan.service failed %d"%status
+        print("Disable as4630-54pe-platform-monitor-fan.service failed %d"%status)
         return False
-    status, output = commands.getstatusoutput("systemctl stop as4630-54pe-platform-monitor-fan.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as4630-54pe-platform-monitor-fan.service"])
     if status:
-        print "Stop as4630-54pe-platform-monitor-fan.service failed %d"%status
+        print("Stop as4630-54pe-platform-monitor-fan.service failed %d"%status)
         return False
 
-    status, output = commands.getstatusoutput("systemctl disable as4630-54pe-platform-monitor-psu.service")
+    status, output = getstatusoutput_noshell(["systemctl", "disable", "as4630-54pe-platform-monitor-psu.service"])
     if status:
-        print "Disable as4630-54pe-platform-monitor-psu.service failed %d"%status
+        print("Disable as4630-54pe-platform-monitor-psu.service failed %d"%status)
         return False
-    status, output = commands.getstatusoutput("systemctl stop as4630-54pe-platform-monitor-psu.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as4630-54pe-platform-monitor-psu.service"])
     if status:
-        print "Stop as4630-54pe-platform-monitor-psu.service failed %d"%status
+        print("Stop as4630-54pe-platform-monitor-psu.service failed %d"%status)
         return False
     
-    status, output = commands.getstatusoutput("systemctl disable as4630-54pe-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "disable", "as4630-54pe-platform-monitor.service"])
     if status:
-        print "Disable as4630-54pe-platform-monitor.service failed %d"%status
+        print("Disable as4630-54pe-platform-monitor.service failed %d"%status)
         return False
-    status, output = commands.getstatusoutput("systemctl stop as4630-54pe-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as4630-54pe-platform-monitor.service"])
     if status:
-        print "Stop as4630-54pe-platform-monitor.service failed %d"%status
+        print("Stop as4630-54pe-platform-monitor.service failed %d"%status)
         return False
 
-    status, output = commands.getstatusoutput("/usr/local/bin/accton_as4630_54pe_util.py clean")
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as4630_54pe_util.py", "clean"])
     if status:
-        print "accton_as4630_54pe_util.py clean command failed %d"%status
+        print("accton_as4630_54pe_util.py clean command failed %d"%status)
         return False
 
     # HACK , stop the pddf-platform-init service if it is active
-    status, output = commands.getstatusoutput("systemctl stop pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
     if status:
-        print "Stop pddf-platform-init.service along with other platform serives failed %d"%status
+        print("Stop pddf-platform-init.service along with other platform serives failed %d"%status)
         return False
-    status, output = commands.getstatusoutput("systemctl stop as4630-54pe-pddf-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as4630-54pe-pddf-platform-monitor.service"])
     if status:
-        print "Stop as4630-54pe-pddf-platform-monitor.service along with other platform serives failed %d"%status
+        print("Stop as4630-54pe-pddf-platform-monitor.service along with other platform serives failed %d"%status)
         return False
 
     return True
     
 def start_platform_svc():
-    status, output = commands.getstatusoutput("/usr/local/bin/accton_as4630_54pe_util.py install")
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as4630_54pe_util.py", "install"])
     if status:
-        print "accton_as4630_54pe_util.py install  command failed %d"%status
+        print("accton_as4630_54pe_util.py install  command failed %d"%status)
         return False
 
-    status, output = commands.getstatusoutput("systemctl enable as4630-54pe-platform-monitor-fan.service")
+    status, output = getstatusoutput_noshell(["systemctl", "enable", "as4630-54pe-platform-monitor-fan.service"])
     if status:
-        print "Enable as4630-54pe-platform-monitor-fan.service failed %d"%status
+        print("Enable as4630-54pe-platform-monitor-fan.service failed %d"%status)
         return False
-    status, output = commands.getstatusoutput("systemctl start as4630-54pe-platform-monitor-fan.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "as4630-54pe-platform-monitor-fan.service"])
     if status:
-        print "Start as4630-54pe-platform-monitor-fan.service failed %d"%status
-        return False
-
-    status, output = commands.getstatusoutput("systemctl enable as4630-54pe-platform-monitor-psu.service")
-    if status:
-        print "Enable as4630-54pe-platform-monitor-psu.service failed %d"%status
-        return False
-    status, output = commands.getstatusoutput("systemctl start as4630-54pe-platform-monitor-psu.service")
-    if status:
-        print "Start as4630-54pe-platform-monitor-psu.service failed %d"%status
+        print("Start as4630-54pe-platform-monitor-fan.service failed %d"%status)
         return False
 
-    status, output = commands.getstatusoutput("systemctl enable as4630-54pe-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "enable", "as4630-54pe-platform-monitor-psu.service"])
     if status:
-        print "Enable as4630-54pe-platform-monitor.service failed %d"%status
+        print("Enable as4630-54pe-platform-monitor-psu.service failed %d"%status)
         return False
-    status, output = commands.getstatusoutput("systemctl start as4630-54pe-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "as4630-54pe-platform-monitor-psu.service"])
     if status:
-        print "Start as4630-54pe-platform-monitor.service failed %d"%status
+        print("Start as4630-54pe-platform-monitor-psu.service failed %d"%status)
+        return False
+
+    status, output = getstatusoutput_noshell(["systemctl", "enable", "as4630-54pe-platform-monitor.service"])
+    if status:
+        print("Enable as4630-54pe-platform-monitor.service failed %d"%status)
+        return False
+    status, output = getstatusoutput_noshell(["systemctl", "start", "as4630-54pe-platform-monitor.service"])
+    if status:
+        print("Start as4630-54pe-platform-monitor.service failed %d"%status)
         return False
 
     return True
 
 def start_platform_pddf():
-    status, output = commands.getstatusoutput("systemctl start pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "pddf-platform-init.service"])
     if status:
-        print "Start pddf-platform-init.service failed %d"%status
+        print("Start pddf-platform-init.service failed %d"%status)
         return False
-    status, output = commands.getstatusoutput("systemctl start as4630-54pe-pddf-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "as4630-54pe-pddf-platform-monitor.service"])
     if status:
-        print "Start as4630-54pe-pddf-platform-monitor.service failed %d"%status
+        print("Start as4630-54pe-pddf-platform-monitor.service failed %d"%status)
         return False
     
     return True
 
 def stop_platform_pddf():
-    status, output = commands.getstatusoutput("systemctl stop pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
     if status:
-        print "Stop pddf-platform-init.service failed %d"%status
+        print("Stop pddf-platform-init.service failed %d"%status)
         return False
-    status, output = commands.getstatusoutput("systemctl stop as4630-54pe-pddf-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as4630-54pe-pddf-platform-monitor.service"])
     if status:
-        print "Stop as4630-54pe-pddf-platform-monitor.service failed %d"%status
+        print("Stop as4630-54pe-pddf-platform-monitor.service failed %d"%status)
         return False
 
     return True

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54te/utils/accton_as4630_54te_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54te/utils/accton_as4630_54te_monitor.py
@@ -195,7 +195,7 @@ class device_monitor(object):
                 'Alarm-Critical for temperature critical is detected, reset DUT')
             cmd_str = ["i2cset", "-y", "-f", "3", "0x60", "0x4", "0xE4"]
             time.sleep(2)
-            return_value = subprocess.run(cmd_str).returncode
+            return_value = subprocess.call(cmd_str)
             logging.warning('Fan set: i2cset -y -f 3 0x60 0x4 0xE4, status is %d', return_value)
 
         #logging.debug('ori_state=%d, current_state=%d, temp_val=%d\n\n',ori_state, fan_policy_state, temp_val)

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54te/utils/accton_as4630_54te_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54te/utils/accton_as4630_54te_monitor.py
@@ -20,7 +20,6 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
     import sys
     import getopt
     import logging
@@ -194,9 +193,9 @@ class device_monitor(object):
             # critical case*/
             logging.critical(
                 'Alarm-Critical for temperature critical is detected, reset DUT')
-            cmd_str = "i2cset -y -f 3 0x60 0x4 0xE4"
+            cmd_str = ["i2cset", "-y", "-f", "3", "0x60", "0x4", "0xE4"]
             time.sleep(2)
-            return_value = os.system(cmd_str)
+            return_value = subprocess.run(cmd_str).returncode
             logging.warning('Fan set: i2cset -y -f 3 0x60 0x4 0xE4, status is %d', return_value)
 
         #logging.debug('ori_state=%d, current_state=%d, temp_val=%d\n\n',ori_state, fan_policy_state, temp_val)

--- a/platform/broadcom/sonic-platform-modules-accton/as7315-27xb/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7315-27xb/classes/fanutil.py
@@ -24,10 +24,8 @@
 # ------------------------------------------------------------------
 
 try:
-    import time
     import logging
-    from collections import namedtuple
-    import subprocess
+    from sonic_py_common.general import getstatusoutput_noshell
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
 
@@ -65,10 +63,11 @@ class FanUtil(object):
         return "fan{0}_{1}".format(fan_num, self.node_postfix[node_num-1])
     
     def _get_fan_i2c_bus_addr(self):
-        cmd_template = 'i2cget -f -y {} 0x{} 0'
+        cmd_template = ['i2cget', '-f', '-y', '', '', '0']
         for bus_no, dev_addr in self.I2CADDR_CANDIDATES:
-            cmd = cmd_template.format(bus_no, dev_addr)
-            if subprocess.getstatusoutput(cmd)[0] == 0:
+            cmd_template[3] = str(bus_no)
+            cmd_template[4] = '0x' + str(dev_addr)
+            if getstatusoutput_noshell(cmd_template)[0] == 0:
                 return bus_no, dev_addr
         raise IOError('Unable to reach fan CPLD via I2C')
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_monitor.py
@@ -23,10 +23,10 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
     import getopt
     import sys
     import logging
+    import subprocess
     import logging.config
     import logging.handlers
     import time  # this is only being used as part of the example
@@ -233,7 +233,7 @@ class device_monitor(object):
            if new_state==LEVEL_TEMP_CRITICAL:
                logging.critical('Alarm for temperature critical is detected, reboot DUT')
                time.sleep(2)
-               os.system('reboot')           
+               subprocess.run(['reboot']).returncode
         if ori_state==LEVEL_FAN_MID:
             if new_state==LEVEL_TEMP_HIGH:
                 if alarm_state==0:
@@ -242,7 +242,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                os.system('reboot') 
+                subprocess.run(['reboot']).returncode
         if ori_state==LEVEL_FAN_MAX:
             if new_state==LEVEL_TEMP_HIGH:
                 if alarm_state==0:
@@ -251,7 +251,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                os.system('reboot') 
+                subprocess.run(['reboot']).returncode
             if alarm_state==1:
                 if temp_get < (fan_policy[3][0] - 5000):  #below 65 C, clear alarm
                     logging.warning('Alarm for temperature high is cleared')
@@ -260,7 +260,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                os.system('reboot')
+                subprocess.run(['reboot']).returncode
             if new_state <= LEVEL_FAN_MID:
                 logging.warning('Alarm for temperature high is cleared')
                 alarm_state=0

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_monitor.py
@@ -233,7 +233,7 @@ class device_monitor(object):
            if new_state==LEVEL_TEMP_CRITICAL:
                logging.critical('Alarm for temperature critical is detected, reboot DUT')
                time.sleep(2)
-               subprocess.run(['reboot']).returncode
+               subprocess.call(['reboot'])
         if ori_state==LEVEL_FAN_MID:
             if new_state==LEVEL_TEMP_HIGH:
                 if alarm_state==0:
@@ -242,7 +242,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                subprocess.run(['reboot']).returncode
+                subprocess.call(['reboot'])
         if ori_state==LEVEL_FAN_MAX:
             if new_state==LEVEL_TEMP_HIGH:
                 if alarm_state==0:
@@ -251,7 +251,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                subprocess.run(['reboot']).returncode
+                subprocess.call(['reboot'])
             if alarm_state==1:
                 if temp_get < (fan_policy[3][0] - 5000):  #below 65 C, clear alarm
                     logging.warning('Alarm for temperature high is cleared')
@@ -260,7 +260,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                subprocess.run(['reboot']).returncode
+                subprocess.call(['reboot'])
             if new_state <= LEVEL_FAN_MID:
                 logging.warning('Alarm for temperature high is cleared')
                 alarm_state=0

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_pddf_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_pddf_monitor.py
@@ -22,10 +22,10 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
     import sys
     import getopt
     import logging
+    import subprocess
     import logging.config
     import logging.handlers
     import time
@@ -218,7 +218,7 @@ class device_monitor(object):
             if new_state == LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected, reboot DUT')
                 time.sleep(2)
-                os.system('reboot')
+                subprocess.run(['reboot']).returncode
         if ori_state == LEVEL_FAN_MID:
             if new_state == LEVEL_TEMP_HIGH:
                 if alarm_state == 0:
@@ -227,7 +227,7 @@ class device_monitor(object):
             if new_state == LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                os.system('reboot')
+                subprocess.run(['reboot']).returncode
         if ori_state == LEVEL_FAN_MAX:
             if new_state == LEVEL_TEMP_HIGH:
                 if alarm_state == 0:
@@ -236,7 +236,7 @@ class device_monitor(object):
             if new_state == LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                os.system('reboot')
+                subprocess.run(['reboot']).returncode
             if alarm_state == 1:
                 if temp_get < (fan_policy[3][0] - 5000):  # below 65 C, clear alarm
                     logging.warning('Alarm for temperature high is cleared')
@@ -245,7 +245,7 @@ class device_monitor(object):
             if new_state == LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                os.system('reboot')
+                subprocess.run(['reboot']).returncode
             if new_state <= LEVEL_FAN_MID:
                 logging.warning('Alarm for temperature high is cleared')
                 alarm_state = 0

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_pddf_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_pddf_monitor.py
@@ -218,7 +218,7 @@ class device_monitor(object):
             if new_state == LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected, reboot DUT')
                 time.sleep(2)
-                subprocess.run(['reboot']).returncode
+                subprocess.call(['reboot'])
         if ori_state == LEVEL_FAN_MID:
             if new_state == LEVEL_TEMP_HIGH:
                 if alarm_state == 0:
@@ -227,7 +227,7 @@ class device_monitor(object):
             if new_state == LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                subprocess.run(['reboot']).returncode
+                subprocess.call(['reboot'])
         if ori_state == LEVEL_FAN_MAX:
             if new_state == LEVEL_TEMP_HIGH:
                 if alarm_state == 0:
@@ -236,7 +236,7 @@ class device_monitor(object):
             if new_state == LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                subprocess.run(['reboot']).returncode
+                subprocess.call(['reboot'])
             if alarm_state == 1:
                 if temp_get < (fan_policy[3][0] - 5000):  # below 65 C, clear alarm
                     logging.warning('Alarm for temperature high is cleared')
@@ -245,7 +245,7 @@ class device_monitor(object):
             if new_state == LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                subprocess.run(['reboot']).returncode
+                subprocess.call(['reboot'])
             if new_state <= LEVEL_FAN_MID:
                 logging.warning('Alarm for temperature high is cleared')
                 alarm_state = 0

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_util.py
@@ -33,7 +33,7 @@ import logging
 import re
 import time
 import os
-
+from sonic_py_common.general import getstatusoutput_noshell
 
 
 PROJECT_NAME = 'as7326_56x'
@@ -100,16 +100,16 @@ def show_help():
 
 
 def dis_i2c_ir3570a(addr):
-    cmd = "i2cset -y 0 0x%x 0xE5 0x01" % addr
-    status, output = subprocess.getstatusoutput(cmd)
-    cmd = "i2cset -y 0 0x%x 0x12 0x02" % addr
-    status, output = subprocess.getstatusoutput(cmd)
+    cmd = ["i2cset", "-y", "0", "0x"+"%x"%addr, "0xE5", "0x01"]
+    status, output = getstatusoutput_noshell(cmd)
+    cmd = ["i2cset", "-y", "0", "0x"+"%x"%addr, "0x12", "0x02"]
+    status, output = getstatusoutput_noshell(cmd)
     return status
 
 def ir3570_check():
-    cmd = "i2cdump -y 0 0x42 s 0x9a"
+    cmd = ["i2cdump", "-y", "0", "0x42", "s", "0x9a"]
     try:
-        status, output = subprocess.getstatusoutput(cmd)
+        status, output = getstatusoutput_noshell(cmd)
         lines = output.split('\n')
         hn = re.findall(r'\w+', lines[-1])
         version = int(hn[1], 16)
@@ -257,8 +257,8 @@ def i2c_order_check():
     return 0
 
 def eeprom_check():
-    cmd = "i2cget -y -f 0 0x56"
-    status, output = subprocess.getstatusoutput(cmd)
+    cmd = ["i2cget", "-y", "-f", "0", "0x56"]
+    status, output = getstatusoutput_noshell(cmd)
     return status
 
 def device_install():

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/pddf_switch_svc.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/pddf_switch_svc.py
@@ -2,39 +2,39 @@
 # Script to stop and start the respective platforms default services. 
 # This will be used while switching the pddf->non-pddf mode and vice versa
 
-import subprocess
+from sonic_py_common.general import getstatusoutput_noshell
 
 def check_pddf_support():
     return True
 
 def stop_platform_svc():
     
-    status, output = subprocess.getstatusoutput("systemctl stop as7326-platform-monitor-fan.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as7326-platform-monitor-fan.service"])
     if status:
         print("Stop as7326-platform-fan.service failed %d"%status)
         return False
     
-    status, output = subprocess.getstatusoutput("systemctl stop as7326-platform-monitor-psu.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as7326-platform-monitor-psu.service"])
     if status:
         print("Stop as7326-platform-psu.service failed %d"%status)
         return False
     
-    status, output = subprocess.getstatusoutput("systemctl stop as7326-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as7326-platform-monitor.service"])
     if status:
         print("Stop as7326-platform-init.service failed %d"%status)
         return False
-    status, output = subprocess.getstatusoutput("systemctl disable as7326-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "disable", "as7326-platform-monitor.service"])
     if status:
         print("Disable as7326-platform-monitor.service failed %d"%status)
         return False
     
-    status, output = subprocess.getstatusoutput("/usr/local/bin/accton_as7326_util.py clean")
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as7326_util.py", "clean"])
     if status:
         print("accton_as7326_util.py clean command failed %d"%status)
         return False
 
     # HACK , stop the pddf-platform-init service if it is active
-    status, output = subprocess.getstatusoutput("systemctl stop pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
     if status:
         print("Stop pddf-platform-init.service along with other platform serives failed %d"%status)
         return False
@@ -42,21 +42,21 @@ def stop_platform_svc():
     return True
     
 def start_platform_svc():
-    status, output = subprocess.getstatusoutput("/usr/local/bin/accton_as7326_util.py install")
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as7326_util.py", "install"])
     if status:
         print("accton_as7326_util.py install command failed %d"%status)
         return False
 
-    status, output = subprocess.getstatusoutput("systemctl enable as7326-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "enable", "as7326-platform-monitor.service"])
     if status:
         print("Enable as7326-platform-monitor.service failed %d"%status)
         return False
-    status, output = subprocess.getstatusoutput("systemctl start as7326-platform-monitor-fan.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "as7326-platform-monitor-fan.service"])
     if status:
         print("Start as7326-platform-monitor-fan.service failed %d"%status)
         return False
         
-    status, output = subprocess.getstatusoutput("systemctl start as7326-platform-monitor-psu.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "as7326-platform-monitor-psu.service"])
     if status:
         print("Start as7326-platform-monitor-psu.service failed %d"%status)
         return False
@@ -64,7 +64,7 @@ def start_platform_svc():
     return True
 
 def start_platform_pddf():
-    status, output = subprocess.getstatusoutput("systemctl start pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "pddf-platform-init.service"])
     if status:
         print("Start pddf-platform-init.service failed %d"%status)
         return False
@@ -72,7 +72,7 @@ def start_platform_pddf():
     return True
 
 def stop_platform_pddf():
-    status, output = subprocess.getstatusoutput("systemctl stop pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
     if status:
         print("Stop pddf-platform-init.service failed %d"%status)
         return False

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/utils/pddf_switch_svc.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/utils/pddf_switch_svc.py
@@ -1,28 +1,28 @@
 #!/usr/bin/env python
 # Script to stop and start the respective platforms default services. 
 # This will be used while switching the pddf->non-pddf mode and vice versa
-import commands
+from sonic_py_common.general import getstatusoutput_noshell
 
 def check_pddf_support():
     return True
 
 def stop_platform_svc():
-    status, output = commands.getstatusoutput("systemctl stop as7712-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as7712-platform-init.service"])
     if status:
         print("Stop as7712-platform-init.service failed %d"%status)
         return False
-    status, output = commands.getstatusoutput("systemctl disable as7712-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "disable", "as7712-platform-init.service"])
     if status:
         print("Disable as7712-platform-init.service failed %d"%status)
         return False
     
-    status, output = commands.getstatusoutput("/usr/local/bin/accton_as7712_util.py clean")
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as7712_util.py", "clean"])
     if status:
-        print("accton_as7712_util.py clean command failed %d"%status)
+        print("accton_as7712_util.py clean failed %d"%status)
         return False
 
     # HACK , stop the pddf-platform-init service if it is active
-    status, output = commands.getstatusoutput("systemctl stop pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
     if status:
         print("Stop pddf-platform-init.service along with other platform serives failed %d"%status)
         return False
@@ -30,16 +30,16 @@ def stop_platform_svc():
     return True
     
 def start_platform_svc():
-    status, output = commands.getstatusoutput("/usr/local/bin/accton_as7712_util.py install")
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as7712_util.py", "install"])
     if status:
-        print("accton_as7712_util.py install command failed %d"%status)
+        print("accton_as7712_util.py install failed %d"%status)
         return False
 
-    status, output = commands.getstatusoutput("systemctl enable as7712-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "enable", "as7712-platform-init.service"])
     if status:
         print("Enable as7712-platform-init.service failed %d"%status)
         return False
-    status, output = commands.getstatusoutput("systemctl start as7712-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "as7712-platform-init.service"])
     if status:
         print("Start as7712-platform-init.service failed %d"%status)
         return False
@@ -47,7 +47,7 @@ def start_platform_svc():
     return True
 
 def start_platform_pddf():
-    status, output = commands.getstatusoutput("systemctl start pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "pddf-platform-init.service"])
     if status:
         print("Start pddf-platform-init.service failed %d"%status)
         return False
@@ -55,7 +55,7 @@ def start_platform_pddf():
     return True
 
 def stop_platform_pddf():
-    status, output = commands.getstatusoutput("systemctl stop pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
     if status:
         print("Stop pddf-platform-init.service failed %d"%status)
         return False

--- a/platform/broadcom/sonic-platform-modules-accton/as7716-32x/utils/accton_as7716_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7716-32x/utils/accton_as7716_util.py
@@ -36,6 +36,7 @@ import sys
 import logging
 import re
 import time
+from sonic_py_common.general import getstatusoutput_noshell
 
 PROJECT_NAME = 'as7716_32x'
 version = '0.0.1'
@@ -220,16 +221,16 @@ def  show_set_help():
     sys.exit(0)
 
 def dis_i2c_ir3570a(addr):
-    cmd = "i2cset -y 0 0x%x 0xE5 0x01" % addr
-    status, output = subprocess.getstatusoutput(cmd)
-    cmd = "i2cset -y 0 0x%x 0x12 0x02" % addr
-    status, output = subprocess.getstatusoutput(cmd)
+    cmd = ["i2cset", "-y", "0", "0x"+"%x"%addr, "0xE5", "0x01"]
+    status, output = getstatusoutput_noshell(cmd)
+    cmd = ["i2cset", "-y", "0", "0x"+"%x"%addr, "0x12", "0x02"]
+    status, output = getstatusoutput_noshell(cmd)
     return status
 
 def ir3570_check():
-    cmd = "i2cdump -y 0 0x42 s 0x9a"
+    cmd = ["i2cdump", "-y", "0", "0x42", "s", "0x9a"]
     try:
-        status, output = subprocess.getstatusoutput(cmd)
+        status, output = getstatusoutput_noshell(cmd)
         lines = output.split('\n')
         hn = re.findall(r'\w+', lines[-1])
         version = int(hn[1], 16)

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_monitor.py
@@ -242,7 +242,7 @@ class device_monitor(object):
            if new_state==LEVEL_TEMP_CRITICAL:
                logging.critical('Alarm for temperature critical is detected, reboot DUT')
                time.sleep(2)
-               subprocess.run(['reboot']).returncode
+               subprocess.call(['reboot'])
         if ori_state==LEVEL_FAN_MID:
             if new_state==LEVEL_TEMP_HIGH:
                 if alarm_state==0:
@@ -251,7 +251,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                subprocess.run(['reboot']).returncode
+                subprocess.call(['reboot'])
         if ori_state==LEVEL_FAN_MAX:
             if new_state==LEVEL_TEMP_HIGH:
                 if alarm_state==0:
@@ -260,7 +260,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                subprocess.run(['reboot']).returncode
+                subprocess.call(['reboot'])
             if alarm_state==1:
                 if temp_get < (fan_policy[3][0] - 5000):  #below 65 C, clear alarm
                     logging.warning('Alarm for temperature high is cleared')
@@ -269,7 +269,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                subprocess.run(['reboot']).returncode
+                subprocess.call(['reboot'])
             if new_state <= LEVEL_FAN_MID:
                 logging.warning('Alarm for temperature high is cleared')
                 alarm_state=0

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_monitor.py
@@ -23,10 +23,10 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
     import getopt
     import sys
     import logging
+    import subprocess
     import logging.config
     import logging.handlers
     import time  # this is only being used as part of the example
@@ -242,7 +242,7 @@ class device_monitor(object):
            if new_state==LEVEL_TEMP_CRITICAL:
                logging.critical('Alarm for temperature critical is detected, reboot DUT')
                time.sleep(2)
-               os.system('reboot')           
+               subprocess.run(['reboot']).returncode
         if ori_state==LEVEL_FAN_MID:
             if new_state==LEVEL_TEMP_HIGH:
                 if alarm_state==0:
@@ -251,7 +251,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                os.system('reboot') 
+                subprocess.run(['reboot']).returncode
         if ori_state==LEVEL_FAN_MAX:
             if new_state==LEVEL_TEMP_HIGH:
                 if alarm_state==0:
@@ -260,7 +260,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                os.system('reboot') 
+                subprocess.run(['reboot']).returncode
             if alarm_state==1:
                 if temp_get < (fan_policy[3][0] - 5000):  #below 65 C, clear alarm
                     logging.warning('Alarm for temperature high is cleared')
@@ -269,7 +269,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                os.system('reboot')
+                subprocess.run(['reboot']).returncode
             if new_state <= LEVEL_FAN_MID:
                 logging.warning('Alarm for temperature high is cleared')
                 alarm_state=0

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_pddf_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_pddf_monitor.py
@@ -230,7 +230,7 @@ class device_monitor(object):
            if new_state==LEVEL_TEMP_CRITICAL:
                logging.critical('Alarm for temperature critical is detected, reboot DUT')
                time.sleep(2)
-               subprocess.run(['reboot']).returncode
+               subprocess.call(['reboot'])
         if ori_state==LEVEL_FAN_MID:
             if new_state==LEVEL_TEMP_HIGH:
                 if alarm_state==0:
@@ -239,7 +239,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                subprocess.run(['reboot']).returncode
+                subprocess.call(['reboot'])
         if ori_state==LEVEL_FAN_MAX:
             if new_state==LEVEL_TEMP_HIGH:
                 if alarm_state==0:
@@ -248,7 +248,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                subprocess.run(['reboot']).returncode
+                subprocess.call(['reboot'])
             if alarm_state==1:
                 if temp_get < (fan_policy[3][0] - 5000):  #below 65 C, clear alarm
                     logging.warning('Alarm for temperature high is cleared')
@@ -257,7 +257,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                subprocess.run(['reboot']).returncode
+                subprocess.call(['reboot'])
             if new_state <= LEVEL_FAN_MID:
                 logging.warning('Alarm for temperature high is cleared')
                 alarm_state=0

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_pddf_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_pddf_monitor.py
@@ -24,10 +24,10 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
     import sys
     import getopt
     import logging
+    import subprocess
     import logging.config
     import logging.handlers
     import time
@@ -230,7 +230,7 @@ class device_monitor(object):
            if new_state==LEVEL_TEMP_CRITICAL:
                logging.critical('Alarm for temperature critical is detected, reboot DUT')
                time.sleep(2)
-               os.system('reboot')           
+               subprocess.run(['reboot']).returncode
         if ori_state==LEVEL_FAN_MID:
             if new_state==LEVEL_TEMP_HIGH:
                 if alarm_state==0:
@@ -239,7 +239,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                os.system('reboot') 
+                subprocess.run(['reboot']).returncode
         if ori_state==LEVEL_FAN_MAX:
             if new_state==LEVEL_TEMP_HIGH:
                 if alarm_state==0:
@@ -248,7 +248,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                os.system('reboot') 
+                subprocess.run(['reboot']).returncode
             if alarm_state==1:
                 if temp_get < (fan_policy[3][0] - 5000):  #below 65 C, clear alarm
                     logging.warning('Alarm for temperature high is cleared')
@@ -257,7 +257,7 @@ class device_monitor(object):
             if new_state==LEVEL_TEMP_CRITICAL:
                 logging.critical('Alarm for temperature critical is detected')
                 time.sleep(2)
-                os.system('reboot')
+                subprocess.run(['reboot']).returncode
             if new_state <= LEVEL_FAN_MID:
                 logging.warning('Alarm for temperature high is cleared')
                 alarm_state=0

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_util.py
@@ -32,6 +32,7 @@ import sys
 import logging
 import re
 import time
+from sonic_py_common.general import getstatusoutput_noshell
 
 PROJECT_NAME = 'as7726_32x'
 version = '0.0.1'
@@ -147,16 +148,16 @@ def show_help():
     sys.exit(0)
 
 def dis_i2c_ir3570a(addr):
-    cmd = "i2cset -y 0 0x%x 0xE5 0x01" % addr
-    status, output = subprocess.getstatusoutput(cmd)
-    cmd = "i2cset -y 0 0x%x 0x12 0x02" % addr
-    status, output = subprocess.getstatusoutput(cmd)
+    cmd = ["i2cset", "-y", "0", "0x"+"%x"%addr, "0xE5", "0x01"]
+    status, output = getstatusoutput_noshell(cmd)
+    cmd = ["i2cset", "-y", "0", "0x"+"%x"%addr, "0x12", "0x02"]
+    status, output = getstatusoutput_noshell(cmd)
     return status
 
 def ir3570_check():
-    cmd = "i2cdump -y 0 0x42 s 0x9a"
+    cmd = ["i2cdump", "-y", "0", "0x42", "s", "0x9a"]
     try:
-        status, output = subprocess.getstatusoutput(cmd)
+        status, output = getstatusoutput_noshell(cmd)
         lines = output.split('\n')
         hn = re.findall(r'\w+', lines[-1])
         version = int(hn[1], 16)

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/pddf_switch_svc.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/pddf_switch_svc.py
@@ -2,44 +2,44 @@
 # Script to stop and start the respective platforms default services. 
 # This will be used while switching the pddf->non-pddf mode and vice versa
 
-import subprocess
+from sonic_py_common.general import getstatusoutput_noshell
 
 def check_pddf_support():
     return True
 
 def stop_platform_svc():
-    status, output = subprocess.getstatusoutput("systemctl stop as7726-32x-platform-monitor-fan.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as7726-32x-platform-monitor-fan.service"])
     if status:
         print("Stop as7726-32x-platform-monitor-fan.service failed %d"%status)
         return False
-    status, output = subprocess.getstatusoutput("systemctl disable as7726-32x-platform-monitor-fan.service")
+    status, output = getstatusoutput_noshell(["systemctl", "disable", "as7726-32x-platform-monitor-fan.service"])
     if status:
         print("Disable as7726-32x-platform-monitor-fan.service failed %d"%status)
         return False
-    status, output = subprocess.getstatusoutput("systemctl stop as7726-32x-platform-monitor-psu.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as7726-32x-platform-monitor-psu.service"])
     if status:
         print("Stop as7726-32x-platform-monitor-psu.service failed %d"%status)
         return False
-    status, output = subprocess.getstatusoutput("systemctl disable as7726-32x-platform-monitor-psu.service")
+    status, output = getstatusoutput_noshell(["systemctl", "disable", "as7726-32x-platform-monitor-psu.service"])
     if status:
         print("Disable as7726-32x-platform-monitor-psu.service failed %d"%status)
         return False
-    status, output = subprocess.getstatusoutput("systemctl stop as7726-32x-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as7726-32x-platform-monitor.service"])
     if status:
         print("Stop as7726-32x-platform-monitor.service failed %d"%status)
         return False
-    status, output = subprocess.getstatusoutput("systemctl disable as7726-32x-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "disable", "as7726-32x-platform-monitor.service"])
     if status:
         print("Disable as7726-32x-platform-monitor.service failed %d"%status)
         return False
     
-    status, output = subprocess.getstatusoutput("/usr/local/bin/accton_as7726_32x_util.py clean")
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as7726_32x_util.py", "clean"])
     if status:
         print("accton_as7726_32x_util.py clean command failed %d"%status)
         return False
 
     # HACK , stop the pddf-platform-init service if it is active
-    status, output = subprocess.getstatusoutput("systemctl stop pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
     if status:
         print("Stop pddf-platform-init.service along with other platform serives failed %d"%status)
         return False
@@ -47,32 +47,32 @@ def stop_platform_svc():
     return True
     
 def start_platform_svc():
-    status, output = subprocess.getstatusoutput("/usr/local/bin/accton_as7726_32x_util.py install")
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as7726_32x_util.py install"])
     if status:
         print("accton_as7726_32x_util.py install command failed %d"%status)
         return False
 
-    status, output = subprocess.getstatusoutput("systemctl enable as7726-32x-platform-monitor-fan.service")
+    status, output = getstatusoutput_noshell(["systemctl", "enable", "as7726-32x-platform-monitor-fan.service"])
     if status:
         print("Enable as7726-32x-platform-monitor-fan.service failed %d"%status)
         return False
-    status, output = subprocess.getstatusoutput("systemctl start as7726-32x-platform-monitor-fan.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "as7726-32x-platform-monitor-fan.service"])
     if status:
         print("Start as7726-32x-platform-monitor-fan.service failed %d"%status)
         return False
-    status, output = subprocess.getstatusoutput("systemctl enable as7726-32x-platform-monitor-psu.service")
+    status, output = getstatusoutput_noshell(["systemctl", "enable", "as7726-32x-platform-monitor-psu.service"])
     if status:
         print("Enable as7726-32x-platform-monitor-psu.service failed %d"%status)
         return False
-    status, output = subprocess.getstatusoutput("systemctl start as7726-32x-platform-monitor-psu.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "as7726-32x-platform-monitor-psu.service"])
     if status:
         print("Start as7726-32x-platform-monitor-psu.service failed %d"%status)
         return False
-    status, output = subprocess.getstatusoutput("systemctl enable as7726-32x-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "enable", "as7726-32x-platform-monitor.service"])
     if status:
         print("Enable as7726-32x-platform-monitor.service failed %d"%status)
         return False
-    status, output = subprocess.getstatusoutput("systemctl start as7726-32x-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "as7726-32x-platform-monitor.service"])
     if status:
         print("Start as7726-32x-platform-monitor.service failed %d"%status)
         return False
@@ -80,7 +80,7 @@ def start_platform_svc():
     return True
 
 def start_platform_pddf():
-    status, output = subprocess.getstatusoutput("systemctl start pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "pddf-platform-init.service"])
     if status:
         print("Start pddf-platform-init.service failed %d"%status)
         return False
@@ -88,7 +88,7 @@ def start_platform_pddf():
     return True
 
 def stop_platform_pddf():
-    status, output = subprocess.getstatusoutput("systemctl stop pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
     if status:
         print("Stop pddf-platform-init.service failed %d"%status)
         return False

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/accton_as7816_64x_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/accton_as7816_64x_util.py
@@ -32,7 +32,7 @@ import logging
 import re
 import time
 import os
-
+from sonic_py_common.general import getstatusoutput_noshell
 
 
 PROJECT_NAME = 'as7816_64x'
@@ -99,18 +99,17 @@ def show_help():
     print( __doc__ % {'scriptName' : sys.argv[0].split("/")[-1]})
     sys.exit(0)
 
-   
 def dis_i2c_ir3570a(addr):
-    cmd = "i2cset -y 0 0x%x 0xE5 0x01" % addr
-    status, output = subprocess.getstatusoutput(cmd)
-    cmd = "i2cset -y 0 0x%x 0x12 0x02" % addr
-    status, output = subprocess.getstatusoutput(cmd)
+    cmd = ["i2cset", "-y", "0", "0x"+"%x"%addr, "0xE5", "0x01"]
+    status, output = getstatusoutput_noshell(cmd)
+    cmd = ["i2cset", "-y", "0", "0x"+"%x"%addr, "0x12", "0x02"]
+    status, output = getstatusoutput_noshell(cmd)
     return status
 
 def ir3570_check():
-    cmd = "i2cdump -y 0 0x42 s 0x9a"
+    cmd = ["i2cdump", "-y", "0", "0x42", "s", "0x9a"]
     try:
-        status, output = subprocess.getstatusoutput(cmd)
+        status, output = getstatusoutput_noshell(cmd)
         lines = output.split('\n')
         hn = re.findall(r'\w+', lines[-1])
         version = int(hn[1], 16)

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/pddf_switch_svc.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/pddf_switch_svc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Script to stop and start the respective platforms default services.
 # This will be used while switching the pddf->non-pddf mode and vice versa
-import subprocess
+from sonic_py_common.general import getstatusoutput_noshell
 
 
 def check_pddf_support():
@@ -10,22 +10,22 @@ def check_pddf_support():
 
 def stop_platform_svc():
 
-    status, output = subprocess.getstatusoutput("systemctl stop as7816-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as7816-platform-init.service"])
     if status:
         print(("Stop as7816-platform-init.service failed %d" % status))
         return False
-    status, output = subprocess.getstatusoutput("systemctl disable as7816-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "disable", "as7816-platform-init.service"])
     if status:
         print(("Disable as7816-platform-init.service failed %d" % status))
         return False
 
-    status, output = subprocess.getstatusoutput("/usr/local/bin/accton_as7816_util.py clean")
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as7816_util.py", "clean"])
     if status:
         print(("accton_as7816_util.py clean command failed %d" % status))
         return False
 
     # HACK , stop the pddf-platform-init service if it is active
-    status, output = subprocess.getstatusoutput("systemctl stop pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
     if status:
         print(("Stop pddf-platform-init.service along with other platform serives failed %d" % status))
         return False
@@ -34,12 +34,12 @@ def stop_platform_svc():
 
 
 def start_platform_svc():
-    status, output = subprocess.getstatusoutput("/usr/local/bin/accton_as7816_util.py install")
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as7816_util.py", "install"])
     if status:
         print(("accton_as7816_util.py install command failed %d" % status))
         return False
 
-    status, output = subprocess.getstatusoutput("systemctl enable as7816-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "enable", "as7816-platform-init.service"])
     if status:
         print(("Enable as7816-platform-init.service failed %d" % status))
         return False
@@ -48,7 +48,7 @@ def start_platform_svc():
 
 
 def start_platform_pddf():
-    status, output = subprocess.getstatusoutput("systemctl start pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "pddf-platform-init.service"])
     if status:
         print(("Start pddf-platform-init.service failed %d" % status))
         return False
@@ -57,7 +57,7 @@ def start_platform_pddf():
 
 
 def stop_platform_pddf():
-    status, output = subprocess.getstatusoutput("systemctl stop pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
     if status:
         print(("Stop pddf-platform-init.service failed %d" % status))
         return False

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_util.py
@@ -32,6 +32,7 @@ import sys
 import logging
 import re
 import time
+from sonic_py_common.general import getstatusoutput_noshell
 
 PROJECT_NAME = 'as9716_32d'
 version = '0.0.1'
@@ -153,16 +154,16 @@ def show_help():
     sys.exit(0)
 
 def dis_i2c_ir3570a(addr):
-    cmd = "i2cset -y 0 0x%x 0xE5 0x01" % addr
-    status, output = subprocess.getstatusoutput(cmd)
-    cmd = "i2cset -y 0 0x%x 0x12 0x02" % addr
-    status, output = subprocess.getstatusoutput(cmd)
+    cmd = ["i2cset", "-y", "0", "0x"+"%x"%addr, "0xE5", "0x01"]
+    status, output = getstatusoutput_noshell(cmd)
+    cmd = ["i2cset", "-y", "0", "0x"+"%x"%addr, "0x12", "0x02"]
+    status, output = getstatusoutput_noshell(cmd)
     return status
 
 def ir3570_check():
-    cmd = "i2cdump -y 0 0x42 s 0x9a"
+    cmd = ["i2cdump", "-y", "0", "0x42", "s", "0x9a"]
     try:
-        status, output = subprocess.getstatusoutput(cmd)
+        status, output = getstatusoutput_noshell(cmd)
         lines = output.split('\n')
         hn = re.findall(r'\w+', lines[-1])
         version = int(hn[1], 16)

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/pddf_switch_svc.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/pddf_switch_svc.py
@@ -1,39 +1,39 @@
 #!/usr/bin/env python
 # Script to stop and start the respective platforms default services. 
 # This will be used while switching the pddf->non-pddf mode and vice versa
-import subprocess
+from sonic_py_common.general import getstatusoutput_noshell
 
 def check_pddf_support():
     return True
 
 def stop_platform_svc():
     
-    status, output = subprocess.getstatusoutput("systemctl stop as9716-32d-platform-monitor-fan.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as9716-32d-platform-monitor-fan.service"])
     if status:
         print("Stop as9716-32d-platform-fan.service failed %d"%status)
         return False
     
-    status, output = subprocess.getstatusoutput("systemctl stop as9716-32d-platform-monitor-psu.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as9716-32d-platform-monitor-psu.service"])
     if status:
         print("Stop as9716-32d-platform-psu.service failed %d"%status)
         return False
     
-    status, output = subprocess.getstatusoutput("systemctl stop as9716-32d-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as9716-32d-platform-monitor.service"])
     if status:
         print("Stop as9716-32d-platform-init.service failed %d"%status)
         return False
-    status, output = subprocess.getstatusoutput("systemctl disable as9716-32d-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "disable", "as9716-32d-platform-monitor.service"])
     if status:
         print("Disable as9716-32d-platform-monitor.service failed %d"%status)
         return False
     
-    status, output = subprocess.getstatusoutput("/usr/local/bin/accton_as9716_32d_util.py clean")
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as9716_32d_util.py", "clean"])
     if status:
         print("accton_as9716_32d_util.py clean command failed %d"%status)
         return False
 
     # HACK , stop the pddf-platform-init service if it is active
-    status, output = subprocess.getstatusoutput("systemctl stop pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
     if status:
         print("Stop pddf-platform-init.service along with other platform serives failed %d"%status)
         return False
@@ -41,21 +41,21 @@ def stop_platform_svc():
     return True
     
 def start_platform_svc():
-    status, output = subprocess.getstatusoutput("/usr/local/bin/accton_as9716_32d_util.py install")
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as9716_32d_util.py", "install"])
     if status:
         print("accton_as9716_32d_util.py install command failed %d"%status)
         return False
 
-    status, output = subprocess.getstatusoutput("systemctl enable as9716-32d-platform-monitor.service")
+    status, output = getstatusoutput_noshell(["systemctl", "enable", "as9716-32d-platform-monitor.service"])
     if status:
         print("Enable as9716-32d-platform-monitor.service failed %d"%status)
         return False
-    status, output = subprocess.getstatusoutput("systemctl start as9716-32d-platform-monitor-fan.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "as9716-32d-platform-monitor-fan.service"])
     if status:
         print("Start as9716-32d-platform-monitor-fan.service failed %d"%status)
         return False
         
-    status, output = subprocess.getstatusoutput("systemctl start as9716-32d-platform-monitor-psu.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "as9716-32d-platform-monitor-psu.service"])
     if status:
         print("Start as9716-32d-platform-monitor-psu.service failed %d"%status)
         return False
@@ -64,7 +64,7 @@ def start_platform_svc():
 
 def start_platform_pddf():   
 
-    status, output = subprocess.getstatusoutput("systemctl start pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "start", "pddf-platform-init.service"])
     if status:
         print("Start pddf-platform-init.service failed %d"%status)
         return False
@@ -73,7 +73,7 @@ def start_platform_pddf():
 
 def stop_platform_pddf():   
 
-    status, output = subprocess.getstatusoutput("systemctl stop pddf-platform-init.service")
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
     if status:
         print("Stop pddf-platform-init.service failed %d"%status)
         return False


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`subprocess.Popen()` and `subprocess.run()` is used with `shell=True`, which is very dangerous for shell injection.
`os` - not secure against maliciously constructed input and dangerous if used to evaluate dynamic content
#### How I did it
Replace `os` by `subprocess`
Remove unused functions
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [X] 201911
- [X] 202006
- [X] 202012
- [X] 202106
- [X] 202111
- [X] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

