### PR TITLE
[sonic-py-common] Add getstatusoutput_noshell() functions to general module

### DIFF
--- a/src/sonic-py-common/sonic_py_common/general.py
+++ b/src/sonic-py-common/sonic_py_common/general.py
@@ -1,4 +1,5 @@
 import sys
+import subprocess
 
 
 def load_module_from_source(module_name, file_path):
@@ -23,3 +24,33 @@ def load_module_from_source(module_name, file_path):
     sys.modules[module_name] = module
 
     return module
+
+
+def getstatusoutput_noshell(cmd):
+    """
+    This function implements getstatusoutput API from subprocess module
+    but using shell=False to prevent shell injection.
+    """
+    p = subprocess.run(cmd, capture_output=True, universal_newlines=True)
+    status, output = p.returncode, p.stdout
+    if output[-1:] == '\n':
+        output = output[:-1]
+    return (status, output)
+
+
+def getstatusoutput_noshell_pipe(cmd1, cmd2):
+    """
+    This function implements getstatusoutput API from subprocess module
+    but using shell=False to prevent shell injection. Input command includes
+    pipe command.
+    """
+    status = 0
+    with subprocess.Popen(cmd1, universal_newlines=True, stdout=subprocess.PIPE) as p1:
+        with subprocess.Popen(cmd2, universal_newlines=True, stdin=p1.stdout, stdout=subprocess.PIPE) as p2:
+            output = p2.communicate()[0]
+            p1.wait()
+            if p1.returncode != 0 and p2.returncode != 0:
+                status = 1
+    if output[-1:] == '\n':
+        output = output[:-1]
+    return (status, output)

--- a/src/sonic-py-common/sonic_py_common/general.py
+++ b/src/sonic-py-common/sonic_py_common/general.py
@@ -1,5 +1,5 @@
 import sys
-import subprocess
+from subprocess import Popen, STDOUT, PIPE, CalledProcessError, check_output
 
 
 def load_module_from_source(module_name, file_path):
@@ -31,11 +31,15 @@ def getstatusoutput_noshell(cmd):
     This function implements getstatusoutput API from subprocess module
     but using shell=False to prevent shell injection.
     """
-    p = subprocess.run(cmd, capture_output=True, universal_newlines=True)
-    status, output = p.returncode, p.stdout
+    try:
+        output = check_output(cmd, text=True, stderr=STDOUT)
+        exitcode = 0
+    except CalledProcessError as ex:
+        output = ex.output
+        exitcode = ex.returncode
     if output[-1:] == '\n':
         output = output[:-1]
-    return (status, output)
+    return exitcode, output
 
 
 def getstatusoutput_noshell_pipe(cmd1, cmd2):
@@ -44,13 +48,36 @@ def getstatusoutput_noshell_pipe(cmd1, cmd2):
     but using shell=False to prevent shell injection. Input command includes
     pipe command.
     """
-    status = 0
-    with subprocess.Popen(cmd1, universal_newlines=True, stdout=subprocess.PIPE) as p1:
-        with subprocess.Popen(cmd2, universal_newlines=True, stdin=p1.stdout, stdout=subprocess.PIPE) as p2:
+    cmd = ' '.join(cmd1) + ' | ' + ' '.join(cmd2)
+    try:
+        with Popen(cmd1, universal_newlines=True, stdout=PIPE) as p1:
+            with Popen(cmd2, universal_newlines=True, stdin=p1.stdout, stdout=PIPE) as p2:
+                output = p2.communicate()[0]
+                p1.wait()
+                if p1.returncode != 0 and p2.returncode != 0:
+                    returncode = p1.returncode if p2.returncode == 0 else p2.returncode
+                    raise CalledProcessError(returncode=returncode, cmd=cmd, output=output)
+        exitcode = 0
+    except CalledProcessError as e:
+        output = e.output
+        exitcode = e.returncode
+    if output[-1:] == '\n':
+        output = output[:-1]
+    return exitcode, output
+
+
+def check_output_pipe(cmd1, cmd2):
+    """
+    This function implements check_output API from subprocess module.
+    Input command includes pipe command.
+    """
+    cmd = ' '.join(cmd1) + ' | ' + ' '.join(cmd2)
+    with Popen(cmd1, universal_newlines=True, stdout=PIPE) as p1:
+        with Popen(cmd2, universal_newlines=True, stdin=p1.stdout, stdout=PIPE) as p2:
             output = p2.communicate()[0]
             p1.wait()
             if p1.returncode != 0 and p2.returncode != 0:
