### PR TITLE
[ruijie] Replace os.system and remove subprocess with shell=True

### DIFF
--- a/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_pcie/pcie_common.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_pcie/pcie_common.py
@@ -37,14 +37,14 @@ class PcieUtil(PcieBase):
         pciList = []
         p1 = "^(\w+):(\w+)\.(\w)\s(.*)\s*\(*.*\)*"
         p2 = "^.*:.*:.*:(\w+)\s*\(*.*\)*"
-        command1 = "sudo lspci"
-        command2 = "sudo lspci -n"
+        command1 = ["sudo", "lspci"]
+        command2 = ["sudo", "lspci", "-n"]
         # run command 1
-        proc1 = subprocess.Popen(command1, shell=True, universal_newlines=True, stdout=subprocess.PIPE)
+        proc1 = subprocess.Popen(command1, universal_newlines=True, stdout=subprocess.PIPE)
         output1 = proc1.stdout.readlines()
         proc1.communicate()
         # run command 2
-        proc2 = subprocess.Popen(command2, shell=True, universal_newlines=True, stdout=subprocess.PIPE)
+        proc2 = subprocess.Popen(command2, universal_newlines=True, stdout=subprocess.PIPE)
         output2 = proc2.stdout.readlines()
         proc2.communicate()
 

--- a/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_platform/chassis.py
@@ -417,7 +417,8 @@ class Chassis(ChassisBase):
         if regval is None:
             print("Invaild color input.")
             return False
-        ret , log = getstatusoutput_noshell(self.set_sys_led_cmd.append(regval))
+        self.set_sys_led_cmd = ["i2cset", "-f", "-y", "2", "0x33", "0xb2", regval]
+        ret , log = getstatusoutput_noshell(self.set_sys_led_cmd)
         if ret != 0:
             print("Cannot execute %s" % self.set_sys_led_cmd + regval)
             return False

--- a/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_platform/chassis.py
@@ -417,8 +417,8 @@ class Chassis(ChassisBase):
         if regval is None:
             print("Invaild color input.")
             return False
-        self.set_sys_led_cmd = ["i2cset", "-f", "-y", "2", "0x33", "0xb2", regval]
-        ret , log = getstatusoutput_noshell(self.set_sys_led_cmd)
+        cmd = self.set_sys_led_cmd + [regval]
+        ret, log = getstatusoutput_noshell(cmd)
         if ret != 0:
             print("Cannot execute %s" % self.set_sys_led_cmd + regval)
             return False

--- a/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_platform/chassis.py
@@ -10,13 +10,13 @@
 
 try:
     import time
-    import subprocess
     from sonic_platform_base.chassis_base import ChassisBase
     from sonic_platform.common import Common
     from sonic_platform.sfp import Sfp
     from sonic_platform.sfp import PORT_START
     from sonic_platform.sfp import PORTS_IN_BLOCK
     from sonic_platform.logger import logger
+    from sonic_py_common.general import getstatusoutput_noshell
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -36,17 +36,17 @@ class Chassis(ChassisBase):
         self.SFP_STATUS_INSERTED = "1"
         self.SFP_STATUS_REMOVED = "0"
         self.port_dict = {}
-        self.enable_read= "i2cset -f -y 2 0x35 0x2a 0x01"
-        self.disable_read = "i2cset -f -y 2 0x35 0x2a 0x00"
-        self.enable_write = "i2cset -f -y 2 0x35 0x2b 0x00"
-        self.disable_write = "i2cset -f -y 2 0x35 0x2b 0x01"
-        self.enable_erase = "i2cset -f -y 2 0x35 0x2c 0x01"
-        self.disable_erase = "i2cset -f -y 2 0x35 0x2c 0x00"
-        self.read_value = "i2cget -f -y 2 0x35 0x25"
-        self.write_value = "i2cset -f -y 2 0x35 0x21 0x0a"
-        self.set_sys_led_cmd = "i2cset -f -y 2 0x33 0xb2 "
-        self.get_sys_led_cmd = "i2cget -f -y 2 0x33 0xb2"
-        self.led_status = "red"
+        self.enable_read= ["i2cset", "-f", "-y", "2", "0x35", "0x2a", "0x01"]
+        self.disable_read = ["i2cset", "-f", "-y", "2", "0x35", "0x2a", "0x00"]
+        self.enable_write = ["i2cset", "-f", "-y", "2", "0x35", "0x2b", "0x00"]
+        self.disable_write = ["i2cset", "-f", "-y", "2", "0x35", "0x2b", "0x01"]
+        self.enable_erase = ["i2cset", "-f", "-y", "2", "0x35", "0x2c", "0x01"]
+        self.disable_erase = ["i2cset", "-f", "-y", "2", "0x35", "0x2c", "0x00"]
+        self.read_value = ["i2cget", "-f", "-y", "2", "0x35", "0x25"]
+        self.write_value = ["i2cset", "-f", "-y", "2", "0x35", "0x21", "0x0a"]
+        self.set_sys_led_cmd = ["i2cset", "-f", "-y", "2", "0x33", "0xb2"]
+        self.get_sys_led_cmd = ["i2cget", "-f", "-y", "2", "0x33", "0xb2"]
+        self.led_status = "red" 
         # Initialize SFP list
         # sfp.py will read eeprom contents and retrive the eeprom data.
         # It will also provide support sfp controls like reset and setting
@@ -210,25 +210,25 @@ class Chassis(ChassisBase):
         try:
             is_power_loss = False
             # enable read
-            subprocess.getstatusoutput(self.disable_write)
-            subprocess.getstatusoutput(self.enable_read)
-            ret , log = subprocess.getstatusoutput(self.read_value)
+            getstatusoutput_noshell(self.disable_write)
+            getstatusoutput_noshell(self.enable_read)
+            ret , log = getstatusoutput_noshell(self.read_value)
             if ret == 0 and "0x0a" in log:
                 is_power_loss = True
 
             # erase i2c and e2
-            subprocess.getstatusoutput(self.enable_erase)
+            getstatusoutput_noshell(self.enable_erase)
             time.sleep(1)
-            subprocess.getstatusoutput(self.disable_erase)
+            getstatusoutput_noshell(self.disable_erase)
             # clear data
-            subprocess.getstatusoutput(self.enable_write)
-            subprocess.getstatusoutput(self.disable_read)
-            subprocess.getstatusoutput(self.disable_write)
-            subprocess.getstatusoutput(self.enable_read)
+            getstatusoutput_noshell(self.enable_write)
+            getstatusoutput_noshell(self.disable_read)
+            getstatusoutput_noshell(self.disable_write)
+            getstatusoutput_noshell(self.enable_read)
             # enable write and set data
