### PR TITLE
[202205][Arista] Fix cmdline generation during warm-reboot from  201811/201911

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -695,17 +695,25 @@ write_default_cmdline() {
     cmdline_clear
 
     if $in_aboot; then
-        # generate the default kernel parameters for the platform
+        # Generate the default kernel parameters for the platform
         cat /etc/cmdline | sed "/^\(${bootconfigvars// /\|}\|crashkernel\|loglevel\|ignore_loglevel\)\(\$\|=\)/d;/^\$/d" | cmdline_append
-    elif grep -q "$delimiter" /proc/cmdline; then
-        # we are on a recent sonic image using delimiter. extracting the part of the
+    elif grep -q "$delimiter" /proc/cmdline && ! grep -Eq "varlog_size=.* $delimiter" /proc/cmdline; then
+        # We are on a recent sonic image using delimiter. extracting the part of the
         # cmdline coming from aboot is trivial.
+        # The 2nd part of the condition ensures that the append bug is not present.
+        # When it is it should go through the last case of this if/else block to
+        # regenerate the aboot cmdline
         cat /proc/cmdline | sed -E "s/^(.*) $delimiter .*$/\1/" | tr ' ' '\n' | cmdline_append
-    else
-        # we are either on SONiC or EOS and the commandline doesn't have a delimiter
-        # for the Aboot part. Take an educated guess at a right delimiter.
-        # Subject to breakage if EOS or SONiC cmdline change.
+    elif grep -q "SWI=" /proc/cmdline; then
+        # We are in EOS and the cmdline doesn't have a delimiter for the aboot part
         cat /proc/cmdline | sed -E 's/^(.*) rw .*$/\1/' | tr ' ' '\n' | cmdline_append
+    else
+        # We are in SONiC and the cmdline doesn't have a delimiter for the aboot part.
+        # sid= should most of the time be the last parameter provided by Aboot
+        # Alternatively we are in SONiC and the cmdline-aboot-end delimiter was
+        # added after image specific parameters due to a BUG which is solved by the
+        # following statement.
+        cat /proc/cmdline | sed -E 's/^(.* sid=[^ ]+).*$/\1/' | tr ' ' '\n' | cmdline_append
     fi
 
     cmdline_add "$delimiter"
@@ -713,9 +721,14 @@ write_default_cmdline() {
 
 write_cmdline() {
     # use extra parameters from kernel-params hook if the file exists
-    if [ -f "$target_path/$kernel_params" ] && ! $secureboot; then
-        info "Loading extra kernel parameters from $kernel_params"
-        cat "$target_path/$kernel_params" | cmdline_append
+    if [ -f "$target_path/$kernel_params" ]; then
+        if $secureboot && $debug; then
+            warn "Unsafe: Loading extra kernel parameters from $kernel_params"
+            cat "$target_path/$kernel_params" | cmdline_append
+        elif ! $secureboot; then
+            info "Loading extra kernel parameters from $kernel_params"
+            cat "$target_path/$kernel_params" | cmdline_append
+        fi
     fi
 
     # FIXME: sonic sometimes adds extra kernel parameters from user space

--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -67,7 +67,7 @@ fi
 
 mountpoint_for_file() {
    local file="$1"
-   df "$file" | tail -1 | tr -s " " | cut -d ' ' -f6
+   df "$file" 2> /dev/null | tail -1 | tr -s " " | cut -d ' ' -f6
 }
 
 # extract mount point from the swi path, e.g., /mnt/flash/sonic.swi --> /mnt/flash
@@ -814,11 +814,11 @@ regular_install() {
 
     mkdir -p $image_path
 
-    info "Generating boot-config, machine.conf and cmdline"
-    write_regular_configs "$image_path"
-
     info "Installing image under $image_path"
     extract_image
+
+    info "Generating boot-config, machine.conf and cmdline"
+    write_regular_configs "$image_path"
 
     run_hooks post-install
 }


### PR DESCRIPTION
#### Why I did it

The cmdline generation has changed between 201911 and 202012 for Arista products.
Doing a fast/warm reboot from 201811 or 201911 to a newer release would lead to cmdline issues.

#### How I did it

Cherry-picked the fix #11161 that was applied to 202012 onto 202205

#### How to verify it

Perform a warm-reboot from 201811/201911 to 202205 to validate.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix cmdline generation during warm-reboot from 201811/201911

