### PR TITLE
[POC] Expire build-in user to force change password

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -686,6 +686,13 @@ if [ "${gid_user}" != "1000" ]; then
     die "expect gid 1000. current:${gid_user}"
 fi
 
+## Create test user to test user password expire
+## TODO: remove this before PR merge
+sudo LANG=C chroot $FILESYSTEM_ROOT useradd -G sudo,docker "test_user" -c "$DEFAULT_USERINFO" -m -s /bin/bash
+## Create password for the default user
+echo "test_user:test_user" | sudo LANG=C chroot $FILESYSTEM_ROOT chpasswd
+
+
 # Expire all build-in user, so they need change password during first time login
 # Keeps admin not change to keep UT and pipeline not break.
 sudo LANG=C chroot $FILESYSTEM_ROOT getent /etc/passwd | while IFS=: read -r name password uid gid gecos home shell; do

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -688,17 +688,18 @@ fi
 
 ## Create test user to test user password expire
 ## TODO: remove this before PR merge
-sudo LANG=C chroot $FILESYSTEM_ROOT useradd -G sudo,docker "test_user" -c "$DEFAULT_USERINFO" -m -s /bin/bash
+TEST_USERINFO="Test user,,,"
+sudo LANG=C chroot $FILESYSTEM_ROOT useradd -G sudo,docker "test_user" -c "$TEST_USERINFO" -m -s /bin/bash
 ## Create password for the default user
 echo "test_user:test_user" | sudo LANG=C chroot $FILESYSTEM_ROOT chpasswd
 
-
 # Expire all build-in user, so they need change password during first time login
 # Keeps admin not change to keep UT and pipeline not break.
-sudo LANG=C chroot $FILESYSTEM_ROOT getent /etc/passwd | while IFS=: read -r name password uid gid gecos home shell; do
+sudo getent $FILESYSTEM_ROOT/etc/passwd | while IFS=: read -r name password uid gid gecos home shell; do
     if [ -d "$home" ] && [ "$(stat -c %u "$home")" = "$uid" ]; then
         if [ ! -z "$shell" ] && [ "$shell" != "/bin/false" ] && [ "$shell" != "/usr/sbin/nologin" ] && [ "$name" != "admin" ]; then
             sudo LANG=C chroot $FILESYSTEM_ROOT passwd --expire $name
+            echo 'expire user $name'
         fi
     fi
 done

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -376,6 +376,9 @@ if [ -f $FIRST_BOOT_FILE ]; then
 
     # Kdump tools configuration
     [ -f /etc/default/kdump-tools ] && sed -i -e "s/__PLATFORM__/$platform/g" /etc/default/kdump-tools
+    
+    # force admin user change password
+    passwd --expire admin
 
     firsttime_exit
 fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