-            subprocess.getstatusoutput(self.enable_write)
-            subprocess.getstatusoutput(self.disable_read)
-            subprocess.getstatusoutput(self.write_value)
+            getstatusoutput_noshell(self.enable_write)
+            getstatusoutput_noshell(self.disable_read)
+            getstatusoutput_noshell(self.write_value)
             if is_power_loss:
                 return(self.REBOOT_CAUSE_POWER_LOSS, None)
         except Exception as e:
@@ -417,7 +417,7 @@ class Chassis(ChassisBase):
         if regval is None:
             print("Invaild color input.")
             return False
-        ret , log = subprocess.getstatusoutput(self.set_sys_led_cmd + regval)
+        ret , log = getstatusoutput_noshell(self.set_sys_led_cmd.append(regval))
         if ret != 0:
             print("Cannot execute %s" % self.set_sys_led_cmd + regval)
             return False
@@ -431,7 +431,7 @@ class Chassis(ChassisBase):
             A string, one of the valid LED color strings which could be vendor
             specified.
         """
-        ret , log = subprocess.getstatusoutput(self.get_sys_led_cmd)
+        ret , log = getstatusoutput_noshell(self.get_sys_led_cmd)
         if ret != 0:
             print("Cannot execute %s" % self.get_sys_led_cmd)
             return False

--- a/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_platform/common.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_platform/common.py
@@ -1,6 +1,6 @@
 import os
 import yaml
-
+import subprocess
 from sonic_py_common import device_info
 
 
@@ -10,13 +10,13 @@ class Common:
     PMON_PLATFORM_PATH = '/usr/share/sonic/platform/'
     CONFIG_DIR = 'sonic_platform_config'
 
-    HOST_CHK_CMD = "docker > /dev/null 2>&1"
+    HOST_CHK_CMD = ["docker"]
 
     def __init__(self):
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
 
     def load_json_file(self, path):
         """

--- a/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_platform/common.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_platform/common.py
@@ -16,7 +16,7 @@ class Common:
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.run(self.HOST_CHK_CMD).returncode == 0
+        return subprocess.call(self.HOST_CHK_CMD) == 0
 
     def load_json_file(self, path):
         """

--- a/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_platform/component.py
@@ -8,10 +8,10 @@
 ########################################################################
 
 try:
-    import subprocess
     from sonic_platform_base.component_base import ComponentBase
     from sonic_platform.regutil import Reg
     from sonic_platform.logger import logger
+    from sonic_py_common.general import getstatusoutput_noshell
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -70,12 +70,12 @@ class Component(ComponentBase):
         """
         try:
             successtips = "CPLD Upgrade succeeded!"
-            status, output = subprocess.getstatusoutput("which firmware_upgrade")
+            status, output = getstatusoutput_noshell(["which", "firmware_upgrade"])
             if status or len(output) <= 0:
                 logger.error("no upgrade tool.")
                 return False
-            cmdstr = "%s %s cpld %d cpld"%(output,image_path,self.slot)
-            ret, log = subprocess.getstatusoutput(cmdstr)
+            cmdstr = [output, image_path, "cpld", self.slot, "cpld"]
+            ret, log = getstatusoutput_noshell(cmdstr)
             if ret == 0 and successtips in log:
                 return True
             logger.error("upgrade failed. ret:%d, log:\n%s" % (ret, log))

--- a/platform/broadcom/sonic-platform-modules-ruijie/common/lib/plat_hal/osutil.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/common/lib/plat_hal/osutil.py
@@ -6,7 +6,6 @@
 #
 #######################################################
 
-import subprocess
 import time
 import glob
 import re
@@ -14,6 +13,7 @@ import re
 from rjutil.smbus import SMBus
 import time
 from  functools import wraps
+from sonic_py_common.general import getstatusoutput_noshell
 
 
 def retry(maxretry =6, delay = 0.01):
@@ -80,13 +80,13 @@ class osutil(object):
 
     @staticmethod
     def command(cmdstr):
-        retcode, output = subprocess.getstatusoutput(cmdstr)
+        retcode, output = getstatusoutput_noshell(cmdstr)
         return retcode, output
 
 
     @staticmethod
     def geti2cword_i2ctool(bus, addr, offset):
-        command_line = "i2cget -f -y %d 0x%02x 0x%02x  wp" % (bus, addr, offset)
+        command_line = ["i2cget", "-f", "-y", str(bus), "0x"+"%02x"%addr, "0x"+"%02x"%offset, "wp"]
         retrytime = 6
         ret_t = ""
         for i in range(retrytime):
@@ -99,7 +99,7 @@ class osutil(object):
 
     @staticmethod
     def seti2cword_i2ctool(bus, addr, offset, val):
-        command_line = "i2cset -f -y %d 0x%02x 0x%0x 0x%04x wp" % (bus, addr, offset, val)
+        command_line = ["i2cset", "-f", "-y", str(bus), "0x"+"%02x"%addr, "0x"+"%0x"%offset, "0x"+"%04x"%val, "wp"]
         retrytime = 6
         ret_t = ""
         for i in range(retrytime):
@@ -111,7 +111,7 @@ class osutil(object):
 
     @staticmethod
     def rji2cget_i2ctool(bus, devno, address):
-        command_line = "i2cget -f -y %d 0x%02x 0x%02x " % (bus, devno, address)
+        command_line = ["i2cget", "-f", "-y", str(bus), "0x"+"%02x"%devno, "0x"+"%02x"%address]
         retrytime = 6
         ret_t = ""
         for i in range(retrytime):
@@ -123,8 +123,7 @@ class osutil(object):
 
     @staticmethod
     def rji2cset_i2ctool(bus, devno, address, byte):
-        command_line = "i2cset -f -y %d 0x%02x 0x%02x 0x%02x" % (
-            bus, devno, address, byte)
+        command_line = ["i2cset", "-f", "-y", str(bus), "0x"+"%02x"%devno, "0x"+"%02x"%address, "0x"+"%02x"%byte]
         retrytime = 6
         ret_t = ""
         for i in range(retrytime):
@@ -166,7 +165,7 @@ class osutil(object):
 
     @staticmethod
     def getdevmem(addr, digit, mask):
-        command_line = "devmem 0x%02x %d" %(addr, digit)
+        command_line = ["devmem", "0x"+"%02x"%addr, str(digit)]
         retrytime = 6
         ret_t = ""
         for i in range(retrytime):
@@ -179,13 +178,13 @@ class osutil(object):
 
     @staticmethod
     def rj_os_system(cmd):
-        status, output = subprocess.getstatusoutput(cmd)
+        status, output = getstatusoutput_noshell(cmd)
         return status, output
 
     @staticmethod
     def getsdkreg(reg):
         try:
