### PR TITLE
[201911] Fix BGP Template rendering failure that needs Loopback4096 IP Address

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
@@ -125,6 +125,9 @@ class BGPPeerMgrBase(Manager):
         if self.check_deployment_id:
             deps.append(("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost/deployment_id"))
 
+        if self.peer_type == 'internal':    
+            deps.append(("CONFIG_DB", swsscommon.CFG_LOOPBACK_INTERFACE_TABLE_NAME, "Loopback4096"))
+
         super(BGPPeerMgrBase, self).__init__(
             common_objs,
             deps,
@@ -160,11 +163,18 @@ class BGPPeerMgrBase(Manager):
         print_data = vrf, nbr, data
         bgp_asn = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]["bgp_asn"]
         #
-        lo0_ipv4 = self.get_lo0_ipv4()
+        lo0_ipv4 = self.get_lo_ipv4("Loopback0|")
         if lo0_ipv4 is None:
             log_warn("Loopback0 ipv4 address is not presented yet")
             return False
         #
+
+        if self.peer_type == 'internal':
+            lo4096_ipv4 = self.get_lo_ipv4("Loopback4096|")
+            if lo4096_ipv4 is None:
+                log_warn("Loopback4096 ipv4 address is not presented yet")
+                return False
+
         if "local_addr" not in data:
             log_warn("Peer %s. Missing attribute 'local_addr'" % nbr)
         else:
@@ -299,15 +309,15 @@ class BGPPeerMgrBase(Manager):
         self.cfg_mgr.push(cmd)
         return True
 
-    def get_lo0_ipv4(self):
+    def get_lo_ipv4(self, loopback_str):
         """
         Extract Loopback0 ipv4 address from the Directory
         :return: ipv4 address for Loopback0, None if nothing found
         """
         loopback0_ipv4 = None
         for loopback in self.directory.get_slot("CONFIG_DB", swsscommon.CFG_LOOPBACK_INTERFACE_TABLE_NAME).iterkeys():
-            if loopback.startswith("Loopback0|"):
-                loopback0_prefix_str = loopback.replace("Loopback0|", "")
+            if loopback.startswith(loopback_str):
+                loopback0_prefix_str = loopback.replace(loopback_str, "")
                 loopback0_ip_str = loopback0_prefix_str[:loopback0_prefix_str.find('/')]
                 if TemplateFabric.is_ipv4(loopback0_ip_str):
                     loopback0_ipv4 = loopback0_ip_str


### PR DESCRIPTION
What I did:
Cherry-pick the commit from master where in multi-asic platforms bgp template rendering fails which needs Loopback4096 IP Address. Issue happens because of timing/race condition where if peer gets added first and then Loopback4096 notification comes to bgpcfgd. For 201911 this causes failure of rendering on this 2 lines:
https://github.com/sonic-net/sonic-buildimage/blob/201911/dockers/docker-fpm-frr/frr/bgpd/templates/internal/policies.conf.j2#L22
https://github.com/sonic-net/sonic-buildimage/blob/201911/dockers/docker-fpm-frr/frr/bgpd/templates/internal/policies.conf.j2#L25

Corresponding Master commit with fix: https://github.com/sonic-net/sonic-buildimage/pull/8966/files#diff-0d6a37ad8efc25e66a5187da192766ce7473ff7809bb6c82e81616f4b7413575

Fix is to add dependency for BGP peer add to Loopback4096 IP Address same as what we are doing for Loopback0 IP Address.

Why I did:

See Below Logs for Working and not working case:

