### PR TITLE
[nokia] Replace os.system and remove subprocess with shell=True

### DIFF
--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/plugins/eeprom.py
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/plugins/eeprom.py
@@ -12,5 +12,5 @@ class board(eeprom_tlvinfo.TlvInfoDecoder):
         if not os.path.exists(self.eeprom_path):
             file = "/sys/class/i2c-adapter/i2c-0/new_device"
             with open(file, 'w') as f:
-                f.write('24c02 0x53')
+                f.write('24c02 0x53\n')
         super(board, self).__init__(self.eeprom_path, 0, '', True)

--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/plugins/eeprom.py
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/plugins/eeprom.py
@@ -10,5 +10,7 @@ class board(eeprom_tlvinfo.TlvInfoDecoder):
     def __init__(self, name, path, cpld_root, ro):
         self.eeprom_path = "/sys/class/i2c-adapter/i2c-0/0-0053/eeprom"
         if not os.path.exists(self.eeprom_path):
-            os.system("echo 24c02 0x53 > /sys/class/i2c-adapter/i2c-0/new_device")
+            file = "/sys/class/i2c-adapter/i2c-0/new_device"
+            with open(file, 'w') as f:
+                f.write('24c02 0x53')
         super(board, self).__init__(self.eeprom_path, 0, '', True)

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/chassis.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/chassis.py
@@ -18,6 +18,7 @@ try:
     from sonic_platform.thermal import Thermal
     from sonic_platform.component import Component
     from sonic_py_common import logger
+    from sonic_py_common.general import getstatusoutput_noshell
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -26,11 +27,6 @@ try:
     import smbus
 except ImportError as e:
     smbus_present = 0
-
-if sys.version_info[0] < 3:
-    import commands as cmd
-else:
-    import subprocess as cmd
 
 MAX_SELECT_DELAY = 3600
 COPPER_PORT_START = 1
@@ -209,7 +205,7 @@ class Chassis(ChassisBase):
             string: Revision value of chassis
         """
         if smbus_present == 0:  # called from host
-            cmdstatus, value = cmd.getstatusoutput('sudo i2cget -y 0 0x41 0x0')
+            cmdstatus, value = getstatusoutput_noshell(['sudo', 'i2cget', '-y', '0', '0x41', '0x0'])
         else:
             bus = smbus.SMBus(0)
             DEVICE_ADDRESS = 0x41
@@ -331,7 +327,7 @@ class Chassis(ChassisBase):
 
         # Write sys led
         if smbus_present == 0:  # called from host (e.g. 'show system-health')
-            cmdstatus, value = cmd.getstatusoutput('sudo i2cset -y 0 0x41 0x7 %d' % value)
+            cmdstatus, value = getstatusoutput_noshell(['sudo', 'i2cset', '-y', '0', '0x41', '0x7', value])
             if cmdstatus:
                 sonic_logger.log_warning("  System LED set %s failed" % value)
                 return False
@@ -353,7 +349,7 @@ class Chassis(ChassisBase):
         """
         # Read sys led
         if smbus_present == 0:  # called from host
-            cmdstatus, value = cmd.getstatusoutput('sudo i2cget -y 0 0x41 0x7')
+            cmdstatus, value = getstatusoutput_noshell(['sudo', 'i2cget', '-y', '0', '0x41', '0x7'])
             value = int(value, 16)
         else:
             bus = smbus.SMBus(0)

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/chassis.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/chassis.py
@@ -327,7 +327,7 @@ class Chassis(ChassisBase):
 
         # Write sys led
         if smbus_present == 0:  # called from host (e.g. 'show system-health')
-            cmdstatus, value = getstatusoutput_noshell(['sudo', 'i2cset', '-y', '0', '0x41', '0x7', value])
+            cmdstatus, value = getstatusoutput_noshell(['sudo', 'i2cset', '-y', '0', '0x41', '0x7', str(value)])
             if cmdstatus:
                 sonic_logger.log_warning("  System LED set %s failed" % value)
                 return False

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/component.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/component.py
@@ -12,7 +12,7 @@ try:
     import subprocess
     import ntpath
     from sonic_platform_base.component_base import ComponentBase
-    from sonic_py_common.general import getstatusoutput_noshell
+    from sonic_py_common.general import getstatusoutput_noshell, getstatusoutput_noshell_pipes
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -130,15 +130,10 @@ class Component(ComponentBase):
             return self._get_cpld_version(self.index)
 
         if self.index == 1:
-            cmd1 = ['grep', '--null-data', 'U-Boot', '/dev/mtd0ro']
-            cmd2 = ['head', '-1']
-            cmd3 = ['cut', '-d', ' ', '-f2-4']
-            with subprocess.Popen(cmd1, universal_newlines=True, stdout=subprocess.PIPE) as p1:
-                with subprocess.Popen(cmd2, universal_newlines=True, stdin=p1.stdout, stdout=subprocess.PIPE) as p2:
-                    with subprocess.Popen(cmd3, universal_newlines=True, stdin=p2.stdout, stdout=subprocess.PIPE) as p3:
-                        uboot_version = p3.communicate()[0].rstrip('\n')
-                        p1.wait()
-                        p2.wait()
+            cmd1 = dict(args=['grep', '--null-data', 'U-Boot', '/dev/mtd0ro'])
+            cmd2 = dict(args=['head', '-1'])
+            cmd3 = dict(args=['cut', '-d', ' ', '-f2-4'])
+            cmdstatus, uboot_version = getstatusoutput_noshell_pipes(cmd1, cmd2, cmd3)
             return uboot_version
 
     def install_firmware(self, image_path):

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/component.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/component.py
@@ -9,10 +9,10 @@
 
 try:
     import os
-    import sys
     import subprocess
     import ntpath
     from sonic_platform_base.component_base import ComponentBase
+    from sonic_py_common.general import getstatusoutput_noshell
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -22,11 +22,6 @@ try:
 except ImportError as e:
     smbus_present = 0
 
-if sys.version_info[0] < 3:
-    import commands as cmd
-else:
-    import subprocess as cmd
-
 
 class Component(ComponentBase):
     """Nokia platform-specific Component class"""
@@ -35,29 +30,20 @@ class Component(ComponentBase):
         ["System-CPLD", "Used for managing SFPs, LEDs, PSUs and FANs "],
         ["U-Boot", "Performs initialization during booting"],
     ]
-    CPLD_UPDATE_COMMAND = 'cp /usr/sbin/vme /tmp; cp {} /tmp; cd /tmp; ./vme {};'
+    CPLD_UPDATE_COMMAND1 = ['cp', '/usr/sbin/vme', '/tmp']
+    CPLD_UPDATE_COMMAND2 = ['cp', '', '/tmp']
+    CPLD_UPDATE_COMMAND3 = ['cd', '/tmp']
+    CPLD_UPDATE_COMMAND4 = ['./vme', '']
 
     def __init__(self, component_index):
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]
 
-    def _get_command_result(self, cmdline):
-        try:
-            proc = subprocess.Popen(cmdline.split(), stdout=subprocess.PIPE,
-                                    stderr=subprocess.STDOUT)
-            stdout = proc.communicate()[0]
-            proc.wait()
-            result = stdout.rstrip('\n')
-        except OSError:
-            result = None
-
-        return result
-
     def _get_cpld_version(self, cpld_number):
 
         if smbus_present == 0:
-            cmdstatus, cpld_version = cmd.getstatusoutput('sudo i2cget -y 0 0x41 0x2')
+            cmdstatus, cpld_version = getstatusoutput_noshell(['sudo', 'i2cget', '-y', '0', '0x41', '0x2'])
         else:
             bus = smbus.SMBus(0)
             DEVICE_ADDRESS = 0x41
@@ -144,7 +130,15 @@ class Component(ComponentBase):
             return self._get_cpld_version(self.index)
 
         if self.index == 1:
-            cmdstatus, uboot_version = cmd.getstatusoutput('grep --null-data U-Boot /dev/mtd0ro|head -1 | cut -d" " -f2-4')
+            cmd1 = ['grep', '--null-data', 'U-Boot', '/dev/mtd0ro']
+            cmd2 = ['head', '-1']
+            cmd3 = ['cut', '-d', ' ', '-f2-4']
+            with subprocess.Popen(cmd1, universal_newlines=True, stdout=subprocess.PIPE) as p1:
+                with subprocess.Popen(cmd2, universal_newlines=True, stdin=p1.stdout, stdout=subprocess.PIPE) as p2:
+                    with subprocess.Popen(cmd3, universal_newlines=True, stdin=p2.stdout, stdout=subprocess.PIPE) as p3:
+                        uboot_version = p3.communicate()[0].rstrip('\n')
+                        p1.wait()
+                        p2.wait()
             return uboot_version
 
     def install_firmware(self, image_path):
@@ -165,12 +159,16 @@ class Component(ComponentBase):
             print("ERROR: the cpld image {} doesn't exist ".format(image_path))
             return False
 
-        cmdline = self.CPLD_UPDATE_COMMAND.format(image_path, image_name)
+        self.CPLD_UPDATE_COMMAND2[1] = image_path
+        self.CPLD_UPDATE_COMMAND4[1] = image_name
 
         success_flag = False
