### PR TITLE
[Build] Fix dbus-run-session command not found issue when install dbus-python

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -72,7 +72,8 @@ RUN apt-get install -y net-tools \
                        {%- if ENABLE_ASAN == "y" %}
                        libasan5 \
                        {%- endif %}
-                       libsystemd0
+                       libsystemd0 \
+                       dbus
 
 # Install redis-server
 {% if CONFIGURED_ARCH == "armhf" %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the dbus-pyhon installation failure when building docker-sonic-vs, caused by the command dbus-run-session not found.
The command "dbus-run-session" should be the new dependency introduced in dbus-python 1.3.2, the old version 1.2.18 does not have the issue.

#### How I did it
Install the dbus debian package which contains the command dbus-run-session.
It is not a blocking issue on release branches. The release branches with reproducible build feature can avoid such issue in official builds and PR builds, it only block the version upgrade (trying to upgrade from 1.2.18 to 1.3.2).

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

