### PR TITLE
[device/common] Replace eval function

### DIFF
--- a/device/common/pddf/plugins/fanutil.py
+++ b/device/common/pddf/plugins/fanutil.py
@@ -11,6 +11,7 @@
 
 import os.path
 import sys
+import ast
 sys.path.append('/usr/share/sonic/platform/plugins')
 import pddfparse
 import json
@@ -170,7 +171,7 @@ class FanUtil(FanBase):
             print("Setting fan speed is not allowed !")
             return False
         else:
-            duty_cycle_to_pwm = eval(plugin_data['FAN']['duty_cycle_to_pwm'])
+            duty_cycle_to_pwm = ast.literal_eval(plugin_data['FAN']['duty_cycle_to_pwm'])
             pwm = duty_cycle_to_pwm(val)
             print("New Speed: %d%% - PWM value to be set is %d\n" % (val, pwm))
 


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`eval()` - not secure against maliciously constructed input, can be dangerous if used to evaluate dynamic content. This may be a code injection vulnerability.
#### How I did it
`eval()` - use `literal_eval()`
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [X] 201911
- [X] 202006
- [X] 202012
- [X] 202106
- [X] 202111
- [X] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

