### PR TITLE
[device/centec] Replace os.system and remove subprocess with shell=True

### DIFF
--- a/device/centec/arm64-centec_e530_24x2c-r0/platform_reboot
+++ b/device/centec/arm64-centec_e530_24x2c-r0/platform_reboot
@@ -3,11 +3,11 @@
 def main():
     # reboot the system
     with open('/sys/class/gpio/export', 'w') as file:
-        file.write('502')
+        file.write('502\n')
     with open('/sys/class/gpio/gpio502/direction', 'w') as file:
-        file.write('out')
+        file.write('out\n')
     with open('/sys/class/gpio/gpio502/value', 'w') as file:
-        file.write('1')
+        file.write('1\n')
 
 if __name__ == "__main__":
     main()

--- a/device/centec/arm64-centec_e530_24x2c-r0/platform_reboot
+++ b/device/centec/arm64-centec_e530_24x2c-r0/platform_reboot
@@ -1,11 +1,13 @@
 #!/usr/bin/python
-import os
 
 def main():
     # reboot the system
-    os.system('echo 502 > /sys/class/gpio/export')
-    os.system('echo out > /sys/class/gpio/gpio502/direction')
-    os.system('echo 1 > /sys/class/gpio/gpio502/value')
+    with open('/sys/class/gpio/export', 'w') as file:
+        file.write('502')
+    with open('/sys/class/gpio/gpio502/direction', 'w') as file:
+        file.write('out')
+    with open('/sys/class/gpio/gpio502/value', 'w') as file:
+        file.write('1')
 
 if __name__ == "__main__":
     main()

--- a/device/centec/arm64-centec_e530_24x2q-r0/platform_reboot
+++ b/device/centec/arm64-centec_e530_24x2q-r0/platform_reboot
@@ -3,11 +3,11 @@
 def main():
     # reboot the system
     with open('/sys/class/gpio/export', 'w') as file:
-        file.write('502')
+        file.write('502\n')
     with open('/sys/class/gpio/gpio502/direction', 'w') as file:
-        file.write('out')
+        file.write('out\n')
     with open('/sys/class/gpio/gpio502/value', 'w') as file:
-        file.write('1')
+        file.write('1\n')
 
 if __name__ == "__main__":
     main()

--- a/device/centec/arm64-centec_e530_24x2q-r0/platform_reboot
+++ b/device/centec/arm64-centec_e530_24x2q-r0/platform_reboot
@@ -1,11 +1,13 @@
 #!/usr/bin/python
-import os
 
 def main():
     # reboot the system
-    os.system('echo 502 > /sys/class/gpio/export')
-    os.system('echo out > /sys/class/gpio/gpio502/direction')
-    os.system('echo 1 > /sys/class/gpio/gpio502/value')
+    with open('/sys/class/gpio/export', 'w') as file:
+        file.write('502')
+    with open('/sys/class/gpio/gpio502/direction', 'w') as file:
+        file.write('out')
+    with open('/sys/class/gpio/gpio502/value', 'w') as file:
+        file.write('1')
 
 if __name__ == "__main__":
     main()

--- a/device/centec/arm64-centec_e530_48s4x-r0/platform_reboot
+++ b/device/centec/arm64-centec_e530_48s4x-r0/platform_reboot
@@ -3,10 +3,10 @@ import subprocess
 
 def main():
     # reboot the system
-    subprocess.run(['modprobe', 'i2c-dev'])
-    subprocess.run(['i2cset', '-y', '0', '0x36', '0x23', '0x0'])
-    subprocess.run(['sleep', '1'])
-    subprocess.run(['i2cset', '-y', '0', '0x36', '0x23', '0x3'])
+    subprocess.call(['modprobe', 'i2c-dev'])
+    subprocess.call(['i2cset', '-y', '0', '0x36', '0x23', '0x0'])
+    subprocess.call(['sleep', '1'])
+    subprocess.call(['i2cset', '-y', '0', '0x36', '0x23', '0x3'])
 
 if __name__ == "__main__":
     main()

--- a/device/centec/arm64-centec_e530_48s4x-r0/platform_reboot
+++ b/device/centec/arm64-centec_e530_48s4x-r0/platform_reboot
@@ -1,12 +1,12 @@
 #!/usr/bin/python
-import os
+import subprocess
 
 def main():
     # reboot the system
