### PR TITLE
[Mellanox] Revert "[Mellanox] Redirect ethtool stderr to subprocess for better error log (#12038)"

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -359,8 +359,7 @@ class SFP(NvidiaSFPCommon):
         try:
             output = subprocess.check_output(ethtool_cmd,
                                              shell=True,
-                                             universal_newlines=True,
-                                             stderr=subprocess.PIPE)
+                                             universal_newlines=True)
             output_lines = output.splitlines()
             first_line_raw = output_lines[0]
             if "Offset" in first_line_raw:
@@ -368,7 +367,6 @@ class SFP(NvidiaSFPCommon):
                     line_split = line.split()
                     eeprom_raw = eeprom_raw + line_split[1:]
         except subprocess.CalledProcessError as e:
-            logger.log_notice("Failed to get EEPROM data for sfp {}: {}".format(self.index, e.stderr))
             return None
 
         eeprom_raw = list(map(lambda h: int(h, base=16), eeprom_raw))


### PR DESCRIPTION
This reverts commit 9750cb48c642281157ddd405674bdca9710e1edc.

There is a PR to handle 202205 branch revert: https://github.com/sonic-net/sonic-buildimage/pull/12184

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The PR to be reverted introduced many notice logs every 1 minute if SFP is not plugged:

```
Cannot get module EEPROM information: Input/output error
```
Before the "bad" PR, the message format is like this:

```
INFO pmon#supervisord: xcvrd Cannot get module EEPROM information: Input/output error
```

It was truncated by rsyslog because every message is the same. However, the "bad" PR introduces SFP index to the message:

```
NOTICE pmon#xcvrd: Failed to get EEPROM data for sfp 39: Cannot get module EEPROM information: Input/output error
```

Rsyslog no longer truncate such log and many such messages are flooded to syslog.

#### How I did it

Revert the PR

#### How to verify it

Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - [PR#2174](https://github.com/sonic-net/sonic-utilities/pull/2174) where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

