### PR TITLE
[AzurePipeline]  Fix vstest step failed by libyang missing.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,7 +113,7 @@ stages:
 
     - script: |
         set -x
-        sudo apt-get install libyang libyang-dev
+        sudo apt-get install libyang0.16
         sudo dpkg -i --force-confask,confnew ../libswsscommon_1.0.0_amd64.deb
         sudo dpkg -i ../python3-swsscommon_1.0.0_amd64.deb
         sudo docker load -i ../target/docker-sonic-vs.gz

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,7 +113,8 @@ stages:
 
     - script: |
         set -x
-        sudo apt-get install libyang0.16
+        sudo apt-get update
+        sudo apt-get install libyang0.16 -y
         sudo dpkg -i --force-confask,confnew ../libswsscommon_1.0.0_amd64.deb
         sudo dpkg -i ../python3-swsscommon_1.0.0_amd64.deb
         sudo docker load -i ../target/docker-sonic-vs.gz

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,6 +113,7 @@ stages:
 
     - script: |
         set -x
+        sudo apt-get install libyang libyang-dev
         sudo dpkg -i --force-confask,confnew ../libswsscommon_1.0.0_amd64.deb
         sudo dpkg -i ../python3-swsscommon_1.0.0_amd64.deb
         sudo docker load -i ../target/docker-sonic-vs.gz


### PR DESCRIPTION
[AzurePipeline] Fix vstest step failed by libyang missing. 

#### Why I did it
Fix PR merge failed because 'vstest' step does not install libyang.

#### How I did it
Install libyang in azure pipeline.

#### How to verify it
Pass vstest step.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
[AzurePipeline] Fix vstest step failed by libyang missing. 

#### Ensure to add label/tag for the feature raised. example - [PR#2174](https://github.com/sonic-net/sonic-utilities/pull/2174) where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

