### PR TITLE
Initialize pointer variable platform before use in get_num_of_asic

### DIFF
--- a/src/systemd-sonic-generator/systemd-sonic-generator.c
+++ b/src/systemd-sonic-generator/systemd-sonic-generator.c
@@ -516,7 +516,7 @@ int get_num_of_asic() {
     FILE *fp;
     char *line = NULL;
     char* token;
-    char* platform;
+    char* platform = NULL;
     char* saveptr;
     size_t len = 0;
     ssize_t nread;


### PR DESCRIPTION
#### Why I did it
Pointer variable platform not initialized before use in get_num_of_asic of src/systemd-sonic-generator/systemd-sonic-generator.c. Then wild pointer will introduce undetermined exception when use in snprintf at line 545 .
Other pointers in this function like token will be assigned the value before use, and will not have such issue.

#### How I did it
Initialized pointer platform to NULL when defined and before use.