-                status = 1
-    if output[-1:] == '\n':
-        output = output[:-1]
-    return (status, output)
+                returncode = p1.returncode if p2.returncode == 0 else p2.returncode
+                raise CalledProcessError(returncode=returncode, cmd=cmd, output=output)
+    return output
+

--- a/src/sonic-py-common/sonic_py_common/general.py
+++ b/src/sonic-py-common/sonic_py_common/general.py
@@ -30,6 +30,7 @@ def getstatusoutput_noshell(cmd):
     """
     This function implements getstatusoutput API from subprocess module
     but using shell=False to prevent shell injection.
+    Ref: https://github.com/python/cpython/blob/3.10/Lib/subprocess.py#L602
     """
     try:
         output = check_output(cmd, text=True, stderr=STDOUT)

--- a/src/sonic-py-common/sonic_py_common/general.py
+++ b/src/sonic-py-common/sonic_py_common/general.py
@@ -43,37 +43,71 @@ def getstatusoutput_noshell(cmd):
     return exitcode, output
 
 
-def getstatusoutput_noshell_pipe(cmd1, cmd2):
+def getstatusoutput_noshell_pipes(*args):
     """
     This function implements getstatusoutput API from subprocess module
-    but using shell=False to prevent shell injection. Input command includes
-    pipe command.
+    but using shell=False to prevent shell injection. Input command
+    includes two or more pipe commands.
     """
-    p1 = Popen(cmd1, universal_newlines=True, stdout=PIPE)
-    p2 = Popen(cmd2, universal_newlines=True, stdin=p1.stdout, stdout=PIPE)
-    p1.stdout.close()
-    output = p2.communicate()[0]
-    p1.wait()
+    if len(args) < 2:
+        raise ValueError("Need at least 2 processes")
+    # Set up more arguments in every processes
+    for arg in args:
+        arg["stdout"] = PIPE
+        arg["universal_newlines"] = True
+        arg["shell"] = False
+
+    # Runs all subprocesses connecting stdins and previous arguments 
+    # to create the pipeline. Closes stdouts to avoid deadlocks.
+    # Ref: https://docs.python.org/2/library/subprocess.html#replacing-shell-pipeline
+    popens = [Popen(**args[0])]
+    for i in range(1,len(args)):
+        args[i]["stdin"] = popens[i-1].stdout
+        popens.append(Popen(**args[i]))
+        popens[i-1].stdout.close()
+    output = popens[-1].communicate()[0]
     if output[-1:] == '\n':
         output = output[:-1]
-    return ([p1.returncode, p2.returncode], output)
+
+    # Wait for the processes to terminate and return the exitcodes
+    exitcodes = [0] * len(popens)
+    while popens:
+        last = popens.pop(-1)
+        exitcodes[len(popens)] = last.wait()
+    return (exitcodes, output)
 
 
-def check_output_pipe(cmd1, cmd2):
+def check_output_pipes(*args):
     """
     This function implements check_output API from subprocess module.
-    Input command includes pipe command.
+    Input command includes two or more pipe command.
     """
