### PR TITLE
Remove swsssdk from sonic OS image and docker container image

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -130,13 +130,6 @@ if [[ $CONFIGURED_ARCH == amd64 ]]; then
     sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio-tools==1.39.0"
 fi
 
-# Install SwSS SDK Python 3 package
-# Note: the scripts will be overwritten by corresponding Python 2 package
-SWSSSDK_PY3_WHEEL_NAME=$(basename {{swsssdk_py3_wheel_path}})
-sudo cp {{swsssdk_py3_wheel_path}} $FILESYSTEM_ROOT/$SWSSSDK_PY3_WHEEL_NAME
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install $SWSSSDK_PY3_WHEEL_NAME
-sudo rm -rf $FILESYSTEM_ROOT/$SWSSSDK_PY3_WHEEL_NAME
-
 # Install sonic-py-common Python 3 package
 SONIC_PY_COMMON_PY3_WHEEL_NAME=$(basename {{sonic_py_common_py3_wheel_path}})
 sudo cp {{sonic_py_common_py3_wheel_path}} $FILESYSTEM_ROOT/$SONIC_PY_COMMON_PY3_WHEEL_NAME

--- a/platform/vs/docker-sonic-vs.mk
+++ b/platform/vs/docker-sonic-vs.mk
@@ -16,10 +16,7 @@ $(DOCKER_SONIC_VS)_DEPENDS += $(SWSS) \
                               $(SONIC_HOST_SERVICES_DATA) \
                               $(IPROUTE2)
 
-# swsssdk is a dependency of sonic-py-common
-# TODO: sonic-py-common should depend on swsscommon instead
-$(DOCKER_SONIC_VS)_PYTHON_WHEELS += $(SWSSSDK_PY3) \
-                                    $(SONIC_PY_COMMON_PY3) \
+$(DOCKER_SONIC_VS)_PYTHON_WHEELS += $(SONIC_PY_COMMON_PY3) \
                                     $(SONIC_PLATFORM_COMMON_PY3) \
                                     $(SONIC_YANG_MODELS_PY3) \
                                     $(SONIC_YANG_MGMT_PY3) \

--- a/rules/sonic-py-common.mk
+++ b/rules/sonic-py-common.mk
@@ -3,6 +3,7 @@ ifeq ($(ENABLE_PY2_MODULES), y)
 
     SONIC_PY_COMMON_PY2 = sonic_py_common-1.0-py2-none-any.whl
     $(SONIC_PY_COMMON_PY2)_SRC_PATH = $(SRC_PATH)/sonic-py-common
+    $(SONIC_PY_COMMON_PY2)_DEPENDS += $(SWSSSDK_PY2)
     $(SONIC_PY_COMMON_PY2)_DEBS_DEPENDS = $(LIBSWSSCOMMON) \
                                           $(PYTHON_SWSSCOMMON)
     $(SONIC_PY_COMMON_PY2)_PYTHON_VERSION = 2
@@ -13,6 +14,7 @@ endif
 
 SONIC_PY_COMMON_PY3 = sonic_py_common-1.0-py3-none-any.whl
 $(SONIC_PY_COMMON_PY3)_SRC_PATH = $(SRC_PATH)/sonic-py-common
+$(SONIC_PY_COMMON_PY3)_DEPENDS += $(SWSSSDK_PY3)
 $(SONIC_PY_COMMON_PY3)_DEBS_DEPENDS = $(PYTHON3_SWSSCOMMON)
 ifeq ($(ENABLE_PY2_MODULES), y)
     # Synthetic dependency to avoid building the Python 2 and 3 packages

--- a/rules/sonic-py-common.mk
+++ b/rules/sonic-py-common.mk
@@ -3,7 +3,6 @@ ifeq ($(ENABLE_PY2_MODULES), y)
 
     SONIC_PY_COMMON_PY2 = sonic_py_common-1.0-py2-none-any.whl
     $(SONIC_PY_COMMON_PY2)_SRC_PATH = $(SRC_PATH)/sonic-py-common
-    $(SONIC_PY_COMMON_PY2)_DEPENDS += $(SWSSSDK_PY2)
     $(SONIC_PY_COMMON_PY2)_DEBS_DEPENDS = $(LIBSWSSCOMMON) \
                                           $(PYTHON_SWSSCOMMON)
     $(SONIC_PY_COMMON_PY2)_PYTHON_VERSION = 2
@@ -14,7 +13,6 @@ endif
 
 SONIC_PY_COMMON_PY3 = sonic_py_common-1.0-py3-none-any.whl
 $(SONIC_PY_COMMON_PY3)_SRC_PATH = $(SRC_PATH)/sonic-py-common
-$(SONIC_PY_COMMON_PY3)_DEPENDS += $(SWSSSDK_PY3)
 $(SONIC_PY_COMMON_PY3)_DEBS_DEPENDS = $(PYTHON3_SWSSCOMMON)
 ifeq ($(ENABLE_PY2_MODULES), y)
     # Synthetic dependency to avoid building the Python 2 and 3 packages

--- a/slave.mk
+++ b/slave.mk
@@ -1214,8 +1214,6 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 	export sonic_py_common_py3_wheel_path="$(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_PY_COMMON_PY3))"
 	export config_engine_py2_wheel_path="$(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_CONFIG_ENGINE_PY2))"
 	export config_engine_py3_wheel_path="$(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_CONFIG_ENGINE_PY3))"
-	export swsssdk_py2_wheel_path="$(addprefix $(PYTHON_WHEELS_PATH)/,$(SWSSSDK_PY2))"
-	export swsssdk_py3_wheel_path="$(addprefix $(PYTHON_WHEELS_PATH)/,$(SWSSSDK_PY3))"
 	export platform_common_py3_wheel_path="$(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_PLATFORM_COMMON_PY3))"
 	export redis_dump_load_py2_wheel_path="$(addprefix $(PYTHON_WHEELS_PATH)/,$(REDIS_DUMP_LOAD_PY2))"
 	export redis_dump_load_py3_wheel_path="$(addprefix $(PYTHON_WHEELS_PATH)/,$(REDIS_DUMP_LOAD_PY3))"


### PR DESCRIPTION
Remove swsssdk from sonic OS image and docker image

#### Why I did it
swsssdk is deprecated, so need remove from image.

#### How I did it
Update config file to remove swsssdk from image.

#### How to verify it
Pass all test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
Remove swsssdk from sonic OS image and docker image

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

