### PR TITLE
Fix sensord service install

### DIFF
--- a/src/lm-sensors/patch/0002-Patch-to-peform-dh_installinit-to-include-sensord.in.patch
+++ b/src/lm-sensors/patch/0002-Patch-to-peform-dh_installinit-to-include-sensord.in.patch
@@ -1,23 +1,13 @@
-From b11fd3d516b62c01513d289bc901820aa150c63e Mon Sep 17 00:00:00 2001
-From: Charlie Chen <charlie_chen@edge-core.com>
-Date: Wed, 1 Apr 2020 06:59:06 +0000
-Subject: Patch to peform dh_installinit to include sensord.install in the
- packed deb
-
-Signed-off-by: Charlie Chen <charlie_chen@edge-core.com>
----
- debian/rules | 1 +
- 1 file changed, 1 insertion(+)
-
 diff --git a/debian/rules b/debian/rules
-index 5ebda06..1d77e28 100755
+index 3cd5314..1dd0983 100755
 --- a/debian/rules
 +++ b/debian/rules
-@@ -56,3 +56,4 @@ override_dh_auto_install-arch:
-
+@@ -66,6 +66,8 @@ override_dh_auto_install-arch:
+ 
  override_dh_installinit-arch:
  	dh_installinit -plm-sensors --no-start
 +	dh_installinit -psensord --no-start
---
-2.17.1
-
+ 
+ override_dh_installsystemd-arch:
+ 	dh_installsystemd -plm-sensors --no-start
++	dh_installsystemd -psensord --no-start


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
https://github.com/sonic-net/sonic-buildimage/issues/4021 describes an issue that is still being observed on master image whereby sensord does not start in pmon due to missing service.

#### How I did it
Updated the lm-sensors install patch with a case for systemd

#### How to verify it
Verified that sensord is up in pmon after boot

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

