### PR TITLE
[Edge-Core][PDDF] Add get_port_or_cage_type

### DIFF
--- a/device/accton/x86_64-accton_as7726_32x-r0/system_health_monitoring_config.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/system_health_monitoring_config.json
@@ -1,0 +1,17 @@
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [
+        "asic",
+        "psu.voltage",
+        "psu.temperature",
+        "PSU1_FAN1.speed",
+        "PSU2_FAN1.speed"
+    ],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "STATUS_LED_COLOR_AMBER",
+        "normal": "STATUS_LED_COLOR_GREEN",
+        "booting": "STATUS_LED_COLOR_GREEN"
+    }
+}

--- a/device/accton/x86_64-accton_as9716_32d-r0/system_health_monitoring_config.json
+++ b/device/accton/x86_64-accton_as9716_32d-r0/system_health_monitoring_config.json
@@ -1,0 +1,17 @@
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [
+        "asic",
+        "psu.voltage",
+        "psu.temperature",
+        "PSU1_FAN1.speed",
+        "PSU2_FAN1.speed"
+    ],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "STATUS_LED_COLOR_AMBER",
+        "normal": "STATUS_LED_COLOR_GREEN",
+        "booting": "STATUS_LED_COLOR_GREEN_BLINK"
+    }
+}

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/sonic_platform/chassis.py
@@ -68,3 +68,15 @@ class Chassis(PddfChassis):
 
     def set_status_led(self, color):
         return self.set_system_led(self.SYSLED_DEV_NAME, color)
+
+
+    def get_port_or_cage_type(self, port):
+        from sonic_platform_base.sfp_base import SfpBase
+        if port in range(1, 49):
+            return SfpBase.SFP_PORT_TYPE_BIT_RJ45
+        elif port in range(49, 53):
+            return SfpBase.SFP_PORT_TYPE_BIT_SFP | SfpBase.SFP_PORT_TYPE_BIT_SFP_PLUS | SfpBase.SFP_PORT_TYPE_BIT_SFP28
+        else:
+            return SfpBase.SFP_PORT_TYPE_BIT_QSFP | SfpBase.SFP_PORT_TYPE_BIT_QSFP_PLUS | SfpBase.SFP_PORT_TYPE_BIT_QSFP28
+
+

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/chassis.py
@@ -8,58 +8,33 @@
 
 try:
     import sys
-    import time
     from sonic_platform_pddf_base.pddf_chassis import PddfChassis
+    from .event import SfpEvent
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
+NUM_COMPONENT = 4
 
 class Chassis(PddfChassis):
     """
     PDDF Platform-specific Chassis class
     """
 
+    SYSLED_DEV_NAME = "DIAG_LED"
     def __init__(self, pddf_data=None, pddf_plugin_data=None):
         PddfChassis.__init__(self, pddf_data, pddf_plugin_data)
+        self.__initialize_components()
+        self._sfpevent = SfpEvent(self.get_all_sfps())
+
+    def __initialize_components(self):
+        from sonic_platform.component import Component
+        for index in range(NUM_COMPONENT):
+            component = Component(index)
+            self._component_list.append(component)
 
     # Provide the functions/variables below for which implementation is to be overwritten
