### PR TITLE
[Platform/Seastone]: fix syseeprom tlv read issue

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
@@ -147,6 +147,12 @@ start)
         sleep 0.1
         done
 
+    # Set pca9548 idle_state
+    echo -2 > /sys/bus/i2c/devices/i2c-${devnum}/0-0071/idle_state
+    echo -2 > /sys/bus/i2c/devices/i2c-${devnum}/0-0073/idle_state
+    echo -2 > /sys/bus/i2c/devices/i2c-${devnum}/0-0077/idle_state
+    sleep 0.1
+
 	bus_en=8
 	cfg_r=`i2cget -y -f 8 0x60 0xD1`
 	((cfg_w=$cfg_r+$bus_en))	


### PR DESCRIPTION
#### Why I did it
Fix Seastone syseeprom tlv header read incorrect issue

#### How I did it
Set mux idle_state to MUX_IDLE_DISCONNECT.

#### How to verify it
``` shell
# i2cdump -y -f 12 0x50 i
```
or
``` python
python3
F = open("/sys/class/i2c-adapter/i2c-12/12-0050/eeprom", "rb")

F.seek(0)
o = F.read(11)
o
F.seek(0)
F.close()
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

