### PR TITLE
01.Version-cache - restructuring of Makefile.work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,14 @@ NOSTRETCH ?= 0
 NOBUSTER ?= 0
 NOBULLSEYE ?= 0
 
+override Q := @
+ifeq ($(QUIET),n)
+  override Q := 
+endif
+override SONIC_OVERRIDE_BUILD_VARS += $(SONIC_BUILD_VARS)
+override SONIC_OVERRIDE_BUILD_VARS += Q=$(Q)
+export Q SONIC_OVERRIDE_BUILD_VARS
+
 ifeq ($(NOJESSIE),0)
 BUILD_JESSIE=1
 endif
@@ -29,50 +37,50 @@ PLATFORM_CHECKOUT_CMD := $(shell if [ -f $(PLATFORM_CHECKOUT_FILE) ]; then PLATF
 %::
 	@echo "+++ --- Making $@ --- +++"
 ifeq ($(NOJESSIE), 0)
-	EXTRA_DOCKER_TARGETS=$(notdir $@) make -f Makefile.work jessie
+	EXTRA_DOCKER_TARGETS=$(notdir $@) $(MAKE) -f Makefile.work jessie
 endif
 ifeq ($(NOSTRETCH), 0)
-	EXTRA_DOCKER_TARGETS=$(notdir $@) BLDENV=stretch make -f Makefile.work stretch
+	EXTRA_DOCKER_TARGETS=$(notdir $@) BLDENV=stretch $(MAKE) -f Makefile.work stretch
 endif
 ifeq ($(NOBUSTER), 0)
-	EXTRA_DOCKER_TARGETS=$(notdir $@) BLDENV=buster make -f Makefile.work buster
+	EXTRA_DOCKER_TARGETS=$(notdir $@) BLDENV=buster $(MAKE) -f Makefile.work buster
 endif
 ifeq ($(NOBULLSEYE), 0)
-	BLDENV=bullseye make -f Makefile.work $@
+	BLDENV=bullseye $(MAKE) -f Makefile.work $@
 endif
-	BLDENV=bullseye make -f Makefile.work docker-cleanup
+	BLDENV=bullseye $(MAKE) -f Makefile.work docker-cleanup
 
 jessie:
 	@echo "+++ Making $@ +++"
 ifeq ($(NOJESSIE), 0)
-	make -f Makefile.work jessie
+	$(MAKE) -f Makefile.work jessie
 endif
 
 stretch:
 	@echo "+++ Making $@ +++"
 ifeq ($(NOSTRETCH), 0)
-	make -f Makefile.work stretch
+	$(MAKE) -f Makefile.work stretch
 endif
 
 buster:
 	@echo "+++ Making $@ +++"
 ifeq ($(NOBUSTER), 0)
-	make -f Makefile.work buster
+	$(MAKE) -f Makefile.work buster
 endif
 
 init:
 	@echo "+++ Making $@ +++"
-	make -f Makefile.work $@
+	$(MAKE) -f Makefile.work $@
 
 #
 # Function to invoke target $@ in Makefile.work with proper BLDENV
 #
 define make_work
 	@echo "+++ Making $@ +++"
-	$(if $(BUILD_JESSIE),make -f Makefile.work $@,)
-	$(if $(BUILD_STRETCH),BLDENV=stretch make -f Makefile.work $@,)
-	$(if $(BUILD_BUSTER),BLDENV=buster make -f Makefile.work $@,)
-	$(if $(BUILD_BULLSEYE),BLDENV=bullseye make -f Makefile.work $@,)
+	$(if $(BUILD_JESSIE),$(MAKE) -f Makefile.work $@,)
+	$(if $(BUILD_STRETCH),BLDENV=stretch $(MAKE) -f Makefile.work $@,)
+	$(if $(BUILD_BUSTER),BLDENV=buster $(MAKE) -f Makefile.work $@,)
+	$(if $(BUILD_BULLSEYE),BLDENV=bullseye $(MAKE) -f Makefile.work $@,)
 endef
 
 .PHONY: $(PLATFORM_PATH)

--- a/Makefile.work
+++ b/Makefile.work
@@ -124,7 +124,7 @@ endif
 # Define a do-nothing target for rules/config.user so that when
 # the file is missing, make won't try to rebuld everything.
 rules/config.user:
-	@echo -n ""
+	$(Q)echo -n ""
 
 include rules/config
 -include rules/config.user
@@ -173,21 +173,59 @@ endif
 endif
 
 # Generate the version control build info
-$(shell SONIC_VERSION_CONTROL_COMPONENTS=$(SONIC_VERSION_CONTROL_COMPONENTS) \
-    TRUSTED_GPG_URLS=$(TRUSTED_GPG_URLS) PACKAGE_URL_PREFIX=$(PACKAGE_URL_PREFIX) \
-    scripts/generate_buildinfo_config.sh)
+$(shell \
+	SONIC_VERSION_CONTROL_COMPONENTS=$(SONIC_VERSION_CONTROL_COMPONENTS) \
+	TRUSTED_GPG_URLS=$(TRUSTED_GPG_URLS) \
+	PACKAGE_URL_PREFIX=$(PACKAGE_URL_PREFIX) \
+	scripts/generate_buildinfo_config.sh)
 
 # Generate the slave Dockerfile, and prepare build info for it
-$(shell CONFIGURED_ARCH=$(CONFIGURED_ARCH) MULTIARCH_QEMU_ENVIRON=$(MULTIARCH_QEMU_ENVIRON) CROSS_BUILD_ENVIRON=$(CROSS_BUILD_ENVIRON) ENABLE_FIPS_FEATURE=$(ENABLE_FIPS_FEATURE) DOCKER_EXTRA_OPTS=$(DOCKER_EXTRA_OPTS) DEFAULT_CONTAINER_REGISTRY=$(DEFAULT_CONTAINER_REGISTRY) j2 $(SLAVE_DIR)/Dockerfile.j2 > $(SLAVE_DIR)/Dockerfile)
-$(shell CONFIGURED_ARCH=$(CONFIGURED_ARCH) MULTIARCH_QEMU_ENVIRON=$(MULTIARCH_QEMU_ENVIRON) CROSS_BUILD_ENVIRON=$(CROSS_BUILD_ENVIRON) j2 $(SLAVE_DIR)/Dockerfile.user.j2 > $(SLAVE_DIR)/Dockerfile.user)
-$(shell BUILD_SLAVE=y DEFAULT_CONTAINER_REGISTRY=$(DEFAULT_CONTAINER_REGISTRY) scripts/prepare_docker_buildinfo.sh $(SLAVE_BASE_IMAGE) $(SLAVE_DIR)/Dockerfile $(CONFIGURED_ARCH) "" $(BLDENV))
+$(shell CONFIGURED_ARCH=$(CONFIGURED_ARCH) \
+	MULTIARCH_QEMU_ENVIRON=$(MULTIARCH_QEMU_ENVIRON) \
+	CROSS_BUILD_ENVIRON=$(CROSS_BUILD_ENVIRON) \
+	ENABLE_FIPS_FEATURE=$(ENABLE_FIPS_FEATURE) \
+	DOCKER_EXTRA_OPTS=$(DOCKER_EXTRA_OPTS) \
+	DEFAULT_CONTAINER_REGISTRY=$(DEFAULT_CONTAINER_REGISTRY) \
+	j2 $(SLAVE_DIR)/Dockerfile.j2 > $(SLAVE_DIR)/Dockerfile)
+
+$(shell CONFIGURED_ARCH=$(CONFIGURED_ARCH) \
+	MULTIARCH_QEMU_ENVIRON=$(MULTIARCH_QEMU_ENVIRON) \
+	CROSS_BUILD_ENVIRON=$(CROSS_BUILD_ENVIRON) \
+	j2 $(SLAVE_DIR)/Dockerfile.user.j2 > $(SLAVE_DIR)/Dockerfile.user)
+
+PREPARE_DOCKER=BUILD_SLAVE=y \
+	DEFAULT_CONTAINER_REGISTRY=$(DEFAULT_CONTAINER_REGISTRY) \
+	scripts/prepare_docker_buildinfo.sh \
+		$(SLAVE_BASE_IMAGE) \
+		$(SLAVE_DIR)/Dockerfile \
+		$(CONFIGURED_ARCH) \
+		"" \
+		$(BLDENV)
+
+$(shell $(PREPARE_DOCKER) )
 
 # Add the versions in the tag, if the version change, need to rebuild the slave
-SLAVE_BASE_TAG = $(shell cat $(SLAVE_DIR)/Dockerfile $(SLAVE_DIR)/buildinfo/versions/versions-* src/sonic-build-hooks/hooks/* | sha1sum | awk '{print substr($$1,0,11);}')
-# Calculate the slave TAG based on $(USER)/$(PWD)/$(CONFIGURED_PLATFORM) to get unique SHA ID
-SLAVE_TAG = $(shell (cat $(SLAVE_DIR)/Dockerfile.user $(SLAVE_DIR)/Dockerfile $(SLAVE_DIR)/buildinfo/versions/versions-* .git/HEAD && echo $(USER)/$(PWD)/$(CONFIGURED_PLATFORM)) \
-			| sha1sum | awk '{print substr($$1,0,11);}')
+SLAVE_BASE_TAG = $(shell \
+	cat $(SLAVE_DIR)/Dockerfile \
+		$(SLAVE_DIR)/buildinfo/versions/versions-* \
+		src/sonic-build-hooks/hooks/* 2>/dev/null \
+	| sha1sum \
+	| awk '{print substr($$1,0,11);}')
 
+# Calculate the slave TAG based on $(USER)/$(PWD)/$(CONFIGURED_PLATFORM) to get unique SHA ID
+SLAVE_TAG = $(shell \
+	(cat $(SLAVE_DIR)/Dockerfile.user \
+		 $(SLAVE_DIR)/Dockerfile \
+		 $(SLAVE_DIR)/buildinfo/versions/versions-* \
+		 .git/HEAD \
+	&& echo $(USER)/$(PWD)/$(CONFIGURED_PLATFORM)) \
+	| sha1sum \
+	| awk '{print substr($$1,0,11);}')
+
+COLLECT_DOCKER=DEFAULT_CONTAINER_REGISTRY=$(DEFAULT_CONTAINER_REGISTRY) \
+	scripts/collect_docker_version_files.sh \
+	$(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) \
+		target 
 OVERLAY_MODULE_CHECK := \
     lsmod | grep -q "^overlay " &>/dev/null || \
     zgrep -q 'CONFIG_OVERLAY_FS=y' /proc/config.gz &>/dev/null || \
@@ -329,7 +367,7 @@ DOCKER_BASE_LOG = $(SLAVE_DIR)/$(SLAVE_BASE_IMAGE)_$(SLAVE_BASE_TAG).log
 DOCKER_LOG = $(SLAVE_DIR)/$(SLAVE_IMAGE)_$(SLAVE_TAG).log
 
 
-DOCKER_BASE_BUILD = docker build --no-cache \
+DOCKER_SLAVE_BASE_BUILD = docker build --no-cache \
 		    -t $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) \
 		    --build-arg http_proxy=$(http_proxy) \
 		    --build-arg https_proxy=$(https_proxy) \
@@ -339,7 +377,7 @@ DOCKER_BASE_BUILD = docker build --no-cache \
 DOCKER_BASE_PULL = docker pull \
 			$(REGISTRY_SERVER):$(REGISTRY_PORT)/$(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG)
 
-DOCKER_BUILD = docker build --no-cache \
+DOCKER_USER_BUILD = docker build --no-cache \
 	       --build-arg user=$(USER) \
 	       --build-arg uid=$(shell id -u) \
 	       --build-arg guid=$(shell id -g) \
@@ -349,7 +387,52 @@ DOCKER_BUILD = docker build --no-cache \
 	       -f $(SLAVE_DIR)/Dockerfile.user \
 	       $(SLAVE_DIR) $(SPLIT_LOG) $(DOCKER_LOG)
 
-SONIC_BUILD_INSTRUCTION :=  make \
+
+DOCKER_SLAVE_BASE_INSPECT = \
+	{ \
+		echo Checking sonic-slave-base image: $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG); \
+		docker inspect --type image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) &> /dev/null; \
+	}
+
+DOCKER_SLAVE_BASE_PULL_REGISTRY = \
+	[ $(ENABLE_DOCKER_BASE_PULL) == y ] && \
+	{ \
+		echo Image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) not found. Pulling...; \
+		$(DOCKER_BASE_PULL); \
+	} && \
+	{ \
+		docker tag $(REGISTRY_SERVER):$(REGISTRY_PORT)/$(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) && \
+		$(COLLECT_DOCKER); \
+	}\
+
+SONIC_SLAVE_BASE_BUILD = \
+	{ \
+		$(DOCKER_SLAVE_BASE_INSPECT); \
+	} || \
+	{ \
+		$(DOCKER_SLAVE_BASE_PULL_REGISTRY); \
+	} || \
+	{ \
+		echo Image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) not found. Building... ; \
+		$(PREPARE_DOCKER) ; \
+		$(DOCKER_SLAVE_BASE_BUILD) ; \
+		$(COLLECT_DOCKER) ; \
+	}
+
+DOCKER_SLAVE_USER_INSPECT = \
+	{ \
+		echo Checking sonic-slave-user image: $(SLAVE_IMAGE):$(SLAVE_TAG); \
+		docker inspect --type image $(SLAVE_IMAGE):$(SLAVE_TAG) &> /dev/null; \
+	}
+
+SONIC_SLAVE_USER_BUILD = \
+	{ $(DOCKER_SLAVE_USER_INSPECT) } || \
+	{ \
+		echo Image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Building... ; \
+		$(DOCKER_USER_BUILD) ; \
+	}
+
+SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            -f slave.mk \
                            PLATFORM=$(PLATFORM) \
                            PLATFORM_ARCH=$(PLATFORM_ARCH) \
@@ -415,87 +498,75 @@ SONIC_BUILD_INSTRUCTION :=  make \
 
 .PHONY: sonic-slave-build sonic-slave-bash init reset
 
+
+ifeq ($(filter clean,$(MAKECMDGOALS)),)
+COLLECT_BUILD_VERSION = { DBGOPT='$(DBGOPT)' scripts/collect_build_version_files.sh $$?; }
+endif
+
+ifdef SOURCE_FOLDER
+	DOCKER_RUN += -v $(SOURCE_FOLDER):/var/$(USER)/src
+endif
+
+ifeq "$(KEEP_SLAVE_ON)" "yes"
+SLAVE_SHELL={ /bin/bash; }
+endif
+
 .DEFAULT_GOAL :=  all
 
-%::
+%:: | sonic-build-hooks
 ifneq ($(filter y, $(MULTIARCH_QEMU_ENVIRON) $(CROSS_BUILD_ENVIRON)),)
-	@$(DOCKER_MULTIARCH_CHECK)
+	$(Q)$(DOCKER_MULTIARCH_CHECK)
 ifneq ($(BLDENV), )
-	@$(DOCKER_SERVICE_MULTIARCH_CHECK)
-	@$(DOCKER_SERVICE_DOCKERFS_CHECK)
+	$(Q)$(DOCKER_SERVICE_MULTIARCH_CHECK)
+	$(Q)$(DOCKER_SERVICE_DOCKERFS_CHECK)
 endif
 endif
-	@$(OVERLAY_MODULE_CHECK)
+	$(Q)$(OVERLAY_MODULE_CHECK)
+	$(Q)$(SONIC_SLAVE_BASE_BUILD)
+	$(Q)$(SONIC_SLAVE_USER_BUILD)
 
-	@pushd src/sonic-build-hooks; TRUSTED_GPG_URLS=$(TRUSTED_GPG_URLS) make all; popd
-	@cp src/sonic-build-hooks/buildinfo/sonic-build-hooks* $(SLAVE_DIR)/buildinfo
-	@docker inspect --type image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) &> /dev/null || \
-	    { [ $(ENABLE_DOCKER_BASE_PULL) == y ] && { echo Image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) not found. Pulling...; } && \
-	      $(DOCKER_BASE_PULL) && \
-		    { docker tag $(REGISTRY_SERVER):$(REGISTRY_PORT)/$(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) && \
-	          scripts/collect_docker_version_files.sh $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) target ; } } || \
-	    { echo Image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) not found. Building... ; \
-	      $(DOCKER_BASE_BUILD) ; \
-	      scripts/collect_docker_version_files.sh $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) target ; }
-	@docker inspect --type image $(SLAVE_IMAGE):$(SLAVE_TAG) &> /dev/null || \
-	    { echo Image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Building... ; \
-	    $(DOCKER_BUILD) ; }
-ifeq "$(KEEP_SLAVE_ON)" "yes"
-    ifdef SOURCE_FOLDER
-		@$(DOCKER_RUN) -v $(SOURCE_FOLDER):/var/$(USER)/src $(SLAVE_IMAGE):$(SLAVE_TAG) bash -c "$(SONIC_BUILD_INSTRUCTION) $@; scripts/collect_build_version_files.sh \$$?; /bin/bash"
-    else
-		@$(DOCKER_RUN) $(SLAVE_IMAGE):$(SLAVE_TAG) bash -c "$(SONIC_BUILD_INSTRUCTION) $@; scripts/collect_build_version_files.sh \$$?; /bin/bash"
-    endif
-else
-	@$(DOCKER_RUN) $(SLAVE_IMAGE):$(SLAVE_TAG) bash -c "$(SONIC_BUILD_INSTRUCTION) $@; scripts/collect_build_version_files.sh \$$?"
-endif
+	$(Q)$(DOCKER_RUN) \
+		$(SLAVE_IMAGE):$(SLAVE_TAG) \
+		bash -c "$(SONIC_BUILD_INSTRUCTION) $@;$(COLLECT_BUILD_VERSION); $(SLAVE_SHELL)"
+	$(Q)$(docker-image-cleanup)
 
 docker-cleanup:
-	$(docker-image-cleanup)
+	$(Q)$(docker-image-cleanup)
 
+.PHONY: sonic-build-hooks
 sonic-build-hooks:
-	@pushd src/sonic-build-hooks; TRUSTED_GPG_URLS=$(TRUSTED_GPG_URLS) make all; popd
-	@cp src/sonic-build-hooks/buildinfo/sonic-build-hooks* $(SLAVE_DIR)/buildinfo
+	$(Q)pushd src/sonic-build-hooks; TRUSTED_GPG_URLS=$(TRUSTED_GPG_URLS) $(MAKE) all; popd
+	$(Q)mkdir -p $(SLAVE_DIR)/buildinfo
+	$(Q)cp src/sonic-build-hooks/buildinfo/sonic-build-hooks* $(SLAVE_DIR)/buildinfo
 
-sonic-slave-base-build : sonic-build-hooks
+sonic-slave-base-build : | sonic-build-hooks
 ifeq ($(MULTIARCH_QEMU_ENVIRON), y)
-	@$(DOCKER_MULTIARCH_CHECK)
+	$(Q)$(DOCKER_MULTIARCH_CHECK)
 endif
-	@$(OVERLAY_MODULE_CHECK)
-	@echo Checking sonic-slave-base image: $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG)
-	@docker inspect --type image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) &> /dev/null || \
-	    { [ $(ENABLE_DOCKER_BASE_PULL) == y ] && { echo Image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) not found. Pulling...; } && \
-	      $(DOCKER_BASE_PULL) && \
-		    { docker tag $(REGISTRY_SERVER):$(REGISTRY_PORT)/$(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) && \
-	          scripts/collect_docker_version_files.sh $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) target ; } } || \
-	    { echo Image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) not found. Building... ; \
-	      $(DOCKER_BASE_BUILD) ; \
-	      scripts/collect_docker_version_files.sh $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) target ; }
+	$(Q)$(OVERLAY_MODULE_CHECK)
+	$(Q)$(SONIC_SLAVE_BASE_BUILD)
 
 sonic-slave-build : sonic-slave-base-build
-	@echo Checking sonic-slave image: $(SLAVE_IMAGE):$(SLAVE_TAG)
-	@docker inspect --type image $(SLAVE_IMAGE):$(SLAVE_TAG) &> /dev/null || \
-	    { echo Image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Building... ; \
-	    $(DOCKER_BUILD) ; }
+	$(Q)$(SONIC_SLAVE_USER_BUILD)
 
 sonic-slave-bash : sonic-slave-build
-	@$(DOCKER_RUN) -t $(SLAVE_IMAGE):$(SLAVE_TAG) bash
+	$(Q)$(DOCKER_RUN) -t $(SLAVE_IMAGE):$(SLAVE_TAG) bash
 
 sonic-slave-run : sonic-slave-build
-	@$(DOCKER_RUN) $(SLAVE_IMAGE):$(SLAVE_TAG) bash -c "$(SONIC_RUN_CMDS)"
+	$(Q)$(DOCKER_RUN) $(SLAVE_IMAGE):$(SLAVE_TAG) bash -c "$(SONIC_RUN_CMDS)"
 
 showtag:
-	@echo $(SLAVE_IMAGE):$(SLAVE_TAG)
-	@echo $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG)
+	$(Q)echo $(SLAVE_IMAGE):$(SLAVE_TAG)
+	$(Q)echo $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG)
 
 init :
-	@git submodule update --init --recursive
-	@git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $$(realpath --relative-to=. $$(cut -d" " -f2 .git))" > .git'
+	$(Q)git submodule update --init --recursive
+	$(Q)git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $$(realpath --relative-to=. $$(cut -d" " -f2 .git))" > .git'
 
 .ONESHELL : reset
 reset :
-	@echo && echo -n "Warning! All local changes will be lost. Proceed? [y/N]: "
-	@read ans && (
+	$(Q)echo && echo -n "Warning! All local changes will be lost. Proceed? [y/N]: "
+	$(Q)read ans && (
 	    if [ $$ans == y ]; then
 	        echo "Resetting local repository. Please wait...";
 	        sudo rm -rf fsroot*;

--- a/slave.mk
+++ b/slave.mk
@@ -92,32 +92,32 @@ export BLDENV
 
 .platform :
 ifneq ($(CONFIGURED_PLATFORM),generic)
-	@echo Build system is not configured, please run make configure
-	@exit 1
+	$(Q)echo Build system is not configured, please run make configure
+	$(Q)exit 1
 endif
 
 configure :
-	@mkdir -p $(JESSIE_DEBS_PATH)
-	@mkdir -p $(STRETCH_DEBS_PATH)
-	@mkdir -p $(BUSTER_DEBS_PATH)
-	@mkdir -p $(BULLSEYE_DEBS_PATH)
-	@mkdir -p $(FILES_PATH)
-	@mkdir -p $(JESSIE_FILES_PATH)
-	@mkdir -p $(STRETCH_FILES_PATH)
-	@mkdir -p $(BUSTER_FILES_PATH)
-	@mkdir -p $(BULLSEYE_FILES_PATH)
-	@mkdir -p $(PYTHON_DEBS_PATH)
-	@mkdir -p $(PYTHON_WHEELS_PATH)
-	@mkdir -p $(DPKG_ADMINDIR_PATH)
-	@echo $(PLATFORM) > .platform
-	@echo $(PLATFORM_ARCH) > .arch
+	$(Q)mkdir -p $(JESSIE_DEBS_PATH)
+	$(Q)mkdir -p $(STRETCH_DEBS_PATH)
+	$(Q)mkdir -p $(BUSTER_DEBS_PATH)
+	$(Q)mkdir -p $(BULLSEYE_DEBS_PATH)
+	$(Q)mkdir -p $(FILES_PATH)
+	$(Q)mkdir -p $(JESSIE_FILES_PATH)
+	$(Q)mkdir -p $(STRETCH_FILES_PATH)
+	$(Q)mkdir -p $(BUSTER_FILES_PATH)
+	$(Q)mkdir -p $(BULLSEYE_FILES_PATH)
+	$(Q)mkdir -p $(PYTHON_DEBS_PATH)
+	$(Q)mkdir -p $(PYTHON_WHEELS_PATH)
+	$(Q)mkdir -p $(DPKG_ADMINDIR_PATH)
+	$(Q)echo $(PLATFORM) > .platform
+	$(Q)echo $(PLATFORM_ARCH) > .arch
 
 distclean : .platform clean
-	@rm -f .platform
-	@rm -f .arch
+	$(Q)rm -f .platform
+	$(Q)rm -f .arch
 
 list :
-	@$(foreach target,$(SONIC_TARGET_LIST),echo $(target);)
+	$(Q)$(foreach target,$(SONIC_TARGET_LIST),echo $(target);)
 
 ###############################################################################
 ## Include other rules
@@ -177,7 +177,7 @@ endif
 # TODO(PINS): Remove when Bazel binaries are available for armhf
 ifeq ($(CONFIGURED_ARCH),armhf)
 	ifeq ($(INCLUDE_P4RT),y)
-		@echo "Disabling P4RT due to incompatible CPU architecture: $(CONFIGURED_ARCH)"
+		$(Q)echo "Disabling P4RT due to incompatible CPU architecture: $(CONFIGURED_ARCH)"
 	endif
 	override INCLUDE_P4RT = n
 endif
@@ -205,7 +205,7 @@ endif
 
 ifeq ($(ENABLE_ASAN),y)
 	ifneq ($(CONFIGURED_ARCH),amd64)
-		@echo "Disabling SWSS address sanitizer due to incompatible CPU architecture: $(CONFIGURED_ARCH)"
+		$(Q)echo "Disabling SWSS address sanitizer due to incompatible CPU architecture: $(CONFIGURED_ARCH)"
 		override ENABLE_ASAN = n
 	endif
 endif
@@ -870,12 +870,12 @@ endif
 
 # start docker daemon
 docker-start :
-	@sudo sed -i 's/--storage-driver=vfs/--storage-driver=$(SONIC_SLAVE_DOCKER_DRIVER)/' /etc/default/docker
-	@sudo sed -i -e '/http_proxy/d' -e '/https_proxy/d' /etc/default/docker
-	@sudo bash -c "{ echo \"export http_proxy=$$http_proxy\"; \
+	$(Q)sudo sed -i 's/--storage-driver=vfs/--storage-driver=$(SONIC_SLAVE_DOCKER_DRIVER)/' /etc/default/docker
+	$(Q)sudo sed -i -e '/http_proxy/d' -e '/https_proxy/d' /etc/default/docker
+	$(Q)sudo bash -c "{ echo \"export http_proxy=$$http_proxy\"; \
 	            echo \"export https_proxy=$$https_proxy\"; \
 	            echo \"export no_proxy=$$no_proxy\"; } >> /etc/default/docker"
-	@test x$(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD) != x"y" && sudo service docker status &> /dev/null || ( sudo service docker start &> /dev/null && ./scripts/wait_for_docker.sh 60 )
+	$(Q)test x$(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD) != x"y" && sudo service docker status &> /dev/null || ( sudo service docker start &> /dev/null && ./scripts/wait_for_docker.sh 60 )
 
 # targets for building simple docker images that do not depend on any debian packages
 $(addprefix $(TARGET_PATH)/, $(SONIC_SIMPLE_DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .platform docker-start $$(addsuffix -load,$$(addprefix $(TARGET_PATH)/,$$($$*.gz_LOAD_DOCKERS)))
@@ -1415,12 +1415,12 @@ SONIC_CLEAN_FILES = $(addsuffix -clean,$(addprefix $(FILES_PATH)/, \
 		   $(SONIC_MAKE_FILES)))
 
 $(SONIC_CLEAN_DEBS) :: $(DEBS_PATH)/%-clean : .platform $$(addsuffix -clean,$$(addprefix $(DEBS_PATH)/,$$($$*_MAIN_DEB)))
-	@# remove derived or extra targets if main one is removed, because we treat them
-	@# as part of one package
-	@rm -f $(addprefix $(DEBS_PATH)/, $* $($*_DERIVED_DEBS) $($*_EXTRA_DEBS))
+	$(Q)# remove derived or extra targets if main one is removed, because we treat them
+	$(Q)# as part of one package
+	$(Q)rm -f $(addprefix $(DEBS_PATH)/, $* $($*_DERIVED_DEBS) $($*_EXTRA_DEBS))
 
 $(SONIC_CLEAN_FILES) :: $(FILES_PATH)/%-clean : .platform
-	@rm -f $(FILES_PATH)/$*
+	$(Q)rm -f $(FILES_PATH)/$*
 
 SONIC_CLEAN_TARGETS += $(addsuffix -clean,$(addprefix $(TARGET_PATH)/, \
 		       $(SONIC_DOCKER_IMAGES) \
@@ -1428,20 +1428,20 @@ SONIC_CLEAN_TARGETS += $(addsuffix -clean,$(addprefix $(TARGET_PATH)/, \
 		       $(SONIC_SIMPLE_DOCKER_IMAGES) \
 		       $(SONIC_INSTALLERS)))
 $(SONIC_CLEAN_TARGETS) :: $(TARGET_PATH)/%-clean : .platform
-	@rm -f $(TARGET_PATH)/$*
+	$(Q)rm -f $(TARGET_PATH)/$*
 
 SONIC_CLEAN_STDEB_DEBS = $(addsuffix -clean,$(addprefix $(PYTHON_DEBS_PATH)/, \
 		     $(SONIC_PYTHON_STDEB_DEBS)))
 $(SONIC_CLEAN_STDEB_DEBS) :: $(PYTHON_DEBS_PATH)/%-clean : .platform
-	@rm -f $(PYTHON_DEBS_PATH)/$*
+	$(Q)rm -f $(PYTHON_DEBS_PATH)/$*
 
 SONIC_CLEAN_WHEELS = $(addsuffix -clean,$(addprefix $(PYTHON_WHEELS_PATH)/, \
 		     $(SONIC_PYTHON_WHEELS)))
 $(SONIC_CLEAN_WHEELS) :: $(PYTHON_WHEELS_PATH)/%-clean : .platform
-	@rm -f $(PYTHON_WHEELS_PATH)/$*
+	$(Q)rm -f $(PYTHON_WHEELS_PATH)/$*
 
 clean-logs :: .platform
-	@rm -f $(TARGET_PATH)/*.log $(DEBS_PATH)/*.log $(FILES_PATH)/*.log $(PYTHON_DEBS_PATH)/*.log $(PYTHON_WHEELS_PATH)/*.log
+	$(Q)rm -f $(TARGET_PATH)/*.log $(DEBS_PATH)/*.log $(FILES_PATH)/*.log $(PYTHON_DEBS_PATH)/*.log $(PYTHON_WHEELS_PATH)/*.log
 
 clean :: .platform clean-logs $$(SONIC_CLEAN_DEBS) $$(SONIC_CLEAN_FILES) $$(SONIC_CLEAN_TARGETS) $$(SONIC_CLEAN_STDEB_DEBS) $$(SONIC_CLEAN_WHEELS)
 


### PR DESCRIPTION
- The Makefile.work becomes complex and it is very difficult to manage the changes across branches.
- Restructured the Makefile.work and it becomes more readable.
- Added $(QUIET) option to turn on command echo mode through command line option.
- Exported the SONIC_BUILD_VARS variable, through which make options can be set dynamically.
	Eg: make SONIC_BUILD_VARS='INCLUDE_NAT=y'

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

