### PR TITLE
[Edgecore][AS9716/PDDF]Support B2F and F2B psu_fan_dir sysfs

### DIFF
--- a/device/accton/x86_64-accton_as9716_32d-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as9716_32d-r0/pddf/pddf-device.json
@@ -165,10 +165,8 @@
             "attr_list": 
             [  
                 { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x3", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
-                { "attr_name":"psu_model_name", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"12" },
                 { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x3", "attr_mask":"0x4", "attr_cmpval":"0x4", "attr_len":"1"},
                 { "attr_name":"psu_mfr_id", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
-                { "attr_name":"psu_fan_dir", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
                 { "attr_name":"psu_v_out", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x8b", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
                 { "attr_name":"psu_i_out", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
                 { "attr_name":"psu_p_out", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x96", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
@@ -185,8 +183,10 @@
         {
             "topo_info":{ "parent_bus":"0xa", "dev_addr":"0x51", "dev_type":"psu_eeprom"}, 
             "attr_list": 
-            [  
-                { "attr_name":"psu_serial_num", "attr_devaddr":"0x51", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"20" }
+            [   
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x51", "attr_devtype":"eeprom", "attr_offset":"0x20", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"11" },
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x51", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"20" },
+                { "attr_name":"psu_fan_dir",    "attr_devaddr":"0x51", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"3" }
             ]
         }
     },
@@ -214,10 +214,8 @@
             "attr_list": 
             [  
                 { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x3", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
-                { "attr_name":"psu_model_name", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"12" },
                 { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x3", "attr_mask":"0x8", "attr_cmpval":"0x8", "attr_len":"1"},
                 { "attr_name":"psu_mfr_id", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
-                { "attr_name":"psu_fan_dir", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
                 { "attr_name":"psu_v_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8b", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
                 { "attr_name":"psu_i_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
                 { "attr_name":"psu_p_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x96", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
@@ -234,8 +232,10 @@
         {
             "topo_info":{ "parent_bus":"0x9", "dev_addr":"0x50", "dev_type":"psu_eeprom"}, 
             "attr_list": 
-            [  
-                { "attr_name":"psu_serial_num", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"20" }
+            [    
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x20", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"11" },
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"20" },
+                { "attr_name":"psu_fan_dir",    "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"3" }
             ]
         }
     },

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/modules/pddf_custom_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/modules/pddf_custom_psu.c
@@ -15,16 +15,22 @@ ssize_t pddf_show_custom_psu_v_out(struct device *dev, struct device_attribute *
 extern PSU_SYSFS_ATTR_DATA access_psu_v_out;
 ssize_t pddf_get_custom_psu_model_name(struct device *dev, struct device_attribute *da, char *buf);
 ssize_t pddf_get_custom_psu_serial_num(struct device *dev, struct device_attribute *da, char *buf);
+ssize_t pddf_get_custom_psu_fan_dir(struct device *dev, struct device_attribute *da, char *buf);
 extern PSU_SYSFS_ATTR_DATA access_psu_model_name;
 extern PSU_SYSFS_ATTR_DATA access_psu_serial_num;
+extern PSU_SYSFS_ATTR_DATA access_psu_fan_dir;
 
-#define MAX_MODEL_NAME          16
+#define MAX_FAN_DIR_LEN         3
+#define MAX_MODEL_NAME          18
 #define MAX_SERIAL_NUMBER       19
+const char FAN_DIR_F2B[] = "F2B";
+const char FAN_DIR_B2F[] = "B2F";
 
 enum psu_type {
-    PSU_TYPE_AC_ACBEL_FSF019,
-    PSU_TYPE_AC_ACBEL_FSH082,
-    PSU_TYPE_YESM1300
+    PSU_TYPE_AC_ACBEL_FSF019_F2B, // FSF019-11G
+    PSU_TYPE_AC_ACBEL_FSH082_F2B, // FSH082-610G
+    PSU_TYPE_AC_ACBEL_FSH095_B2F, // FSH095-610G
+    PSU_TYPE_3Y_YESM1300AM // YESM1300AM-2A01P10(F2B) or YESM1300AM-2R01P10(B2F)
 };
 
 struct model_name_info {
@@ -33,6 +39,7 @@ struct model_name_info {
     u8 length;
     u8 chk_length;
     char* model_name;
+    const char* fan_dir;
 };
 
 struct serial_number_info {
@@ -42,22 +49,24 @@ struct serial_number_info {
     u8 chk_length;
     char* serial_number;
 };
-
 struct model_name_info models[] = {
-{PSU_TYPE_AC_ACBEL_FSF019, 0x15, 10, 7, "FSF019-"},
-{PSU_TYPE_AC_ACBEL_FSH082, 0x20, 10, 7, "FSH082-"},
-{PSU_TYPE_YESM1300, 0x20, 11, 8, "YESM1300"},
+    { PSU_TYPE_AC_ACBEL_FSF019_F2B, 0x15, 13, 6, "FSF019", FAN_DIR_F2B },
+    { PSU_TYPE_AC_ACBEL_FSH082_F2B, 0x20, 13, 6, "FSH082", FAN_DIR_F2B },
+    { PSU_TYPE_AC_ACBEL_FSH095_B2F, 0x20, 13, 6, "FSH095", FAN_DIR_B2F },
+    { PSU_TYPE_3Y_YESM1300AM, 0x20, 19, 8, "YESM1300", NULL }
 };
 
 struct serial_number_info serials[] = {
-{PSU_TYPE_AC_ACBEL_FSF019, 0x2e, 16, 16, "FSF019-"},
-{PSU_TYPE_AC_ACBEL_FSH082, 0x35, 18, 18, "FSH082-"},
-{PSU_TYPE_YESM1300,   0x35, 20, 19, "YESM1300"},
+    { PSU_TYPE_AC_ACBEL_FSF019_F2B, 0x2e, 16, 16, "FSF019" },
+    { PSU_TYPE_AC_ACBEL_FSH082_F2B, 0x35, 18, 18, "FSH082" },
+    { PSU_TYPE_AC_ACBEL_FSH095_B2F, 0x35, 18, 18, "FSH095" },
+    { PSU_TYPE_3Y_YESM1300AM, 0x35, 19, 19, "YESM1300" }
 };
 
 struct pddf_psu_data {    
     char model_name[MAX_MODEL_NAME+1];
     char serial_number[MAX_SERIAL_NUMBER+1];
+    char fan_dir[MAX_FAN_DIR_LEN+1];
 };
 
 
@@ -89,7 +98,6 @@ static int pddf_psu_read_block(struct i2c_client *client, u8 command, u8 *data,
 
     return result;
 }
-
 
 static int two_complement_to_int(u16 data, u8 valid_bit, int mask)
 {
@@ -182,12 +190,14 @@ ssize_t pddf_get_custom_psu_serial_num(struct device *dev, struct device_attribu
 	struct i2c_client *client = to_i2c_client(dev);
 	struct pddf_psu_data data;
     int i, status;
+    char buffer[32]={0};
     
     for (i = 0; i < ARRAY_SIZE(models); i++) {
         memset(data.serial_number, 0, sizeof(data.serial_number));
+        memset(buffer, 0, sizeof(buffer));
 
         status = pddf_psu_read_block(client, models[i].offset,
-                                           data.model_name, models[i].length);
+                                           buffer, models[i].length);
         if (status < 0) {
             data.model_name[0] = '\0';
             dev_dbg(&client->dev, "unable to read model name from (0x%x) offset(0x%x)\n",
@@ -195,13 +205,13 @@ ssize_t pddf_get_custom_psu_serial_num(struct device *dev, struct device_attribu
             return status;
         }
         else {
-            data.model_name[models[i].length] = '\0';
+            buffer[models[i].length] = '\0';
         }
 
         /* Determine if the model name is known, if not, read next index
          */
         
-        if (strncmp(data.model_name, models[i].model_name, models[i].chk_length) == 0) {
+        if (strncmp(buffer, models[i].model_name, models[i].chk_length) == 0) {
             status = pddf_psu_read_block(client, serials[i].offset,
                                            data.serial_number, serials[i].length);
             
@@ -252,41 +262,114 @@ ssize_t pddf_get_custom_psu_model_name(struct device *dev, struct device_attribu
         /* Determine if the model name is known, if not, read next index
          */
         if (strncmp(data.model_name, models[i].model_name, models[i].chk_length) == 0) {
-            if (models[i].type==PSU_TYPE_YESM1300)
-            {
-                if (data.model_name[9]=='A' && data.model_name[10]=='M')
-                {
-                    data.model_name[8]='A';
-                    data.model_name[9]='M';
-                    data.model_name[strlen("YESM1300AM")]='\0';
-                }
-                else  
-                    data.model_name[strlen("YESM1300")]='\0';
+            if (models[i].type==PSU_TYPE_3Y_YESM1300AM)
+            {      
+                char buf[10] = {0};
+                memcpy(buf, &data.model_name[9], 10);
+                memcpy(&data.model_name[8], buf, 10);
+                data.model_name[MAX_MODEL_NAME] = '\0';
             }
-
+            else if ((models[i].type == PSU_TYPE_AC_ACBEL_FSH082_F2B) ||
+                     (models[i].type == PSU_TYPE_AC_ACBEL_FSH095_B2F) ||
+                     (models[i].type == PSU_TYPE_AC_ACBEL_FSF019_F2B)) {
+                      // Adjust model name for FSH082 / FSH095 / FSF019
+                char buf[4] = {0};
+                memcpy(buf, &data.model_name[9], 4);
+                memcpy(&data.model_name[7], buf, 4);
+                data.model_name[6] = '-';
+                data.model_name[11] = '\0';
+            }
+            else
+                data.model_name[0]='\0';
+           
             return sprintf(buf, "%s\n", data.model_name);
         }
         else {
             data.model_name[0] = '\0';
         }
+        
+        
     }
 
     return -ENODATA;
 
 }
 
+ssize_t pddf_get_custom_psu_fan_dir(struct device *dev, struct device_attribute *da, char *buf)
+{
+	struct i2c_client *client = to_i2c_client(dev);
+	struct pddf_psu_data data;
+    int i, status;
+    char buffer[32]={0};
+    for (i = 0; i < ARRAY_SIZE(models); i++) {
+        memset(buffer, 0, sizeof(buffer));
+        memset(data.fan_dir, 0, sizeof(data.fan_dir));
 
+        status = pddf_psu_read_block(client, models[i].offset,
+                                           buffer, models[i].length);
+        if (status < 0) {
+            buffer[0] = '\0';
+            dev_dbg(&client->dev, "unable to read model name from (0x%x) offset(0x%x)\n",
+                                  client->addr, models[i].offset);
+            return status;
+        }
+        else {
+            buffer[models[i].length] = '\0';
+        }
+
+        /* Determine if the model name is known, if not, read next index
+         */
+        if (strncmp(buffer, models[i].model_name, models[i].chk_length) == 0) {
+            if (models[i].type==PSU_TYPE_3Y_YESM1300AM)
+            {      
+               /*YESM1300AM-2A01P10(F2B) or YESM1300AM-2R01P10(B2F)*/
+               if(strstr(buffer, "2A01P10"))
+               {
+                   strncpy(data.fan_dir, "F2B", MAX_FAN_DIR_LEN);
+               }
+               else if(strstr(buffer, "2R01P10"))
+               {
+                   strncpy(data.fan_dir, "B2F", MAX_FAN_DIR_LEN);
+               }
+
+            }
+            else if ((models[i].type == PSU_TYPE_AC_ACBEL_FSH082_F2B) ||
+                     (models[i].type == PSU_TYPE_AC_ACBEL_FSF019_F2B))
+            {
+                strncpy(data.fan_dir, "F2B", MAX_FAN_DIR_LEN);
+            }
+            else if ((models[i].type == PSU_TYPE_AC_ACBEL_FSH095_B2F))
+            {
+                strncpy(data.fan_dir, "B2F", MAX_FAN_DIR_LEN);
+            }
+
+            data.fan_dir[MAX_FAN_DIR_LEN] = '\0';
+           
+            return sprintf(buf, "%s\n", data.fan_dir);
+        }
+        else {
+            data.fan_dir[0] = '\0';
+        }
+    }
+   
+    return -ENODATA;
+
+	
+}
 
 static int __init pddf_custom_psu_init(void)
 {
-	access_psu_v_out.show = pddf_show_custom_psu_v_out;
-	access_psu_v_out.do_get = NULL;
+    access_psu_v_out.show = pddf_show_custom_psu_v_out;
+    access_psu_v_out.do_get = NULL;
 
-	access_psu_serial_num.show = pddf_get_custom_psu_serial_num;
-	access_psu_serial_num.do_get = NULL;
+    access_psu_serial_num.show = pddf_get_custom_psu_serial_num;
+    access_psu_serial_num.do_get = NULL;
 	
-	access_psu_model_name.show = pddf_get_custom_psu_model_name;
-	access_psu_model_name.do_get = NULL;	
+    access_psu_model_name.show = pddf_get_custom_psu_model_name;
+    access_psu_model_name.do_get = NULL;
+	
+    access_psu_fan_dir.show = pddf_get_custom_psu_fan_dir;
+    access_psu_fan_dir.do_get = NULL;
 	
 	return 0;
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Because the DUT support different PSU and their fan direction is different.  So need drv to provide sysfs for psu_fan_dir.
#### How I did it
These PSU don't support pmbus cmd, so read from eeprom and  create  sysfs to provide fan-direction.
#### How to verify it
Test show platform fan. Log as below,

     N/A  green   PSU1_FAN1      77%       intake     Present        OK  20220908 08:01:31
     N/A  green   PSU2_FAN1      76%       intake     Present        OK  20220908 08:01:31


     N/A  green   PSU1_FAN1      77%      exhaust     Present        OK  20220908 08:11:31
     N/A  green   PSU2_FAN1      76%      exhaust     Present        OK  20220908 08:11:31
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

