### PR TITLE
[minigraph] Remove SLB and bgp monitor peers for storage backend

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1790,6 +1790,11 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     if is_storage_device:
         results['DEVICE_METADATA']['localhost']['storage_device'] = "true"
 
+    # remove bgp monitor and slb peers for storage backend
+    if is_storage_device and 'BackEnd' in current_device['type']:
+        results['BGP_MONITORS'] = {}
+        results['BGP_PEER_RANGE'] = {}
+
     results['VLAN'] = vlans
     results['VLAN_MEMBER'] = vlan_members
 

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -804,6 +804,14 @@ class TestCfgGen(TestCase):
             output = self.run_script(argument)
             self.assertEqual(output.strip(), "")
 
+            # SLB and BGP Monitor table does not exist
+            argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "BGP_PEER_RANGE"'
+            output = self.run_script(argument)
+            self.assertEqual(output.strip(), "")
+            argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "BGP_MONITORS"'
+            output = self.run_script(argument)
+            self.assertEqual(output.strip(), "")
+
             # ACL_TABLE should not contain EVERFLOW related entries
             argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "ACL_TABLE"'
             output = self.run_script(argument)

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -807,10 +807,10 @@ class TestCfgGen(TestCase):
             # SLB and BGP Monitor table does not exist
             argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "BGP_PEER_RANGE"'
             output = self.run_script(argument)
-            self.assertEqual(output.strip(), "")
+            self.assertEqual(output.strip(), "{}")
             argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "BGP_MONITORS"'
             output = self.run_script(argument)
-            self.assertEqual(output.strip(), "")
+            self.assertEqual(output.strip(), "{}")
 
             # ACL_TABLE should not contain EVERFLOW related entries
             argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "ACL_TABLE"'


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
slb and bgp mon peers are not needed for storage backend. These neighbor are present in the minigraph.

#### How I did it
After minigraph parsing, remove these neighbors if it is a storage backend device

#### How to verify it
Unit tests
Verified on the device that once these tables are removed, these peers don't show up in "show runningconfig bgp" output

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

