### PR TITLE
[Celestica] Add Celestica Silverstone-X platform deb dependency files

### DIFF
--- a/device/celestica/x86_64-cel_silverstone-x-r0/sonic_platform/thermal.py
+++ b/device/celestica/x86_64-cel_silverstone-x-r0/sonic_platform/thermal.py
@@ -36,7 +36,7 @@ THERMAL_INFO = [
     {'name': 'PSU2_Temp3', 'temp': 'na'},  # 12
     {'name': 'TEMP_SW_U52', 'temp': 'na'},  # 13
     {'name': 'TEMP_SW_U16', 'temp': 'na'},  # 14
-    {'name': 'I89_CORE_Temp', 'temp': 'na'},  # 15
+    {'name': 'I91_CORE_Temp', 'temp': 'na'},  # 15
     {'name': 'I89_AVDD_Temp', 'temp': 'na'},  # 16
     {'name': 'QSFP_DD_Temp1', 'temp': 'na'},  # 17
     {'name': 'QSFP_DD_Temp2', 'temp': 'na'},  # 18
@@ -72,7 +72,7 @@ thermal_temp_dict = {
                     "max": {"B2F": NULL_VAL, "F2B": 58}, "high_critical_threshold": {"B2F": NULL_VAL, "F2B": 62}},
     "TEMP_SW_U16": {"low_critical_threshold": NULL_VAL, "min": NULL_VAL,
                     "max": NULL_VAL, "high_critical_threshold": NULL_VAL},
-    "I89_CORE_Temp": {"low_critical_threshold": NULL_VAL, "min": NULL_VAL,
+    "I91_CORE_Temp": {"low_critical_threshold": NULL_VAL, "min": NULL_VAL,
                      "max": NULL_VAL, "high_critical_threshold": 125},
     "I89_AVDD_Temp": {"low_critical_threshold": NULL_VAL, "min": NULL_VAL,
                      "max": NULL_VAL, "high_critical_threshold": 125},

--- a/platform/innovium/sonic-platform-modules-cel/debian/platform-modules-silverstone-x.init
+++ b/platform/innovium/sonic-platform-modules-cel/debian/platform-modules-silverstone-x.init
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+### BEGIN INIT INFO
+# Provides:          setup-board
+# Required-Start:    $portmap
+# Required-Stop:
+# Should-Start:
+# Should-Stop:
+# Default-Start:     S
+# Default-Stop:      0 6
+# Short-Description: Setup SilverStone-x board.
+### END INIT INFO
+HAVE_BMC=0
+if [[ -e "/dev/ipmi0" || -e "/dev/ipmi/0" || -e "/dev/ipmidev/0" ]]; then
+    # if BMC exists, fan control strategy is owned by BMC and no need to implement here.
+    HAVE_BMC=1
+fi
+
+case "$1" in
+start)
+        echo -n "Setting up board... "
+
+        modprobe i2c-dev
+        modprobe i2c-i801
+        modprobe ipmi_devintf
+        modprobe fpga_device
+        modprobe fpga_system
+        modprobe i2c_switchcpld
+        modprobe fpga_i2c_ocores
+        modprobe fpga_xcvr
+        modprobe lpc_basecpld
+        modprobe mc24lc64t
+        modprobe optoe
+        if [ $HAVE_BMC -eq 0 ]; then
+            modprobe pmbus
+            modprobe pmbus_core
+            modprobe industrialio
+            modprobe lm75
+            modprobe platform_fan
+            modprobe platform_psu
+            modprobe ucd90120
+            modprobe ucd90160
+            modprobe mp2975
+            modprobe mcp3425_smbus
+            modprobe tps536c7
+
+            echo 24lc64t 0x50 > /sys/bus/i2c/devices/i2c-6/new_device
+            echo 24lc64t 0x50 > /sys/bus/i2c/devices/i2c-3/new_device
+            echo 24lc64t 0x57 > /sys/bus/i2c/devices/i2c-3/new_device
+            echo 24c02 0x50 > /sys/bus/i2c/devices/i2c-7/new_device
+            echo 24c02 0x51 > /sys/bus/i2c/devices/i2c-7/new_device
+            
+            devname=`cat /sys/bus/i2c/devices/i2c-9/name`
+            if [[ $devname == 'fpga-xiic-i2c' ]]; then
+                echo platform_fan 0x0d > /sys/bus/i2c/devices/i2c-9/new_device
+                echo pca9548 0x77 > /sys/bus/i2c/devices/i2c-9/new_device
+            fi
+            devname=`cat /sys/bus/i2c/devices/i2c-7/name`
+            if [[ $devname == 'fpga-xiic-i2c' ]]; then
+                echo platform_psu 0x59 > /sys/bus/i2c/devices/i2c-7/new_device
+                echo platform_psu 0x58 > /sys/bus/i2c/devices/i2c-7/new_device
+            fi
+
+            devname=`cat /sys/bus/i2c/devices/i2c-4/name`
+            if [[ $devname == 'fpga-xiic-i2c' ]]; then
+                echo ucd90160 0x34 > /sys/bus/i2c/devices/i2c-4/new_device
+                echo ucd90120 0x35 > /sys/bus/i2c/devices/i2c-4/new_device
+                echo tps536c7 0x6c > /sys/bus/i2c/devices/i2c-4/new_device
+            fi
+
+            devname=`cat /sys/bus/i2c/devices/i2c-5/name`
+            if [[ $devname == 'fpga-xiic-i2c' ]]; then
+                echo mp2975 0x70 > /sys/bus/i2c/devices/i2c-5/new_device
+                echo mp2975 0x76 > /sys/bus/i2c/devices/i2c-5/new_device
+                echo mp2975 0x7b > /sys/bus/i2c/devices/i2c-5/new_device
+            fi
+
+            devname=`cat /sys/bus/i2c/devices/i2c-8/name`
+            if [[ $devname == 'fpga-xiic-i2c' ]]; then
+                echo mcp3425_smbus 0x68 > /sys/bus/i2c/devices/i2c-8/new_device
+                echo lm75b 0x48 > /sys/bus/i2c/devices/i2c-8/new_device
+                echo lm75b 0x49 > /sys/bus/i2c/devices/i2c-8/new_device
+                echo lm75b 0x4a > /sys/bus/i2c/devices/i2c-8/new_device
+            fi
+
+            i=58
+            devname=`cat /sys/bus/i2c/devices/i2c-"$i"/name`
+            if [[ $devname == *'mux'* ]]; then
+                echo 24lc64t 0x50 > /sys/bus/i2c/devices/i2c-"$i"/new_device
+                echo lm75b 0x48 > /sys/bus/i2c/devices/i2c-"$i"/new_device
+                echo lm75b 0x49 > /sys/bus/i2c/devices/i2c-"$i"/new_device
+            fi
+        fi
+
+        # Instantiate TLV EEPROM device on I801/ISMT bus
+        devname=`cat /sys/bus/i2c/devices/i2c-0/name`
+        if [[ $devname == 'SMBus'* ]]; then
+                echo 24lc64t 0x56 > /sys/bus/i2c/devices/i2c-0/new_device
+        fi
+        devname=`cat /sys/bus/i2c/devices/i2c-10/name`
+        if [[ $devname == 'fpga-xiic-i2c' ]]; then
+            echo switchboard 0x30 > /sys/bus/i2c/devices/i2c-10/new_device
+            echo switchboard 0x31 > /sys/bus/i2c/devices/i2c-10/new_device
+
+        fi
+
+        # bus 12~43 for 32 qsfp ports and 44 for sfp1 45 for sfp2
+        for i in {12..43}; do
+        devname=`cat /sys/bus/i2c/devices/i2c-"$i"/name`
+        if [[ $devname == *'mux'* ]]; then
+            echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-"$i"/new_device
+            port=`expr $i - 11`
+            echo qsfp$port  > /sys/bus/i2c/devices/i2c-"$i"/"$i"-0050/port_name
+        fi
+        done
+        for i in {44..45}; do
+        devname=`cat /sys/bus/i2c/devices/i2c-"$i"/name`
+        if [[ $devname == *'mux'* ]]; then
+            echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-"$i"/new_device
+                port=`expr $i - 43`
+            echo sfp$port  > /sys/bus/i2c/devices/i2c-"$i"/"$i"-0050/port_name
+        fi
+        done
+
+        decode-syseeprom --init 2> /dev/null &
+
+        /bin/sh /usr/local/bin/platform_api_mgnt.sh init
+
+        echo "done."
+        ;;
+
+stop)
+        rmmod optoe
+        rmmod mc24lc64t
+        rmmod lpc_basecpld
+        rmmod fpga_xcvr
+        rmmod i2c_switchcpld
+        rmmod fpga_system
+        rmmod fpga_i2c_ocores
+        rmmod fpga_device
+        rmmod ipmi_devintf
+        rmmod i2c-dev
+        if [ $HAVE_BMC -eq 0 ]; then
+            rmmod platform_fan
+            rmmod platform_psu
+            rmmod ucd90120
+            rmmod ucd90160
+            rmmod mp2975
+            rmmod mcp3425_smbus
+            rmmod tps536c7
+            rmmod lm75
+            rmmod pmbus
+            rmmod pmbus_core
+            rmmod industrialio
+        fi
+        rmmod i2c_mux_pca954x
+        rmmod i2c-i801
+        echo "done."
+        ;;
+
+force-reload|restart)
+        echo "Not supported"
+        ;;
+
+*)
+        echo "Usage: /etc/init.d/platform-modules-silverstone-x.init {start|stop}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/platform/innovium/sonic-platform-modules-cel/debian/platform-modules-silverstone-x.install
+++ b/platform/innovium/sonic-platform-modules-cel/debian/platform-modules-silverstone-x.install
@@ -8,5 +8,5 @@ silverstone-x/systemd/fancontrol/fancontrol-F2B                     usr/share/so
 silverstone-x/systemd/fancontrol/fancontrol.sh          etc/init.d
 silverstone-x/systemd/fancontrol/fancontrol.service     lib/systemd/system
 silverstone-x/systemd/fancontrol/fancontrol  usr/local/bin