-    sfp_change_event_data = {'valid': 0, 'last': 0, 'present': 0}
-    def get_change_event(self, timeout=2000):
-        now = time.time()
-        port_dict = {}
-        change_dict = {}
-        change_dict['sfp'] = port_dict
-
-        if timeout < 1000:
-            timeout = 1000
-        timeout = timeout / float(1000)  # Convert to secs
-
-        if now < (self.sfp_change_event_data['last'] + timeout) and self.sfp_change_event_data['valid']:
-            return True, change_dict
-
-        bitmap = 0
-        for i in range(58):
-            modpres = self.get_sfp(i+1).get_presence()
-            if modpres:
-                bitmap = bitmap | (1 << i)
-
-        changed_ports = self.sfp_change_event_data['present'] ^ bitmap
-        if changed_ports:
-            for i in range(58):
-                if (changed_ports & (1 << i)):
-                    if (bitmap & (1 << i)) == 0:
-                        port_dict[i+1] = '0'
-                    else:
-                        port_dict[i+1] = '1'
-
-
-            # Update teh cache dict
-            self.sfp_change_event_data['present'] = bitmap
-            self.sfp_change_event_data['last'] = now
-            self.sfp_change_event_data['valid'] = 1
-            return True, change_dict
-        else:
-            return True, change_dict
+    def get_change_event(self, timeout=0):
+        return self._sfpevent.get_sfp_event(timeout)
 
     def get_sfp(self, index):
         """
@@ -83,3 +58,21 @@ class Chassis(PddfChassis):
             sys.stderr.write("SFP index {} out of range (1-{})\n".format(
                              index, len(self._sfp_list)))
         return sfp
+
+    def initizalize_system_led(self):
+        return
+
+    def get_status_led(self):
+        return self.get_system_led(self.SYSLED_DEV_NAME)
+
+    def set_status_led(self, color):
+        return self.set_system_led(self.SYSLED_DEV_NAME, color)
+        
+    def get_port_or_cage_type(self, port):
+        from sonic_platform_base.sfp_base import SfpBase
+        if port in range(1, 49):
+            return SfpBase.SFP_PORT_TYPE_BIT_SFP28
+        elif port in range(49, 57):
+            return SfpBase.SFP_PORT_TYPE_BIT_QSFP28
+        else:
+            return SfpBase.SFP_PORT_TYPE_BIT_SFP

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/component.py
@@ -1,0 +1,100 @@
+#############################################################################
+# 
+# Component contains an implementation of SONiC Platform Base API and
+# provides the components firmware management function
+#
+#############################################################################
+
+try:
+    import subprocess
+    from sonic_platform_base.component_base import ComponentBase
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+CPLD_ADDR_MAPPING = {
+    "CPLD1": ['18', '0x60'],
+    "CPLD2": ['12', '0x62'],
+    "CPLD3": ['19', '0x64']
+}
+SYSFS_PATH = "/sys/bus/i2c/devices/"
+BIOS_VERSION_PATH = "/sys/class/dmi/id/bios_version"
+COMPONENT_LIST= [
+   ("CPLD1", "CPLD 1"),
+   ("CPLD2", "CPLD 2"),
+   ("CPLD3", "CPLD 3"),
+   ("BIOS", "Basic Input/Output System")
+   
+]
+
+class Component(ComponentBase):
+    """Platform-specific Component class"""
+
+    DEVICE_TYPE = "component"
+
+    def __init__(self, component_index=0):
+        self.index = component_index
+        self.name = self.get_name()
+
+    def __get_bios_version(self):
+        # Retrieves the BIOS firmware version
+        try:
+            with open(BIOS_VERSION_PATH, 'r') as fd:
+                bios_version = fd.read()
+                return bios_version.strip()
+        except Exception as e:
+            return None
+   
+    def __get_cpld_version(self):
+        # Retrieves the CPLD firmware version
+        cpld_version = dict()
+        for cpld_name in CPLD_ADDR_MAPPING:
+            cmd = "i2cget -f -y {0} {1} 0x1".format(CPLD_ADDR_MAPPING[cpld_name][0], CPLD_ADDR_MAPPING[cpld_name][1])
+            status, value = subprocess.getstatusoutput(cmd)
+            if not status:
+                cpld_version_raw = value.rstrip()
+                cpld_version[cpld_name] = "{}".format(int(cpld_version_raw,16))
+
+        return cpld_version
+
+
+    def get_name(self):
+        """
+        Retrieves the name of the component
+         Returns:
+            A string containing the name of the component
+        """
+        return COMPONENT_LIST[self.index][0]
+
+    def get_description(self):
+        """
+        Retrieves the description of the component
+            Returns:
+            A string containing the description of the component
+        """
+        return COMPONENT_LIST[self.index][1]
+
+    def get_firmware_version(self):
+        """
+        Retrieves the firmware version of module
+        Returns:
+            string: The firmware versions of the module
+        """
+        fw_version = None
+
+        if self.name == "BIOS":
+            fw_version = self.__get_bios_version()
+        elif "CPLD" in self.name:
+            cpld_version = self.__get_cpld_version()
+            fw_version = cpld_version.get(self.name)
+
+        return fw_version
+
+    def install_firmware(self, image_path):
+        """
+        Install firmware to module
+        Args:
+            image_path: A string, path to firmware image
+        Returns:
+            A boolean, True if install successfully, False if not
+        """
+        raise NotImplementedError

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/event.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/event.py
@@ -1,0 +1,60 @@
+try:
+    import time
+    from sonic_py_common.logger import Logger
+except ImportError as e:
+    raise ImportError(repr(e) + " - required module not found")
+
+POLL_INTERVAL_IN_SEC = 1
+
+class SfpEvent:
+    ''' Listen to insert/remove sfp events '''
+
+    def __init__(self, sfp_list):
+        self._sfp_list = sfp_list
+        self._logger = Logger()
+        self._sfp_change_event_data = {'present': 0}
+
+    def get_presence_bitmap(self):
+        bitmap = 0
+        for sfp in self._sfp_list:
+            modpres = sfp.get_presence()
+            i=sfp.get_position_in_parent() - 1
+            if modpres:
+                bitmap = bitmap | (1 << i)
+        return bitmap
+
+    def get_sfp_event(self, timeout=2000):
+        port_dict = {}
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            cd_ms = 1000
+        else:
+            cd_ms = timeout
+
+        while cd_ms > 0:
+            bitmap = self.get_presence_bitmap()
+            changed_ports = self._sfp_change_event_data['present'] ^ bitmap
+            if changed_ports != 0:
+                break
+            time.sleep(POLL_INTERVAL_IN_SEC)
+            # timeout=0 means wait for event forever
+            if timeout != 0:
+                cd_ms = cd_ms - POLL_INTERVAL_IN_SEC * 1000
+
+        if changed_ports != 0:
+            for sfp in self._sfp_list:
+                i=sfp.get_position_in_parent() - 1
+                if (changed_ports & (1 << i)):
+                    if (bitmap & (1 << i)) == 0:
+                        port_dict[i+1] = '0'
+                    else:
+                        port_dict[i+1] = '1'
+
+
+            # Update the cache dict
+            self._sfp_change_event_data['present'] = bitmap
+            return True, change_dict
+        else:
+            return True, change_dict

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/sfp.py
@@ -15,3 +15,6 @@ class Sfp(PddfSfp):
         PddfSfp.__init__(self, index, pddf_data, pddf_plugin_data)
 
     # Provide the functions/variables below for which implementation is to be overwritten
+    def get_position_in_parent(self):
+        """Retrieves 1-based relative physical position in parent device."""
+        return self.port_index

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/chassis.py
@@ -57,3 +57,10 @@ class Chassis(PddfChassis):
             sys.stderr.write("SFP index {} out of range (1-{})\n".format(
                              index, len(self._sfp_list)))
         return sfp
+
+        def get_port_or_cage_type(self, port):
+            from sonic_platform_base.sfp_base import SfpBase
+            if port in range(1, 33):
+                return SfpBase.SFP_PORT_TYPE_BIT_QSFP | SfpBase.SFP_PORT_TYPE_BIT_QSFP_PLUS | SfpBase.SFP_PORT_TYPE_BIT_QSFP28
+            else:
+                return None

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/chassis.py
@@ -8,59 +8,34 @@
 
 try:
     import sys
-    import time
     from sonic_platform_pddf_base.pddf_chassis import PddfChassis
+    from .event import SfpEvent
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
+NUM_COMPONENT = 4
 
 class Chassis(PddfChassis):
     """
     PDDF Platform-specific Chassis class
     """
 
+    SYSLED_DEV_NAME = "DIAG_LED"
+
     def __init__(self, pddf_data=None, pddf_plugin_data=None):
         PddfChassis.__init__(self, pddf_data, pddf_plugin_data)
+        self.__initialize_components()
+        self._sfpevent = SfpEvent(self.get_all_sfps())
+
+    def __initialize_components(self):
+        from sonic_platform.component import Component
+        for index in range(NUM_COMPONENT):
+            component = Component(index)
+            self._component_list.append(component)
 
     # Provide the functions/variables below for which implementation is to be overwritten
-    sfp_change_event_data = {'valid': 0, 'last': 0, 'present': 0}
-    def get_change_event(self, timeout=2000):
-        now = time.time()
-        port_dict = {}
-        change_dict = {}
-        change_dict['sfp'] = port_dict
-
-        if timeout < 1000:
-            timeout = 1000
-        timeout = timeout / float(1000)  # Convert to secs
-
-        if now < (self.sfp_change_event_data['last'] + timeout) and self.sfp_change_event_data['valid']:
-            return True, change_dict
-        
-        bitmap = 0
-        for i in range(34):
-            modpres = self.get_sfp(i+1).get_presence()
-            if modpres:
-                bitmap = bitmap | (1 << i)
-
-        changed_ports = self.sfp_change_event_data['present'] ^ bitmap
-        if changed_ports:
-            for i in range(34):
-                if (changed_ports & (1 << i)):
-                    if (bitmap & (1 << i)) == 0:
-                        port_dict[i+1] = '0'
-                    else:
-                        port_dict[i+1] = '1'
-
-
-            # Update teh cache dict
-            self.sfp_change_event_data['present'] = bitmap
-            self.sfp_change_event_data['last'] = now
-            self.sfp_change_event_data['valid'] = 1
-            return True, change_dict
-        else:
-            return True, change_dict
-
+    def get_change_event(self, timeout=0):
+        return self._sfpevent.get_sfp_event(timeout)
 
     def get_sfp(self, index):
         """