Not working Case:
```
We get Loopback0 Notification 

Sep 14 21:22:27.387021 xxxxxxxx DEBUG bgp5#bgpcfgd: Received message : '('Loopback0|2603:10b0:606:9::/128', 'SET', (('NULL', 'NULL'),))'
Sep 14 21:22:27.387227 xxxxxxxx DEBUG bgp5#bgpcfgd: Received message : '('Loopback0', 'SET', (('NULL', 'NULL'),))'
Sep 14 21:22:27.387350 xxxxxxxx WARNING bgp5#bgpcfgd: Loopback0 ipv4 address is not presented yet
Sep 14 21:22:27.388625 xxxxxxxx WARNING bgp5#bgpcfgd: message repeated 15 times: [ Loopback0 ipv4 address is not presented yet]
Sep 14 21:22:27.388625 xxxxxxxx DEBUG bgp5#bgpcfgd: Received message : '('Loopback0|25.103.164.9/32', 'SET', (('NULL', 'NULL'),))'

Routing Policy Update Start Happening (not waiting for Loopback4096 as we don’t have dependency)
Sep 14 21:22:27.408610 xxxxxxxx INFO bgp5#bgpcfgd: Routing policy for peer 'ASIC3' has been scheduled to be updated

Finally we get loopback4096 notification
Sep 14 21:22:27.413444 xxxxxxxx DEBUG bgp5#bgpcfgd: Received message : '('Loopback4096|10.0.107.21/32', 'SET', (('NULL', 'NULL'),))'
Sep 14 21:22:27.413689 xxxxxxxx DEBUG bgp5#bgpcfgd: Received message : '('Loopback4096|2603:10e2:400::5/128', 'SET', (('NULL', 'NULL'),))'
Sep 14 21:22:27.413974 xxxxxxxx DEBUG bgp5#bgpcfgd: Received message : '('Loopback4096', 'SET', (('NULL', 'NULL'),))'

```

Working Case:

```
First we get Notification of Loopback Interface Table all entries (Loopback0 and Loopback4096)

Sep 14 21:37:11.946222 xxxxxxxx DEBUG bgp5#bgpcfgd: Received message : '('Loopback0|25.75.58.183/32', 'SET', (('NULL', 'NULL'),))'
Sep 14 21:37:11.946366 xxxxxxxx DEBUG bgp5#bgpcfgd: Received message : '('Loopback4096|2603:10e2:400::5/128', 'SET', (('NULL', 'NULL'),))'
Sep 14 21:37:11.946553 xxxxxxxx DEBUG bgp5#bgpcfgd: Received message : '('Loopback4096', 'SET', (('NULL', 'NULL'),))'
Sep 14 21:37:11.946620 xxxxxxxx DEBUG bgp5#bgpcfgd: Received message : '('Loopback0|2a01:111:214:fc90::/128', 'SET', (('NULL', 'NULL'),))'
Sep 14 21:37:11.946800 xxxxxxxx DEBUG bgp5#bgpcfgd: Received message : '('Loopback4096|10.0.107.21/32', 'SET', (('NULL', 'NULL'),))'
Sep 14 21:37:11.946934 xxxxxxxx DEBUG bgp5#bgpcfgd: Received message : '('Loopback0', 'SET', (('NULL', 'NULL'),))'

Route Policy Update schedule to happen afterwards

Sep 14 21:37:11.966729 xxxxxxxx INFO bgp5#bgpcfgd: Routing policy for peer 'ASIC3' has been scheduled to be updated
Sep 14 21:37:11.966729 xxxxxxxx INFO bgp5#bgpcfgd: Peer-group for peer 'ASIC3' has been scheduled to be updated
Sep 14 21:37:11.966829 xxxxxxxx INFO bgp5#bgpcfgd: Peer '(default|10.0.107.15)' has been scheduled to be added with attributes '{'rrclient': '0', 'name': 'ASIC3', 'local_addr': '10.0.107.14', 'nhopself': '0', 'admin_status': 'up', 'holdtime': '0', 'asn': '64827', 'keepalive': '0'}'
Sep 14 21:37:11.967544 xxxxxxxx INFO bgp5#bgpcfgd: Routing policy for peer 'ASIC1' has been scheduled to be updated

```

