### PR TITLE
Pin version of bazelisk to v1.13.0

### DIFF
--- a/files/build/versions/default/versions-web
+++ b/files/build/versions/default/versions-web
@@ -38,8 +38,8 @@ https://deb.nodesource.com/setup_14.x==b692a224c718ad6e1cbd17eda8aaa673
 https://download.docker.com/linux/debian/gpg==1afae06b34a13c1b3d9cb61a26285a15
 https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/bfnplatform_20220408_sai_1.9.1_deb10.deb==890a53ca1374dfcf8c12091d74fd2ef8
 https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/bfnsdk_20220408_sai_1.9.1_deb10.deb==a54c351ee84ddb63837085272a1c4eae
-https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
-https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-arm64==9d20e147b108fb9638dd65b1ad9a1503
+https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
+https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-arm64==9d20e147b108fb9638dd65b1ad9a1503
 https://github.com/CentecNetworks/sonic-binaries/raw/master/amd64/sai/libsai_1.9.1-0_amd64.deb==08e1a82bd42ca1cba08fd6deec43c02a
 https://github.com/CentecNetworks/sonic-binaries/raw/master/amd64/third_party/advantech/_Susi4.so==5e1b8daef522c9da00af400abe25810b
 https://github.com/CentecNetworks/sonic-binaries/raw/master/amd64/third_party/advantech/libSUSI-4.00.so.1==393a94b0abba146777e276e1febe0cb0

--- a/files/build/versions/default/versions-web
+++ b/files/build/versions/default/versions-web
@@ -38,8 +38,8 @@ https://deb.nodesource.com/setup_14.x==b692a224c718ad6e1cbd17eda8aaa673
 https://download.docker.com/linux/debian/gpg==1afae06b34a13c1b3d9cb61a26285a15
 https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/bfnplatform_20220408_sai_1.9.1_deb10.deb==890a53ca1374dfcf8c12091d74fd2ef8
 https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/bfnsdk_20220408_sai_1.9.1_deb10.deb==a54c351ee84ddb63837085272a1c4eae
-https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
-https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-arm64==9d20e147b108fb9638dd65b1ad9a1503
+https://github.com/bazelbuild/bazelisk/releases/download/v1.13.0/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
+https://github.com/bazelbuild/bazelisk/releases/download/v1.13.0/bazelisk-linux-arm64==9d20e147b108fb9638dd65b1ad9a1503
 https://github.com/CentecNetworks/sonic-binaries/raw/master/amd64/sai/libsai_1.9.1-0_amd64.deb==08e1a82bd42ca1cba08fd6deec43c02a
 https://github.com/CentecNetworks/sonic-binaries/raw/master/amd64/third_party/advantech/_Susi4.so==5e1b8daef522c9da00af400abe25810b
 https://github.com/CentecNetworks/sonic-binaries/raw/master/amd64/third_party/advantech/libSUSI-4.00.so.1==393a94b0abba146777e276e1febe0cb0

--- a/files/build/versions/dockers/sonic-slave-bullseye/versions-web
+++ b/files/build/versions/dockers/sonic-slave-bullseye/versions-web
@@ -1,4 +1,4 @@
 https://download.docker.com/linux/debian/gpg==1afae06b34a13c1b3d9cb61a26285a15
-https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
+https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
 https://sonicstorage.blob.core.windows.net/public/fips/bullseye/0.1/amd64/golang-1.15-go_1.15.15-1~deb11u4%2Bfips_amd64.deb==b60f6db62805696b47ab422ab798fe56
 https://sonicstorage.blob.core.windows.net/public/fips/bullseye/0.1/amd64/golang-1.15-src_1.15.15-1~deb11u4%2Bfips_amd64.deb==1c920937aa49b602a1bfec3c49747131

--- a/files/build/versions/dockers/sonic-slave-bullseye/versions-web
+++ b/files/build/versions/dockers/sonic-slave-bullseye/versions-web
@@ -1,4 +1,4 @@
 https://download.docker.com/linux/debian/gpg==1afae06b34a13c1b3d9cb61a26285a15
