### PR TITLE
Fixed radvd.conf generation traceback when VLAN_INTERFACE is not defined

### DIFF
--- a/dockers/docker-router-advertiser/radvd.conf.j2
+++ b/dockers/docker-router-advertiser/radvd.conf.j2
@@ -23,7 +23,6 @@
 {% set _ = vlan_list.update({name: prefix_list}) %}
 {% endif %}
 {% endfor %}
-{% endif %}
 {% for name, prefixes in vlan_list.items() %}
 interface {{ name }}
 {
@@ -47,3 +46,4 @@ interface {{ name }}
 };
 
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
Signed-off-by: anamehra anamehra@cisco.com

    Fixed the if block scope to prevent traceback due to undefined vlan_list when
    VLAN_INTERFACE is not defined.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes https://github.com/sonic-net/sonic-buildimage/issues/12031

#### How I did it
Fixed the if - endif block scope

#### How to verify it
Bring up router without VLAN_INTERFACE configuration.
'Check docker logs radv' for no traceback
/etc/radvd.conf  and /usr/bin/wait_for_link.sh files are generated properly in radv docker.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed radvd.conf generation traceback when VLAN_INTERFACE is not defined

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

