### PR TITLE
[202205][Arista] Fix content of platform.json for DCS-7050CX3-32S

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/platform.json
+++ b/device/arista/x86_64-arista_7050cx3_32s/platform.json
@@ -1,7 +1,20 @@
 {
     "chassis": {
         "name": "DCS-7050CX3-32S",
-        "components": [],
+        "components": [
+            {
+                "name": "Scd()"
+            },
+            {
+                "name": "Ucd90120A(addr=3-004e)"
+            },
+            {
+                "name": "Ucd90120A(addr=16-004e)"
+            },
+            {
+                "name": "CrowSysCpld(addr=2-0023)"
+            }
+        ],
         "fans": [],
         "fan_drawers": [
             {
@@ -40,11 +53,25 @@
         "psus": [
             {
                 "name": "psu1",
-                "fans": []
+                "fans": [
+                    {
+                        "name": "psu1/1",
+                        "speed": {
+                            "controllable": false
+                        }
+                    }
+                ]
             },
             {
                 "name": "psu2",
-                "fans": []
+                "fans": [
+                    {
+                        "name": "psu2/1",
+                        "speed": {
+                            "controllable": false
+                        }
+                    }
+                ]
             }
         ],
         "thermals": [
@@ -62,24 +89,6 @@
             },
             {
                 "name": "Front-panel temp sensor"
-            },
-            {
-                "name": "Power supply 1 hotspot sensor"
-            },
-            {
-                "name": "Power supply 1 inlet temp sensor"
-            },
-            {
-                "name": "Power supply 1 exhaust temp sensor"
-            },
-            {
-                "name": "Power supply 2 hotspot sensor"
-            },
-            {
-                "name": "Power supply 2 inlet temp sensor"
-            },
-            {
-                "name": "Power supply 2 exhaust temp sensor"
             }
         ],
         "sfps": [

--- a/device/arista/x86_64-arista_7050cx3_32s/platform.json
+++ b/device/arista/x86_64-arista_7050cx3_32s/platform.json
@@ -3,7 +3,10 @@
         "name": "DCS-7050CX3-32S",
         "components": [
             {
-                "name": "Scd()"
+                "name": "Aboot()"
+            },
+            {
+                "name": "Scd(addr=0000:02:00.0)"
             },
             {
                 "name": "Ucd90120A(addr=3-004e)"

--- a/device/arista/x86_64-arista_7050cx3_32s/platform_components.json
+++ b/device/arista/x86_64-arista_7050cx3_32s/platform_components.json
@@ -1,0 +1,13 @@
+{
+    "chassis": {
+        "DCS-7050CX3-32S": {
+            "component": {
+                "Aboot()": {},
+                "Scd(addr=0000:00:18.7)": {},
+                "Ucd90120A(addr=3-004e)": {},
+                "Ucd90120A(addr=16-004e)": {},
+                "CrowSysCpld(addr=2-0023)": {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Some tests under `platform_tests/api` were failing on the 7050CX3 due to outdated facts in platform.json

#### How I did it
Updated platform.json facts with appropriate values

#### How to verify it
Run tests under `platform_tests/api` to verify no failures

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - [PR#2174](https://github.com/sonic-net/sonic-utilities/pull/2174) where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

