### PR TITLE
Add support for platform topology configuration service

### DIFF
--- a/files/build_templates/config-setup.service.j2
+++ b/files/build_templates/config-setup.service.j2
@@ -2,6 +2,8 @@
 Description=Config initialization and migration service
 After=rc-local.service
 After=database.service
+After=config-topology.service
+Requires=config-topology.service
 Requires=database.service
 {% if sonic_asic_platform == 'mellanox' -%}
 Requires=hw-management.service

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -554,6 +554,11 @@ echo "topology.service" | sudo tee -a $GENERATED_SERVICE_FILE
 sudo cp $IMAGE_CONFIGS/topology/topology.sh $FILESYSTEM_ROOT/usr/bin
 {%- endif %}
 
+# Copy platform topology configuration scripts
+sudo cp $IMAGE_CONFIGS/config-topology/config-topology.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
+echo "config-topology.service" | sudo tee -a $GENERATED_SERVICE_FILE
+sudo cp $IMAGE_CONFIGS/config-topology/config-topology.sh $FILESYSTEM_ROOT/usr/bin
+
 # Copy updategraph script and service file
 j2 files/build_templates/updategraph.service.j2 | sudo tee $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/updategraph.service
 sudo cp $IMAGE_CONFIGS/updategraph/updategraph $FILESYSTEM_ROOT/usr/bin/

--- a/files/image_config/config-topology/config-topology.service
+++ b/files/image_config/config-topology/config-topology.service
@@ -4,7 +4,6 @@ After=database.service
 After=database-chassis.service
 Requires=database.service
 Requires=database-chassis.service
-PartOf=database.service
 Before=config-setup.service
 
 [Service]

--- a/files/image_config/config-topology/config-topology.service
+++ b/files/image_config/config-topology/config-topology.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=Platform topology configuration service
-Requires=database.service
 After=database.service
+After=database-chassis.service
+Requires=database.service
+Requires=database-chassis.service
 PartOf=database.service
 Before=config-setup.service
 

--- a/files/image_config/config-topology/config-topology.service
+++ b/files/image_config/config-topology/config-topology.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Platform topology configuration service
+Requires=database.service
+After=database.service
+PartOf=database.service
+Before=config-setup.service
+
+[Service]
+Type=oneshot
+User=root
+RemainAfterExit=yes
+ExecStart=/usr/bin/config-topology.sh start
+ExecStop=/usr/bin/config-topology.sh stop
+
+[Install]
+WantedBy=multi-user.target
+

--- a/files/image_config/config-topology/config-topology.sh
+++ b/files/image_config/config-topology/config-topology.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This script is invoked by config-topology.service.
+# This script invokes platform plugin script if present
+# which could be used for platform specific topology configuration
+#
+start() {
+    PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
+    #Path to platform topology script
+    TOPOLOGY_SCRIPT="/usr/share/sonic/device/$PLATFORM/plugins/config-topology.sh"
+    #if topology script file not present, do nothing and return 0
+    [ ! -f $TOPOLOGY_SCRIPT ] && exit 0
+    $TOPOLOGY_SCRIPT start
+}
+
+stop() {
+    PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
+    #Path to platform topology script
+    TOPOLOGY_SCRIPT="/usr/share/sonic/device/$PLATFORM/plugins/config-topology.sh"
+    #if topology script file not present, do nothing and return 0
+    [ ! -f $TOPOLOGY_SCRIPT ] && exit 0
+    $TOPOLOGY_SCRIPT stop
+}
+
+# read SONiC immutable variables
+[ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
+
+case "$1" in
+    start|stop)
+        $1
+        ;;
+    *)
+        echo "Usage: $0 {start|stop}"
+        ;;
+esac

