### PR TITLE
Fix to improve hostname handling

### DIFF
--- a/files/image_config/hostname/hostname-config.sh
+++ b/files/image_config/hostname/hostname-config.sh
@@ -4,8 +4,8 @@ CURRENT_HOSTNAME=`hostname`
 HOSTNAME=`sonic-cfggen -d -v DEVICE_METADATA[\'localhost\'][\'hostname\']`
 
 if [ -z "$HOSTNAME" ] ; then
-       echo "Missing hostname in the config file!"
-       exit 0
+       echo "Missing hostname in the config file, setting to default 'sonic'"
+       HOSTNAME='sonic'
 fi
 
 echo $HOSTNAME > /etc/hostname

--- a/files/image_config/hostname/hostname-config.sh
+++ b/files/image_config/hostname/hostname-config.sh
@@ -3,6 +3,11 @@
 CURRENT_HOSTNAME=`hostname`
 HOSTNAME=`sonic-cfggen -d -v DEVICE_METADATA[\'localhost\'][\'hostname\']`
 
+if [ -z "$HOSTNAME" ] ; then
+       echo "Missing hostname in the config file!"
+       exit 0
+fi
+
 echo $HOSTNAME > /etc/hostname
 hostname -F /etc/hostname
 


### PR DESCRIPTION

#### Why I did it
If config_db.json is missing hostname entry, hostname-config.sh ends up deleting existing entry too and hostname changes to default 'localhost'

#### How I did it
If hostname is not available from config_db.json, do not edit /etc/hostname and exit

#### How to verify it
with missing hostname entry in config_db.json, /etc/hostname entry is not cleared

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012 for Cisco 8102 
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

