### PR TITLE
[Arista] Add other chassis names to platform_components.json for 720DT-48S

### DIFF
--- a/device/arista/x86_64-arista_720dt_48s/platform_components.json
+++ b/device/arista/x86_64-arista_720dt_48s/platform_components.json
@@ -5,6 +5,18 @@
                 "Aboot()": {},
                 "Scd(addr=0000:00:18.7)": {}
             }
+        },
+        "CCS-720DT-48S-2F": {
+            "component": {
+                "Aboot()": {},
+                "Scd(addr=0000:00:18.7)": {}
+            }
+        },
+        "CCS-720DT-48S-2R": {
+            "component": {
+                "Aboot()": {},
+                "Scd(addr=0000:00:18.7)": {}
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The 720DT-48S platform has variants with different chassis names, and these need to all be included in platform_components.json to ensure that sonic-mgmt platform_tests/fwutil/test_fwutil.py::test_fwutil_show passes

#### How I did it
Updated platform_components.json with the variant names for 720DT-48S.

#### How to verify it
Ran aforementioned testcase and verified that it passes on the different variants.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