-
-        try:
-            subprocess.check_call(cmdline, stderr=subprocess.STDOUT, shell=True)
+ 
+        try:   
+            subprocess.check_call(self.CPLD_UPDATE_COMMAND1, stderr=subprocess.STDOUT)
+            subprocess.check_call(self.CPLD_UPDATE_COMMAND2, stderr=subprocess.STDOUT)
+            subprocess.check_call(self.CPLD_UPDATE_COMMAND3, stderr=subprocess.STDOUT)
+            subprocess.check_call(self.CPLD_UPDATE_COMMAND4, stderr=subprocess.STDOUT)
             success_flag = True
         except subprocess.CalledProcessError as e:
             print("ERROR: Failed to upgrade CPLD: rc={}".format(e.returncode))

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/component.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/component.py
@@ -12,7 +12,7 @@ try:
     import subprocess
     import ntpath
     from sonic_platform_base.component_base import ComponentBase
-    from sonic_py_common.general import getstatusoutput_noshell, getstatusoutput_noshell_pipes
+    from sonic_py_common.general import getstatusoutput_noshell, getstatusoutput_noshell_pipe
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -130,10 +130,10 @@ class Component(ComponentBase):
             return self._get_cpld_version(self.index)
 
         if self.index == 1:
-            cmd1 = dict(args=['grep', '--null-data', 'U-Boot', '/dev/mtd0ro'])
-            cmd2 = dict(args=['head', '-1'])
-            cmd3 = dict(args=['cut', '-d', ' ', '-f2-4'])
-            cmdstatus, uboot_version = getstatusoutput_noshell_pipes(cmd1, cmd2, cmd3)
+            cmd1 = ['grep', '--null-data', 'U-Boot', '/dev/mtd0ro']
+            cmd2 = ['head', '-1']
+            cmd3 = ['cut', '-d', ' ', '-f2-4']
+            cmdstatus, uboot_version = getstatusoutput_noshell_pipe(cmd1, cmd2, cmd3)
             return uboot_version
 
     def install_firmware(self, image_path):

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/psu.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/psu.py
@@ -8,17 +8,12 @@
 
 try:
     import os
-    import sys
     from sonic_platform_base.psu_base import PsuBase
     from sonic_py_common import logger
     from sonic_platform.eeprom import Eeprom
+    from sonic_py_common.general import getstatusoutput_noshell
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
-
-if sys.version_info[0] < 3:
-    import commands as cmd
-else:
-    import subprocess as cmd
 
 smbus_present = 1
 try:
@@ -86,7 +81,7 @@ class Psu(PsuBase):
         """
 
         if smbus_present == 0:  # if called from psuutil outside of pmon
-            cmdstatus, psustatus = cmd.getstatusoutput('sudo i2cget -y 0 0x41 0xa')
+            cmdstatus, psustatus = getstatusoutput_noshell(['sudo', 'i2cget', '-y', '0', '0x41', '0xa'])
             psustatus = int(psustatus, 16)
         else:
             bus = smbus.SMBus(0)
@@ -150,7 +145,7 @@ class Psu(PsuBase):
         """
 
         if smbus_present == 0:
-            cmdstatus, psustatus = cmd.getstatusoutput('sudo i2cget -y 0 0x41 0xa')
+            cmdstatus, psustatus = getstatusoutput_noshell(['sudo', 'i2cget', '-y', '0', '0x41', '0xa'])
             psustatus = int(psustatus, 16)
             sonic_logger.log_warning("PMON psu-smbus - presence = 0 ")
         else:
@@ -179,7 +174,7 @@ class Psu(PsuBase):
             e.g. 12.1
         """
         if smbus_present == 0:
-            cmdstatus, psustatus = cmd.getstatusoutput('sudo i2cget -y 0 0x41 0xa')
+            cmdstatus, psustatus = getstatusoutput_noshell(['sudo', 'i2cget', '-y', '0', '0x41', '0xa'])
             psustatus = int(psustatus, 16)
         else:
             bus = smbus.SMBus(0)
@@ -226,7 +221,7 @@ class Psu(PsuBase):
         """
 
         if smbus_present == 0:
-            cmdstatus, psustatus = cmd.getstatusoutput('sudo i2cget -y 0 0x41 0xa')
+            cmdstatus, psustatus = getstatusoutput_noshell(['sudo', 'i2cget', '-y', '0', '0x41', '0xa'])
             psustatus = int(psustatus, 16)
         else:
             bus = smbus.SMBus(0)

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp.py
@@ -181,7 +181,7 @@ class Sfp(SfpBase):
             return 'N/A'
 
     def __is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
+        return subprocess.call(self.HOST_CHK_CMD) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp.py
@@ -3,8 +3,7 @@
 #
 #############################################################################
 
-import os
-import sys
+import subprocess
 
 try:
     from sonic_platform_base.sfp_base import SfpBase