@@ -84,3 +59,19 @@ class Chassis(PddfChassis):
             sys.stderr.write("SFP index {} out of range (1-{})\n".format(
                              index, len(self._sfp_list)))
         return sfp
+
+    def initizalize_system_led(self):
+        return
+
+    def get_status_led(self):
+        return self.get_system_led(self.SYSLED_DEV_NAME)
+
+    def set_status_led(self, color):
+        return self.set_system_led(self.SYSLED_DEV_NAME, color)
+    
+    def get_port_or_cage_type(self, port):
+        from sonic_platform_base.sfp_base import SfpBase
+        if port in range(1, 32):
+            return SfpBase.SFP_PORT_TYPE_BIT_QSFP | SfpBase.SFP_PORT_TYPE_BIT_QSFP_PLUS | SfpBase.SFP_PORT_TYPE_BIT_QSFP28
+        else:
+            return SfpBase.SFP_PORT_TYPE_BIT_SFP | SfpBase.SFP_PORT_TYPE_BIT_SFP_PLUS

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/component.py
@@ -1,0 +1,115 @@
+#############################################################################
+# 
+# Component contains an implementation of SONiC Platform Base API and
+# provides the components firmware management function
+#
+#############################################################################
+
+try:
+    import subprocess
+    from sonic_platform_base.component_base import ComponentBase
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+CPLD_ADDR_MAPPING = {
+    "CPLD1": ['11', '0x60'],
+    "CPLD2": ['12', '0x62'],
+    "CPLD3": ['13', '0x64']
+}
+SYSFS_PATH = "/sys/bus/i2c/devices/"
+BIOS_VERSION_PATH = "/sys/class/dmi/id/bios_version"
+COMPONENT_LIST= [
+   ("CPLD1", "CPLD 1"),
+   ("CPLD2", "CPLD 2"),
+   ("CPLD3", "CPLD 3"),
+   ("BIOS", "Basic Input/Output System")
+   
+]
+
+class Component(ComponentBase):
+    """Platform-specific Component class"""
+
+    DEVICE_TYPE = "component"
+
+    def __init__(self, component_index=0):
+        self.index = component_index
+        self.name = self.get_name()
+
+    def __run_command(self, command):
+        # Run bash command and print output to stdout
+        try:
+            process = subprocess.Popen(
+                shlex.split(command), stdout=subprocess.PIPE)
+            while True:
+                output = process.stdout.readline()
+                if output == '' and process.poll() is not None:
+                    break
+            rc = process.poll()
+            if rc != 0:
+                return False
+        except Exception:
+            return False
+        return True
+
+    def __get_bios_version(self):
+        # Retrieves the BIOS firmware version
+        try:
+            with open(BIOS_VERSION_PATH, 'r') as fd:
+                bios_version = fd.read()
+                return bios_version.strip()
+        except Exception as e:
+            return None
+   
+    def __get_cpld_version(self):
+        # Retrieves the CPLD firmware version
+        cpld_version = dict()
+        for cpld_name in CPLD_ADDR_MAPPING:
+            cmd = "i2cget -f -y {0} {1} 0x1".format(CPLD_ADDR_MAPPING[cpld_name][0], CPLD_ADDR_MAPPING[cpld_name][1])
+            status, value = subprocess.getstatusoutput(cmd)
+            if not status:
+                cpld_version_raw = value.rstrip()
+                cpld_version[cpld_name] = "{}".format(int(cpld_version_raw,16))
+
+        return cpld_version
+
+    def get_name(self):
+        """
+        Retrieves the name of the component
+         Returns:
+            A string containing the name of the component
+        """
+        return COMPONENT_LIST[self.index][0]
+
+    def get_description(self):
+        """
+        Retrieves the description of the component
+            Returns:
+            A string containing the description of the component
+        """
+        return COMPONENT_LIST[self.index][1]
+
+    def get_firmware_version(self):
+        """
+        Retrieves the firmware version of module
+        Returns:
+            string: The firmware versions of the module
+        """
+        fw_version = None
+
+        if self.name == "BIOS":
+            fw_version = self.__get_bios_version()
+        elif "CPLD" in self.name:
+            cpld_version = self.__get_cpld_version()
+            fw_version = cpld_version.get(self.name)
+
+        return fw_version
+
+    def install_firmware(self, image_path):
+        """
+        Install firmware to module
+        Args:
+            image_path: A string, path to firmware image
+        Returns:
+            A boolean, True if install successfully, False if not
+        """
+        raise NotImplementedError

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/event.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/event.py
@@ -1,0 +1,60 @@
+try:
+    import time
+    from sonic_py_common.logger import Logger
+except ImportError as e:
+    raise ImportError(repr(e) + " - required module not found")
+
+POLL_INTERVAL_IN_SEC = 1
+
+class SfpEvent:
+    ''' Listen to insert/remove sfp events '''
+
+    def __init__(self, sfp_list):
+        self._sfp_list = sfp_list
+        self._logger = Logger()
+        self._sfp_change_event_data = {'present': 0}
+
+    def get_presence_bitmap(self):
+        bitmap = 0
+        for sfp in self._sfp_list:
+            modpres = sfp.get_presence()
+            i=sfp.get_position_in_parent() - 1
+            if modpres:
+                bitmap = bitmap | (1 << i)
+        return bitmap
+
+    def get_sfp_event(self, timeout=2000):
+        port_dict = {}
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            cd_ms = 1000
+        else:
+            cd_ms = timeout
+
+        while cd_ms > 0:
+            bitmap = self.get_presence_bitmap()
+            changed_ports = self._sfp_change_event_data['present'] ^ bitmap
+            if changed_ports != 0:
+                break
+            time.sleep(POLL_INTERVAL_IN_SEC)
+            # timeout=0 means wait for event forever
+            if timeout != 0:
+                cd_ms = cd_ms - POLL_INTERVAL_IN_SEC * 1000
+
+        if changed_ports != 0:
+            for sfp in self._sfp_list:
+                i=sfp.get_position_in_parent() - 1
+                if (changed_ports & (1 << i)):
+                    if (bitmap & (1 << i)) == 0:
+                        port_dict[i+1] = '0'
+                    else:
+                        port_dict[i+1] = '1'
+
+
+            # Update the cache dict
+            self._sfp_change_event_data['present'] = bitmap
+            return True, change_dict
+        else:
+            return True, change_dict

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/sfp.py
@@ -15,3 +15,6 @@ class Sfp(PddfSfp):
         PddfSfp.__init__(self, index, pddf_data, pddf_plugin_data)
 
     # Provide the functions/variables below for which implementation is to be overwritten
