### PR TITLE
[device/wistron] Replace os.system and remove subprocess with shell=True

### DIFF
--- a/device/wistron/x86_64-wistron_6512_32r-r0/sonic_platform/chassis.py
+++ b/device/wistron/x86_64-wistron_6512_32r-r0/sonic_platform/chassis.py
@@ -75,7 +75,7 @@ class Chassis(ChassisBase):
         self._eeprom = Tlv()
 
     def __is_host(self):
-        return subprocess.run(HOST_CHK_CMD).returncode == 0
+        return subprocess.call(HOST_CHK_CMD) == 0
 
     def __read_txt_file(self, file_path):
         try:

--- a/device/wistron/x86_64-wistron_6512_32r-r0/sonic_platform/chassis.py
+++ b/device/wistron/x86_64-wistron_6512_32r-r0/sonic_platform/chassis.py
@@ -8,7 +8,6 @@
 #############################################################################
 try:
     import sys
-    import os
     import time
     import subprocess
     from sonic_platform_base.chassis_base import ChassisBase
@@ -23,9 +22,9 @@ HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
 PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
-HOST_CHK_CMD = "docker > /dev/null 2>&1"
-GET_HWSKU_CMD = "sonic-cfggen -d -v DEVICE_METADATA.localhost.hwsku"
-GET_PLATFORM_CMD = "sonic-cfggen -d -v DEVICE_METADATA.localhost.platform"
+HOST_CHK_CMD = ["docker"]
+GET_HWSKU_CMD = ["sonic-cfggen", "-d", "-v", "DEVICE_METADATA.localhost.hwsku"]
+GET_PLATFORM_CMD = ["sonic-cfggen", "-d", "-v", "DEVICE_METADATA.localhost.platform"]
 
 class Chassis(ChassisBase):
     """Platform-specific Chassis class"""
@@ -76,7 +75,7 @@ class Chassis(ChassisBase):
         self._eeprom = Tlv()
 
     def __is_host(self):
-        return os.system(HOST_CHK_CMD) == 0
+        return subprocess.run(HOST_CHK_CMD).returncode == 0
 
     def __read_txt_file(self, file_path):
         try:
@@ -141,12 +140,12 @@ class Chassis(ChassisBase):
         return (reboot_cause, description)
 
     def _get_sku_name(self):
-        p = subprocess.Popen(GET_HWSKU_CMD, shell=True, stdout=subprocess.PIPE)
+        p = subprocess.Popen(GET_HWSKU_CMD, stdout=subprocess.PIPE)
         out, err = p.communicate()
         return out.decode().rstrip('\n')
 
     def _get_platform_name(self):
-        p = subprocess.Popen(GET_PLATFORM_CMD, shell=True, stdout=subprocess.PIPE)
+        p = subprocess.Popen(GET_PLATFORM_CMD, stdout=subprocess.PIPE)
         out, err = p.communicate()
         return out.decode().rstrip('\n')
 
@@ -206,7 +205,7 @@ class Chassis(ChassisBase):
                         port_dict[port] = '0'
 
             self._transceiver_presence = cur_presence
-            if change_event == True:
+            if change_event is True:
                 break
 
             if not forever:


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`subprocess.Popen()` and `subprocess.run()` is used with `shell=True`, which is very dangerous for shell injection.
`os` - not secure against maliciously constructed input and dangerous if used to evaluate dynamic content
#### How I did it
Replace `os` by `subprocess`
Remove `shell=True`, use `shell=False`
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [X] 201911
- [X] 202006
- [X] 202012
- [X] 202106
- [X] 202111
- [X] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - [PR#2174](https://github.com/sonic-net/sonic-utilities/pull/2174) where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

