### PR TITLE
[FRR] add patch in zebra to ignore route update on RT_TABLE_DEFAULT

### DIFF
--- a/src/sonic-frr/patch/0009-ignore-route-from-default-table.patch
+++ b/src/sonic-frr/patch/0009-ignore-route-from-default-table.patch
@@ -1,0 +1,32 @@
+From 96dadc6719dafdd7d58e715f59e0d1a8edc3d58f Mon Sep 17 00:00:00 2001
+From: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>
+Date: Wed, 7 Sep 2022 23:59:03 +0000
+Subject: [PATCH] ignore route from default table
+
+Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>
+---
+ zebra/zebra_fpm_netlink.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/zebra/zebra_fpm_netlink.c b/zebra/zebra_fpm_netlink.c
+index 60ea7f97e..c6a2edf03 100644
+--- a/zebra/zebra_fpm_netlink.c
++++ b/zebra/zebra_fpm_netlink.c
+@@ -284,6 +284,14 @@ static int netlink_route_info_fill(struct netlink_route_info *ri, int cmd,
+ {
+ 	struct nexthop *nexthop;
+ 
++    struct rib_table_info *table_info =
++        rib_table_info(rib_dest_table(dest));
++
++    if (table_info->table_id == RT_TABLE_DEFAULT) {
++        zfpm_debug("%s: Discard default table route", __func__);
++        return 0;
++    }
++
+ 	memset(ri, 0, sizeof(*ri));
+ 
+ 	ri->prefix = rib_dest_prefix(dest);
+-- 
+2.25.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -5,3 +5,4 @@
 0005-nexthops-compare-vrf-only-if-ip-type.patch
 0007-frr-remove-frr-log-outchannel-to-var-log-frr.log.patch
 0008-Add-support-of-bgp-l3vni-evpn.patch
+0009-ignore-route-from-default-table.patch


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes #11995 and #9188 

#### How I did it
Add a patch for zebra to ignore sending netlink messages for routes in the table `RT_DEFAULT_TABLE`
#### How to verify it
Test mentioned in the github issues  #11995 and #9188 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

