### PR TITLE
Root cause: Cannot get DHCPv6 default gateway when setting IPv4 as static mode and IPv6 as dhcp mode.

### DIFF
--- a/files/dhcp/90-dhcp6-systcl.conf.j2
+++ b/files/dhcp/90-dhcp6-systcl.conf.j2
@@ -1,6 +1,13 @@
 {% if MGMT_INTERFACE %}
+{% for (name, prefix) in MGMT_INTERFACE|pfx_filter %}
+{% if (prefix|ipv6) %}
 net.ipv6.conf.eth0.accept_ra_defrtr = 0
 net.ipv6.conf.eth0.accept_ra = 0
+{% else %}
+net.ipv6.conf.eth0.accept_ra_defrtr = 1
+net.ipv6.conf.eth0.accept_ra = 1
+{% endif %}
+{% endfor %}
 {% else %}
 net.ipv6.conf.eth0.accept_ra_defrtr = 1
 net.ipv6.conf.eth0.accept_ra = 1


### PR DESCRIPTION
"net.ipv6.conf.eth0.accept_ra_defrtr" and "net.ipv6.conf.eth0.accept_ra" are turned off. So we cannot get the deafult gateway from RA if we set IPv4 static mode and IPv6 dhcp mode

Solution:
Turn on "net.ipv6.conf.eth0.accept_ra_defrtr" and "net.ipv6.conf.eth0.accept_ra" when DHCPv6 exist.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cannot get DHCPv6 default gateway when setting IPv4 as static mode and IPv6 as dhcp mode.
#### How I did it
Turn on "net.ipv6.conf.eth0.accept_ra_defrtr" and "net.ipv6.conf.eth0.accept_ra" in files 90-dhcp6-systcl.conf.j2 when DHCPv6 exist.
#### How to verify it
1. Set IPv4 as static mode and IPv6 as dhcp mode.
2. Check the DHCPv6 default gateway
#### Which release branch to backport (provide reason below if selected)
sonic-buildimage
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - [PR#2174](https://github.com/sonic-net/sonic-utilities/pull/2174) where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

