### PR TITLE
Revert "[database] Fix docker-database flush_unused_database failed issue"

### DIFF
--- a/dockers/docker-database/docker-database-init.sh
+++ b/dockers/docker-database/docker-database-init.sh
@@ -79,7 +79,7 @@ rm $db_cfg_file_tmp
 
 # copy dump.rdb file to each instance for restoration
 DUMPFILE=/var/lib/redis/dump.rdb
-redis_inst_list=`/usr/bin/python3 -c "from swsscommon import swsscommon; print(' '.join(swsscommon.SonicDBConfig.getInstanceList().keys()))"`
+redis_inst_list=`/usr/bin/python3 -c "import swsssdk; print(' '.join(swsssdk.SonicDBConfig.get_instancelist().keys()))"`
 for inst in $redis_inst_list
 do
     mkdir -p /var/lib/$inst

--- a/dockers/docker-database/flush_unused_database
+++ b/dockers/docker-database/flush_unused_database
@@ -11,15 +11,15 @@ while(True):
         break
     time.sleep(1)
 
-instlists = swsscommon.SonicDBConfig.getInstanceList()
+instlists = swsssdk.SonicDBConfig.get_instancelist()
 for instname, v in instlists.items():
-    insthost = v.hostname
-    instsocket = v.unixSocketPath
+    insthost = v['hostname']
+    instsocket = v['unix_socket_path']
 
-    dblists = swsscommon.SonicDBConfig.getDbList()
+    dblists = swsssdk.SonicDBConfig.get_dblist()
     for dbname in dblists:
-        dbid = swsscommon.SonicDBConfig.getDbId(dbname)
-        dbinst = swsscommon.SonicDBConfig.getDbInst(dbname)
+        dbid = swsssdk.SonicDBConfig.get_dbid(dbname)
+        dbinst = swsssdk.SonicDBConfig.get_instancename(dbname)
 
         # this DB is on current instance, skip flush
         if dbinst == instname:


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#11677

#### Why I did it
The master branch PR https://github.com/sonic-net/sonic-buildimage/pull/11600 been cherry to 202205 branch by mistake.

#### How I did it
Revert change in sonic-net/sonic-buildimage#11677

#### How to verify it
Pass all E2E test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
Fix docker-database flush_unused_database failed issue: https://github.com/Azure/sonic-buildimage/issues/11597
When change flush_unused_database from use swsssdk to use swsscommon, get_instancelist() and get_dblist() name changed but not update.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

