### PR TITLE
Sync Accton wedge100bf-32qs with Barefoot wedge100bf-32x platform.

### DIFF
--- a/device/accton/x86_64-accton_wedge100bf_32qs-r0/montara/buffers_defaults_t0.j2
+++ b/device/accton/x86_64-accton_wedge100bf_32qs-r0/montara/buffers_defaults_t0.j2
@@ -66,7 +66,7 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
-        "{{ port }}|0-1": {
+        "{{ port }}|0-2": {
             "profile" : "q_lossy_profile"
         },
 {% endfor %}

--- a/device/accton/x86_64-accton_wedge100bf_32qs-r0/montara/buffers_defaults_t1.j2
+++ b/device/accton/x86_64-accton_wedge100bf_32qs-r0/montara/buffers_defaults_t1.j2
@@ -66,7 +66,7 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
-        "{{ port }}|0-1": {
+        "{{ port }}|0-2": {
             "profile" : "q_lossy_profile"
         },
 {% endfor %}

--- a/device/accton/x86_64-accton_wedge100bf_32qs-r0/platform.json
+++ b/device/accton/x86_64-accton_wedge100bf_32qs-r0/platform.json
@@ -1,6 +1,14 @@
 {
     "chassis": {
         "name": "Wedge100BF-32QS-O-AC-F-BF",
+        "components": [
+            {
+                "name": "BIOS"
+            },
+            {
+                "name": "BMC"
+            }
+        ],
         "fans": [
             {
                 "name": "counter-rotating-fan-1"
@@ -50,43 +58,49 @@
         ],
         "thermals": [
             {
-                "name": "com_e_driver-i2c-4-33:memory-temp"
-            },
-            {
                 "name": "com_e_driver-i2c-4-33:cpu-temp"
             },
             {
-                "name": "pfe1100-i2c-7-59:temp1"
+                "name": "com_e_driver-i2c-4-33:memory-temp"
             },
             {
-                "name": "pfe1100-i2c-7-59:temp2"
+                "name": "psu_driver-i2c-7-59:psu2-temp1"
             },
             {
-                "name": "pfe1100-i2c-7-5a:temp1"
+                "name": "psu_driver-i2c-7-59:psu2-temp2"
             },
             {
-                "name": "pfe1100-i2c-7-5a:temp2"
+                "name": "psu_driver-i2c-7-5a:psu1-temp1"
             },
             {
-                "name": "tmp75-i2c-3-48:outlet-middle-temp"
+                "name": "psu_driver-i2c-7-5a:psu1-temp2"
             },
             {
-                "name": "tmp75-i2c-3-49:inlet-middle-temp"
+                "name": "tmp75-i2c-3-48:chip-temp"
             },
             {
-                "name": "tmp75-i2c-3-4a:inlet-left-temp"
+                "name": "tmp75-i2c-3-49:exhaust2-temp"
             },
             {
-                "name": "tmp75-i2c-3-4b:switch-temp"
+                "name": "tmp75-i2c-3-4a:exhaust-temp"
             },
             {
-                "name": "tmp75-i2c-3-4c:inlet-right-temp"
+                "name": "tmp75-i2c-3-4b:intake-temp"
+            },
+            {
+                "name": "tmp75-i2c-3-4c:tofino-temp"
+            },
+            {
+                "name": "tmp75-i2c-3-4d:intake2-temp"
             },
             {
                 "name": "tmp75-i2c-8-48:outlet-right-temp"
             },
             {
                 "name": "tmp75-i2c-8-49:outlet-left-temp"
+            },
+            {
+                "name": "pch_haswell-virtual-0:temp1"
             },
             {
                 "name": "coretemp-isa-0000:package-id-0"
@@ -104,7 +118,16 @@
                 "name": "coretemp-isa-0000:core-3"
             },
             {
-                "name": "pch_haswell-virtual-0:temp1"
+                "name": "coretemp-isa-0000:core-4"
+            },
+            {
+                "name": "coretemp-isa-0000:core-5"
+            },
+            {
+                "name": "coretemp-isa-0000:core-6"
+            },
+            {
+                "name": "coretemp-isa-0000:core-7"
             }
         ],
         "sfps": [

--- a/device/accton/x86_64-accton_wedge100bf_32qs-r0/platform_components.json
+++ b/device/accton/x86_64-accton_wedge100bf_32qs-r0/platform_components.json
@@ -2,6 +2,8 @@
     "chassis": {
         "Wedge100BF-32QS-O-AC-F": {
             "component": {
+                "BIOS": { },
+                "BMC": { }
             }
         }
     }

--- a/device/accton/x86_64-accton_wedge100bf_32qs-r0/system_health_monitoring_config.json
+++ b/device/accton/x86_64-accton_wedge100bf_32qs-r0/system_health_monitoring_config.json
@@ -1,0 +1,11 @@
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "amber",
+        "normal": "green",
+        "booting": "orange_blink"
+    }
+}

--- a/device/accton/x86_64-accton_wedge100bf_32qs-r0/thermal_thresholds.json
+++ b/device/accton/x86_64-accton_wedge100bf_32qs-r0/thermal_thresholds.json
@@ -1,0 +1,76 @@
+{
+    "thermals": [
+        {
+            "com_e_driver-i2c-4-33:cpu-temp" : [99.0, 89.0, 11.0, 1.0]
+        },
+        {
+            "com_e_driver-i2c-4-33:memory-temp" : [85.0, 75.0, 11.0, 1.0]
+        },
+        {
+            "psu_driver-i2c-7-59:psu2-temp1" : [50.0, 40.0, 11.0, 1.0]
+        },
+        {
+            "psu_driver-i2c-7-59:psu2-temp2" : [90.0, 80.0, 11.0, 1.0]
+        },
+        {
+            "psu_driver-i2c-7-5a:psu1-temp1" : [50.0, 40.0, 11.0, 1.0]
+        },
+        {
+            "psu_driver-i2c-7-5a:psu1-temp2" : [90.0, 80.0, 11.0, 1.0]
+        },
+        {
+            "tmp75-i2c-3-48:chip-temp" : [90.0, 80.0, 11.0, 1.0]
+        },
+        {
+            "tmp75-i2c-3-49:exhaust2-temp" : [80.0, 70.0, 11.0, 1.0]
+        },
+        {
+            "tmp75-i2c-3-4a:exhaust-temp" : [60.0, 50.0, 11.0, 1.0]
+        },
+        {
+            "tmp75-i2c-3-4b:intake-temp" : [60.0, 50.0, 11.0, 1.0]
+        },
+        {
+            "tmp75-i2c-3-4c:tofino-temp" : [99.0, 89.0, 11.0, 1.0]
+        },
+        {
+            "tmp75-i2c-3-4d:intake2-temp" : [60.0, 50.0, 11.0, 1.0]
+        },
+        {
+            "tmp75-i2c-8-48:outlet-right-temp" : [60.0, 50.0, 11.0, 1.0]
+        },
+        {
+            "tmp75-i2c-8-49:outlet-left-temp" : [60.0, 50.0, 11.0, 1.0]
+        },
+        {
+            "pch_haswell-virtual-0:temp1" : [60.0, 50.0, 11.0, 1.0]
+        },
+        {
+            "coretemp-isa-0000:package-id-0" : [80.0, 70.0, 11.0, 1.0]
+        },
+        {
+            "coretemp-isa-0000:core-0" : [99.0, 89.0, 11.0, 1.0]
+        },
+        {
+            "coretemp-isa-0000:core-1" : [99.0, 89.0, 11.0, 1.0]
+        },
+        {
+            "coretemp-isa-0000:core-2" : [99.0, 89.0, 11.0, 1.0]
+        },
+        {
+            "coretemp-isa-0000:core-3" : [99.0, 89.0, 11.0, 1.0]
+        },
+        {
+            "coretemp-isa-0000:core-4" : [99.0, 89.0, 11.0, 1.0]
+        },
+        {
+            "coretemp-isa-0000:core-5" : [99.0, 89.0, 11.0, 1.0]
+        },
+        {
+            "coretemp-isa-0000:core-6" : [99.0, 89.0, 11.0, 1.0]
+        },
+        {
+            "coretemp-isa-0000:core-7" : [99.0, 89.0, 11.0, 1.0]
+        }
+    ]
+}

--- a/platform/barefoot/sonic-platform-modules-accton/debian/control
+++ b/platform/barefoot/sonic-platform-modules-accton/debian/control
@@ -2,11 +2,11 @@ Source: sonic-accton-platform-modules
 Section: main
 Priority: extra
 Maintainer: Support <support@edge-core.com>
-Build-Depends: debhelper (>= 9.0.0), bzip2
+Build-Depends: debhelper (>= 9.0.0), bzip2, python3
 Standards-Version: 3.9.3
 
 Package: sonic-platform-accton-wedge100bf-32qs
 Architecture: amd64
-Depends: linux-image-4.19.0-12-2-amd64-unsigned
+Depends: linux-image-5.10.0-12-2-amd64-unsigned
 Description: kernel modules for platform devices such as fan, led, sfp
 

--- a/platform/barefoot/sonic-platform-modules-accton/wedge100bf-32qs/conf/usb0
+++ b/platform/barefoot/sonic-platform-modules-accton/wedge100bf-32qs/conf/usb0
@@ -2,4 +2,5 @@
 auto usb0
 allow-hotplug usb0
 iface usb0 inet6
+up sysctl net.ipv6.neigh.usb0.base_reachable_time_ms=30000
 up ifconfig usb0 txqueuelen 64


### PR DESCRIPTION
Signed-off-by: Weichen Chen <weichen_chen@accton.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Since the latest uploading for Accton wedge100bf-32qs platform is in 2021, thus update wedge100bf-32qs platform.  
#### How I did it
Modify wedge100bf-32qs according to Barefoot wedge100bf-32x latest update.
#### How to verify it
show platform fan
show platform psustatus
show platform syseeprom
show platform temperature
show interfaces status
show interfaces transceiver eeprom
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - [PR#2174](https://github.com/sonic-net/sonic-utilities/pull/2174) where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