@@ -12,13 +11,9 @@ try:
     from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
     from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
     from sonic_py_common import logger
+    from sonic_py_common.general import getstatusoutput_noshell
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
-
-if sys.version_info[0] < 3:
-    import commands as cmd
-else:
-    import subprocess as cmd
 
 smbus_present = 1
 
@@ -118,7 +113,7 @@ class Sfp(SfpBase):
     # Paths
     PLATFORM_ROOT_PATH = "/usr/share/sonic/device"
     PMON_HWSKU_PATH = "/usr/share/sonic/hwsku"
-    HOST_CHK_CMD = "docker > /dev/null 2>&1"
+    HOST_CHK_CMD = ["docker"]
 
     PLATFORM = "armhf-nokia_ixs7215_52x-r0"
     HWSKU = "Nokia-7215"
@@ -186,7 +181,7 @@ class Sfp(SfpBase):
             return 'N/A'
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])
@@ -811,7 +806,7 @@ class Sfp(SfpBase):
             return False
 
         if smbus_present == 0:  # if called from sfputil outside of pmon
-            cmdstatus, register = cmd.getstatusoutput('sudo i2cget -y 0 0x41 0x5')
+            cmdstatus, register = getstatusoutput_noshell(['sudo', 'i2cget', '-y', '0', '0x41', '0x5'])
             if cmdstatus:
                 sonic_logger.log_warning("sfp cmdstatus i2c get failed %s" % register )
                 return False
@@ -824,13 +819,13 @@ class Sfp(SfpBase):
 
         pos = [1, 2, 4, 8]
         mask = pos[self.index-SFP_PORT_START]
-        if tx_disable == True:
+        if tx_disable is True:
             setbits = register | mask
         else:
             setbits = register & ~mask
 
         if smbus_present == 0:  # if called from sfputil outside of pmon
-            cmdstatus, output = cmd.getstatusoutput('sudo i2cset -y -m 0x0f 0 0x41 0x5 %d' % setbits)
+            cmdstatus, output = getstatusoutput_noshell(['sudo', 'i2cset', '-y', '-m', '0x0f', '0', '0x41', '0x5', str(setbits)])
             if cmdstatus:
                 sonic_logger.log_warning("sfp cmdstatus i2c write failed %s" % output )
                 return False
@@ -912,7 +907,7 @@ class Sfp(SfpBase):
             return False
 
         if smbus_present == 0:  # if called from sfputil outside of pmon
-            cmdstatus, sfpstatus = cmd.getstatusoutput('sudo i2cget -y 0 0x41 0x3')
+            cmdstatus, sfpstatus = getstatusoutput_noshell(['sudo', 'i2cget', '-y', '0', '0x41', '0x3'])
             sfpstatus = int(sfpstatus, 16)
         else:
             bus = smbus.SMBus(0)

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp_event.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp_event.py
@@ -1,9 +1,9 @@
 '''
 listen for the SFP change event and return to chassis.
 '''
-import sys
 import time
 from sonic_py_common import logger
+from sonic_py_common.general import getstatusoutput_noshell
 
 smbus_present = 1
 
@@ -11,11 +11,6 @@ try:
     import smbus
 except ImportError as e:
     smbus_present = 0
-
-if sys.version_info[0] < 3:
-    import commands as cmd
-else:
-    import subprocess as cmd
 
 # system level event/error
 EVENT_ON_ALL_SFP = '-1'
@@ -51,7 +46,7 @@ class sfp_event:
     def _get_transceiver_status(self):
         if smbus_present == 0:
             sonic_logger.log_info("  PMON - smbus ERROR - DEBUG sfp_event   ")
-            cmdstatus, sfpstatus = cmd.getstatusoutput('sudo i2cget -y 0 0x41 0x3')
+            cmdstatus, sfpstatus = getstatusoutput_noshell(['sudo', 'i2cget', '-y', '0', '0x41', '0x3'])
             sfpstatus = int(sfpstatus, 16)
         else:
             bus = smbus.SMBus(0)


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Dependency: [https://github.com/sonic-net/sonic-buildimage/pull/12065](https://github.com/sonic-net/sonic-buildimage/pull/12065)
#### Why I did it
`subprocess.Popen()` and `subprocess.run()` is used with `shell=True`, which is very dangerous for shell injection.
`os` - not secure against maliciously constructed input and dangerous if used to evaluate dynamic content
`getstatusoutput` is dangerous because it contains `shell=True` in the implementation
#### How I did it
Replace `os` by `subprocess`, use with `shell=False`
Remove unused functions
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [X] 201911
- [X] 202006
- [X] 202012
- [X] 202106
- [X] 202111
- [X] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - [PR#2174](https://github.com/sonic-net/sonic-utilities/pull/2174) where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