-            cmd = "bcmcmd -t 1 'getr %s ' < /dev/null" % reg
+            cmd = ["bcmcmd", "-t", "1", "getr"+str(reg)]
             ret, result = osutil.rj_os_system(cmd)
             result_t = result.strip().replace("\r", "").replace("\n", "")
             if ret != 0 or "Error:" in result_t:
@@ -203,8 +202,8 @@ class osutil(object):
             result = {}
             #waitForDocker()
             #need to exec twice
-            osutil.rj_os_system("bcmcmd -t 1 \"show temp\" < /dev/null")
-            ret, log = osutil.rj_os_system("bcmcmd -t 1 \"show temp\" < /dev/null")
+            osutil.rj_os_system(["bcmcmd", "-t", "1", "show temp"])
+            ret, log = osutil.rj_os_system(["bcmcmd", "-t", "1", "show temp"])
             if ret:
                 return False, result
             else:

--- a/platform/broadcom/sonic-platform-modules-ruijie/common/lib/plat_hal/osutil.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/common/lib/plat_hal/osutil.py
@@ -99,7 +99,7 @@ class osutil(object):
 
     @staticmethod
     def seti2cword_i2ctool(bus, addr, offset, val):
-        command_line = ["i2cset", "-f", "-y", str(bus), "0x"+"%02x"%addr, "0x"+"%0x"%offset, "0x"+"%04x"%val, "wp"]
+        command_line = ["i2cset", "-f", "-y", str(bus), "0x%02x"%addr, "0x%0x"%offset, "0x%04x"%val, "wp"]
         retrytime = 6
         ret_t = ""
         for i in range(retrytime):
@@ -111,7 +111,7 @@ class osutil(object):
 
     @staticmethod
     def rji2cget_i2ctool(bus, devno, address):
-        command_line = ["i2cget", "-f", "-y", str(bus), "0x"+"%02x"%devno, "0x"+"%02x"%address]
+        command_line = ["i2cget", "-f", "-y", str(bus), "0x%02x"%devno, "0x%02x"%address]
         retrytime = 6
         ret_t = ""
         for i in range(retrytime):
@@ -123,7 +123,7 @@ class osutil(object):
 
     @staticmethod
     def rji2cset_i2ctool(bus, devno, address, byte):
-        command_line = ["i2cset", "-f", "-y", str(bus), "0x"+"%02x"%devno, "0x"+"%02x"%address, "0x"+"%02x"%byte]
+        command_line = ["i2cset", "-f", "-y", str(bus), "0x%02x"%devno, "0x%02x"%address, "0x%02x"%byte]
         retrytime = 6
         ret_t = ""
         for i in range(retrytime):
@@ -165,7 +165,7 @@ class osutil(object):
 
     @staticmethod
     def getdevmem(addr, digit, mask):
-        command_line = ["devmem", "0x"+"%02x"%addr, str(digit)]
+        command_line = ["devmem", "0x%02x"%addr, str(digit)]
         retrytime = 6
         ret_t = ""
         for i in range(retrytime):

--- a/platform/broadcom/sonic-platform-modules-ruijie/common/lib/plat_hal/osutil.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/common/lib/plat_hal/osutil.py
@@ -86,7 +86,7 @@ class osutil(object):
 
     @staticmethod
     def geti2cword_i2ctool(bus, addr, offset):
-        command_line = ["i2cget", "-f", "-y", str(bus), "0x"+"%02x"%addr, "0x"+"%02x"%offset, "wp"]
+        command_line = ["i2cget", "-f", "-y", str(bus), "0x%02x"%addr, "0x%02x"%offset, "wp"]
         retrytime = 6
         ret_t = ""
         for i in range(retrytime):

--- a/platform/broadcom/sonic-platform-modules-ruijie/common/script/device_i2c.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/common/script/device_i2c.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import time
 from  ruijieconfig import GLOBALCONFIG, GLOBALINITPARAM, GLOBALINITCOMMAND, MAC_LED_RESET, STARTMODULE, i2ccheck_params
-
+from sonic_py_common.general import getstatusoutput_noshell, getstatusoutput_noshell_pipe
 from  ruijieutil   import rjpciwr
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
@@ -46,7 +46,7 @@ def write_sysfs_value(reg_name, value):
 
 def check_driver():
     u'''whether there is driver start with rg'''
-    status, output = log_os_system("lsmod | grep rg | wc -l")
+    status, output = getstatusoutput_noshell(["lsmod"], ["grep", "rg"], ["wc", "-l"])
     #System execution error
     if status: 
         return False
@@ -70,61 +70,59 @@ def i2c_getPid(name):
     return ret
 
 def startAvscontrol():
-    cmd = "nohup avscontrol.py start >/dev/null 2>&1 &"
+    cmd = ["nohup", "avscontrol.py", "start"]
     rets = i2c_getPid("avscontrol.py")
     if len(rets) == 0:
-        os.system(cmd)
+        subprocess.run(cmd).returncode
 
 def startFanctrol():
     if STARTMODULE['fancontrol'] == 1:
-        cmd = "nohup fancontrol.py start >/dev/null 2>&1 &"
+        cmd = ["nohup", "fancontrol.py", "start"]
         rets = i2c_getPid("fancontrol.py")
         if len(rets) == 0:
-            os.system(cmd)
+            subprocess.run(cmd).returncode
 
 def starthal_fanctrl():
     if STARTMODULE.get('hal_fanctrl',0) == 1:
-        cmd = "nohup hal_fanctrl.py start >/dev/null 2>&1 &"
+        cmd = ["nohup", "hal_fanctrl.py", "start"]
         rets = i2c_getPid("hal_fanctrl.py")
         if len(rets) == 0:
-            os.system(cmd)
+            subprocess.run(cmd).returncode
 
 def starthal_ledctrl():
     if STARTMODULE.get('hal_ledctrl',0) == 1:
-        cmd = "nohup hal_ledctrl.py start >/dev/null 2>&1 &"
+        cmd = ["nohup", "hal_ledctrl.py", "start"]
         rets = i2c_getPid("hal_ledctrl.py")
         if len(rets) == 0:
-            os.system(cmd)
-
+            subprocess.run(cmd).returncode
 def startDevmonitor():
     if STARTMODULE.get('dev_monitor',0) == 1:
-        cmd = "nohup dev_monitor.py start >/dev/null 2>&1 &"
+        cmd = ["nohup", "dev_monitor.py", "start"]
         rets = i2c_getPid("dev_monitor.py")
         if len(rets) == 0:
-            os.system(cmd)
-
+            subprocess.run(cmd).returncode
 def startSlotmonitor():
     if STARTMODULE.get('slot_monitor',0) == 1:
-        cmd = "nohup slot_monitor.py start >/dev/null 2>&1 &"
+        cmd = ["nohup", "slot_monitor.py", "start"]
         rets = i2c_getPid("slot_monitor.py")
         if len(rets) == 0:
