### PR TITLE
[TACACS] Send remote address in TACACS+ authorization message.

### DIFF
--- a/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
+++ b/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
@@ -1,17 +1,17 @@
-From 7228127e9e846b834e5ec81416763e9a607f253e Mon Sep 17 00:00:00 2001
+From ee47eb11cbfc37600a59f06ae153da5c2c486fea Mon Sep 17 00:00:00 2001
 From: liuh-80 <liuh@microsoft.com>
 Date: Tue, 25 Oct 2022 10:34:08 +0800
 Subject: [PATCH] Send remote address in TACACS+ authorization message.
 
 ---
- nss_tacplus.c | 69 ++++++++++++++++++++++++++++++++++++++++++++++++++-
- 1 file changed, 68 insertions(+), 1 deletion(-)
+ nss_tacplus.c | 77 ++++++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 76 insertions(+), 1 deletion(-)
 
 diff --git a/nss_tacplus.c b/nss_tacplus.c
-index 2de00a6..d59869b 100644
+index 2de00a6..048745a 100644
 --- a/nss_tacplus.c
 +++ b/nss_tacplus.c
-@@ -33,6 +33,7 @@
+@@ -33,12 +33,20 @@
  #include <ctype.h>
  #include <netdb.h>
  #include <nss.h>
@@ -19,7 +19,20 @@ index 2de00a6..d59869b 100644
  
  #include <libtac/libtac.h>
  
-@@ -717,6 +718,66 @@ connect_tacacs(struct tac_attrib **attr, int srvr)
+ #define MIN_TACACS_USER_PRIV (1)
+ #define MAX_TACACS_USER_PRIV (15)
+ 
++#define GET_ENV_VARIABLE_OK                 0
++#define GET_ENV_VARIABLE_NOT_FOUND          1
++#define GET_ENV_VARIABLE_INCORRECT_FORMAT   2
++#define GET_ENV_VARIABLE_NOT_ENOUGH_BUFFER  3
++#define GET_REMOTE_ADDRESS_OK               0
++#define GET_REMOTE_ADDRESS_FAILED           1
++
+ static const char *nssname = "nss_tacplus"; /* for syslogs */
+ static const char *config_file = "/etc/tacplus_nss.conf";
+ static const char *user_conf = "/etc/tacplus_user";
+@@ -717,6 +725,66 @@ connect_tacacs(struct tac_attrib **attr, int srvr)
      return fd;
  }
  
@@ -36,7 +49,7 @@ index 2de00a6..d59869b 100644
 +            syslog(LOG_DEBUG, "%s: can't get environment variable %s, errno=%d", nssname, name, errno);
 +        }
 +
-+        return 1;
++        return GET_ENV_VARIABLE_NOT_FOUND;
 +    }
 +
 +    char* context = NULL;
@@ -46,7 +59,7 @@ index 2de00a6..d59869b 100644
 +            syslog(LOG_DEBUG, "%s: can't split %s by delimiters %s", nssname, variable, delimiters);
 +        }
 +
-+        return 2;
++        return GET_ENV_VARIABLE_INCORRECT_FORMAT;
 +    }
 +
 +    int first_part_len = strlen(first_part);
@@ -55,7 +68,7 @@ index 2de00a6..d59869b 100644
 +            syslog(LOG_DEBUG, "%s: dest buffer size %d not enough for %s", nssname, size, first_part);
 +        }
 +
-+        return 3;
++        return GET_ENV_VARIABLE_NOT_ENOUGH_BUFFER;
 +    }
 +
 +    strncpy(dst, first_part, size);
@@ -63,7 +76,7 @@ index 2de00a6..d59869b 100644
 +        syslog(LOG_DEBUG, "%s: remote address=%s", nssname, dst);
 +    }
 +
