### PR TITLE
[build] Fix dpkg front lock issue caused by apt-get install

### DIFF
--- a/src/sonic-build-hooks/hooks/dpkg
+++ b/src/sonic-build-hooks/hooks/dpkg
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+. /usr/local/share/buildinfo/scripts/buildinfo_base.sh
+REAL_COMMAND=$(get_command dpkg)
+COMMAND_INFO="Locked by command: $REAL_COMMAND $@"
+lock_result=$(acquire_apt_installation_lock "$COMMAND_INFO" )
+$REAL_COMMAND "$@"
+command_result=$?
+[ "$lock_result" == y ] && release_apt_installation_lock
+exit $command_result


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
'dpkg -i' maybe conflict with 'apt-get install'.
#### How I did it
Use the same lock with apt-get when running 'dpkg -i'.
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