-services/platform_api/platform_api_mgnt.sh usr/local/bin
+services/platform_api/platform_api_mgnt.sh   usr/local/bin
 

--- a/platform/innovium/sonic-platform-modules-cel/debian/platform-modules-silverstone-x.install
+++ b/platform/innovium/sonic-platform-modules-cel/debian/platform-modules-silverstone-x.install
@@ -1,0 +1,12 @@
+silverstone-x/scripts/sensors usr/bin
+silverstone-x/scripts/platform_sensors.py usr/local/bin
+silverstone-x/cfg/silverstone-x-modules.conf etc/modules-load.d
+silverstone-x/systemd/platform-modules-silverstone-x.service lib/systemd/system
+silverstone-x/modules/sonic_platform-1.0-py2-none-any.whl usr/share/sonic/device/x86_64-cel_silverstone-x-r0
+silverstone-x/systemd/fancontrol/fancontrol-B2F                     usr/share/sonic/device/x86_64-cel_silverstone-x-r0
+silverstone-x/systemd/fancontrol/fancontrol-F2B                     usr/share/sonic/device/x86_64-cel_silverstone-x-r0 
+silverstone-x/systemd/fancontrol/fancontrol.sh          etc/init.d
+silverstone-x/systemd/fancontrol/fancontrol.service     lib/systemd/system
+silverstone-x/systemd/fancontrol/fancontrol  usr/local/bin
+services/platform_api/platform_api_mgnt.sh usr/local/bin
+

