### PR TITLE
[netberg] Replace os.system

### DIFF
--- a/platform/barefoot/sonic-platform-modules-netberg/aurora-610/sonic_platform/component.py
+++ b/platform/barefoot/sonic-platform-modules-netberg/aurora-610/sonic_platform/component.py
@@ -4,7 +4,7 @@ try:
     import os
     import re
     import logging
-    from subprocess import Popen, PIPE
+    from subprocess import run, Popen, PIPE
     from sonic_platform_base.component_base import ComponentBase
 
 except ImportError as e:
@@ -39,10 +39,10 @@ COMPONENT_DESC_LIST = [
 
 
 FW_INSTALL_CMD_LIST = [
-    "/usr/share/sonic/platform/plugins/cpld -b 1 -s 0x60 {}",
-    "/usr/share/sonic/platform/plugins/Yafuflash -cd {} -img-select 3 -non-interactive",
-    "/usr/share/sonic/platform/plugins/afulnx_64 {} /B /P /N /K",
-    "/usr/share/sonic/platform/plugins/afulnx_64 {} /B /P /N /K",
+    ["/usr/share/sonic/platform/plugins/cpld", "-b", "1", "-s", "0x60", ""],
+    ["/usr/share/sonic/platform/plugins/Yafuflash", "-cd", "", "-img-select", "3", "-non-interactive"],
+    ["/usr/share/sonic/platform/plugins/afulnx_64", "", "/B", "/P", "/N", "/K"],
+    ["/usr/share/sonic/platform/plugins/afulnx_64", "", "/B", "/P", "/N", "/K"],
 ]
 
 BIOS_ID_MAPPING_TABLE = {
@@ -157,11 +157,20 @@ class Component(ComponentBase):
 
         return bios_version
 
+    def __get_cmd(self, image_path):
+        if self.index == 0:
+            FW_INSTALL_CMD_LIST[self.index][5] = image_path
+        elif self.index == 1:
+            FW_INSTALL_CMD_LIST[self.index][2] = image_path
+        elif self.index == 2 or self.index == 3:
+            FW_INSTALL_CMD_LIST[self.index][1] = image_path
+        return FW_INSTALL_CMD_LIST
+
     def __install_cpld_firmware(self, image_path):
         result = False
-        cmd = FW_INSTALL_CMD_LIST[self.index].format(image_path)
+        cmd = self.__get_cmd(image_path)
 
-        ret = os.system(cmd)
+        ret = run(cmd).returncode
         if ret == OS_SYSTEM_SUCCESS:
             result = True
 
@@ -169,9 +178,9 @@ class Component(ComponentBase):
 
     def __install_bmc_firmware(self, image_path):
         result = False
-        cmd = FW_INSTALL_CMD_LIST[self.index].format(image_path)
+        cmd = self.__get_cmd(image_path)
 
-        ret = os.system(cmd)
+        ret = run(cmd).returncode
         if ret == OS_SYSTEM_SUCCESS:
             result = True
         return result
@@ -200,8 +209,8 @@ class Component(ComponentBase):
                 logging.error("Not support BIOS index %d", self.index)
 
             if ret:
-                cmd = FW_INSTALL_CMD_LIST[self.index].format(image_path)
-                ret = os.system(cmd)
+                cmd = self.__get_cmd(image_path)
+                ret = run(cmd).returncode
                 if ret == OS_SYSTEM_SUCCESS:
                     result = True
                 else:

--- a/platform/barefoot/sonic-platform-modules-netberg/aurora-610/sonic_platform/component.py
+++ b/platform/barefoot/sonic-platform-modules-netberg/aurora-610/sonic_platform/component.py
@@ -4,7 +4,7 @@ try:
     import os
     import re
     import logging
-    from subprocess import run, Popen, PIPE
+    from subprocess import call, Popen, PIPE
     from sonic_platform_base.component_base import ComponentBase
 
 except ImportError as e:
@@ -170,7 +170,7 @@ class Component(ComponentBase):
         result = False
         cmd = self.__get_cmd(image_path)
 
-        ret = run(cmd).returncode
+        ret = call(cmd)
         if ret == OS_SYSTEM_SUCCESS:
             result = True
 
@@ -180,7 +180,7 @@ class Component(ComponentBase):
         result = False
         cmd = self.__get_cmd(image_path)
 
-        ret = run(cmd).returncode
+        ret = call(cmd)
         if ret == OS_SYSTEM_SUCCESS:
             result = True
         return result
@@ -210,7 +210,7 @@ class Component(ComponentBase):
 
             if ret:
                 cmd = self.__get_cmd(image_path)
-                ret = run(cmd).returncode
+                ret = call(cmd)
                 if ret == OS_SYSTEM_SUCCESS:
                     result = True
                 else:

--- a/platform/barefoot/sonic-platform-modules-netberg/aurora-610/sonic_platform/qsfp.py
+++ b/platform/barefoot/sonic-platform-modules-netberg/aurora-610/sonic_platform/qsfp.py
@@ -132,7 +132,7 @@ class QSfp(SfpBase):
         return True
 
     def __is_host(self):
-        return subprocess.run(["docker"]).returncode == 0
+        return subprocess.call(["docker"]) == 0
 
     def __get_path_to_port_config_file(self):
         host_platform_root_path = '/usr/share/sonic/device'

--- a/platform/barefoot/sonic-platform-modules-netberg/aurora-610/sonic_platform/qsfp.py
+++ b/platform/barefoot/sonic-platform-modules-netberg/aurora-610/sonic_platform/qsfp.py
@@ -8,6 +8,7 @@
 try:
     import os
     import logging
+    import subprocess
     from ctypes import create_string_buffer
     from sonic_platform_base.sfp_base import SfpBase
     from sonic_platform_base.sonic_sfp.sff8436 import sff8436Dom
@@ -131,7 +132,7 @@ class QSfp(SfpBase):
         return True
 
     def __is_host(self):
-        return os.system("docker > /dev/null 2>&1") == 0
+        return subprocess.run(["docker"]).returncode == 0
 
     def __get_path_to_port_config_file(self):
         host_platform_root_path = '/usr/share/sonic/device'

--- a/platform/barefoot/sonic-platform-modules-netberg/aurora-610/sonic_platform/sfp.py
+++ b/platform/barefoot/sonic-platform-modules-netberg/aurora-610/sonic_platform/sfp.py
@@ -116,7 +116,7 @@ class Sfp(SfpBase):
         return True
 
     def __is_host(self):
-        return subprocess.run(["docker"]).returncode == 0
+        return subprocess.call(["docker"]) == 0
 
     def __get_path_to_port_config_file(self):
         host_platform_root_path = '/usr/share/sonic/device'

--- a/platform/barefoot/sonic-platform-modules-netberg/aurora-610/sonic_platform/sfp.py
+++ b/platform/barefoot/sonic-platform-modules-netberg/aurora-610/sonic_platform/sfp.py
@@ -9,6 +9,7 @@
 try:
     import os
     import logging
+    import subprocess
     from ctypes import create_string_buffer
     from sonic_platform_base.sfp_base import SfpBase
     from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
@@ -115,7 +116,7 @@ class Sfp(SfpBase):
         return True
 
     def __is_host(self):
-        return os.system("docker > /dev/null 2>&1") == 0
+        return subprocess.run(["docker"]).returncode == 0
 
     def __get_path_to_port_config_file(self):
         host_platform_root_path = '/usr/share/sonic/device'


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`os` - not secure against maliciously constructed input and dangerous if used to evaluate dynamic content
#### How I did it
Replace `os` by `subprocess`
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [X] 201911
- [X] 202006
- [X] 202012
- [X] 202106
- [X] 202111
- [X] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

