### PR TITLE
[Mellanox] Provide dummy implementation for get_rx_los and get_tx_fault

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -757,6 +757,24 @@ class SFP(NvidiaSFPCommon):
             error_description = "Unknow SFP module status ({})".format(oper_status)
         return error_description
 
+    def get_rx_los(self):
+        """Accessing rx los is not supproted, return all False
+
+        Returns:
+            list: [False] * channels
+        """
+        api = self.get_xcvr_api()
+        return [False] * api.NUM_CHANNELS if api else None
+
+    def get_tx_fault(self):
+        """Accessing tx fault is not supproted, return all False
+
+        Returns:
+            list: [False] * channels
+        """
+        api = self.get_xcvr_api()
+        return [False] * api.NUM_CHANNELS if api else None
+
 
 class RJ45Port(NvidiaSFPCommon):
     """class derived from SFP, representing RJ45 ports"""

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -775,6 +775,19 @@ class SFP(NvidiaSFPCommon):
         api = self.get_xcvr_api()
         return [False] * api.NUM_CHANNELS if api else None
 
+    def get_xcvr_api(self):
+        """
+        Retrieves the XcvrApi associated with this SFP
+
+        Returns:
+            An object derived from XcvrApi that corresponds to the SFP
+        """
+        if self._xcvr_api is None:
+            self.refresh_xcvr_api()
+            self._xcvr_api.get_rx_los = self.get_rx_los
+            self._xcvr_api.get_tx_fault = self.get_tx_fault
+        return self._xcvr_api
+
 
 class RJ45Port(NvidiaSFPCommon):
     """class derived from SFP, representing RJ45 ports"""

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -784,8 +784,9 @@ class SFP(NvidiaSFPCommon):
         """
         if self._xcvr_api is None:
             self.refresh_xcvr_api()
-            self._xcvr_api.get_rx_los = self.get_rx_los
-            self._xcvr_api.get_tx_fault = self.get_tx_fault
+            if  self._xcvr_api is not None:
+                self._xcvr_api.get_rx_los = self.get_rx_los
+                self._xcvr_api.get_tx_fault = self.get_tx_fault
         return self._xcvr_api
 
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -119,3 +119,17 @@ class TestSfp:
 
         mock_port_status.return_value = (0, False)
         assert not SFP.is_port_admin_status_up(None, None)
+
+    @mock.patch('sonic_platform.sfp.SFP.get_xcvr_api')
+    def test_dummy_apis(self, mock_get_xcvr_api):
+        mock_api = mock.MagicMock()
+        mock_api.NUM_CHANNELS = 4
+        mock_get_xcvr_api.return_value = mock_api
+
+        sfp = SFP(0)
+        assert sfp.get_rx_los() == [False] * 4
+        assert sfp.get_tx_fault() == [False] * 4
+
+        mock_get_xcvr_api.return_value = None
+        assert sfp.get_rx_los() is None
+        assert sfp.get_tx_fault() is None


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

get_rx_los and get_tx_fault is not supported via the exisitng interface used, need provide dummy implementation for them.
NOTE: in later releases we will get them back via different interface.

#### How I did it

Return False * lane_num for get_rx_los and get_tx_fault

#### How to verify it

Added unit test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - [PR#2174](https://github.com/sonic-net/sonic-utilities/pull/2174) where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