-    os.system('modprobe i2c-dev')
-    os.system('i2cset -y 0 0x36 0x23 0x0')
-    os.system('sleep 1')
-    os.system('i2cset -y 0 0x36 0x23 0x3')
+    subprocess.run(['modprobe', 'i2c-dev'])
+    subprocess.run(['i2cset', '-y', '0', '0x36', '0x23', '0x0'])
+    subprocess.run(['sleep', '1'])
+    subprocess.run(['i2cset', '-y', '0', '0x36', '0x23', '0x3'])
 
 if __name__ == "__main__":
     main()

--- a/device/centec/arm64-centec_e530_48t4x_p-r0/platform_reboot
+++ b/device/centec/arm64-centec_e530_48t4x_p-r0/platform_reboot
@@ -3,11 +3,11 @@
 def main():
     # reboot the system
     with open('/sys/class/gpio/export', 'w') as file:
-        file.write('502')
+        file.write('502\n')
     with open('/sys/class/gpio/gpio502/direction', 'w') as file:
-        file.write('out')
+        file.write('out\n')
     with open('/sys/class/gpio/gpio502/value', 'w') as file:
-        file.write('1')
+        file.write('1\n')
 
 if __name__ == "__main__":
     main()

--- a/device/centec/arm64-centec_e530_48t4x_p-r0/platform_reboot
+++ b/device/centec/arm64-centec_e530_48t4x_p-r0/platform_reboot
@@ -1,11 +1,13 @@
 #!/usr/bin/python
-import os
 
 def main():
     # reboot the system
-    os.system('echo 502 > /sys/class/gpio/export')
-    os.system('echo out > /sys/class/gpio/gpio502/direction')
-    os.system('echo 1 > /sys/class/gpio/gpio502/value')
+    with open('/sys/class/gpio/export', 'w') as file:
+        file.write('502')
+    with open('/sys/class/gpio/gpio502/direction', 'w') as file:
+        file.write('out')
+    with open('/sys/class/gpio/gpio502/value', 'w') as file:
+        file.write('1')
 
 if __name__ == "__main__":
     main()

--- a/device/centec/x86_64-centec_v682_48x8c-r0/platform_reboot
+++ b/device/centec/x86_64-centec_v682_48x8c-r0/platform_reboot
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
-import os
+import subprocess
 import time
 
 def main():
-    os.system('hwclock -w -f /dev/rtc1')
+    subprocess.run(['hwclock', '-w', '-f', '/dev/rtc1'])
     time.sleep(1)
 
-    os.system('i2cset -y 0 0x36 0x23 0')
+    subprocess.run(['i2cset', '-y', '0', '0x36', '0x23', '0'])
     time.sleep(1)
-    os.system('i2cset -y 0 0x36 0x23 1')
+    subprocess.run(['i2cset', '-y', '0', '0x36', '0x23', '1'])
 
 if __name__ == '__main__':
     main()

--- a/device/centec/x86_64-centec_v682_48x8c-r0/platform_reboot
+++ b/device/centec/x86_64-centec_v682_48x8c-r0/platform_reboot
@@ -4,12 +4,12 @@ import subprocess
 import time
 
 def main():
-    subprocess.run(['hwclock', '-w', '-f', '/dev/rtc1'])
+    subprocess.call(['hwclock', '-w', '-f', '/dev/rtc1'])
     time.sleep(1)
 
-    subprocess.run(['i2cset', '-y', '0', '0x36', '0x23', '0'])
+    subprocess.call(['i2cset', '-y', '0', '0x36', '0x23', '0'])
     time.sleep(1)
-    subprocess.run(['i2cset', '-y', '0', '0x36', '0x23', '1'])
+    subprocess.call(['i2cset', '-y', '0', '0x36', '0x23', '1'])
 
 if __name__ == '__main__':
     main()

--- a/device/centec/x86_64-centec_v682_48x8c-r0/plugins/led_control.py
+++ b/device/centec/x86_64-centec_v682_48x8c-r0/plugins/led_control.py
@@ -166,11 +166,11 @@ class LedControl(LedControlBase):
 
     def _initSystemLed(self):
         try:
-            cmd = 'i2cset -y 0 0x36 0x2 0x5'
-            Popen(cmd, shell=True)
+            cmd = ['i2cset', '-y', '0', '0x36', '0x2', '0x5']
+            Popen(cmd)
             DBG_PRINT("init system led to normal")