-https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
+https://github.com/bazelbuild/bazelisk/releases/download/v1.13.0/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
 https://sonicstorage.blob.core.windows.net/public/fips/bullseye/0.1/amd64/golang-1.15-go_1.15.15-1~deb11u4%2Bfips_amd64.deb==b60f6db62805696b47ab422ab798fe56
 https://sonicstorage.blob.core.windows.net/public/fips/bullseye/0.1/amd64/golang-1.15-src_1.15.15-1~deb11u4%2Bfips_amd64.deb==1c920937aa49b602a1bfec3c49747131

--- a/files/build/versions/dockers/sonic-slave-buster/versions-web
+++ b/files/build/versions/dockers/sonic-slave-buster/versions-web
@@ -1,3 +1,3 @@
 https://download.docker.com/linux/debian/gpg==1afae06b34a13c1b3d9cb61a26285a15
-https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
+https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
 https://storage.googleapis.com/golang/go1.14.2.linux-amd64.tar.gz==856d248e3ea8a287d13e5f6afd086282

--- a/files/build/versions/dockers/sonic-slave-buster/versions-web
+++ b/files/build/versions/dockers/sonic-slave-buster/versions-web
@@ -1,3 +1,3 @@
 https://download.docker.com/linux/debian/gpg==1afae06b34a13c1b3d9cb61a26285a15
-https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
+https://github.com/bazelbuild/bazelisk/releases/download/v1.13.0/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
 https://storage.googleapis.com/golang/go1.14.2.linux-amd64.tar.gz==856d248e3ea8a287d13e5f6afd086282

--- a/files/build/versions/dockers/sonic-slave-stretch/versions-web
+++ b/files/build/versions/dockers/sonic-slave-stretch/versions-web
@@ -1,5 +1,5 @@
 https://download.docker.com/linux/debian/gpg==1afae06b34a13c1b3d9cb61a26285a15
-https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
+https://github.com/bazelbuild/bazelisk/releases/download/v1.13.0/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
 https://sonicstorage.blob.core.windows.net/packages/cmake/cmake-data_3.13.2-1_bpo9%2B1_all.deb?st=2020-03-27T02%3A22%3A24Z&se=2100-03-26T19%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=Xby%2Bm3OZOjPB%2FSlDbHD65yDcPzAgoys%2FA3vK8RB4BzA%3D==147cf42f3a68f6d6f1e53d95a599a1af
 https://sonicstorage.blob.core.windows.net/packages/cmake/cmake_3.13.2-1_bpo9%2B1_amd64.deb?st=2020-03-27T02%3A27%3A21Z&se=2100-03-26T19%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=4MvmmDBQuicFEJYakLm7xCNU19yJ8GIP4ankFSnITKY%3D==e75c741e8b6918b8f03625e456fa0275
 https://storage.googleapis.com/golang/go1.14.2.linux-amd64.tar.gz==856d248e3ea8a287d13e5f6afd086282

--- a/files/build/versions/dockers/sonic-slave-stretch/versions-web
+++ b/files/build/versions/dockers/sonic-slave-stretch/versions-web
@@ -1,5 +1,5 @@
 https://download.docker.com/linux/debian/gpg==1afae06b34a13c1b3d9cb61a26285a15
-https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
+https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-amd64==1227b24db77557d552701f6add122edc
 https://sonicstorage.blob.core.windows.net/packages/cmake/cmake-data_3.13.2-1_bpo9%2B1_all.deb?st=2020-03-27T02%3A22%3A24Z&se=2100-03-26T19%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=Xby%2Bm3OZOjPB%2FSlDbHD65yDcPzAgoys%2FA3vK8RB4BzA%3D==147cf42f3a68f6d6f1e53d95a599a1af
 https://sonicstorage.blob.core.windows.net/packages/cmake/cmake_3.13.2-1_bpo9%2B1_amd64.deb?st=2020-03-27T02%3A27%3A21Z&se=2100-03-26T19%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=4MvmmDBQuicFEJYakLm7xCNU19yJ8GIP4ankFSnITKY%3D==e75c741e8b6918b8f03625e456fa0275
 https://storage.googleapis.com/golang/go1.14.2.linux-amd64.tar.gz==856d248e3ea8a287d13e5f6afd086282

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -534,7 +534,7 @@ LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"
 # Install Bazel build system (amd64 and arm64 architectures are supported using this method)
 # TODO(PINS): Remove once pre-build Bazel binaries are available for armhf (armv7l)
 {%- if CONFIGURED_ARCH == "amd64" or CONFIGURED_ARCH == "arm64" %}
-ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-{{ CONFIGURED_ARCH }}
+ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/download/v1.13.0/bazelisk-linux-{{ CONFIGURED_ARCH }}
 RUN curl -fsSL -o /usr/local/bin/bazel ${bazelisk_url} && chmod 755 /usr/local/bin/bazel
 # Bazel requires "python"
 # TODO(PINS): remove when Bazel is okay with "python3" binary name

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -534,7 +534,7 @@ LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"
 # Install Bazel build system (amd64 and arm64 architectures are supported using this method)
 # TODO(PINS): Remove once pre-build Bazel binaries are available for armhf (armv7l)
 {%- if CONFIGURED_ARCH == "amd64" or CONFIGURED_ARCH == "arm64" %}
-ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-{{ CONFIGURED_ARCH }}
+ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-{{ CONFIGURED_ARCH }}
 RUN curl -fsSL -o /usr/local/bin/bazel ${bazelisk_url} && chmod 755 /usr/local/bin/bazel
 # Bazel requires "python"
 # TODO(PINS): remove when Bazel is okay with "python3" binary name

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -561,6 +561,6 @@ LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"
 # Install Bazel build system (amd64 and arm64 architectures are supported using this method)
 # TODO(PINS): Remove once pre-build Bazel binaries are available for armhf (armv7l)
 {%- if CONFIGURED_ARCH == "amd64" or CONFIGURED_ARCH == "arm64" %}
-ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-{{ CONFIGURED_ARCH }}
+ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-{{ CONFIGURED_ARCH }}
 RUN curl -fsSL -o /usr/local/bin/bazel ${bazelisk_url} && chmod 755 /usr/local/bin/bazel
 {% endif -%}

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -561,6 +561,6 @@ LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"
 # Install Bazel build system (amd64 and arm64 architectures are supported using this method)
 # TODO(PINS): Remove once pre-build Bazel binaries are available for armhf (armv7l)
 {%- if CONFIGURED_ARCH == "amd64" or CONFIGURED_ARCH == "arm64" %}
-ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-{{ CONFIGURED_ARCH }}
+ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/download/v1.13.0/bazelisk-linux-{{ CONFIGURED_ARCH }}
 RUN curl -fsSL -o /usr/local/bin/bazel ${bazelisk_url} && chmod 755 /usr/local/bin/bazel
 {% endif -%}

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -463,6 +463,6 @@ LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"
 # Install Bazel build system (amd64 and arm64 architectures are supported using this method)
 # TODO(PINS): Remove once pre-build Bazel binaries are available for armhf (armv7l)
 {%- if CONFIGURED_ARCH == "amd64" or CONFIGURED_ARCH == "arm64" %}
-ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-{{ CONFIGURED_ARCH }}
+ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/download/v1.13.0/bazelisk-linux-{{ CONFIGURED_ARCH }}
 RUN curl -fsSL -o /usr/local/bin/bazel ${bazelisk_url} && chmod 755 /usr/local/bin/bazel
 {% endif -%}

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -463,6 +463,6 @@ LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"
 # Install Bazel build system (amd64 and arm64 architectures are supported using this method)
 # TODO(PINS): Remove once pre-build Bazel binaries are available for armhf (armv7l)
 {%- if CONFIGURED_ARCH == "amd64" or CONFIGURED_ARCH == "arm64" %}
-ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-{{ CONFIGURED_ARCH }}
+ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/v1.13.0/download/bazelisk-linux-{{ CONFIGURED_ARCH }}
 RUN curl -fsSL -o /usr/local/bin/bazel ${bazelisk_url} && chmod 755 /usr/local/bin/bazel
 {% endif -%}


### PR DESCRIPTION
This tries to avoid builds failures due to the latest version of bazelisk changing and causing hash mismatches.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

