### PR TITLE
python http-server host service implementation

### DIFF
--- a/src/sonic-host-services-data/debian/rules
+++ b/src/sonic-host-services-data/debian/rules
@@ -19,5 +19,6 @@ override_dh_installsystemd:
 	dh_installsystemd --no-start --name=procdockerstatsd
 	dh_installsystemd --no-start --name=determine-reboot-cause
 	dh_installsystemd --no-start --name=process-reboot-cause
+	dh_installsystemd --name=http-server
 	dh_installsystemd $(HOST_SERVICE_OPTS) --name=sonic-hostservice
 

--- a/src/sonic-host-services-data/debian/sonic-host-services-data.http-server.service
+++ b/src/sonic-host-services-data/debian/sonic-host-services-data.http-server.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Http-server service daemon
+Requires=updategraph.service
+After=updategraph.service
+BindsTo=sonic.target
+After=sonic.target
+StartLimitIntervalSec=1200
+StartLimitBurst=3
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/http-server
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=sonic.target


### PR DESCRIPTION
Signed-off-by: anamehra <anamehra@cisco.com>

```
# Python HTTP Server service.
# This service runs based the configuration provided in
# device/<platform>/platform_env.conf
#
# Configuration parameters provided by platform_env.conf are as follows:
#
# start_http_server: if "yes" or "1", http-server will be started on this
#     node
# http_server_ip   : IP address for http-server. The service also writes this
#     entry in /etc/hosts to map to http-server host name
# http_server_port : Port to bind to, default: 8000
# http_server_dir  : HTTP server home directory path, default: /var/www/
#

# Example of config on Supervisor node:
'''
start_http_server=yes
http_server_ip=127.0.0.10
http_server_port=8001
http_server_dir=/var/www/tftp
'''
# Example of config on Line Card:
'''
http_server_ip=127.0.0.10
'''
```

http-server is not added as a host configurable feature as host features are required to run dockers for the feature name. If the docker is not running, monit service will raise an error for missing docker. The http-server service depends on the presence of platform_env.conf file and the above mentioned configuration in the file.

This PR requires https://github.com/sonic-net/sonic-host-services/pull/17.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Enable http-server as host service on Chassis supervisor to enable LCs to download image and config files from Supervisor.

#### How I did it
Added http-server as host service.
The service starts a python based http-server on the midplane network.

#### How to verify it
Add device//platform_env.conf with following data:
start_http_server=yes
http_server_ip=127.0.0.10
http_server_port=8001
http_server_dir=/var/www/tftp

Boot with the image with the above data.

put an image file at /var/www/tftp/filename
check 'systemctl status http-service'
curl http://http-server:8000/filename -o out_file
compare file_out with /var/www/tftp/filename

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

