### PR TITLE
[202205][Arista] Add emmc quirks to boot0

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -613,6 +613,7 @@ write_platform_specific_cmdline() {
     if in_array "$platform" "crow" "magpie"; then
         cmdline_add amd_iommu=off
         cmdline_add modprobe.blacklist=snd_hda_intel,hdaudio
+        cmdline_add sdhci.append_quirks2=0x40
         read_system_eeprom
     fi
     if in_array "$platform" "woodpecker"; then


### PR DESCRIPTION
#### Why I did it
Fix some unreliability seen on emmc device with some AMD CPUs

#### How I did it
Added a kernel parameter to add quirks to
It depends on a sonic-linux-kernel change to work properly but will be a no-op without it.

#### How to verify it
Check that the settings is properly set on the cmdline when running on a 7060CX-32S

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add emmc quirks for Upperlake