-            os.system(cmd)
+            subprocess.run(cmd).returncode
 
 def stopFanctrol():
     u'''disable fan timer service'''
     if STARTMODULE['fancontrol'] == 1:
         rets = i2c_getPid("fancontrol.py")  #
         for ret in rets:
-            cmd = "kill "+ ret
-            os.system(cmd)
+            cmd = ["kill", ret]
+            subprocess.run(cmd).returncode
         return True
 
 def stophal_ledctrl():
     if STARTMODULE.get('hal_ledctrl',0) == 1:
         rets = i2c_getPid("hal_ledctrl.py")
         for ret in rets:
-            cmd = "kill "+ ret
-            os.system(cmd)
+            cmd = ["kill", ret]
+            subprocess.run(cmd).returncode
         return True
 
 
@@ -133,8 +131,8 @@ def stopDevmonitor():
     if STARTMODULE.get('dev_monitor',0) == 1:
         rets = i2c_getPid("dev_monitor.py")  #
         for ret in rets:
-            cmd = "kill "+ ret
-            os.system(cmd)
+            cmd = ["kill", ret]
+            subprocess.run(cmd).returncode
         return True
 
 def stopSlotmonitor():
@@ -142,15 +140,16 @@ def stopSlotmonitor():
     if STARTMODULE.get('slot_monitor',0) == 1:
         rets = i2c_getPid("slot_monitor.py")  #
         for ret in rets:
-            cmd = "kill "+ ret
-            os.system(cmd)
+            cmd = ["kill", ret]
+            subprocess.run(cmd).returncode
         return True
 
 def removeDev(bus, loc):
-    cmd = "echo  0x%02x > /sys/bus/i2c/devices/i2c-%d/delete_device" % (loc, bus)
     devpath = "/sys/bus/i2c/devices/%d-%04x"%(bus, loc)
     if os.path.exists(devpath):
-        log_os_system(cmd)
+        file = "/sys/bus/i2c/devices/i2c-%d/delete_device" % bus
+        with open(file, 'w') as f:
+            f.write('0x'+'%02x'%str(bus)+'\n')
         
 def addDev(name, bus, loc):
     if name == "lm75":
@@ -166,7 +165,9 @@ def addDev(name, bus, loc):
     cmd = "echo  %s 0x%02x > /sys/bus/i2c/devices/i2c-%d/new_device" % (name, loc, bus)
     devpath = "/sys/bus/i2c/devices/%d-%04x"%(bus, loc)
     if os.path.exists(devpath) == False:
-        os.system(cmd)
+        file = "/sys/bus/i2c/devices/i2c-%d/new_device" % bus
+        with open(file, 'w') as f:
+            f.write('%s 0x%02x' % (name, loc) + '\n')
 
 def removedevs():
     devs = GLOBALCONFIG["DEVS"]
@@ -179,8 +180,7 @@ def adddevs():
         addDev(devs[dev]["name"], devs[dev]["bus"] , devs[dev]["loc"])
 
 def checksignaldriver(name):
-    modisexistcmd = "lsmod | grep %s | wc -l" % name
-    status, output = log_os_system(modisexistcmd)
+    status, output = getstatusoutput_noshell_pipe(["lsmod"], ["grep", name], ["wc", "-l"])
     #System execution error
     if status: 
         return False
@@ -190,17 +190,17 @@ def checksignaldriver(name):
         return False
 
 def adddriver(name, delay):
-    cmd = "modprobe %s" % name
+    cmd = ["modprobe", name]
     if delay != 0:
         time.sleep(delay)
     if checksignaldriver(name) != True:
-        log_os_system(cmd)
+        getstatusoutput_noshell(cmd)
 
 def removedriver(name, delay):
     realname = name.lstrip().split(" ")[0];
-    cmd = "rmmod -f %s" % realname
+    cmd = ["rmmod", "-f", realname]
     if checksignaldriver(realname):
-        log_os_system(cmd)
+        getstatusoutput_noshell(cmd)
 
 def removedrivers():
     u'''remove all drivers'''

--- a/platform/broadcom/sonic-platform-modules-ruijie/common/script/device_i2c.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/common/script/device_i2c.py
@@ -70,43 +70,43 @@ def i2c_getPid(name):
     return ret
 
 def startAvscontrol():
-    cmd = ["nohup", "avscontrol.py", "start"]
+    cmd = ["avscontrol.py", "start"]
     rets = i2c_getPid("avscontrol.py")
     if len(rets) == 0:
-        subprocess.run(cmd).returncode
+        subprocess.Popen(cmd)
 
 def startFanctrol():
     if STARTMODULE['fancontrol'] == 1:
-        cmd = ["nohup", "fancontrol.py", "start"]
+        cmd = ["fancontrol.py", "start"]
         rets = i2c_getPid("fancontrol.py")
         if len(rets) == 0:
-            subprocess.run(cmd).returncode
+            subprocess.Popen(cmd)
 
 def starthal_fanctrl():
     if STARTMODULE.get('hal_fanctrl',0) == 1:
-        cmd = ["nohup", "hal_fanctrl.py", "start"]
+        cmd = ["hal_fanctrl.py", "start"]
         rets = i2c_getPid("hal_fanctrl.py")
         if len(rets) == 0:
-            subprocess.run(cmd).returncode
+            subprocess.Popen(cmd)
 
 def starthal_ledctrl():
     if STARTMODULE.get('hal_ledctrl',0) == 1:
-        cmd = ["nohup", "hal_ledctrl.py", "start"]
+        cmd = ["hal_ledctrl.py", "start"]
         rets = i2c_getPid("hal_ledctrl.py")
         if len(rets) == 0:
-            subprocess.run(cmd).returncode
+            subprocess.Popen(cmd)
 def startDevmonitor():
     if STARTMODULE.get('dev_monitor',0) == 1:
-        cmd = ["nohup", "dev_monitor.py", "start"]
+        cmd = ["dev_monitor.py", "start"]
         rets = i2c_getPid("dev_monitor.py")
         if len(rets) == 0:
-            subprocess.run(cmd).returncode
+            subprocess.Popen(cmd)
 def startSlotmonitor():
     if STARTMODULE.get('slot_monitor',0) == 1:
-        cmd = ["nohup", "slot_monitor.py", "start"]
+        cmd = ["slot_monitor.py", "start"]
         rets = i2c_getPid("slot_monitor.py")
         if len(rets) == 0:
-            subprocess.run(cmd).returncode
+            subprocess.Popen(cmd)
 
 def stopFanctrol():
     u'''disable fan timer service'''
@@ -114,7 +114,7 @@ def stopFanctrol():
         rets = i2c_getPid("fancontrol.py")  #
         for ret in rets:
             cmd = ["kill", ret]
