### PR TITLE
[Build] Fix sonic-config low dpkg hit rate issue

### DIFF
--- a/rules/sonic-config.dep
+++ b/rules/sonic-config.dep
@@ -4,7 +4,7 @@ SPATH       := $($(SONIC_CONFIG_ENGINE_PY3)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/sonic-config.mk rules/sonic-config.dep   
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(SPATH))
-DEP_FILES   += files/image_config/interfaces/interfaces.j2 dockers/docker-orchagent/ports.json.j2 dockers/docker-dhcp-relay/wait_for_intf.sh.j2 dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2 dockers/docker-lldp/lldpd.conf.j2 dockers/docker-orchagent/ipinip.json.j2 $(shell find device -type f) files/build_templates/qos_config.j2 dockers/docker-orchagent/switch.json.j2 dockers/docker-orchagent/vxlan.json.j2 files/image_config/constants/constants.yml
+DEP_FILES   += files/image_config/interfaces/interfaces.j2 dockers/docker-orchagent/ports.json.j2 dockers/docker-dhcp-relay/wait_for_intf.sh.j2 dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2 dockers/docker-lldp/lldpd.conf.j2 dockers/docker-orchagent/ipinip.json.j2 $(shell find device -type f | sort) files/build_templates/qos_config.j2 dockers/docker-orchagent/switch.json.j2 dockers/docker-orchagent/vxlan.json.j2 files/image_config/constants/constants.yml
 
 ifeq ($(ENABLE_PY2_MODULES), y)
     $(SONIC_CONFIG_ENGINE_PY2)_CACHE_MODE  := GIT_CONTENT_SHA 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When sending a PR only CI change, as expected, the target target/python-wheels/buster/sonic_config_engine-1.0-py2-none-any.whl should be from the cache, because the depended files were not changed, but it rebuilt.

See log in PR: https://github.com/sonic-net/sonic-buildimage/pull/12240
```
2022-09-30T07:16:16.9270567Z [ building ] [ target/python-wheels/buster/sonic_config_engine-1.0-py2-none-any.whl ] 
2022-09-30T07:17:52.6637892Z [ finished ] [ target/python-wheels/buster/sonic_config_engine-1.0-py2-none-any.whl ] 
```

Comparing the dpkg dep file sonic_config_engine-1.0-py3-none-any.whl.dep with the official build, the depended files are in different order, it leads to the different hash value.

The cache hit rate of the last 30 days was 11.9%, lower than expected, all the targets that depended on the targets were rebuilt.
```
AzurePipelineBuildLogs
| where startTime > ago(30d)
| where type contains "task"
| where reason contains "pullRequest"
| where content contains "[ target/python-wheels/buster/sonic_config_engine-1.0-py2-none-any.whl ]"
| summarize CachedCount = dcountif(buildId, content contains "[ cached ] [ target/python-wheels/buster/sonic_config_engine-1.0-py2-none-any.whl ]"), noneCachedCount=dcountif(buildId,content contains "[ finished ] [ target/python-wheels/buster/sonic_config_engine-1.0-py2-none-any.whl ]")
| project CachedCount/toreal(CachedCount + noneCachedCount)
```

#### How I did it
Sort the files by name.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - [PR#2174](https://github.com/sonic-net/sonic-utilities/pull/2174) where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