-            cmd = 'i2cset -y 0 0x36 0x3 0x1'
-            Popen(cmd, shell=True)
+            cmd = ['i2cset', '-y', '0', '0x36', '0x3', '0x1']
+            Popen(cmd)
             DBG_PRINT("init idn led to off")
         except IOError as e:
             DBG_PRINT(str(e))

--- a/device/centec/x86_64-centec_v682_48x8c-r0/plugins/psuutil.py
+++ b/device/centec/x86_64-centec_v682_48x8c-r0/plugins/psuutil.py
@@ -40,8 +40,8 @@ class PsuUtil(PsuBase):
         if index is None:
             return False
 
-        cmd = 'i2cget -y 0 0x36 0x1e'
-        status = int(Popen(cmd, stdout=PIPE, stderr=STDOUT, shell=True).stdout.readline(), 16)
+        cmd = ['i2cget', '-y', '0', '0x36', '0x1e']
+        status = int(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.readline(), 16)
         powergood = ((status & (1 << (3 * (index - 1) + 2))) != 0)
         return powergood
 
@@ -56,7 +56,7 @@ class PsuUtil(PsuBase):
         if index is None:
             return False
 
-        cmd = 'i2cget -y 0 0x36 0x1e'
-        status = int(Popen(cmd, stdout=PIPE, stderr=STDOUT, shell=True).stdout.readline(), 16)
+        cmd = ['i2cget', '-y', '0', '0x36', '0x1e']
+        status = int(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.readline(), 16)
         presence = ((status & (1 << (3 * (index - 1) + 1))) == 0)
         return presence

--- a/device/centec/x86_64-centec_v682_48y8c-r0/platform_reboot
+++ b/device/centec/x86_64-centec_v682_48y8c-r0/platform_reboot
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
-import os
+import subprocess
 import time
 
 def main():
-    os.system('hwclock -w -f /dev/rtc1')
+    subprocess.run(['hwclock', '-w', '-f', '/dev/rtc1'])
     time.sleep(1)
 
-    os.system('i2cset -y 0 0x36 0x23 0')
+    subprocess.run(['i2cset', '-y', '0', '0x36', '0x23', '0'])
     time.sleep(1)
-    os.system('i2cset -y 0 0x36 0x23 1')
+    subprocess.run(['i2cset', '-y', '0', '0x36', '0x23', '1'])
 
 if __name__ == '__main__':
     main()

--- a/device/centec/x86_64-centec_v682_48y8c-r0/platform_reboot
+++ b/device/centec/x86_64-centec_v682_48y8c-r0/platform_reboot
@@ -4,12 +4,12 @@ import subprocess
 import time
 
 def main():
-    subprocess.run(['hwclock', '-w', '-f', '/dev/rtc1'])
+    subprocess.call(['hwclock', '-w', '-f', '/dev/rtc1'])
     time.sleep(1)
 
-    subprocess.run(['i2cset', '-y', '0', '0x36', '0x23', '0'])
+    subprocess.call(['i2cset', '-y', '0', '0x36', '0x23', '0'])
     time.sleep(1)
-    subprocess.run(['i2cset', '-y', '0', '0x36', '0x23', '1'])
+    subprocess.call(['i2cset', '-y', '0', '0x36', '0x23', '1'])
 
 if __name__ == '__main__':
     main()

--- a/device/centec/x86_64-centec_v682_48y8c-r0/plugins/led_control.py
+++ b/device/centec/x86_64-centec_v682_48y8c-r0/plugins/led_control.py
@@ -166,11 +166,11 @@ class LedControl(LedControlBase):
 
     def _initSystemLed(self):
         try:
-            cmd = 'i2cset -y 0 0x36 0x2 0x5'
-            Popen(cmd, shell=True)
+            cmd = ['i2cset', '-y', '0', '0x36', '0x2', '0x5']
+            Popen(cmd)
             DBG_PRINT("init system led to normal")
-            cmd = 'i2cset -y 0 0x36 0x3 0x1'
-            Popen(cmd, shell=True)
+            cmd = ['i2cset', '-y', '0', '0x36', '0x3', '0x1']
+            Popen(cmd)
             DBG_PRINT("init idn led to off")
         except IOError as e:
             DBG_PRINT(str(e))

--- a/device/centec/x86_64-centec_v682_48y8c-r0/plugins/psuutil.py
+++ b/device/centec/x86_64-centec_v682_48y8c-r0/plugins/psuutil.py
@@ -40,8 +40,8 @@ class PsuUtil(PsuBase):
         if index is None:
             return False
 
