### PR TITLE
[armhf][sonic-installer] Fix the sonic-installer install images on  armhf platform issue

### DIFF
--- a/platform/marvell-armhf/platform.conf
+++ b/platform/marvell-armhf/platform.conf
@@ -165,11 +165,11 @@ prepare_boot_menu() {
         fw_setenv ${FW_ARG} mtdparts 'mtdparts=spi0.0:4m(boot),-(spi-rootfs)' > /dev/null
     fi
     fw_setenv ${FW_ARG} ubi_sonic_boot_mount_ubi 'ubi part SONIC; ubifsmount ubi0' > /dev/null
-    fw_setenv ${FW_ARG} ubi_sonic_boot_bootargs $BOOTARGS > /dev/null
-    fw_setenv ${FW_ARG} ubi_sonic_boot_load $UBI_LOAD > /dev/null
+    fw_setenv ${FW_ARG} ubi_sonic_boot_bootargs "$BOOTARGS" > /dev/null
+    fw_setenv ${FW_ARG} ubi_sonic_boot_load "$UBI_LOAD" > /dev/null
     fw_setenv ${FW_ARG} sonic_image_1 "$UBIBOOTCMD" > /dev/null
-    fw_setenv ${FW_ARG} ubi_sonic_boot_bootargs_old $BOOTARGS_OLD > /dev/null
-    fw_setenv ${FW_ARG} ubi_sonic_boot_load_old $UBI_LOAD_OLD > /dev/null
+    fw_setenv ${FW_ARG} ubi_sonic_boot_bootargs_old "$BOOTARGS_OLD" > /dev/null
+    fw_setenv ${FW_ARG} ubi_sonic_boot_load_old "$UBI_LOAD_OLD" > /dev/null
     fw_setenv ${FW_ARG} sonic_image_2 "$UBIBOOTCMD_OLD" > /dev/null
     fw_setenv ${FW_ARG} boot_next  'run sonic_image_1'> /dev/null
     fw_setenv ${FW_ARG} bootcmd 'run print_menu; usb start; test -n "$boot_once" && run boot_once; run boot_next' > /dev/null


### PR DESCRIPTION
#### Why I did it
When using "sonic-installer install" to install a new image on  Marvell  armhf platform., the installation fails in the middle of the install process as the following:  
```
Installing image SONiC-OS-20220531.06 and setting it as default...
Command: bash /tmp/sonic_image
Error: illegal character '=' in variable name "rootfstype=ext4"
Verifying image checksum ... OK.
Preparing image archive ... OK.
Installing SONiC in SONiC
ONIE Installer: platform: armhf-marvell-armhf-r0
onie_platform: armhf-nokia_ixs7215_52x-r0
Preparing for installation ...
Intalling SONiC from sonic on Platform armhf-nokia_ixs7215_52x-r0
Removing old SONiC installation /host/image-202205.0-dirty-20221003.184014
Archive:  fs.zip
   creating: /host/image-20220531.06/boot/
  inflating: /host/image-20220531.06/boot/config-5.10.0-12-2-armmp  
  inflating: /host/image-20220531.06/boot/System.map-5.10.0-12-2-armmp  
  inflating: /host/image-20220531.06/boot/vmlinuz-5.10.0-12-2-armmp  
  inflating: /host/image-20220531.06/boot/armada-385-ipd6448m-5x.dtb  
  inflating: /host/image-20220531.06/boot/armada-385-ET6448M_4G_Nand.dtb  
  inflating: /host/image-20220531.06/boot/armada-385-ipd6448m.dtb  
  inflating: /host/image-20220531.06/boot/initrd.img-5.10.0-12-2-armmp  
extracting: /host/image-20220531.06/fs.squashfs  
EXTRA_CMDLINE_LINUX=
Sync up cache ...
Setting up U-Boot environment...
Using pre-configured uboot env
Using pre-configured uboot env for armhf-nokia_ixs7215_52x-r0
admin@sonic:~$ 
```
#### How I did it
The failure is caused by the uboot environment  attributes are not defined in the double quotes in the variable.  Missing double quote in the argument will cause the lost of the parameters when using in the bash.   To address this issue, add double quotes to arguments which are used with the fw_setven command in platform.conf.

#### How to verify it
Using "sonic-installer install" a new image which includes this fix.  The installation should be success.
```
Installing image SONiC-OS-202205.0-dirty-20221004.205824 and setting it as default...
Command: bash /tmp/sonic_image
Verifying image checksum ... OK.
Preparing image archive ... OK.
Installing SONiC in SONiC
ONIE Installer: platform: armhf-marvell-armhf-r0
onie_platform: armhf-nokia_ixs7215_52x-r0
Preparing for installation ... 
Intalling SONiC from sonic on Platform armhf-nokia_ixs7215_52x-r0
Removing old SONiC installation /host/image-202205.0-dirty-20221004.220503
Archive:  fs.zip
   creating: /host/image-202205.0-dirty-20221004.205824/boot/
  inflating: /host/image-202205.0-dirty-20221004.205824/boot/System.map-5.10.0-12-2-armmp  
  inflating: /host/image-202205.0-dirty-20221004.205824/boot/armada-385-ET6448M_4G_Nand.dtb  
  inflating: /host/image-202205.0-dirty-20221004.205824/boot/config-5.10.0-12-2-armmp  
  inflating: /host/image-202205.0-dirty-20221004.205824/boot/initrd.img-5.10.0-12-2-armmp  
  inflating: /host/image-202205.0-dirty-20221004.205824/boot/armada-385-ipd6448m.dtb  
  inflating: /host/image-202205.0-dirty-20221004.205824/boot/armada-385-ipd6448m-5x.dtb  
  inflating: /host/image-202205.0-dirty-20221004.205824/boot/vmlinuz-5.10.0-12-2-armmp  
 extracting: /host/image-202205.0-dirty-20221004.205824/fs.squashfs  
EXTRA_CMDLINE_LINUX=
Sync up cache ...
Setting up U-Boot environment...
Using pre-configured uboot env
Using pre-configured uboot env for armhf-nokia_ixs7215_52x-r0
mlok BOOTARGS=setenv bootargs root=/dev/sda2 rw rootwait rootfstype=ext4 panic=1 console=ttyS0,${baudrate} ${othbootargs} ${mtdparts} ${linuxargs}
mlok_old BOOTARGS_OLD=setenv bootargs root=/dev/sda2 rw rootwait rootfstype=ext4 panic=1 console=ttyS0,${baudrate} ${othbootargs} ${mtdparts} ${linuxargs_old}

Command: config-setup backup
Taking backup of current configuration

Command: mkdir -p /tmp/image-202205.0-dirty-20221004.205824-fs
Command: mount -t squashfs /host/image-202205.0-dirty-20221004.205824/fs.squashfs /tmp/image-202205.0-dirty-20221004.205824-fs
Command: sonic-cfggen -d -y /tmp/image-202205.0-dirty-20221004.205824-fs/etc/sonic/sonic_version.yml -t /tmp/image-202205.0-dirty-20221004.205824-fs/usr/share/sonic/templates/sonic-environment.j2
Command: umount -r -f /tmp/image-202205.0-dirty-20221004.205824-fs
Command: rm -rf /tmp/image-202205.0-dirty-20221004.205824-fs
Command: mkdir -p /tmp/image-202205.0-dirty-20221004.205824-fs
Command: mount -t squashfs /host/image-202205.0-dirty-20221004.205824/fs.squashfs /tmp/image-202205.0-dirty-20221004.205824-fs
Command: mkdir -p /host/image-202205.0-dirty-20221004.205824/rw
Command: mkdir -p /host/image-202205.0-dirty-20221004.205824/work
Command: mkdir -p /tmp/image-202205.0-dirty-20221004.205824-fs
Command: mount overlay -t overlay -o rw,relatime,lowerdir=/tmp/image-202205.0-dirty-20221004.205824-fs,upperdir=/host/image-202205.0-dirty-20221004.205824/rw,workdir=/host/image-202205.0-dirty-20221004.205824/work /tmp/image-202205.0-dirty-20221004.205824-fs
Command: mkdir -p /tmp/image-202205.0-dirty-20221004.205824-fs/var/lib/docker
Command: mount --bind /host/image-202205.0-dirty-20221004.205824/docker /tmp/image-202205.0-dirty-20221004.205824-fs/var/lib/docker
Command: chroot /tmp/image-202205.0-dirty-20221004.205824-fs mount proc /proc -t proc
Command: chroot /tmp/image-202205.0-dirty-20221004.205824-fs mount sysfs /sys -t sysfs
Command: chroot /tmp/image-202205.0-dirty-20221004.205824-fs /usr/lib/docker/docker.sh start
mount: /sys/fs/cgroup/cpu: cgroup already mounted on /sys/fs/cgroup.
mount: /sys/fs/cgroup/cpuacct: cgroup already mounted on /sys/fs/cgroup.
Command: cp /var/lib/sonic-package-manager/packages.json /tmp/image-202205.0-dirty-20221004.205824-fs/tmp/packages.json
Command: touch /tmp/image-202205.0-dirty-20221004.205824-fs/tmp/docker.sock
Command: mount --bind /var/run/docker.sock /tmp/image-202205.0-dirty-20221004.205824-fs/tmp/docker.sock
Command: chroot /tmp/image-202205.0-dirty-20221004.205824-fs sh -c command -v sonic-package-manager
Command: chroot /tmp/image-202205.0-dirty-20221004.205824-fs sonic-package-manager migrate /tmp/packages.json --dockerd-socket /tmp/docker.sock -y
migrating package dhcp-relay
skipping dhcp-relay as installed version is newer
migrating package macsec
skipping macsec as installed version is newer
Command: chroot /tmp/image-202205.0-dirty-20221004.205824-fs /usr/lib/docker/docker.sh stop
Command: umount -f -R /tmp/image-202205.0-dirty-20221004.205824-fs
Command: umount -r -f /tmp/image-202205.0-dirty-20221004.205824-fs
Command: rm -rf /tmp/image-202205.0-dirty-20221004.205824-fs
Command: sync;sync;sync

Command: sleep 3

Done
```
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - [PR#2174](https://github.com/sonic-net/sonic-utilities/pull/2174) where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