--- a/src/systemd-sonic-generator/systemd-sonic-generator.c
+++ b/src/systemd-sonic-generator/systemd-sonic-generator.c
@@ -104,7 +104,22 @@ static int get_target_lines(char* unit_file, char* target_lines[]) {
 static bool is_multi_instance_service(char *service_name){
     int i;
     for(i=0; i < num_multi_inst; i++){
-        if (strstr(service_name, multi_instance_services[i]) != NULL) {
+        /*
+         * The service name may contain @.service or .service. Remove these
+         * postfixes and extract service name. Compare service name for absolute
+         * match in multi_instance_services[].
+         * This is to prevent services like database-chassis and systemd-timesyncd marked
+         * as multi instance services as they contain strings 'database' and 'syncd' respectively
+         * which are multi instance services in multi_instance_services[].
+         */
+        char *token = strtok(service_name, "@");
+        if (token) {
+            if (strstr(token, ".service") != NULL) {
+                /* If we are here, service_name did not have '@' delimiter but contains '.service' */
+                token = strtok(service_name, ".");
+            }
+        }
+        if (strncmp(service_name, multi_instance_services[i], strlen(service_name)) == 0) {
             return true;
         }
     }

--- a/src/systemd-sonic-generator/systemd-sonic-generator.c
+++ b/src/systemd-sonic-generator/systemd-sonic-generator.c
@@ -112,11 +112,12 @@ static bool is_multi_instance_service(char *service_name){
          * as multi instance services as they contain strings 'database' and 'syncd' respectively
          * which are multi instance services in multi_instance_services[].
          */
-        char *token = strtok(service_name, "@");
+        char *saveptr;
+        char *token = strtok_r(service_name, "@", &saveptr);
         if (token) {
             if (strstr(token, ".service") != NULL) {
                 /* If we are here, service_name did not have '@' delimiter but contains '.service' */
-                token = strtok(service_name, ".");
+                token = strtok_r(service_name, ".", &saveptr);
             }
         }
         if (strncmp(service_name, multi_instance_services[i], strlen(service_name)) == 0) {


### PR DESCRIPTION
    This service invokes the platform plugin for platform specific topology
    configuration.
    The path for platform plugin script is:
    /usr/share/sonic/device/$PLATFORM/plugins/config-topology.sh
    If the platform plugin is not available, this service does nothing.

Signed-off-by: anamehra <anamehra@cisco.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For the chassis, the platform requires to generate the chassis topology from the available inventory. Based on the inventory config files for the platform and ASICs are generated. Some configs are global as well as ASIC specific. This needs to be done on both RP and LC and requires the availability of database-chassis and database services.
 Adding this systemd dependency in platform side service unit files causes first boot issues as the database service is not known when rc.local starts the platform service.
Secondly, sonic-systemd-generator generates the dependency on multi-instance services during boot based on num_asics and for that Sonic systemd generator needs to know about the platform services. For example, if a service defines:
After=database.service
sonic systemd generator creates the dependency for the global database and all namespace database instances
After=database.service
After=database@0.service
After=database@1.service

This is not possible if the service is added as a platform-side service.

This is also helpful in use cases where a platform service may require to be restarted when database-chassis or database service restarts. Without a proper dependency defined on Sonic side, the platform service won't restart.

Systemd-sonic-generator issue:
The check for multi instance service, checks if the srvice name string is present in the multi_instance_service[].
This results in database-chassis marked as multi instance service when added as dependency.

#### How I did it
Added a common service that defines the dependency on Sonic build side to handle the above limitations. The service calls a platform plugin, if present. If the platform plugin is not available, the service exits as successful and will do nothing for the platform.

#### How to verify it
1. Load the image with changes.
2. check systemctl status config-topology.service logs
3. Validated that the services starts after database services and before config-setup service.

Fix for systemd-sonic-generator:
The service name may contain @.service or .service. Remove these
postfixes and extract service name. Compare service name for the absolute
match in multi_instance_services[].
This is to prevent services like database-chassis and systemd-timesyncd marked
as multi instance services as they contain strings 'database' and 'syncd' respectively
which are multi instance services in multi_instance_services[].

UT logs:
[UT.txt](https://github.com/sonic-net/sonic-buildimage/files/10396524/UT.txt)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