--- a/platform/innovium/sonic-platform-modules-cel/debian/platform-modules-silverstone-x.postinst
+++ b/platform/innovium/sonic-platform-modules-cel/debian/platform-modules-silverstone-x.postinst
@@ -1,0 +1,15 @@
+for i in $(seq 1 5); do
+    ret=$(depmod -a)
+    if [ -n "$ret" ]; then
+        break
+    fi
+    sleep 2
+    echo "run depmod again"
+done
+systemctl enable platform-modules-silverstone-x.service
+systemctl start platform-modules-silverstone-x.service
+systemctl enable fancontrol.service
+systemctl start fancontrol.service
+
+/usr/local/bin/platform_api_mgnt.sh install
+/etc/init.d/fancontrol.sh install


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
.gitignore in source code root path ignores files in platform/**/debian/* , therefore Celestica Silverstone-X platform deb dependency files are missing in merge and need to upload these files.

#### How I did it
Add Celestica Silverstone-X platform deb dependency files.
#### How to verify it
verified by SONiC tested platform APIs
verified by SONiC APIs including
"psuutil
psushow(show platform psustatus)
sfputil
sfpshow
tempershow(show platform temperature)
fanshow(show platform fan)
watchdogutil
fwutil(show platform firmware status)
decode-syseeprom -d(show platform syseeprom)
show platform ssdhealth
show platform summary
show interfaces status
"
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add Celestica Silverstone-X platform deb dependency files.
One sensor name needs to be revised.

#### Ensure to add label/tag for the feature raised. example - [PR#2174](https://github.com/sonic-net/sonic-utilities/pull/2174) where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