-    cmd = ' '.join(cmd1) + ' | ' + ' '.join(cmd2)
-    p1 = Popen(cmd1, universal_newlines=True, stdout=PIPE)
-    p2 = Popen(cmd2, universal_newlines=True, stdin=p1.stdout, stdout=PIPE)
-    p1.stdout.close()
-    output = p2.communicate()[0]
-    p1.wait()
-    if p1.returncode != 0 or p2.returncode != 0:
-        if p1.returncode != 0:
-            raise CalledProcessError(returncode=p1.returncode, cmd=cmd1, output=p1.stdout)
-        else:
-            raise CalledProcessError(returncode=p2.returncode, cmd=cmd, output=output)
+    if len(args) < 2:
+        raise ValueError("Needs at least 2 processes")
+    # Set up more arguments in every processes
+    for arg in args:
+        arg["stdout"] = PIPE
+        arg["universal_newlines"] = True
+        arg["shell"] = False
+
+    # Runs all subprocesses connecting stdins and previous arguments 
+    # to create the pipeline. Closes stdouts to avoid deadlocks.
+    # Ref: https://docs.python.org/2/library/subprocess.html#replacing-shell-pipeline
+    popens = [Popen(**args[0])]
+    for i in range(1,len(args)):
+        args[i]["stdin"] = popens[i-1].stdout
+        popens.append(Popen(**args[i]))
+        popens[i-1].stdout.close()
+    output = popens[-1].communicate()[0]
+
+    # Wait for the processes to terminate and raise an exeption if exitcode is non zero
+    i = 0
+    while popens:
+        current = popens.pop(0)
+        exitcode = current.wait()
+        if exitcode != 0:
+            raise CalledProcessError(returncode=exitcode, cmd=args[i], output=current.stdout)
+        i += 1
+
     return output
 

--- a/src/sonic-py-common/sonic_py_common/general.py
+++ b/src/sonic-py-common/sonic_py_common/general.py
@@ -72,7 +72,7 @@ def check_output_pipe(cmd1, cmd2):
     p1.wait()
     if p1.returncode != 0 or p2.returncode != 0:
         if p1.returncode != 0:
-            raise CalledProcessError(returncode=p1.returncode, cmd=cmd1, output=output)
+            raise CalledProcessError(returncode=p1.returncode, cmd=cmd1, output=p1.stdout)
         else:
             raise CalledProcessError(returncode=p2.returncode, cmd=cmd, output=output)
     return output

--- a/src/sonic-py-common/tests/test_general.py
+++ b/src/sonic-py-common/tests/test_general.py
@@ -1,7 +1,7 @@
 import sys
 import pytest
 import subprocess
-from sonic_py_common.general import getstatusoutput_noshell, getstatusoutput_noshell_pipe, check_output_pipe
+from sonic_py_common.general import getstatusoutput_noshell, getstatusoutput_noshell_pipes, check_output_pipes
 
 
 def test_getstatusoutput_noshell(tmp_path):
@@ -11,21 +11,21 @@ def test_getstatusoutput_noshell(tmp_path):
     exitcode, output = getstatusoutput_noshell([sys.executable, "-c", "import sys; sys.exit(6)"])
     assert exitcode != 0
 
-def test_getstatusoutput_noshell_pipe():
-    exitcode, output = getstatusoutput_noshell_pipe(['echo', 'sonic'], ['awk', '{print $1}'])
+def test_getstatusoutput_noshell_pipes():
+    exitcode, output = getstatusoutput_noshell_pipes(dict(args=['echo', 'sonic']), dict(args=['awk', '{print $1}']))
     assert (exitcode, output) == ([0, 0], 'sonic')
 
-    exitcode, output = getstatusoutput_noshell_pipe([sys.executable, "-c", "import sys; sys.exit(6)"], [sys.executable, "-c", "import sys; sys.exit(8)"])
+    exitcode, output = getstatusoutput_noshell_pipes(dict(args=[sys.executable, "-c", "import sys; sys.exit(6)"]), dict(args=[sys.executable, "-c", "import sys; sys.exit(8)"]))
     assert exitcode == [6, 8]
 
-def test_check_output_pipe():
-    output = check_output_pipe(['echo', 'sonic'], ['awk', '{print $1}'])
+def test_check_output_pipes():
+    output = check_output_pipes(dict(args=['echo', 'sonic']), dict(args=['awk', '{print $1}']))
     assert output == 'sonic\n'
 
     with pytest.raises(subprocess.CalledProcessError) as e:
-        check_output_pipe([sys.executable, "-c", "import sys; sys.exit(6)"], [sys.executable, "-c", "import sys; sys.exit(0)"])
+        check_output_pipes(dict(args=[sys.executable, "-c", "import sys; sys.exit(6)"]), dict(args=[sys.executable, "-c", "import sys; sys.exit(0)"]))
         assert e.returncode == [6, 0]
 
     with pytest.raises(subprocess.CalledProcessError) as e:
-        check_output_pipe([sys.executable, "-c", "import sys; sys.exit(0)"], [sys.executable, "-c", "import sys; sys.exit(6)"])
+        check_output_pipes(dict(args=[sys.executable, "-c", "import sys; sys.exit(0)"]), dict(args=[sys.executable, "-c", "import sys; sys.exit(6)"]))
         assert e.returncode == [0, 6]

--- a/src/sonic-py-common/tests/test_general.py
+++ b/src/sonic-py-common/tests/test_general.py
@@ -1,16 +1,14 @@
-import os
 import sys
 import pytest
 import subprocess
 from sonic_py_common.general import getstatusoutput_noshell, getstatusoutput_noshell_pipe, check_output_pipe
 
 
-def test_getstatusoutput_noshell(tmpdir):
+def test_getstatusoutput_noshell(tmp_path):
     exitcode, output = getstatusoutput_noshell(['echo', 'sonic'])
     assert (exitcode, output) == (0, 'sonic')
 
-    name = os.path.join(tmpdir, 'foo')
-    exitcode, output = getstatusoutput_noshell(['cat', name])
+    exitcode, output = getstatusoutput_noshell([sys.executable, "-c", "import sys; sys.exit(6)"])
     assert exitcode != 0
 
 def test_getstatusoutput_noshell_pipe():

--- a/src/sonic-py-common/tests/test_general.py
+++ b/src/sonic-py-common/tests/test_general.py
@@ -1,7 +1,7 @@
 import sys
 import pytest
 import subprocess
-from sonic_py_common.general import getstatusoutput_noshell, getstatusoutput_noshell_pipes, check_output_pipes
+from sonic_py_common.general import getstatusoutput_noshell, getstatusoutput_noshell_pipe, check_output_pipe
 
 
 def test_getstatusoutput_noshell(tmp_path):
@@ -12,20 +12,20 @@ def test_getstatusoutput_noshell(tmp_path):
     assert exitcode != 0
 
 def test_getstatusoutput_noshell_pipes():
-    exitcode, output = getstatusoutput_noshell_pipes(dict(args=['echo', 'sonic']), dict(args=['awk', '{print $1}']))
+    exitcode, output = getstatusoutput_noshell_pipe(['echo', 'sonic'], ['awk', '{print $1}'])
     assert (exitcode, output) == ([0, 0], 'sonic')
 
-    exitcode, output = getstatusoutput_noshell_pipes(dict(args=[sys.executable, "-c", "import sys; sys.exit(6)"]), dict(args=[sys.executable, "-c", "import sys; sys.exit(8)"]))
+    exitcode, output = getstatusoutput_noshell_pipe([sys.executable, "-c", "import sys; sys.exit(6)"], [sys.executable, "-c", "import sys; sys.exit(8)"])
     assert exitcode == [6, 8]
 
 def test_check_output_pipes():
-    output = check_output_pipes(dict(args=['echo', 'sonic']), dict(args=['awk', '{print $1}']))
+    output = check_output_pipe(['echo', 'sonic'], ['awk', '{print $1}'])
     assert output == 'sonic\n'
 
     with pytest.raises(subprocess.CalledProcessError) as e:
-        check_output_pipes(dict(args=[sys.executable, "-c", "import sys; sys.exit(6)"]), dict(args=[sys.executable, "-c", "import sys; sys.exit(0)"]))
+        check_output_pipe([sys.executable, "-c", "import sys; sys.exit(6)"], [sys.executable, "-c", "import sys; sys.exit(0)"])
         assert e.returncode == [6, 0]
 
     with pytest.raises(subprocess.CalledProcessError) as e:
-        check_output_pipes(dict(args=[sys.executable, "-c", "import sys; sys.exit(0)"]), dict(args=[sys.executable, "-c", "import sys; sys.exit(6)"]))
+        check_output_pipe([sys.executable, "-c", "import sys; sys.exit(0)"], [sys.executable, "-c", "import sys; sys.exit(6)"])
         assert e.returncode == [0, 6]

--- a/src/sonic-py-common/tests/test_general.py
+++ b/src/sonic-py-common/tests/test_general.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import pytest
+import subprocess
+from sonic_py_common.general import getstatusoutput_noshell, getstatusoutput_noshell_pipe, check_output_pipe
+
+
+def test_getstatusoutput_noshell(tmpdir):
+    exitcode, output = getstatusoutput_noshell(['echo', 'sonic'])
+    assert (exitcode, output) == (0, 'sonic')
+
+    name = os.path.join(tmpdir, 'foo')
+    exitcode, output = getstatusoutput_noshell(['cat', name])
+    assert exitcode != 0
+
+def test_getstatusoutput_noshell_pipe():
+    exitcode, output = getstatusoutput_noshell_pipe(['echo', 'sonic'], ['awk', '{print $1}'])
+    assert (exitcode, output) == ([0, 0], 'sonic')
+
+    exitcode, output = getstatusoutput_noshell_pipe([sys.executable, "-c", "import sys; sys.exit(6)"], [sys.executable, "-c", "import sys; sys.exit(8)"])
+    assert exitcode == [6, 8]
+
+def test_check_output_pipe():
+    output = check_output_pipe(['echo', 'sonic'], ['awk', '{print $1}'])
+    assert output == 'sonic\n'
+
+    with pytest.raises(subprocess.CalledProcessError) as e:
+        check_output_pipe([sys.executable, "-c", "import sys; sys.exit(6)"], [sys.executable, "-c", "import sys; sys.exit(0)"])
+        assert e.returncode == [6, 0]
+
+    with pytest.raises(subprocess.CalledProcessError) as e:
+        check_output_pipe([sys.executable, "-c", "import sys; sys.exit(0)"], [sys.executable, "-c", "import sys; sys.exit(6)"])
+        assert e.returncode == [0, 6]

--- a/src/sonic-py-common/tests/test_general.py
+++ b/src/sonic-py-common/tests/test_general.py
@@ -11,14 +11,14 @@ def test_getstatusoutput_noshell(tmp_path):
     exitcode, output = getstatusoutput_noshell([sys.executable, "-c", "import sys; sys.exit(6)"])
     assert exitcode != 0
 
-def test_getstatusoutput_noshell_pipes():
+def test_getstatusoutput_noshell_pipe():
     exitcode, output = getstatusoutput_noshell_pipe(['echo', 'sonic'], ['awk', '{print $1}'])
     assert (exitcode, output) == ([0, 0], 'sonic')
 
     exitcode, output = getstatusoutput_noshell_pipe([sys.executable, "-c", "import sys; sys.exit(6)"], [sys.executable, "-c", "import sys; sys.exit(8)"])
     assert exitcode == [6, 8]
 
-def test_check_output_pipes():
+def test_check_output_pipe():
     output = check_output_pipe(['echo', 'sonic'], ['awk', '{print $1}'])
     assert output == 'sonic\n'
 


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`getstatusoutput()` function from `subprocess` module has shell injection issue because it includes `shell=True` in the implementation
Eliminate duplicate code
#### How I did it
Reimplement `getstatusoutput_noshell()` and `getstatusoutput_noshell_pipe()` functions with `shell=False`
Add `check_output_pipe()` function
#### How to verify it
Pass UT
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

