### PR TITLE
Static Lag Support Libteam fixes for lb mode load-balance

### DIFF
--- a/src/libteam/patch/0013-Revert-Disregard-current-state-when-considering-port-enablement.patch
+++ b/src/libteam/patch/0013-Revert-Disregard-current-state-when-considering-port-enablement.patch
@@ -1,0 +1,49 @@
+commit 43ba045cb88067eadfe7ae462cb8c9807c54d506
+Author: skannan <skannan@celestica.com>
+Date:   Tue Oct 11 07:10:15 2022 +0000
+
+    Revert "teamd: Disregard current state when considering port enablement"
+    This reverts commit deadb5b.
+    
+    As Patrick noticed, with that commit, teamd_port_check_enable()
+    would set the team port to the new state unconditionally, which
+    triggers another change message from kernel to userspace, then
+    teamd_port_check_enable() is called again to set the team port
+    to the new state.
+    
+    This would go around and around to update the team port state,
+    and even cause teamd to consume 100% cpu.
+    
+    As the issue caused by that commit is serious, it has to be
+    reverted. As for the issued fixed by that commit, I would
+    propose a new fix later.
+    
+    Signed-off-by: Jiri Pirko <jiri@nvidia.com>
+    
+    Signed-off-by: skannan <skannan@celestica.com>
+
+diff --git a/teamd/teamd_per_port.c b/teamd/teamd_per_port.c
+index cefd6c2..0e46e09 100644
+--- a/teamd/teamd_per_port.c
++++ b/teamd/teamd_per_port.c
+@@ -448,14 +448,18 @@ int teamd_port_check_enable(struct teamd_context *ctx,
+ 			    bool should_enable, bool should_disable)
+ {
+ 	bool new_enabled_state;
++	bool curr_enabled_state;
+ 	int err;
+ 
+ 	if (!teamd_port_present(ctx, tdport))
+ 		return 0;
++	err = teamd_port_enabled(ctx, tdport, &curr_enabled_state);
++	if (err)
++		return err;
+ 
+-	if (should_enable)
++	if (!curr_enabled_state && should_enable)
+ 		new_enabled_state = true;
+-	else if (should_disable)
++	else if (curr_enabled_state  && should_disable)
+ 		new_enabled_state = false;
+ 	else
+ 		return 0;

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -10,3 +10,4 @@
 0010-When-read-of-timerfd-returned-0-don-t-consider-this-.patch
 0011-Remove-extensive-debug-output.patch
 0012-Increase-min_ports-upper-limit-to-1024.patch
+0013-Revert-Disregard-current-state-when-considering-port-enablement.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Static port channel support is the feature not existing in SONIC this pull requests handles the changes needed for libteam to support Static port channel with load-balance mode.
https://github.com/sonic-net/SONiC/pull/1039

#### How I did it
Libteam goes to 100% when static lag is configured with load-balance mode due to following change 
https://github.com/jpirko/libteam/commit/deadb5b715227429a1879b187f5906b39151eca9
This was reverted using the following pull request
https://github.com/jpirko/libteam/commit/61efd6de2fbb8ee077863ee5a355ac3dfd9365b9 
but sonic still downloads the older change which causes CPU spike when teamd is configured 
with loadbalance option for static lag

Reverting the change fixes the issue @madhukar-kamarapu from broadcom provided the above history.


#### How to verify it
    1       Create static port channel with static flag     pass
    2       verify static has option flag true or false     pass
    3       Add static member see the portchannel is up     pass
    4       verify teamd is created with loadbalance option by default
    pass
    5       Remove last portchannel member check port channel down  pass
    6       Remove portchannel member check port channel still up   pass
    7       verify teamdctl config dump     pass
    8       verify teamdctl state dump      pass
    9       shutdown the portchannel check the kernel state pass
    10      no shutdown the portchannel check the kernel state      pass
    11      "Check the show output matches the review comment
    root@sonic:~# show inter port
    Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not
    available,
           S - selected, D - deselected, * - not synced
      No.  Team Dev      Protocol     Ports
    -----  ------------  -----------  ------------
        1  PortChannel1  NONE(A)(Up)  Ethernet0(S)
        2  PortChannel2  NONE(A)(Up)  Ethernet8(S)
        4  PortChannel4  NONE(A)(Dw)
    "       pass
    12      teamnl is set to loadbalance    pass
    13      save and reload and verify portchannel is up    pass
    14      "docker restart teamd
    teamd stopped
    swss stopped
    syncd stopped

    swss started
    syncd started
    teamd started"  pass

    15. verify teamd settles doesnt hog cpu with 100% cpu usage pass
  
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

