### PR TITLE
Use the macsec_enabled flag in platform to enable macsec feature state

### DIFF
--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/platform_env.conf
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/platform_env.conf
@@ -1,2 +1,3 @@
 usemsi=1
 dmasize=64M
+macsec_enabled=1

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_env.conf
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_env.conf
@@ -1,3 +1,4 @@
 usemsi=1
 dmasize=512M
 default_mtu=9100
+macsec_enabled=1

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -52,7 +52,7 @@
 {%- if include_p4rt == "y" %}{% do features.append(("p4rt", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_restapi == "y" %}{% do features.append(("restapi", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_sflow == "y" %}{% do features.append(("sflow", "disabled", false, "enabled")) %}{% endif %}
-{%- if include_macsec == "y" %}{% do features.append(("macsec", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and MACSEC_SUPPORTED %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}{% endif %}
+{%- if include_macsec == "y" %}{% do features.append(("macsec", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and DEVICE_RUNTIME_METADATA['MACSEC_SUPPORTED'] %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}{% endif %}
 {%- if include_system_telemetry == "y" %}{% do features.append(("telemetry", "enabled", true, "enabled")) %}{% endif %}
     "FEATURE": {
 {# has_timer field if set, will start the feature systemd .timer unit instead of .service unit #}

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -52,7 +52,7 @@
 {%- if include_p4rt == "y" %}{% do features.append(("p4rt", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_restapi == "y" %}{% do features.append(("restapi", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_sflow == "y" %}{% do features.append(("sflow", "disabled", false, "enabled")) %}{% endif %}
-{%- if include_macsec == "y" %}{% do features.append(("macsec", "disabled", false, "enabled")) %}{% endif %}
+{%- if include_macsec == "y" %}{% do features.append(("macsec", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and MACSEC_SUPPORTED %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}{% endif %}
 {%- if include_system_telemetry == "y" %}{% do features.append(("telemetry", "enabled", true, "enabled")) %}{% endif %}
     "FEATURE": {
 {# has_timer field if set, will start the feature systemd .timer unit instead of .service unit #}

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -654,3 +654,29 @@ def is_fast_reboot_enabled():
         fb_system_state = stdout.rstrip('\n')
 
     return fb_system_state
+
+
+# Check if this platform has macsec capability.
+def is_macsec_supported():
+    supported = 0
+    platform_env_conf_file_path = get_platform_env_conf_file_path()
+
+    # platform_env.conf file not present for platform
+    if platform_env_conf_file_path is None:
+        return supported
+
+    # Else open the file check for keyword - macsec_enabled -
+    with open(platform_env_conf_file_path) as platform_env_conf_file:
+        for line in platform_env_conf_file:
+            tokens = line.split('=')
+            if len(tokens) < 2:
+               continue
+            if tokens[0].lower() == 'macsec_enabled':
+                supported = tokens[1].strip()
+                break
+    return int(supported)
+
+
+def get_macsec_support_metadata():
+    macsec_support_metadata = {'MACSEC_SUPPORTED': True if is_macsec_supported() else False}
+    return macsec_support_metadata

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -469,6 +469,27 @@ def is_supervisor():
                     return True
         return False
 
+# Check if this platform has macsec capability.
+def is_macsec_supported():
+    supported = 0
+    platform_env_conf_file_path = get_platform_env_conf_file_path()
+
+    # platform_env.conf file not present for platform
+    if platform_env_conf_file_path is None:
+        return supported
+
+    # Else open the file check for keyword - macsec_enabled -
+    with open(platform_env_conf_file_path) as platform_env_conf_file:
+        for line in platform_env_conf_file:
+            tokens = line.split('=')
+            if len(tokens) < 2:
+               continue
+            if tokens[0].lower() == 'macsec_enabled':
+                supported = tokens[1].strip()
+                break
+    return int(supported)
+
+
 def get_device_runtime_metadata():
     chassis_metadata = {}
     if is_chassis():
@@ -476,9 +497,11 @@ def get_device_runtime_metadata():
                                                 'chassis_type': 'voq' if is_voq_chassis() else 'packet'}}
 
     port_metadata = {'ETHERNET_PORTS_PRESENT': True if get_path_to_port_config_file(hwsku=None, asic="0" if is_multi_npu() else None) else False}
+    macsec_support_metadata = {'MACSEC_SUPPORTED': True if is_macsec_supported() else False}
     runtime_metadata = {}
     runtime_metadata.update(chassis_metadata)
     runtime_metadata.update(port_metadata)
+    runtime_metadata.update(macsec_support_metadata)
     return {'DEVICE_RUNTIME_METADATA': runtime_metadata }
 
 def get_npu_id_from_name(npu_name):
@@ -654,29 +677,3 @@ def is_fast_reboot_enabled():
         fb_system_state = stdout.rstrip('\n')
 
     return fb_system_state
-
-
-# Check if this platform has macsec capability.
-def is_macsec_supported():
-    supported = 0
-    platform_env_conf_file_path = get_platform_env_conf_file_path()
-
-    # platform_env.conf file not present for platform
-    if platform_env_conf_file_path is None:
-        return supported
-
-    # Else open the file check for keyword - macsec_enabled -
-    with open(platform_env_conf_file_path) as platform_env_conf_file:
-        for line in platform_env_conf_file:
-            tokens = line.split('=')
-            if len(tokens) < 2:
-               continue
-            if tokens[0].lower() == 'macsec_enabled':
-                supported = tokens[1].strip()
-                break
-    return int(supported)
-
-
-def get_macsec_support_metadata():
-    macsec_support_metadata = {'MACSEC_SUPPORTED': True if is_macsec_supported() else False}
-    return macsec_support_metadata


### PR DESCRIPTION
#### Why I did it
Plan to use the macsec capability flag in the platform - to enable macsec feature which inturn hep hostcfgd to start the macsec dockers 

#### How I did it
Add a new flag "macsec_enabled" in the platform_env.conf in the platform directory - which states if that platform  has macsec capability

Add a new API in device_info to get the macsec capability from platform and export to an environment variable MACSEC_SUPPORTED used in hostcfgd.

#### How to verify it
Verified that the MACSEC_SUPPORTED variable is updated as per the "macsec_enabled" flag set in the platform_env.conf -- and hostcfgd updates the macsec feature state accordingly.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