-        cmd = 'i2cget -y 0 0x36 0x1e'
-        status = int(Popen(cmd, stdout=PIPE, stderr=STDOUT, shell=True).stdout.readline(), 16)
+        cmd = ['i2cget', '-y', '0', '0x36', '0x1e']
+        status = int(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.readline(), 16)
         powergood = ((status & (1 << (3 * (index - 1) + 2))) != 0)
         return powergood
 
@@ -56,7 +56,7 @@ class PsuUtil(PsuBase):
         if index is None:
             return False
 
-        cmd = 'i2cget -y 0 0x36 0x1e'
-        status = int(Popen(cmd, stdout=PIPE, stderr=STDOUT, shell=True).stdout.readline(), 16)
+        cmd = ['i2cget', '-y', '0', '0x36', '0x1e']
+        status = int(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.readline(), 16)
         presence = ((status & (1 << (3 * (index - 1) + 1))) == 0)
         return presence

--- a/device/centec/x86_64-ew_es6220_x48q2h4-r0/plugins/psuutil.py
+++ b/device/centec/x86_64-ew_es6220_x48q2h4-r0/plugins/psuutil.py
@@ -1,4 +1,4 @@
-import os.path
+import subprocess
 
 try:
     from sonic_psu.psu_base import PsuBase
@@ -14,7 +14,7 @@ class PsuUtil(PsuBase):
 
         self.psu_path = "/sys/bus/i2c/devices/{}-0058/"
         self.psu_oper_status = "in1_input"
-        self.psu_presence = "i2cget -y {} 0x50 0x00"
+        self.psu_presence = ["i2cget", "-y", "", "0x50", "0x00"]
 
     def get_num_psus(self):
         """ 
@@ -46,8 +46,9 @@ class PsuUtil(PsuBase):
         Base_bus_number = 39
         status = 0
         try:
-            p = os.popen(self.psu_presence.format(index + Base_bus_number) + "> /dev/null 2>&1")
-            if p.readline() != None:
+            self.psu_presence[2] = str(index + Base_bus_number)
+            p = subprocess.Popen(self.psu_presence)
+            if p.stdout.readline() is not None:
                 status = 1
             p.close()
         except IOError:

--- a/device/centec/x86_64-ew_es6220_x48q2h4-r0/plugins/sfputil.py
+++ b/device/centec/x86_64-ew_es6220_x48q2h4-r0/plugins/sfputil.py
@@ -5,7 +5,6 @@
 
 try:
     import time
-    import os
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
@@ -46,32 +45,6 @@ class SfpUtil(SfpUtilBase):
                 x + self.EEPROM_OFFSET)
 
         SfpUtilBase.__init__(self)
-
-    def get_presence(self, port_name):
-        # modify by zhw to get sfp presence
-        # Check for invalid port_num
-        port_num = int(port_name[8:])
-
-        if port_num < (self.port_start+1) or port_num > (self.port_end+1):
-            return False
-
-        # cpld info from "CPLD Register for es5800A2.2(V1.1)"
-        cpld_map = {0: '0x82', 1: '0x83', 2: '0x84',
-                    3: '0x85', 4: '0x86', 5: '0x87', 6: '0x8E'}
-        cpld_key = (port_num - 1)/8
-        cpld_mask = (1 << (port_num - 1) % 8)
-
-        # use i2cget cmd to get cpld data
-        output = os.popen('i2cdetect -l | grep CP')
-        bus_num = output.read()[4]
-        cmd = "i2cget -y "+bus_num+" 0x5 "+cpld_map[cpld_key]
-        tmp = os.popen(cmd).read().replace("\n", "")
-        cpld_value = int(tmp, 16)
-
-        if cpld_value & cpld_mask == 0:
-            return True
-        else:
-            return False
 
     def get_low_power_mode(self, port_num):
         '''


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`subprocess.Popen()` and `subprocess.run()` is used with `shell=True`, which is very dangerous for shell injection.
`os` - not secure against maliciously constructed input and dangerous if used to evaluate dynamic content
#### How I did it
Replace `os` by `subprocess`, remove `shell=True`
Remove unused functions
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [X] 201911
- [X] 202006
- [X] 202012
- [X] 202106
- [X] 202111
- [X] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

