### PR TITLE
[action] Fix PR pre-cherry-pick action wrong author issue.

### DIFF
--- a/.github/workflows/pr_cherrypick_prestep.yml
+++ b/.github/workflows/pr_cherrypick_prestep.yml
@@ -33,7 +33,7 @@ jobs:
         pr_url=$(echo $GITHUB_CONTEXT | jq -r ".event.pull_request._links.html.href")
         repository=$(echo $GITHUB_CONTEXT | jq -r ".repository")
         labels=$(echo $GITHUB_CONTEXT | jq -r ".event.pull_request.labels[].name")
-        author=$(echo $GITHUB_CONTEXT | jq -r ".event.pull_request.base.user.login")
+        author=$(echo $GITHUB_CONTEXT | jq -r ".event.pull_request.user.login")
         branches=$(git branch -a --list 'origin/20????' | awk -F/ '{print$3}' | grep -E "202[0-9]{3}")
         if [[ $(echo $GITHUB_CONTEXT | jq -r ".event.action") == "labeled" ]];then
           labels=$(echo $GITHUB_CONTEXT | jq -r ".event.label.name")


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The pre-cherry-pick action get a wrong author: sonic-net.
Fix it to help PR owner to realize that there is conflict.
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

