### PR TITLE
[Build] Fix the build unstable issue caused by the kvm not ready

### DIFF
--- a/scripts/build_kvm_image.sh
+++ b/scripts/build_kvm_image.sh
@@ -49,6 +49,19 @@ prepare_installer_disk()
     umount $tmpdir
 }
 
+wait_kvm_ready()
+{
+    local count=30
+    local waiting_in_seconds=2.0
+    for ((i=1; i<=$count; i++)); do
+        sleep $waiting_in_seconds
+        echo "$(date) [$i/$count] waiting for the port $KVM_PORT ready"
+        if netstat -l | grep -q ":$KVM_PORT"; then
+          break
+        fi
+    done
+}
+
 apt-get install -y net-tools
 create_disk
 prepare_installer_disk
@@ -86,7 +99,7 @@ echo "Installing SONiC"
 
 kvm_pid=$!
 
-sleep 2.0
+wait_kvm_ready
 
 [ -d "/proc/$kvm_pid" ] || {
         echo "ERROR: kvm died."
@@ -114,7 +127,7 @@ echo "Booting up SONiC"
 
 kvm_pid=$!
 
-sleep 2.0
+wait_kvm_ready
 
 [ -d "/proc/$kvm_pid" ] || {
         echo "ERROR: kvm died."


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the build unstable issue caused by the kvm 9000 port is not ready to use in 2 seconds.
```
2022-09-02T10:57:30.8122304Z + /usr/bin/kvm -m 8192 -name onie -boot order=cd,once=d -cdrom target/files/bullseye/onie-recovery-x86_64-kvm_x86_64_4_asic-r0.iso -device e1000,netdev=onienet -netdev user,id=onienet,hostfwd=:0.0.0.0:3041-:22 -vnc 0.0.0.0:0 -vga std -drive file=target/sonic-6asic-vs.img,media=disk,if=virtio,index=0 -drive file=./sonic-installer.img,if=virtio,index=1 -serial telnet:127.0.0.1:9000,server
2022-09-02T10:57:30.8123378Z + sleep 2.0
2022-09-02T10:57:30.8123889Z + '[' -d /proc/284923 ']'
2022-09-02T10:57:30.8124528Z + echo 'to kill kvm:  sudo kill 284923'
2022-09-02T10:57:30.8124994Z to kill kvm:  sudo kill 284923
2022-09-02T10:57:30.8125362Z + ./install_sonic.py
2022-09-02T10:57:30.8125720Z Trying 127.0.0.1...
2022-09-02T10:57:30.8126041Z telnet: Unable to connect to remote host: Connection refused
2022-09-02T10:57:30.8126453Z Traceback (most recent call last):
2022-09-02T10:57:30.8126882Z   File "/sonic/./install_sonic.py", line 49, in <module>
2022-09-02T10:57:30.8127269Z     main()
2022-09-02T10:57:30.8127540Z   File "/sonic/./install_sonic.py", line 36, in main
2022-09-02T10:57:30.8127940Z     p.expect(grub_selection)
2022-09-02T10:57:30.8128617Z   File "/usr/local/lib/python3.9/dist-packages/pexpect/spawnbase.py", line 343, in expect
2022-09-02T10:57:30.8129158Z     return self.expect_list(compiled_pattern_list,
2022-09-02T10:57:30.8129888Z   File "/usr/local/lib/python3.9/dist-packages/pexpect/spawnbase.py", line 372, in expect_list
2022-09-02T10:57:30.8130434Z     return exp.expect_loop(timeout)
2022-09-02T10:57:30.8131301Z   File "/usr/local/lib/python3.9/dist-packages/pexpect/expect.py", line 179, in expect_loop
2022-09-02T10:57:30.8132072Z     return self.eof(e)
2022-09-02T10:57:30.8132791Z   File "/usr/local/lib/python3.9/dist-packages/pexpect/expect.py", line 122, in eof
2022-09-02T10:57:30.8133306Z     raise exc
2022-09-02T10:57:30.8133920Z pexpect.exceptions.EOF: End Of File (EOF). Exception style platform.
2022-09-02T10:57:30.8134438Z <pexpect.pty_spawn.spawn object at 0x7f85aea2b4f0>
2022-09-02T10:57:30.8135075Z command: /usr/bin/telnet
2022-09-02T10:57:30.8135672Z args: [b'/usr/bin/telnet', b'127.0.0.1', b'9000']
2022-09-02T10:57:30.8136490Z buffer (last 100 chars): ''
2022-09-02T10:57:30.8138294Z before (last 100 chars): 'Trying 127.0.0.1
```


#### How I did it
Waiting more time until the tcp port 9000 is ready, waiting for 60 seconds in maximum.

#### How to verify it
See the log below, it waited for 4 seconds, then the port 9000 was ready.
```
Installing SONiC
+ kvm_pid=1129381
+ wait_kvm_ready
+ /usr/bin/kvm -m 8192 -name onie -boot order=cd,once=d -cdrom target/files/bullseye/onie-recovery-x86_64-kvm_x86_64-r0.iso -device e1000,netdev=onienet -netdev user,id=onienet,hostfwd=:0.0.0.0:3041-:22 -vnc 0.0.0.0:0 -vga std -drive file=target/sonic-vs.img,media=disk,if=virtio,index=0 -drive file=./sonic-installer.img,if=virtio,index=1 -serial telnet:127.0.0.1:9000,server
+ local count=10
+ local waiting_in_seconds=2.0
+ (( i=1 ))
+ (( i<=10 ))
+ sleep 2.0
++ date
+ echo 'Sun Sep 25 05:34:51 UTC 2022 [1/10] waiting for the port 9000 ready'
Sun Sep 25 05:34:51 UTC 2022 [1/10] waiting for the port 9000 ready
+ netstat -l
+ grep -q :9000
+ (( i++ ))
+ (( i<=10 ))
+ sleep 2.0
++ date
+ echo 'Sun Sep 25 05:34:53 UTC 2022 [2/10] waiting for the port 9000 ready'
Sun Sep 25 05:34:53 UTC 2022 [2/10] waiting for the port 9000 ready
+ netstat -l
+ grep -q :9000
+ break
+ '[' -d /proc/1129381 ']'
+ echo 'to kill kvm:  sudo kill 1129381'
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - [PR#2174](https://github.com/sonic-net/sonic-utilities/pull/2174) where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