-            subprocess.run(cmd).returncode
+            subprocess.call(cmd)
         return True
 
 def stophal_ledctrl():
@@ -122,7 +122,7 @@ def stophal_ledctrl():
         rets = i2c_getPid("hal_ledctrl.py")
         for ret in rets:
             cmd = ["kill", ret]
-            subprocess.run(cmd).returncode
+            subprocess.call(cmd)
         return True
 
 
@@ -132,7 +132,7 @@ def stopDevmonitor():
         rets = i2c_getPid("dev_monitor.py")  #
         for ret in rets:
             cmd = ["kill", ret]
-            subprocess.run(cmd).returncode
+            subprocess.call(cmd)
         return True
 
 def stopSlotmonitor():
@@ -141,7 +141,7 @@ def stopSlotmonitor():
         rets = i2c_getPid("slot_monitor.py")  #
         for ret in rets:
             cmd = ["kill", ret]
-            subprocess.run(cmd).returncode
+            subprocess.call(cmd)
         return True
 
 def removeDev(bus, loc):
@@ -149,7 +149,7 @@ def removeDev(bus, loc):
     if os.path.exists(devpath):
         file = "/sys/bus/i2c/devices/i2c-%d/delete_device" % bus
         with open(file, 'w') as f:
-            f.write('0x'+'%02x'%str(bus)+'\n')
+            f.write('0x%02x'%str(bus)+'\n')
         
 def addDev(name, bus, loc):
     if name == "lm75":
@@ -162,7 +162,6 @@ def addDev(name, bus, loc):
         if i % 10 == 0:
             click.echo("%%DEVICE_I2C-INIT: %s not found, wait 0.1 second ! i %d " % (pdevpath,i))
             
-    cmd = "echo  %s 0x%02x > /sys/bus/i2c/devices/i2c-%d/new_device" % (name, loc, bus)
     devpath = "/sys/bus/i2c/devices/%d-%04x"%(bus, loc)
     if os.path.exists(devpath) == False:
         file = "/sys/bus/i2c/devices/i2c-%d/new_device" % bus

--- a/platform/broadcom/sonic-platform-modules-ruijie/common/script/device_i2c.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/common/script/device_i2c.py
@@ -46,7 +46,7 @@ def write_sysfs_value(reg_name, value):
 
 def check_driver():
     u'''whether there is driver start with rg'''
-    status, output = getstatusoutput_noshell(["lsmod"], ["grep", "rg"], ["wc", "-l"])
+    status, output = getstatusoutput_noshell_pipe(["lsmod"], ["grep", "rg"], ["wc", "-l"])
     #System execution error
     if status: 
         return False
@@ -149,7 +149,7 @@ def removeDev(bus, loc):
     if os.path.exists(devpath):
         file = "/sys/bus/i2c/devices/i2c-%d/delete_device" % bus
         with open(file, 'w') as f:
-            f.write('0x%02x'%str(bus)+'\n')
+            f.write('0x%02x\n'%str(bus))
         
 def addDev(name, bus, loc):
     if name == "lm75":
@@ -166,7 +166,7 @@ def addDev(name, bus, loc):
     if os.path.exists(devpath) == False:
         file = "/sys/bus/i2c/devices/i2c-%d/new_device" % bus
         with open(file, 'w') as f:
-            f.write('%s 0x%02x' % (name, loc) + '\n')
+            f.write('%s 0x%02x\n' % (name, loc))
 
 def removedevs():
     devs = GLOBALCONFIG["DEVS"]

--- a/platform/broadcom/sonic-platform-modules-ruijie/common/script/fancontrol.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/common/script/fancontrol.py
@@ -767,7 +767,7 @@ class FanControl(object):
                     self.fanSpeedSetMax()  # fan full speed
                     self.critnum += 1 # anti-shake
                     if self.critnum >= MONITOR_CONST.CRITICAL_NUM:
-                        subprocess.run(["reboot"])
+                        subprocess.call(["reboot"])
                     fanwarningdebuglog(DEBUG_FANCONTROL,"crit次数:%d" % self.critnum)
                 else:
                     self.critnum = 0

--- a/platform/broadcom/sonic-platform-modules-ruijie/common/script/fancontrol.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/common/script/fancontrol.py
@@ -4,6 +4,7 @@ import click
 import os
 import time
 import syslog
+import subprocess
 from ruijieconfig import MONITOR_CONST, FANCTROLDEBUG, MONITOR_FANS_LED, DEV_LEDS, MONITOR_PSU_STATUS, \
         MONITOR_SYS_PSU_LED, MONITOR_DEV_STATUS, MONITOR_FAN_STATUS, MONITOR_DEV_STATUS_DECODE, \
         MONITOR_SYS_FAN_LED, MONITOR_SYS_LED, fanloc
@@ -766,7 +767,7 @@ class FanControl(object):
                     self.fanSpeedSetMax()  # fan full speed
                     self.critnum += 1 # anti-shake
                     if self.critnum >= MONITOR_CONST.CRITICAL_NUM:
-                       os.system("reboot")
+                        subprocess.run(["reboot"])
                     fanwarningdebuglog(DEBUG_FANCONTROL,"crit次数:%d" % self.critnum)
                 else:
                     self.critnum = 0

--- a/platform/broadcom/sonic-platform-modules-ruijie/common/script/ruijieutil.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/common/script/ruijieutil.py
@@ -1042,7 +1042,7 @@ def rjsysset(location, value):
             with open(location, 'w') as f:
                 f.write('0x'+'%02x'%value+'\n')
         except (IOError, FileNotFoundError):
-            return False, ''
+            return False, 'cannot write to file'
     return True, ''
 
 

--- a/platform/broadcom/sonic-platform-modules-ruijie/common/script/ruijieutil.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/common/script/ruijieutil.py
@@ -19,7 +19,6 @@ import termios
 import threading
 import click
 import mmap
-from shlex import split
 from sonic_py_common.general import getstatusoutput_noshell, getstatusoutput_noshell_pipe
 from ruijieconfig import rg_eeprom, FRULISTS, MAC_DEFAULT_PARAM, MAC_AVS_PARAM, FANS_DEF, \
         FAN_PROTECT, E2_LOC, E2_PROTECT, RUIJIE_SERVICE_TAG, RUIJIE_DIAG_VERSION, \
@@ -981,7 +980,7 @@ def generate_ext(cardid):
 
 
 def rji2cget(bus, devno, address):
-    command_line = ["i2cget", "-f", "-y", str(bus), "0x"+"%02x"%str(devno), "0x"+"%02x"%str(address)]
+    command_line = ["i2cget", "-f", "-y", str(bus), "0x%02x"%str(devno), "0x%02x"%str(address)]
     retrytime = 6
     ret_t = ""
     for i in range(retrytime):