+    def get_position_in_parent(self):
+        """Retrieves 1-based relative physical position in parent device."""
+        return self.port_index

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/chassis.py
@@ -7,60 +7,34 @@
 #############################################################################
 
 try:
-    import sys
-    import time
     from sonic_platform_pddf_base.pddf_chassis import PddfChassis
+    from .event import SfpEvent
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
+NUM_COMPONENT = 5
 
 class Chassis(PddfChassis):
     """
     PDDF Platform-specific Chassis class
     """
 
+    SYSLED_DEV_NAME = "DIAG_LED"
+
     def __init__(self, pddf_data=None, pddf_plugin_data=None):
         PddfChassis.__init__(self, pddf_data, pddf_plugin_data)
+        self.__initialize_components()
+        self._sfpevent = SfpEvent(self.get_all_sfps())
+
+    def __initialize_components(self):
+        from sonic_platform.component import Component
+        for index in range(NUM_COMPONENT):
+            component = Component(index)
+            self._component_list.append(component)
 
     # Provide the functions/variables below for which implementation is to be overwritten
-    sfp_change_event_data = {'valid': 0, 'last': 0, 'present': 0}
-    def get_change_event(self, timeout=2000):
-        now = time.time()
-        port_dict = {}
-        change_dict = {}
-        change_dict['sfp'] = port_dict
-
-        if timeout < 1000:
-            timeout = 1000
-        timeout = timeout / float(1000)  # Convert to secs
-
-        if now < (self.sfp_change_event_data['last'] + timeout) and self.sfp_change_event_data['valid']:
-            return True, change_dict
-        
-        bitmap = 0
-        for i in range(64):
-            modpres = self.get_sfp(i+1).get_presence()
-            if modpres:
-                bitmap = bitmap | (1 << i)
-
-        changed_ports = self.sfp_change_event_data['present'] ^ bitmap
-        if changed_ports:
-            for i in range(64):
-                if (changed_ports & (1 << i)):
-                    if (bitmap & (1 << i)) == 0:
-                        port_dict[i+1] = '0'
-                    else:
-                        port_dict[i+1] = '1'
-
-
-            # Update teh cache dict
-            self.sfp_change_event_data['present'] = bitmap
-            self.sfp_change_event_data['last'] = now
-            self.sfp_change_event_data['valid'] = 1
-            return True, change_dict
-        else:
-            return True, change_dict
-
+    def get_change_event(self, timeout=0):
+        return self._sfpevent.get_sfp_event(timeout)
 
     def get_sfp(self, index):
         """
@@ -84,3 +58,16 @@ class Chassis(PddfChassis):
             sys.stderr.write("SFP index {} out of range (1-{})\n".format(
                              index, len(self._sfp_list)))
         return sfp
+
+    def initizalize_system_led(self):
+        return
+
+    def get_status_led(self):
+        return self.get_system_led(self.SYSLED_DEV_NAME)
+
+    def set_status_led(self, color):
+        return self.set_system_led(self.SYSLED_DEV_NAME, color)
+
+    def get_port_or_cage_type(self, port):
+        from sonic_platform_base.sfp_base import SfpBase
+        return SfpBase.SFP_PORT_TYPE_BIT_QSFP28

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/component.py
@@ -1,0 +1,117 @@
+#############################################################################
+# 
+# Component contains an implementation of SONiC Platform Base API and
+# provides the components firmware management function
+#
+#############################################################################
+
+try:
+    import subprocess
+    from sonic_platform_base.component_base import ComponentBase
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+CPLD_ADDR_MAPPING = {
+    "CPLD1": ['19', '0x60'],
+    "CPLD2": ['20', '0x62'],
+    "CPLD3": ['21', '0x64'],
+    "CPLD4": ['22', '0x66']
+}
+SYSFS_PATH = "/sys/bus/i2c/devices/"
+BIOS_VERSION_PATH = "/sys/class/dmi/id/bios_version"
+COMPONENT_LIST= [
+   ("CPLD1", "CPLD 1"),
+   ("CPLD2", "CPLD 2"),
+   ("CPLD3", "CPLD 3"),
+   ("CPLD4", "CPLD 4"),
+   ("BIOS", "Basic Input/Output System")
+   
+]
+
+class Component(ComponentBase):
+    """Platform-specific Component class"""
+
+    DEVICE_TYPE = "component"
+
+    def __init__(self, component_index=0):
+        self.index = component_index
+        self.name = self.get_name()
+
+    def __run_command(self, command):
+        # Run bash command and print output to stdout
+        try:
+            process = subprocess.Popen(
+                shlex.split(command), stdout=subprocess.PIPE)
+            while True:
+                output = process.stdout.readline()
+                if output == '' and process.poll() is not None:
+                    break
+            rc = process.poll()
+            if rc != 0:
+                return False
+        except Exception:
+            return False
+        return True
+
+    def __get_bios_version(self):
+        # Retrieves the BIOS firmware version
+        try:
+            with open(BIOS_VERSION_PATH, 'r') as fd:
+                bios_version = fd.read()
+                return bios_version.strip()
+        except Exception as e:
+            return None
+   
+    def __get_cpld_version(self):
+        # Retrieves the CPLD firmware version
+        cpld_version = dict()
+        for cpld_name in CPLD_ADDR_MAPPING:
+            cmd = "i2cget -f -y {0} {1} 0x1".format(CPLD_ADDR_MAPPING[cpld_name][0], CPLD_ADDR_MAPPING[cpld_name][1])
+            status, value = subprocess.getstatusoutput(cmd)
+            if not status:
+                cpld_version_raw = value.rstrip()
+                cpld_version[cpld_name] = "{}".format(int(cpld_version_raw,16))
+
+        return cpld_version
+
+    def get_name(self):
+        """
+        Retrieves the name of the component
+         Returns:
+            A string containing the name of the component
+        """
+        return COMPONENT_LIST[self.index][0]
+
+    def get_description(self):
+        """
+        Retrieves the description of the component
+            Returns:
+            A string containing the description of the component
+        """
+        return COMPONENT_LIST[self.index][1]
+
+    def get_firmware_version(self):
+        """
+        Retrieves the firmware version of module
+        Returns:
+            string: The firmware versions of the module
+        """
+        fw_version = None
+
+        if self.name == "BIOS":
+            fw_version = self.__get_bios_version()
+        elif "CPLD" in self.name:
+            cpld_version = self.__get_cpld_version()
+            fw_version = cpld_version.get(self.name)
+
+        return fw_version
+
+    def install_firmware(self, image_path):
+        """
+        Install firmware to module
+        Args:
+            image_path: A string, path to firmware image
+        Returns:
+            A boolean, True if install successfully, False if not
+        """
+        raise NotImplementedError

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/event.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/event.py
@@ -1,0 +1,60 @@
+try:
+    import time
+    from sonic_py_common.logger import Logger
+except ImportError as e:
+    raise ImportError(repr(e) + " - required module not found")
+
+POLL_INTERVAL_IN_SEC = 1
+
+class SfpEvent:
+    ''' Listen to insert/remove sfp events '''
+
+    def __init__(self, sfp_list):
+        self._sfp_list = sfp_list
+        self._logger = Logger()
+        self._sfp_change_event_data = {'present': 0}
+
+    def get_presence_bitmap(self):
+        bitmap = 0
+        for sfp in self._sfp_list:
+            modpres = sfp.get_presence()
+            i=sfp.get_position_in_parent() - 1
+            if modpres:
+                bitmap = bitmap | (1 << i)
+        return bitmap
+
+    def get_sfp_event(self, timeout=2000):
+        port_dict = {}
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            cd_ms = 1000
+        else:
+            cd_ms = timeout
+
+        while cd_ms > 0:
+            bitmap = self.get_presence_bitmap()
+            changed_ports = self._sfp_change_event_data['present'] ^ bitmap
+            if changed_ports != 0:
+                break
+            time.sleep(POLL_INTERVAL_IN_SEC)
+            # timeout=0 means wait for event forever
+            if timeout != 0:
+                cd_ms = cd_ms - POLL_INTERVAL_IN_SEC * 1000
+
+        if changed_ports != 0:
+            for sfp in self._sfp_list:
+                i=sfp.get_position_in_parent() - 1
+                if (changed_ports & (1 << i)):
+                    if (bitmap & (1 << i)) == 0:
+                        port_dict[i+1] = '0'
+                    else:
+                        port_dict[i+1] = '1'
+
+
+            # Update the cache dict
+            self._sfp_change_event_data['present'] = bitmap
+            return True, change_dict
+        else:
+            return True, change_dict

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/sfp.py
@@ -15,3 +15,6 @@ class Sfp(PddfSfp):
         PddfSfp.__init__(self, index, pddf_data, pddf_plugin_data)
 
     # Provide the functions/variables below for which implementation is to be overwritten
+    def get_position_in_parent(self):
+        """Retrieves 1-based relative physical position in parent device."""
+        return self.port_index

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/chassis.py
@@ -8,59 +8,34 @@
 
 try:
     import sys
-    import time
     from sonic_platform_pddf_base.pddf_chassis import PddfChassis
+    from .event import SfpEvent
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
+NUM_COMPONENT = 4
 
 class Chassis(PddfChassis):
     """
     PDDF Platform-specific Chassis class
     """
 
+    SYSLED_DEV_NAME = "DIAG_LED"
+
     def __init__(self, pddf_data=None, pddf_plugin_data=None):
         PddfChassis.__init__(self, pddf_data, pddf_plugin_data)
+        self.__initialize_components()
+        self._sfpevent = SfpEvent(self.get_all_sfps())
+
+    def __initialize_components(self):
+        from sonic_platform.component import Component
+        for index in range(NUM_COMPONENT):
+            component = Component(index)
+            self._component_list.append(component)
 
     # Provide the functions/variables below for which implementation is to be overwritten
-    sfp_change_event_data = {'valid': 0, 'last': 0, 'present': 0}
-    def get_change_event(self, timeout=2000):
-        now = time.time()
-        port_dict = {}
-        change_dict = {}
-        change_dict['sfp'] = port_dict
-
-        if timeout < 1000:
-            timeout = 1000
-        timeout = timeout / float(1000)  # Convert to secs
-
-        if now < (self.sfp_change_event_data['last'] + timeout) and self.sfp_change_event_data['valid']:
-            return True, change_dict
-        
-        bitmap = 0
-        for i in range(34):
-            modpres = self.get_sfp(i+1).get_presence()
-            if modpres:
-                bitmap = bitmap | (1 << i)
-
-        changed_ports = self.sfp_change_event_data['present'] ^ bitmap
-        if changed_ports:
-            for i in range(34):
-                if (changed_ports & (1 << i)):
-                    if (bitmap & (1 << i)) == 0:
-                        port_dict[i+1] = '0'
-                    else:
-                        port_dict[i+1] = '1'
-
-
-            # Update teh cache dict
-            self.sfp_change_event_data['present'] = bitmap
-            self.sfp_change_event_data['last'] = now
-            self.sfp_change_event_data['valid'] = 1
-            return True, change_dict
-        else:
-            return True, change_dict
-
+    def get_change_event(self, timeout=0):
+        return self._sfpevent.get_sfp_event(timeout)
 
     def get_sfp(self, index):
         """
