### PR TITLE
[201811] Change submodule path from Azure to sonic-net

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,17 +1,17 @@
 [submodule "sonic-swss-common"]
 	path = src/sonic-swss-common
-	url = https://github.com/Azure/sonic-swss-common
+	url = https://github.com/sonic-net/sonic-swss-common
 	branch = 201811
 [submodule "sonic-linux-kernel"]
 	path = src/sonic-linux-kernel
-	url = https://github.com/Azure/sonic-linux-kernel
+	url = https://github.com/sonic-net/sonic-linux-kernel
 [submodule "sonic-sairedis"]
 	path = src/sonic-sairedis
-	url = https://github.com/Azure/sonic-sairedis
+	url = https://github.com/sonic-net/sonic-sairedis
 	branch = 201811
 [submodule "sonic-swss"]
 	path = src/sonic-swss
-	url = https://github.com/Azure/sonic-swss
+	url = https://github.com/sonic-net/sonic-swss
 	branch = 201811
 [submodule "src/p4c-bm/p4c-bm"]
 	path = platform/p4/p4c-bm/p4c-bm
@@ -21,37 +21,37 @@
 	url = https://github.com/p4lang/p4-hlir
 [submodule "quagga"]
 	path = src/sonic-quagga
-	url = https://github.com/Azure/sonic-quagga
+	url = https://github.com/sonic-net/sonic-quagga
 	branch = 201811
 [submodule "sonic-dbsyncd"]
 	path = src/sonic-dbsyncd
-	url = https://github.com/Azure/sonic-dbsyncd
+	url = https://github.com/sonic-net/sonic-dbsyncd
 [submodule "src/sonic-py-swsssdk"]
 	path = src/sonic-py-swsssdk
-	url = https://github.com/Azure/sonic-py-swsssdk.git
+	url = https://github.com/sonic-net/sonic-py-swsssdk.git
 [submodule "src/sonic-snmpagent"]
 	path = src/sonic-snmpagent
-	url = https://github.com/Azure/sonic-snmpagent
+	url = https://github.com/sonic-net/sonic-snmpagent
 [submodule "src/ptf"]
 	path = src/ptf
 	url = https://github.com/p4lang/ptf.git
 [submodule "src/sonic-utilities"]
 	path = src/sonic-utilities
-	url = https://github.com/Azure/sonic-utilities
+	url = https://github.com/sonic-net/sonic-utilities
 	branch = 201811
 [submodule "platform/broadcom/sonic-platform-modules-arista"]
 	path = platform/broadcom/sonic-platform-modules-arista
 	url = https://github.com/aristanetworks/sonic
 [submodule "src/sonic-platform-common"]
 	path = src/sonic-platform-common
-	url = https://github.com/Azure/sonic-platform-common
+	url = https://github.com/sonic-net/sonic-platform-common
 	branch = 201811
 [submodule "src/sonic-platform-daemons"]
 	path = src/sonic-platform-daemons
-	url = https://github.com/Azure/sonic-platform-daemons
+	url = https://github.com/sonic-net/sonic-platform-daemons
 [submodule "src/sonic-frr/frr"]
 	path = src/sonic-frr/frr
-	url = https://github.com/Azure/sonic-frr.git
+	url = https://github.com/sonic-net/sonic-frr.git
 [submodule "platform/p4/p4-hlir/p4-hlir-v1.1"]
 	path = platform/p4/p4-hlir/p4-hlir-v1.1
 	url = https://github.com/p4lang/p4-hlir.git
@@ -69,4 +69,4 @@
 	url = https://github.com/p/redis-dump-load.git
 [submodule "src/telemetry/sonic-telemetry"]
 	path = src/telemetry/sonic-telemetry
-	url = https://github.com/Azure/sonic-telemetry.git
+	url = https://github.com/sonic-net/sonic-telemetry.git

--- a/files/image_config/environment/motd
+++ b/files/image_config/environment/motd
@@ -10,5 +10,5 @@ You are on
 Unauthorized access and/or use are prohibited.
 All access and/or use are subject to monitoring.
 
-Help:    http://azure.github.io/SONiC/
+Help:    https://sonic-net.github.io/SONiC/
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Change the path of sonic submodules that point to "Azure" to point to "sonic-net"

#### How I did it
Replace "Azure" with "sonic-net" on all relevant paths of sonic submodules

#### How to verify it


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)