### PR TITLE
Revert PR#11831 "Upgrade docker-sonic-mgmt base image from Ubuntu18.04 to 20.04"

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -1,5 +1,5 @@
 {% set prefix = DEFAULT_CONTAINER_REGISTRY %}
-FROM {{ prefix }}ubuntu:20.04
+FROM {{ prefix }}ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -21,6 +21,8 @@ RUN apt-get update && apt-get install -y build-essential \
                                          psmisc \
                                          python \
                                          python-dev \
+                                         python-scapy \
+                                         python-pip \
                                          python3-pip \
                                          python3-venv \
                                          rsyslog \
@@ -29,16 +31,10 @@ RUN apt-get update && apt-get install -y build-essential \
                                          sudo \
                                          tcpdump \
                                          telnet \
-                                         vim \
-                                         python-is-python2 \
-                                         software-properties-common
-
-RUN add-apt-repository -y universe
-RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py \
-    && python2 get-pip.py
+                                         vim
 
 RUN pip install setuptools==44.1.1
-RUN pip install cffi==1.12.0 \
+RUN pip install cffi==1.10.0 \
                 contextlib2==0.6.0.post1 \
                 cryptography==3.3.2 \
                 "future>=0.16.0" \
@@ -100,7 +96,7 @@ RUN pip install cffi==1.12.0 \
     && rm -f 1.0.0.tar.gz  \
     && pip install nnpy    \
     && pip install dpkt    \
-    && pip install scapy==2.4.5 --upgrade --ignore-installed
+    && pip install scapy==2.4.5 --upgrade
 
 # Install docker-ce-cli
 RUN apt-get update                  \
@@ -131,7 +127,7 @@ debs/{{ deb }}{{' '}}
 {%- endfor -%}
 debs/
 
-RUN dpkg --force-all -i \
+RUN dpkg -i \
 {% for deb in docker_sonic_mgmt_debs.split(' ') -%}
 debs/{{ deb }}{{' '}}
 {%- endfor %}
@@ -197,7 +193,8 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONIOENCODING=UTF-8
 
-RUN python3 -m pip install --upgrade --ignore-installed pip setuptools==58.4.0 wheel==0.33.6
+RUN python3 -m pip install --upgrade --ignore-installed pip setuptools==58.4.0
+
 RUN python3 -m pip install setuptools-rust \
                             aiohttp \
                             defusedxml \
@@ -240,6 +237,7 @@ RUN python3 -m pip install setuptools-rust \
                             tabulate \
                             textfsm==1.1.2 \
                             virtualenv \
+                            wheel==0.33.6 \
                             pysubnettree \
                             nnpy \
                             dpkt \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Issue is raised: https://github.com/sonic-net/sonic-buildimage/issues/11950

#### How I did it
Revert PR: https://github.com/sonic-net/sonic-buildimage/pull/11831

#### How to verify it
Docker image can be built

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
N/A

#### A picture of a cute animal (not mandatory but encouraged)