-+    return 0;
++    return GET_ENV_VARIABLE_OK;
 +}
 +
 +/*
@@ -72,21 +85,21 @@ index 2de00a6..d59869b 100644
 +int get_remote_address(char* dst, socklen_t size)
 +{
 +    // SSHD will create environment variable SSH_CONNECTION after user session created.
-+    if (!get_environment_variable_first_part(dst, size, "SSH_CONNECTION", " ")) {
-+        return 0;
++    if (get_environment_variable_first_part(dst, size, "SSH_CONNECTION", " ") == GET_ENV_VARIABLE_OK) {
++        return GET_REMOTE_ADDRESS_OK;
 +    }
 +
 +    // Before user session created, SSHD will create environment variable SSH_CLIENT_IPADDR_PORT.
-+    if (!get_environment_variable_first_part(dst, size, "SSH_CLIENT_IPADDR_PORT", " ")) {
-+        return 0;
++    if (get_environment_variable_first_part(dst, size, "SSH_CLIENT_IPADDR_PORT", " ") == GET_ENV_VARIABLE_OK) {
++        return GET_REMOTE_ADDRESS_OK;
 +    }
 +
-+    return 1;
++    return GET_REMOTE_ADDRESS_FAILED;
 +}
  
  /*
   * lookup the user on a TACACS server.  Returns 0 on successful lookup, else 1
-@@ -735,6 +795,13 @@ lookup_tacacs_user(struct pwbuf *pb)
+@@ -735,6 +803,13 @@ lookup_tacacs_user(struct pwbuf *pb)
      int ret = 1, done = 0;
      struct tac_attrib *attr;
      int tac_fd, srvr;
@@ -94,13 +107,13 @@ index 2de00a6..d59869b 100644
 +    const char* current_tty = getenv("SSH_TTY");
 +
 +    int result = get_remote_address(remote_addr, sizeof(remote_addr));
-+    if (result && debug) {
++    if ((result != GET_REMOTE_ADDRESS_OK) && debug) {
 +        syslog(LOG_DEBUG, "%s: can't get remote address from environment variable, result=%d", nssname, result);
 +    }
  
      for(srvr=0; srvr < tac_srv_no && !done; srvr++) {
          arep.msg = NULL;
-@@ -748,7 +815,7 @@ lookup_tacacs_user(struct pwbuf *pb)
+@@ -748,7 +823,7 @@ lookup_tacacs_user(struct pwbuf *pb)
                      tac_ntop(tac_srv[srvr].addr->ai_addr) : "unknown", tac_fd);
              continue;
          }
@@ -110,5 +123,5 @@ index 2de00a6..d59869b 100644
              if(debug)
                  syslog(LOG_WARNING, "%s: TACACS+ server %s send failed (%d) for"
 -- 
-2.35.1.windows.2
+2.37.1.windows.1
 

--- a/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
+++ b/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
@@ -19,7 +19,7 @@ index 2de00a6..d59869b 100644
  
  #include <libtac/libtac.h>
  
-@@ -717,6 +718,65 @@ connect_tacacs(struct tac_attrib **attr, int srvr)
+@@ -717,6 +718,66 @@ connect_tacacs(struct tac_attrib **attr, int srvr)
      return fd;
  }
  
@@ -39,7 +39,8 @@ index 2de00a6..d59869b 100644
 +        return 1;
 +    }
 +
-+    char* first_part = strtok((char *)variable, delimiters);
++    char* context = NULL;
++    char* first_part = strtok_r((char *)variable, delimiters, &context);
 +    if (first_part == NULL) {
 +        if (debug) {
 +            syslog(LOG_DEBUG, "%s: can't split %s by delimiters %s", nssname, variable, delimiters);

--- a/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
+++ b/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
@@ -56,7 +56,7 @@ index 2de00a6..8cd1770 100644
 +            return 1;
 +        }
 +
-+        strncpy_s(dst, size, ssh_remote_ip, remote_ip_length);
++        strncpy(dst, ssh_remote_ip, size);
 +        if (debug) {
 +            syslog(LOG_DEBUG, "%s: remote address=%s", nssname, dst);
 +        }

--- a/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
+++ b/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
@@ -19,7 +19,7 @@ index 2de00a6..8cd1770 100644
  
  #include <libtac/libtac.h>
  
-@@ -717,6 +718,51 @@ connect_tacacs(struct tac_attrib **attr, int srvr)
+@@ -717,6 +718,52 @@ connect_tacacs(struct tac_attrib **attr, int srvr)
      return fd;
  }
  
@@ -50,12 +50,13 @@ index 2de00a6..8cd1770 100644
 +    // Before user session created, SSHD will create environment variable SSH_REMOTE_IP.
 +    const char* ssh_remote_ip = getenv("SSH_REMOTE_IP");
 +    if (ssh_remote_ip != NULL) {
-+        if (strlen(ssh_remote_ip) >= size) {
++        int remote_ip_length = strlen(ssh_remote_ip);
++        if (remote_ip_length >= size) {
 +            // dst buffer does not have enough space.
 +            return 1;
 +        }
 +
-+        snprintf(dst, size, "%s", ssh_remote_ip);
++        strncpy(dst, ssh_remote_ip, remote_ip_length);
 +        if (debug) {
 +            syslog(LOG_DEBUG, "%s: remote address=%s", nssname, dst);
 +        }

--- a/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
+++ b/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
@@ -1,14 +1,14 @@
-From aa99eb2c0c7ccb4e434524cba6fa1bcc85d4256b Mon Sep 17 00:00:00 2001
+From 7228127e9e846b834e5ec81416763e9a607f253e Mon Sep 17 00:00:00 2001
 From: liuh-80 <liuh@microsoft.com>
-Date: Wed, 28 Sep 2022 17:12:18 +0800
+Date: Tue, 25 Oct 2022 10:34:08 +0800
 Subject: [PATCH] Send remote address in TACACS+ authorization message.
 
 ---
- nss_tacplus.c | 55 ++++++++++++++++++++++++++++++++++++++++++++++++++-
- 1 file changed, 54 insertions(+), 1 deletion(-)
+ nss_tacplus.c | 69 ++++++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 68 insertions(+), 1 deletion(-)
 
 diff --git a/nss_tacplus.c b/nss_tacplus.c
-index 2de00a6..8cd1770 100644
+index 2de00a6..d59869b 100644
 --- a/nss_tacplus.c
 +++ b/nss_tacplus.c
 @@ -33,6 +33,7 @@
@@ -19,60 +19,73 @@ index 2de00a6..8cd1770 100644
  
  #include <libtac/libtac.h>
  
-@@ -717,6 +718,52 @@ connect_tacacs(struct tac_attrib **attr, int srvr)
+@@ -717,6 +718,65 @@ connect_tacacs(struct tac_attrib **attr, int srvr)
      return fd;
  }
  
++/*
++ * Get environment variable first part by name and delimiters
++ */
++int get_environment_variable_first_part(char* dst, socklen_t size, const char* name, const char* delimiters)
++{
++    memset(dst, 0, size);
++
++    const char* variable = getenv(name);
++    if (variable == NULL) {
++        if (debug) {
++            syslog(LOG_DEBUG, "%s: can't get environment variable %s, errno=%d", nssname, name, errno);
++        }
++
++        return 1;
++    }
++
++    char* first_part = strtok((char *)variable, delimiters);
++    if (first_part == NULL) {
++        if (debug) {
++            syslog(LOG_DEBUG, "%s: can't split %s by delimiters %s", nssname, variable, delimiters);
++        }
++
++        return 2;
++    }
++
++    int first_part_len = strlen(first_part);
++    if (first_part_len >= size) {
++        if (debug) {
++            syslog(LOG_DEBUG, "%s: dest buffer size %d not enough for %s", nssname, size, first_part);
++        }
++
++        return 3;
++    }
++
++    strncpy(dst, first_part, size);
++    if (debug) {
++        syslog(LOG_DEBUG, "%s: remote address=%s", nssname, dst);
++    }
++
++    return 0;
++}
++
 +/*
 + * Get current SSH session remote address from environment variable
 + */
 +int get_remote_address(char* dst, socklen_t size)
 +{
-+    memset(dst, 0, size);
-+    char format[32];
-+    snprintf(format, sizeof(format), "%%%ds", (int)(size-1));
-+
 +    // SSHD will create environment variable SSH_CONNECTION after user session created.
-+    const char* ssh_connection = getenv("SSH_CONNECTION");
-+    if (ssh_connection != NULL) {
-+        // The first part of $SSH_CONNECTION is client IP address
-+        sscanf(ssh_connection, format, dst);
-+        if (debug) {
-+            syslog(LOG_DEBUG, "%s: remote address=%s, SSH_CONNECTION=%s", nssname, ssh_connection, dst);
-+        }
++    if (!get_environment_variable_first_part(dst, size, "SSH_CONNECTION", " ")) {
 +        return 0;
-+    }
-+
-+    if (debug) {
-+        syslog(LOG_DEBUG, "%s: can't get environment variable SSH_CONNECTION, errno=%d", nssname, errno);
 +    }
 +
 +    // Before user session created, SSHD will create environment variable SSH_REMOTE_IP.
-+    const char* ssh_remote_ip = getenv("SSH_REMOTE_IP");
-+    if (ssh_remote_ip != NULL) {
-+        int remote_ip_length = strlen(ssh_remote_ip);
-+        if (remote_ip_length >= size) {
-+            // dst buffer does not have enough space.
-+            return 1;
-+        }
-+
-+        strncpy(dst, ssh_remote_ip, size);
-+        if (debug) {
-+            syslog(LOG_DEBUG, "%s: remote address=%s", nssname, dst);
-+        }
++    if (!get_environment_variable_first_part(dst, size, "SSH_CLIENT_IPADDR_PORT", " ")) {
 +        return 0;
 +    }
 +
-+    if (debug) {
-+        syslog(LOG_DEBUG, "%s: can't get environment variable SSH_REMOTE_IP, errno=%d", nssname, errno);
-+    }
-+
-+    return 2;
++    return 1;
 +}
  
  /*
   * lookup the user on a TACACS server.  Returns 0 on successful lookup, else 1
-@@ -735,6 +781,13 @@ lookup_tacacs_user(struct pwbuf *pb)
+@@ -735,6 +795,13 @@ lookup_tacacs_user(struct pwbuf *pb)
      int ret = 1, done = 0;
      struct tac_attrib *attr;
      int tac_fd, srvr;
@@ -86,7 +99,7 @@ index 2de00a6..8cd1770 100644
  
      for(srvr=0; srvr < tac_srv_no && !done; srvr++) {
          arep.msg = NULL;
-@@ -748,7 +801,7 @@ lookup_tacacs_user(struct pwbuf *pb)
+@@ -748,7 +815,7 @@ lookup_tacacs_user(struct pwbuf *pb)
                      tac_ntop(tac_srv[srvr].addr->ai_addr) : "unknown", tac_fd);
              continue;
          }
@@ -96,5 +109,5 @@ index 2de00a6..8cd1770 100644
              if(debug)
                  syslog(LOG_WARNING, "%s: TACACS+ server %s send failed (%d) for"
 -- 
-2.37.1.windows.1
+2.35.1.windows.2
 

--- a/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
+++ b/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
@@ -1,14 +1,14 @@
-From aec0ad4da85b0edbfa45f6deab1c0abbeecd4bbb Mon Sep 17 00:00:00 2001
+From aa99eb2c0c7ccb4e434524cba6fa1bcc85d4256b Mon Sep 17 00:00:00 2001
 From: liuh-80 <liuh@microsoft.com>
 Date: Wed, 28 Sep 2022 17:12:18 +0800
 Subject: [PATCH] Send remote address in TACACS+ authorization message.
 
 ---
- nss_tacplus.c | 53 ++++++++++++++++++++++++++++++++++++++++++++++++++-
- 1 file changed, 52 insertions(+), 1 deletion(-)
+ nss_tacplus.c | 55 ++++++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 54 insertions(+), 1 deletion(-)
 
 diff --git a/nss_tacplus.c b/nss_tacplus.c
-index 2de00a6..00b0d17 100644
+index 2de00a6..8cd1770 100644
 --- a/nss_tacplus.c
 +++ b/nss_tacplus.c
 @@ -33,6 +33,7 @@
@@ -19,14 +19,14 @@ index 2de00a6..00b0d17 100644
  
  #include <libtac/libtac.h>
  
-@@ -717,6 +718,44 @@ connect_tacacs(struct tac_attrib **attr, int srvr)
+@@ -717,6 +718,51 @@ connect_tacacs(struct tac_attrib **attr, int srvr)
      return fd;
  }
  
 +/*
 + * Get current SSH session remote address from environment variable
 + */
-+void get_remote_address(char* dst, socklen_t size)
++int get_remote_address(char* dst, socklen_t size)
 +{
 +    memset(dst, 0, size);
 +    char format[32];
@@ -36,50 +36,61 @@ index 2de00a6..00b0d17 100644
 +    const char* ssh_connection = getenv("SSH_CONNECTION");
 +    if (ssh_connection != NULL) {
 +        // The first part of $SSH_CONNECTION is client IP address
-+        sscanf(ssh_connection , format, dst);
-+        if(debug) {
++        sscanf(ssh_connection, format, dst);
++        if (debug) {
 +            syslog(LOG_DEBUG, "%s: remote address=%s, SSH_CONNECTION=%s", nssname, ssh_connection, dst);
 +        }
-+        return;
++        return 0;
 +    }
 +
-+    if(debug) {
++    if (debug) {
 +        syslog(LOG_DEBUG, "%s: can't get environment variable SSH_CONNECTION, errno=%d", nssname, errno);
 +    }
 +
 +    // Before user session created, SSHD will create environment variable SSH_REMOTE_IP.
 +    const char* ssh_remote_ip = getenv("SSH_REMOTE_IP");
 +    if (ssh_remote_ip != NULL) {
-+        snprintf (dst , size, "%s", ssh_remote_ip);
-+        if(debug) {
++        if (strlen(ssh_remote_ip) >= size) {
++            // dst buffer does not have enough space.
++            return 1;
++        }
++
++        snprintf(dst, size, "%s", ssh_remote_ip);
++        if (debug) {
 +            syslog(LOG_DEBUG, "%s: remote address=%s", nssname, dst);
 +        }
-+        return;
++        return 0;
 +    }
 +
-+    if(debug) {
++    if (debug) {
 +        syslog(LOG_DEBUG, "%s: can't get environment variable SSH_REMOTE_IP, errno=%d", nssname, errno);
 +    }
++
++    return 2;
 +}
  
  /*
   * lookup the user on a TACACS server.  Returns 0 on successful lookup, else 1
-@@ -735,6 +778,9 @@ lookup_tacacs_user(struct pwbuf *pb)
+@@ -735,6 +781,13 @@ lookup_tacacs_user(struct pwbuf *pb)
      int ret = 1, done = 0;
      struct tac_attrib *attr;
      int tac_fd, srvr;
-+    char remote_addr[INET6_ADDRSTRLEN + 1];
++    char remote_addr[INET6_ADDRSTRLEN];
++    const char* current_tty = getenv("SSH_TTY");
 +
-+    get_remote_address(remote_addr, sizeof(remote_addr));
++    int result = get_remote_address(remote_addr, sizeof(remote_addr));
++    if (result && debug) {
++        syslog(LOG_DEBUG, "%s: can't get remote address from environment variable, result=%d", nssname, result);
++    }
  
      for(srvr=0; srvr < tac_srv_no && !done; srvr++) {
          arep.msg = NULL;
-@@ -748,7 +796,7 @@ lookup_tacacs_user(struct pwbuf *pb)
+@@ -748,7 +801,7 @@ lookup_tacacs_user(struct pwbuf *pb)
                      tac_ntop(tac_srv[srvr].addr->ai_addr) : "unknown", tac_fd);
              continue;
          }
 -        ret = tac_author_send(tac_fd, pb->name, "", "", attr);
-+        ret = tac_author_send(tac_fd, pb->name, "", remote_addr, attr);
++        ret = tac_author_send(tac_fd, pb->name, current_tty != NULL ? current_tty : "", remote_addr, attr);
          if(ret < 0) {
              if(debug)
                  syslog(LOG_WARNING, "%s: TACACS+ server %s send failed (%d) for"

--- a/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
+++ b/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
@@ -75,7 +75,7 @@ index 2de00a6..d59869b 100644
 +        return 0;
 +    }
 +
-+    // Before user session created, SSHD will create environment variable SSH_REMOTE_IP.
++    // Before user session created, SSHD will create environment variable SSH_CLIENT_IPADDR_PORT.
 +    if (!get_environment_variable_first_part(dst, size, "SSH_CLIENT_IPADDR_PORT", " ")) {
 +        return 0;
 +    }

--- a/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
+++ b/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
@@ -1,0 +1,88 @@
+From aec0ad4da85b0edbfa45f6deab1c0abbeecd4bbb Mon Sep 17 00:00:00 2001
+From: liuh-80 <liuh@microsoft.com>
+Date: Wed, 28 Sep 2022 17:12:18 +0800
+Subject: [PATCH] Send remote address in TACACS+ authorization message.
+
+---
+ nss_tacplus.c | 53 ++++++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 52 insertions(+), 1 deletion(-)
+
+diff --git a/nss_tacplus.c b/nss_tacplus.c
+index 2de00a6..00b0d17 100644
+--- a/nss_tacplus.c
++++ b/nss_tacplus.c
+@@ -33,6 +33,7 @@
+ #include <ctype.h>
+ #include <netdb.h>
+ #include <nss.h>
++#include <limits.h>
+ 
+ #include <libtac/libtac.h>
+ 
+@@ -717,6 +718,44 @@ connect_tacacs(struct tac_attrib **attr, int srvr)
+     return fd;
+ }
+ 
++/*
++ * Get current SSH session remote address from environment variable
++ */
++void get_remote_address(char* dst, socklen_t size)
++{
++    memset(dst, 0, size);
++    char format[32];
++    snprintf(format, sizeof(format), "%%%ds", (int)(size-1));
++
++    // SSHD will create environment variable SSH_CONNECTION after user session created.
++    const char* ssh_connection = getenv("SSH_CONNECTION");
++    if (ssh_connection != NULL) {
++        // The first part of $SSH_CONNECTION is client IP address
++        sscanf(ssh_connection , format, dst);
++        if(debug) {
++            syslog(LOG_DEBUG, "%s: remote address=%s, SSH_CONNECTION=%s", nssname, ssh_connection, dst);
++        }
++        return;
++    }
++
++    if(debug) {
++        syslog(LOG_DEBUG, "%s: can't get environment variable SSH_CONNECTION, errno=%d", nssname, errno);
++    }
++
++    // Before user session created, SSHD will create environment variable SSH_REMOTE_IP.
++    const char* ssh_remote_ip = getenv("SSH_REMOTE_IP");
++    if (ssh_remote_ip != NULL) {
++        snprintf (dst , size, "%s", ssh_remote_ip);
++        if(debug) {
++            syslog(LOG_DEBUG, "%s: remote address=%s", nssname, dst);
++        }
++        return;
++    }
++
++    if(debug) {
++        syslog(LOG_DEBUG, "%s: can't get environment variable SSH_REMOTE_IP, errno=%d", nssname, errno);
++    }
++}
+ 
+ /*
+  * lookup the user on a TACACS server.  Returns 0 on successful lookup, else 1
+@@ -735,6 +778,9 @@ lookup_tacacs_user(struct pwbuf *pb)
+     int ret = 1, done = 0;
+     struct tac_attrib *attr;
+     int tac_fd, srvr;
++    char remote_addr[INET6_ADDRSTRLEN + 1];
++
++    get_remote_address(remote_addr, sizeof(remote_addr));
+ 
+     for(srvr=0; srvr < tac_srv_no && !done; srvr++) {
+         arep.msg = NULL;
+@@ -748,7 +796,7 @@ lookup_tacacs_user(struct pwbuf *pb)
+                     tac_ntop(tac_srv[srvr].addr->ai_addr) : "unknown", tac_fd);
+             continue;
+         }
+-        ret = tac_author_send(tac_fd, pb->name, "", "", attr);
++        ret = tac_author_send(tac_fd, pb->name, "", remote_addr, attr);
+         if(ret < 0) {
+             if(debug)
+                 syslog(LOG_WARNING, "%s: TACACS+ server %s send failed (%d) for"
+-- 
+2.37.1.windows.1
+

--- a/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
+++ b/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
@@ -56,7 +56,7 @@ index 2de00a6..8cd1770 100644
 +            return 1;
 +        }
 +
-+        strncpy(dst, ssh_remote_ip, remote_ip_length);
++        strncpy_s(dst, size, ssh_remote_ip, remote_ip_length);
 +        if (debug) {
 +            syslog(LOG_DEBUG, "%s: remote address=%s", nssname, dst);
 +        }
@@ -91,7 +91,7 @@ index 2de00a6..8cd1770 100644
              continue;
          }
 -        ret = tac_author_send(tac_fd, pb->name, "", "", attr);
-+        ret = tac_author_send(tac_fd, pb->name, current_tty != NULL ? current_tty : "", remote_addr, attr);
++        ret = tac_author_send(tac_fd, pb->name, current_tty != NULL ? (char *)current_tty : "", remote_addr, attr);
          if(ret < 0) {
              if(debug)
                  syslog(LOG_WARNING, "%s: TACACS+ server %s send failed (%d) for"

--- a/src/tacacs/nss/patch/series
+++ b/src/tacacs/nss/patch/series
@@ -7,3 +7,4 @@
 0007-Add-support-for-TACACS-source-address.patch
 0008-do-not-create-or-modify-local-user-if-there-is-no-pr.patch
 0009-fix-compile-error-strncpy.patch
+0010-Send-remote-address-in-TACACS-authorization-message.patch


### PR DESCRIPTION
Send remote address in TACACS+ authorization message.

#### Why I did it
TACACS+ authorization message not send remote address to server side.

#### How I did it
Send remote address in TACACS+ authorization message.

#### How to verify it
Pass all E2E test.
Create new test case to validate remote address been send to server side.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
Send remote address in TACACS+ authorization message.

#### Ensure to add label/tag for the feature raised. example - [PR#2174](https://github.com/sonic-net/sonic-utilities/pull/2174) where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