@@ -993,7 +992,7 @@ def rji2cget(bus, devno, address):
 
 
 def rji2cset(bus, devno, address, byte):
-    command_line = ["i2cset", "-f", "-y", str(bus), "0x"+"%02x"%str(devno), "0x"+"%02x"%str(address), "0x"+"%02x"%str(byte)]
+    command_line = ["i2cset", "-f", "-y", str(bus), "0x%02x"%str(devno), "0x%02x"%str(address), "0x%02x"%str(byte)]
     retrytime = 6
     ret_t = ""
     for i in range(retrytime):
@@ -1034,20 +1033,18 @@ def rjpciwr(pcibus , slot ,fn, bar, offset, data):
     data.close()
 
 def rjsysset(location, value):
-    command_line = "echo 0x%02x > %s" % (value, location)
     retrytime = 6
-    ret_t = ""
     for i in range(retrytime):
         try:
             with open(location, 'w') as f:
-                f.write('0x'+'%02x'%value+'\n')
+                f.write('0x%02x\n'%value)
         except (IOError, FileNotFoundError) as e:
             return False, str(e)
     return True, ''
 
 
 def rji2cgetWord(bus, devno, address):
-    command_line = ["i2cget", "-f", "-y", str(bus), "0x"+"%02x"%str(devno), "0x"+"%02x"%str(address), "w"]
+    command_line = ["i2cget", "-f", "-y", str(bus), "0x%02x"%str(devno), "0x%02x"%str(address), "w"]
     retrytime = 3
     ret_t = ""
     for i in range(retrytime):
@@ -1058,7 +1055,7 @@ def rji2cgetWord(bus, devno, address):
 
 
 def rji2csetWord(bus, devno, address, byte):
-    command_line = ["i2cset", "-f", "-y", str(bus), "0x"+"%02x"%str(devno), "0x"+"%02x"%str(address), "0x"+"%x"%str(byte), "w"]
+    command_line = ["i2cset", "-f", "-y", str(bus), "0x%02x"%str(devno), "0x%02x"%str(address), "0x%x"%str(byte), "w"]
     getstatusoutput_noshell(command_line)
 
 
@@ -1674,7 +1671,7 @@ def getDmiSysByType(type_t):
     if ret != 0 or len(log) <= 0:
         error = "cmd find dmidecode"
         return False, error
-    cmd = split(log) + ["-t", str(type_t)]
+    cmd = [log[0].rstrip('\n')] + ["-t", str(type_t)]
     # get total number
     ret1, log1 = getstatusoutput_noshell(cmd)
     if ret1 != 0 or len(log1) <= 0:

--- a/platform/broadcom/sonic-platform-modules-ruijie/common/script/ruijieutil.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/common/script/ruijieutil.py
@@ -1041,8 +1041,8 @@ def rjsysset(location, value):
         try:
             with open(location, 'w') as f:
                 f.write('0x'+'%02x'%value+'\n')
-        except (IOError, FileNotFoundError):
-            return False, 'cannot write to file'
+        except (IOError, FileNotFoundError) as e:
+            return False, str(e)
     return True, ''
 
 
@@ -1616,7 +1616,7 @@ def getsysmeminfo():
     if ret != 0 or len(log) <= 0:
         error = "cmd find dmidecode"
         return False, error
-    cmd1 = split(log)
+    cmd1 = [log[0].rstrip('\n')]
     cmd2 = ["grep", "-P", "-A5", "Memory\s+Device"]
     cmd3 = ["grep", "Size"]
     cmd4 = ["grep", "-v", "Range"]
@@ -1646,7 +1646,7 @@ def getsysmeminfo_detail():
     if ret != 0 or len(log) <= 0:
         error = "cmd find dmidecode"
         return False, error
-    cmd1 = split(log) + ["-t", "17"]
+    cmd1 = [log[0].rstrip('\n')] + ["-t", "17"]
     cmd2 = ["grep", "-A21", "Memory Device"]  # 17
     # get total number
     ret1, log1 = getstatusoutput_noshell_pipe(cmd1, cmd2)

--- a/platform/broadcom/sonic-platform-modules-ruijie/common/script/ruijieutil.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/common/script/ruijieutil.py
@@ -11,7 +11,6 @@
 import sys
 import os
 import re
-import subprocess
 import syslog
 import time
 import binascii
@@ -20,6 +19,8 @@ import termios
 import threading
 import click
 import mmap
+from shlex import split
+from sonic_py_common.general import getstatusoutput_noshell, getstatusoutput_noshell_pipe
 from ruijieconfig import rg_eeprom, FRULISTS, MAC_DEFAULT_PARAM, MAC_AVS_PARAM, FANS_DEF, \
         FAN_PROTECT, E2_LOC, E2_PROTECT, RUIJIE_SERVICE_TAG, RUIJIE_DIAG_VERSION, \
         STARTMODULE, RUIJIE_CARDID, RUIJIE_PRODUCTNAME, RUIJIE_PART_NUMBER, \
@@ -538,8 +539,8 @@ class BMC():
 
 def getSdkReg(reg):
     try:
-        cmd = "bcmcmd -t 1 'getr %s ' < /dev/null" % reg
-        ret, result = rj_os_system(cmd)
+        cmd = ["bcmcmd", "-t", "1", "getr"+str(reg)]
+        ret, result = getstatusoutput_noshell(cmd)
         result_t = result.strip().replace("\r", "").replace("\n", "")
         if ret != 0 or "Error:" in result_t:
             return False, result
@@ -632,8 +633,8 @@ def getMacTemp():
     result = {}
     #waitForDocker()
     # exec twice, get the second result
-    rj_os_system("bcmcmd -t 1 \"show temp\" < /dev/null")
-    ret, log = rj_os_system("bcmcmd -t 1 \"show temp\" < /dev/null")
+    getstatusoutput_noshell(["bcmcmd", "-t", "1", "show temp"])
+    ret, log = getstatusoutput_noshell(["bcmcmd", "-t", "1", "show temp"])
     if ret:
         return False, result
     else:
@@ -689,21 +690,21 @@ def getMacTemp_sysfs(mactempconf):
 
 def restartDockerService(force=False):
     container_name = ["database","snmp","syncd","swss","dhcp_relay","radv","teamd","pmon"]
-    ret, status = rj_os_system("docker ps")
+    ret, status = getstatusoutput_noshell(["docker", "ps"])
     if ret == 0 :
         for tmpname in container_name:
             if (tmpname not in status):
                 if (force == True):
-                    rj_os_system("docker restart %s"%tmpname)
+                    getstatusoutput_noshell(["docker", "restart", tmpname])
                 else:
-                    rj_os_system("systemctl restart %s"%tmpname)
+                    getstatusoutput_noshell(["systemctl", "restart", tmpname])
 
 
 def waitForDhcp(timeout):
     time_cnt = 0
     while True:
         try:
-            ret, status = rj_os_system("systemctl status dhcp_relay.service")
+            ret, status = getstatusoutput_noshell(["systemctl", "status", "dhcp_relay.service"])
             if (ret == 0 and "running" in status)  or "SUCCESS" in status:
                 break
             else:
@@ -839,8 +840,10 @@ def util_setmac(eth, mac):
     rulefile = "/etc/udev/rules.d/70-persistent-net.rules"
     if isValidMac(mac) == False:
         return False, "MAC invaild"
-    cmd = "ethtool -e %s | grep 0x0010 | awk '{print \"0x\"$13$12$15$14}'" % eth
-    ret, log = rj_os_system(cmd)
+    cmd1 = ["ethtool", "-e", eth] 
+    cmd2 = ["grep", "0x0010"]
+    cmd3 = ["awk", '{print \"0x\"$13$12$15$14}']
+    ret, log = getstatusoutput_noshell_pipe(cmd1, cmd2, cmd3)
     log_debug(log)
     magic = ""
     if ret == 0 and len(log):
@@ -848,23 +851,22 @@ def util_setmac(eth, mac):
     macs = mac.upper().split(":")
 
     # chage ETH0 to value after setmac
-    ifconfigcmd = "ifconfig eth0 hw ether %s" % mac
-    log_debug(ifconfigcmd)
-    ret, status = rj_os_system(ifconfigcmd)
+    ifconfigcmd = ["ifconfig", "eth0", "hw", "ether", mac]
+    log_debug(' '.join(ifconfigcmd))
+    ret, status = getstatusoutput_noshell(ifconfigcmd)
     if ret:
         raise SETMACException("software set  Internet cardMAC error")
     index = 0
     for item in macs:
-        cmd = "ethtool -E %s magic %s offset %d value 0x%s" % (
-            eth, magic, index, item)
+        cmd = ["ethtool", "-E", eht, "magic", magic, "offset", str(index), "value", "0x"+item]
         log_debug(cmd)
         index += 1
-        ret, log = rj_os_system(cmd)
+        ret, log = getstatusoutput_noshell(cmd)
         if ret != 0:
             raise SETMACException(" set hardware Internet card MAC error")
     # get value after setting 
-    cmd_t = "ethtool -e eth0 offset 0 length 6"
-    ret, log = rj_os_system(cmd_t)
+    cmd_t = ["ethtool", "-e", "eth0", "offset", "0", "length", "6"]
+    ret, log = getstatusoutput_noshell(cmd_t)
     m = re.split(':', log)[-1].strip().upper()
     mac_result = m.upper().split(" ")
 
@@ -979,11 +981,11 @@ def generate_ext(cardid):
 
 
 def rji2cget(bus, devno, address):
-    command_line = "i2cget -f -y %d 0x%02x 0x%02x " % (bus, devno, address)
+    command_line = ["i2cget", "-f", "-y", str(bus), "0x"+"%02x"%str(devno), "0x"+"%02x"%str(address)]
     retrytime = 6
     ret_t = ""
     for i in range(retrytime):
-        ret, ret_t = rj_os_system(command_line)
+        ret, ret_t = getstatusoutput_noshell(command_line)
         if ret == 0:
             return True, ret_t
         time.sleep(0.1)
@@ -991,12 +993,11 @@ def rji2cget(bus, devno, address):
 
 
 def rji2cset(bus, devno, address, byte):
-    command_line = "i2cset -f -y %d 0x%02x 0x%02x 0x%02x" % (
-        bus, devno, address, byte)
+    command_line = ["i2cset", "-f", "-y", str(bus), "0x"+"%02x"%str(devno), "0x"+"%02x"%str(address), "0x"+"%02x"%str(byte)]
     retrytime = 6
     ret_t = ""
     for i in range(retrytime):
-        ret, ret_t = rj_os_system(command_line)
+        ret, ret_t = getstatusoutput_noshell(command_line)
         if ret == 0:
             return True, ret_t
     return False, ret_t
@@ -1037,27 +1038,28 @@ def rjsysset(location, value):
     retrytime = 6
     ret_t = ""
     for i in range(retrytime):
-        ret, ret_t = rj_os_system(command_line)
-        if ret == 0:
-            return True, ret_t
-    return False, ret_t
+        try:
+            with open(location, 'w') as f:
+                f.write('0x'+'%02x'%value+'\n')
+        except (IOError, FileNotFoundError):
+            return False, ''
+    return True, ''
 
 
 def rji2cgetWord(bus, devno, address):
-    command_line = "i2cget -f -y %d 0x%02x 0x%02x w" % (bus, devno, address)
+    command_line = ["i2cget", "-f", "-y", str(bus), "0x"+"%02x"%str(devno), "0x"+"%02x"%str(address), "w"]
     retrytime = 3
     ret_t = ""
     for i in range(retrytime):
-        ret, ret_t = rj_os_system(command_line)
+        ret, ret_t = getstatusoutput_noshell(command_line)
         if ret == 0:
             return True, ret_t
     return False, ret_t
 
 
 def rji2csetWord(bus, devno, address, byte):
-    command_line = "i2cset -f -y %d 0x%02x 0x%02x 0x%x w" % (
-        bus, devno, address, byte)
-    rj_os_system(command_line)
+    command_line = ["i2cset", "-f", "-y", str(bus), "0x"+"%02x"%str(devno), "0x"+"%02x"%str(address), "0x"+"%x"%str(byte), "w"]
+    getstatusoutput_noshell(command_line)
 
 
 def fan_setmac():
@@ -1264,14 +1266,15 @@ def writeToEEprom(rst_arr):
     elif dealtype == "io":
         io_wr(E2_PROTECT["io_addr"], E2_PROTECT["close"])
     # deal last drivers
-    os.system("rmmod at24 ")
-    os.system("modprobe at24 ")
-    os.system("rm -f /var/cache/sonic/decode-syseeprom/syseeprom_cache")
+    getstatusoutput_noshell(["rmmod", "at24"])
+    getstatusoutput_noshell(["modprobe", "at24"])
+    getstatusoutput_noshell(["rm", "-f", "/var/cache/sonic/decode-syseeprom/syseeprom_cache"])
 
 
 def get_local_eth0_mac():
-    cmd = "ifconfig eth0 |grep HWaddr"
-    print(rj_os_system(cmd))
+    cmd1 = ["ifconfig", "eth0"]
+    cmd2 = ["grep", "HWaddr"]
+    print(getstatusoutput_noshell_pipe(cmd1, cmd2))
 
 def getonieversion():
     if not os.path.isfile('/host/machine.conf'):
