### PR TITLE
[202205][FRR] revert change in bgp_zebra_nexthop_set

### DIFF
--- a/src/sonic-frr/patch/0010-FRR-revert-change-in-bgp_zebra_nexthop_set.patch
+++ b/src/sonic-frr/patch/0010-FRR-revert-change-in-bgp_zebra_nexthop_set.patch
@@ -1,0 +1,83 @@
+From ed3baad73619bb3a7dd845ef68bf9c51071cbfb2 Mon Sep 17 00:00:00 2001
+From: Ying Xie <ying.xie@microsoft.com>
+Date: Wed, 12 Oct 2022 04:54:49 +0000
+Subject: [PATCH 10/10] [FRR] revert change in bgp_zebra_nexthop_set
+
+Signed-off-by: Ying Xie <ying.xie@microsoft.com>
+---
+ bgpd/bgp_zebra.c | 27 ++++-----------------------
+ 1 file changed, 4 insertions(+), 23 deletions(-)
+
+diff --git a/bgpd/bgp_zebra.c b/bgpd/bgp_zebra.c
+index 21912d143..dbf2a34ed 100644
+--- a/bgpd/bgp_zebra.c
++++ b/bgpd/bgp_zebra.c
+@@ -762,7 +762,6 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
+ {
+ 	int ret = 0;
+ 	struct interface *ifp = NULL;
+-	bool v6_ll_avail = true;
+ 
+ 	memset(nexthop, 0, sizeof(struct bgp_nexthop));
+ 
+@@ -788,9 +787,6 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
+ 								? peer->conf_if
+ 								: peer->ifname,
+ 							peer->bgp->vrf_id);
+-			else if (peer->update_if)
+-				ifp = if_lookup_by_name(peer->update_if,
+-							peer->bgp->vrf_id);
+ 		} else if (peer->update_if)
+ 			ifp = if_lookup_by_name(peer->update_if,
+ 						peer->bgp->vrf_id);
+@@ -835,20 +831,12 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
+ 			 * route-map to
+ 			 * specify the global IPv6 nexthop.
+ 			 */
+-			v6_ll_avail =
+-				if_get_ipv6_local(ifp, &nexthop->v6_global);
++			if_get_ipv6_local(ifp, &nexthop->v6_global);
+ 			memcpy(&nexthop->v6_local, &nexthop->v6_global,
+ 			       IPV6_MAX_BYTELEN);
+ 		} else
+-			v6_ll_avail =
+-				if_get_ipv6_local(ifp, &nexthop->v6_local);
++			if_get_ipv6_local(ifp, &nexthop->v6_local);
+ 
+-		/*
+-		 * If we are a v4 connection and we are not doing unnumbered
+-		 * not having a v6 LL address is ok
+-		 */
+-		if (!v6_ll_avail && !peer->conf_if)
+-			v6_ll_avail = true;
+ 		if (if_lookup_by_ipv4(&remote->sin.sin_addr, peer->bgp->vrf_id))
+ 			peer->shared_network = 1;
+ 		else
+@@ -874,14 +862,7 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
+ 						   remote->sin6.sin6_scope_id,
+ 						   peer->bgp->vrf_id);
+ 			if (direct)
+-				v6_ll_avail = if_get_ipv6_local(
+-					ifp, &nexthop->v6_local);
+-			/*
+-			 * It's fine to not have a v6 LL when using
+-			 * update-source loopback/vrf
+-			 */
+-			if (!v6_ll_avail && if_is_loopback(ifp))
+-				v6_ll_avail = true;
++				if_get_ipv6_local(ifp, &nexthop->v6_local);
+ 		} else
+ 		/* Link-local address. */
+ 		{
+@@ -928,7 +909,7 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
+ 
+ 	/* If we have identified the local interface, there is no error for now.
+ 	 */
+-	return v6_ll_avail;
++	return true;
+ }
+ 
+ static struct in6_addr *
+-- 
+2.17.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -8,3 +8,4 @@
 0008-Link-local-scope-was-not-set-while-binding-socket-for-bgp-ipv6-link-local-neighbors.patch
 Disable-ipv6-src-address-test-in-pceplib.patch
 0009-ignore-route-from-default-table.patch
+0010-FRR-revert-change-in-bgp_zebra_nexthop_set.patch


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

