### PR TITLE
[202205] [services] Update "WantedBy=" section for tacacs-config.timer. (#11893)

### DIFF
--- a/files/build_templates/tacacs-config.timer
+++ b/files/build_templates/tacacs-config.timer
@@ -9,4 +9,4 @@ OnBootSec=5min 30 sec
 Unit=tacacs-config.service
 
 [Install]
-WantedBy=timers.target updategraph.service
+WantedBy=timers.target sonic.target sonic-delayed.target


### PR DESCRIPTION
Manually cherry-picking #11893 

#### Why I did it
The timer execution may fail if triggered during a config reload (when the sonic.target is stopped). This might happen in a rare situation if config reload is executed after reboot in a small time slot (for 0 to 30 seconds) before the tacacs-config timer is triggered:

systemctl status tacacs-config.timer
 tacacs-config.timer - Delays tacacs apply until SONiC has started
     Loaded: loaded (/lib/systemd/system/tacacs-config.timer; enabled-runtime; vendor preset: enabled)
     Active: failed (Result: resources) since Mon 2022-08-29 15:53:03 IDT; 1min 28s ago
    Trigger: n/a
   Triggers:  tacacs-config.service

Aug 29 15:47:53 r-boxer-sw01 systemd[1]: Started Delays tacacs apply until SONiC has started.
Aug 29 15:53:03 r-boxer-sw01 systemd[1]: tacacs-config.timer: Failed to queue unit startup job: Transaction for tacacs-config.service/start is destructive (mgmt-framework.timer has 's>
Aug 29 15:53:03 r-boxer-sw01 systemd[1]: tacacs-config.timer: Failed with result 'resources'.

#### How I did it
To ensure that timer execution will be resumed after a config reload the WantedBy section of the systemd service is updated to describe relation to sonic.target.

#### How to verify it
Reboot the system
After reboot monitor tacacs-config.timer status. 30 seconds before timer activation run "config reload -y" command.
Check system status.