@@ -1348,12 +1351,12 @@ def fac_board_setmac():
 
 def ipmi_set_mac(mac):
     macs = mac.split(":")
-    cmdinit = "ipmitool raw 0x0c 0x01 0x01 0xc2 0x00"
-    cmdset = "ipmitool raw 0x0c 0x01 0x01 0x05"
+    cmdinit = ["ipmitool", "raw", "0x0c", "0x01", "0x01", "0xc2", "0x00"]
+    cmdset = ["ipmitool", "raw", "0x0c", "0x01", "0x01", "0x05"]
     for ind in range(len(macs)):
-        cmdset += " 0x%02x" % int(macs[ind], 16)
-    rj_os_system(cmdinit)
-    ret, status = rj_os_system(cmdset)
+        cmdset.append("0x%02x" % int(macs[ind], 16))
+    getstatusoutput_noshell(cmdinit)
+    ret, status = getstatusoutput_noshell(cmdset)
     if ret:
         RJPRINTERR("\n\n%s\n\n" % status)
         return False
@@ -1393,11 +1396,11 @@ def closeProtocol():
     log_info("disable LLDP")
     sys.stdout.write(".")
     sys.stdout.flush()
-    rj_os_system("systemctl stop lldp.service")
+    getstatusoutput_noshell(["systemctl", "stop", "lldp.service"])
     log_info("disable lldp service")
     sys.stdout.write(".")
     sys.stdout.flush()
-    rj_os_system("systemctl stop bgp.service")
+    getstatusoutput_noshell(["systemctl", "stop", "bgp.service"])
     log_info("disable bgp service")
     sys.stdout.write(".")
     sys.stdout.flush()
@@ -1420,8 +1423,8 @@ def checkSdkMem():
     with open(file_name, "w") as f:
         f.write(file_data)
     print("change SDK memory to 256, reboot required")
-    rj_os_system("sync")
-    rj_os_system("reboot")
+    getstatusoutput_noshell(["sync"])
+    getstatusoutput_noshell(["reboot"])
 
 ##########################################################################
 # receives a character setting
@@ -1604,25 +1607,22 @@ def getCardId():
             return item.get('value',None)
     return None
 
-# ====================================
-# execute shell command
-# ====================================
-def rj_os_system(cmd):
-    status, output = subprocess.getstatusoutput(cmd)
-    return status, output
 
 ###########################################
 # get memory slot and number via DMI command
 ###########################################
 def getsysmeminfo():
-    ret, log = rj_os_system("which dmidecode ")
+    ret, log = getstatusoutput_noshell(["which", "dmidecode"])
     if ret != 0 or len(log) <= 0:
         error = "cmd find dmidecode"
         return False, error
-    cmd = log + "|grep -P -A5 \"Memory\s+Device\"|grep Size|grep -v Range"
+    cmd1 = split(log)
+    cmd2 = ["grep", "-P", "-A5", "Memory\s+Device"]
+    cmd3 = ["grep", "Size"]
+    cmd4 = ["grep", "-v", "Range"]
     # get total number first
     result = []
-    ret1, log1 = rj_os_system(cmd)
+    ret1, log1 = getstatusoutput_noshell_pipe(cmd1, cmd2, cmd3, cmd4)
     if ret1 == 0 and len(log1):
         log1 = log1.lstrip()
         arr = log1.split("\n")
@@ -1642,15 +1642,16 @@ def getsysmeminfo():
 # return various arrays
 ###########################################
 def getsysmeminfo_detail():
-    ret, log = rj_os_system("which dmidecode ")
+    ret, log = getstatusoutput_noshell(["which", "dmidecode"])
     if ret != 0 or len(log) <= 0:
         error = "cmd find dmidecode"
         return False, error
-    cmd = log + " -t 17 | grep  -A21 \"Memory Device\""  # 17
+    cmd1 = split(log) + ["-t", "17"]
+    cmd2 = ["grep", "-A21", "Memory Device"]  # 17
     # get total number
-    ret1, log1 = rj_os_system(cmd)
+    ret1, log1 = getstatusoutput_noshell_pipe(cmd1, cmd2)
     if ret1 != 0 or len(log1) <= 0:
-        return False, "command execution error[%s]" % cmd
+        return False, "command execution error[%s][%s]" % (cmd1, cmd2)
     result_t = log1.split("--")
     mem_rets = []
     for item in result_t:
@@ -1669,13 +1670,13 @@ def getsysmeminfo_detail():
 # get BIOS info via DMI command
 ###########################################
 def getDmiSysByType(type_t):
-    ret, log = rj_os_system("which dmidecode ")
+    ret, log = getstatusoutput_noshell(["which", "dmidecode"])
     if ret != 0 or len(log) <= 0:
         error = "cmd find dmidecode"
         return False, error
-    cmd = log + " -t %s" % type_t
+    cmd = split(log) + ["-t", str(type_t)]
     # get total number
-    ret1, log1 = rj_os_system(cmd)
+    ret1, log1 = getstatusoutput_noshell(cmd)
     if ret1 != 0 or len(log1) <= 0:
         return False, "command execution error[%s]" % cmd
     its = log1.replace("\t", "").strip().split("\n")
@@ -1742,11 +1743,12 @@ def getusbinfo():
         return False, "Err"
 
 def get_cpu_info():
-    cmd = "cat /proc/cpuinfo |grep processor -A18"  # 17
+    cmd1 = ["cat", "/proc/cpuinfo"]
+    cmd2 = ["grep", "processor", "-A18"]  # 17
 
-    ret, log1 = rj_os_system(cmd)
+    ret, log1 = getstatusoutput_noshell_pipe(cmd1, cmd2)
     if ret != 0 or len(log1) <= 0:
-        return False, "command execution error[%s]" % cmd
+        return False, "command execution error[%s][%s]" % (cmd1, cmd2)
     result_t = log1.split("--")
     mem_rets = []
     for item in result_t:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Dependency: [https://github.com/sonic-net/sonic-buildimage/pull/12065](https://github.com/sonic-net/sonic-buildimage/pull/12065)
#### Why I did it
1. `getstatusoutput` is used without a static string and it uses `shell=True`
2. `subprocess()` - when using with `shell=True` is dangerous. Using subprocess function without a static string can lead to command injection.
3. `os` - not secure against maliciously constructed input and dangerous if used to evaluate dynamic content.
#### How I did it
1. use `getstatusoutput` without shell=True
2. `subprocess()` - use `shell=False` instead. use an array string. Ref: [https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation](https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation)
3. `os` - use with `subprocess`
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - [PR#2174](https://github.com/sonic-net/sonic-utilities/pull/2174) where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