@@ -84,3 +59,20 @@ class Chassis(PddfChassis):
             sys.stderr.write("SFP index {} out of range (1-{})\n".format(
                              index, len(self._sfp_list)))
         return sfp
+
+    def initizalize_system_led(self):
+        return
+
+    def get_status_led(self):
+        return self.get_system_led(self.SYSLED_DEV_NAME)
+
+    def set_status_led(self, color):
+        return self.set_system_led(self.SYSLED_DEV_NAME, color)
+        
+    def get_port_or_cage_type(self, port):
+        from sonic_platform_base.sfp_base import SfpBase
+        if port in range(1, 33):
+            return SfpBase.SFP_PORT_TYPE_BIT_QSFP | SfpBase.SFP_PORT_TYPE_BIT_QSFP_PLUS | SfpBase.SFP_PORT_TYPE_BIT_QSFP28 | SfpBase.SFP_PORT_TYPE_BIT_QSFP56 | SfpBase.SFP_PORT_TYPE_BIT_QSFPDD
+        else:
+            return SfpBase.SFP_PORT_TYPE_BIT_SFP
+        

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/component.py
@@ -1,0 +1,115 @@
+#############################################################################
+# 
+# Component contains an implementation of SONiC Platform Base API and
+# provides the components firmware management function
+#
+#############################################################################
+
+try:
+    import subprocess
+    from sonic_platform_base.component_base import ComponentBase
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+CPLD_ADDR_MAPPING = {
+    "CPLD1": ['19', '0x60'],
+    "CPLD2": ['20', '0x61'],
+    "CPLD3": ['21', '0x62']
+}
+SYSFS_PATH = "/sys/bus/i2c/devices/"
+BIOS_VERSION_PATH = "/sys/class/dmi/id/bios_version"
+COMPONENT_LIST= [
+   ("CPLD1", "CPLD 1"),
+   ("CPLD2", "CPLD 2"),
+   ("CPLD3", "CPLD 3"),
+   ("BIOS", "Basic Input/Output System")
+   
+]
+
+class Component(ComponentBase):
+    """Platform-specific Component class"""
+
+    DEVICE_TYPE = "component"
+
+    def __init__(self, component_index=0):
+        self.index = component_index
+        self.name = self.get_name()
+
+    def __run_command(self, command):
+        # Run bash command and print output to stdout
+        try:
+            process = subprocess.Popen(
+                shlex.split(command), stdout=subprocess.PIPE)
+            while True:
+                output = process.stdout.readline()
+                if output == '' and process.poll() is not None:
+                    break
+            rc = process.poll()
+            if rc != 0:
+                return False
+        except Exception:
+            return False
+        return True
+
+    def __get_bios_version(self):
+        # Retrieves the BIOS firmware version
+        try:
+            with open(BIOS_VERSION_PATH, 'r') as fd:
+                bios_version = fd.read()
+                return bios_version.strip()
+        except Exception as e:
+            return None
+   
+    def __get_cpld_version(self):
+        # Retrieves the CPLD firmware version
+        cpld_version = dict()
+        for cpld_name in CPLD_ADDR_MAPPING:
+            cmd = "i2cget -f -y {0} {1} 0x1".format(CPLD_ADDR_MAPPING[cpld_name][0], CPLD_ADDR_MAPPING[cpld_name][1])
+            status, value = subprocess.getstatusoutput(cmd)
+            if not status:
+                cpld_version_raw = value.rstrip()
+                cpld_version[cpld_name] = "{}".format(int(cpld_version_raw,16))
+
+        return cpld_version
+
+    def get_name(self):
+        """
+        Retrieves the name of the component
+         Returns:
+            A string containing the name of the component
+        """
+        return COMPONENT_LIST[self.index][0]
+
+    def get_description(self):
+        """
+        Retrieves the description of the component
+            Returns:
+            A string containing the description of the component
+        """
+        return COMPONENT_LIST[self.index][1]
+
+    def get_firmware_version(self):
+        """
+        Retrieves the firmware version of module
+        Returns:
+            string: The firmware versions of the module
+        """
+        fw_version = None
+
+        if self.name == "BIOS":
+            fw_version = self.__get_bios_version()
+        elif "CPLD" in self.name:
+            cpld_version = self.__get_cpld_version()
+            fw_version = cpld_version.get(self.name)
+
+        return fw_version
+
+    def install_firmware(self, image_path):
+        """
+        Install firmware to module
+        Args:
+            image_path: A string, path to firmware image
+        Returns:
+            A boolean, True if install successfully, False if not
+        """
+        raise NotImplementedError

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/event.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/event.py
@@ -1,0 +1,60 @@
+try:
+    import time
+    from sonic_py_common.logger import Logger
+except ImportError as e:
+    raise ImportError(repr(e) + " - required module not found")
+
+POLL_INTERVAL_IN_SEC = 1
+
+class SfpEvent:
+    ''' Listen to insert/remove sfp events '''
+
+    def __init__(self, sfp_list):
+        self._sfp_list = sfp_list
+        self._logger = Logger()
+        self._sfp_change_event_data = {'present': 0}
+
+    def get_presence_bitmap(self):
+        bitmap = 0
+        for sfp in self._sfp_list:
+            modpres = sfp.get_presence()
+            i=sfp.get_position_in_parent() - 1
+            if modpres:
+                bitmap = bitmap | (1 << i)
+        return bitmap
+
+    def get_sfp_event(self, timeout=2000):
+        port_dict = {}
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            cd_ms = 1000
+        else:
+            cd_ms = timeout
+
+        while cd_ms > 0:
+            bitmap = self.get_presence_bitmap()
+            changed_ports = self._sfp_change_event_data['present'] ^ bitmap
+            if changed_ports != 0:
+                break
+            time.sleep(POLL_INTERVAL_IN_SEC)
+            # timeout=0 means wait for event forever
+            if timeout != 0:
+                cd_ms = cd_ms - POLL_INTERVAL_IN_SEC * 1000
+
+        if changed_ports != 0:
+            for sfp in self._sfp_list:
+                i=sfp.get_position_in_parent() - 1
+                if (changed_ports & (1 << i)):
+                    if (bitmap & (1 << i)) == 0:
+                        port_dict[i+1] = '0'
+                    else:
+                        port_dict[i+1] = '1'
+
+
+            # Update the cache dict
+            self._sfp_change_event_data['present'] = bitmap
+            return True, change_dict
+        else:
+            return True, change_dict

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/sfp.py
@@ -15,3 +15,6 @@ class Sfp(PddfSfp):
         PddfSfp.__init__(self, index, pddf_data, pddf_plugin_data)
 
     # Provide the functions/variables below for which implementation is to be overwritten
+    def get_position_in_parent(self):
+        """Retrieves 1-based relative physical position in parent device."""
+        return self.port_index


### PR DESCRIPTION
Signed-off-by: jostar-yang <jostar_yang@edge-core.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. Add get_port_or_cage_type() t chassis.py
2. Support show platform firmware status cmd for pddf platform
3. Support show system-health cmd for pddf platform
#### How I did it
Implement needed code
#### How to verify it
Test show platform firmware status and  sfputil show lpmode.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [X] 202205
-->Some customer need these feature
#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - [PR#2174](https://github.com/sonic-net/sonic-utilities/pull/2174) where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

