### PR TITLE
Change submoduel path from Azure to sonic-net

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "sonic-swss-common"]
 	path = src/sonic-swss-common
-	url = https://github.com/Azure/sonic-swss-common
+	url = https://github.com/sonic-net/sonic-swss-common
 [submodule "sonic-linux-kernel"]
 	path = src/sonic-linux-kernel
-	url = https://github.com/Azure/sonic-linux-kernel
+	url = https://github.com/sonic-net/sonic-linux-kernel
 [submodule "sonic-sairedis"]
 	path = src/sonic-sairedis
-	url = https://github.com/Azure/sonic-sairedis
+	url = https://github.com/sonic-net/sonic-sairedis
 [submodule "sonic-swss"]
 	path = src/sonic-swss
-	url = https://github.com/Azure/sonic-swss
+	url = https://github.com/sonic-net/sonic-swss
 [submodule "src/p4c-bm/p4c-bm"]
 	path = platform/p4/p4c-bm/p4c-bm
 	url = https://github.com/krambn/p4c-bm
@@ -18,33 +18,33 @@
 	url = https://github.com/p4lang/p4-hlir
 [submodule "sonic-dbsyncd"]
 	path = src/sonic-dbsyncd
-	url = https://github.com/Azure/sonic-dbsyncd
+	url = https://github.com/sonic-net/sonic-dbsyncd
 [submodule "src/sonic-py-swsssdk"]
 	path = src/sonic-py-swsssdk
-	url = https://github.com/Azure/sonic-py-swsssdk.git
+	url = https://github.com/sonic-net/sonic-py-swsssdk.git
 [submodule "src/sonic-snmpagent"]
 	path = src/sonic-snmpagent
-	url = https://github.com/Azure/sonic-snmpagent
+	url = https://github.com/sonic-net/sonic-snmpagent
 [submodule "src/ptf"]
 	path = src/ptf
 	url = https://github.com/p4lang/ptf.git
 [submodule "src/sonic-utilities"]
 	path = src/sonic-utilities
-	url = https://github.com/Azure/sonic-utilities
+	url = https://github.com/sonic-net/sonic-utilities
 	branch = 202012
 [submodule "platform/broadcom/sonic-platform-modules-arista"]
 	path = platform/broadcom/sonic-platform-modules-arista
 	url = https://github.com/aristanetworks/sonic
 [submodule "src/sonic-platform-common"]
 	path = src/sonic-platform-common
-	url = https://github.com/Azure/sonic-platform-common
+	url = https://github.com/sonic-net/sonic-platform-common
 	branch = 202012
 [submodule "src/sonic-platform-daemons"]
 	path = src/sonic-platform-daemons
-	url = https://github.com/Azure/sonic-platform-daemons
+	url = https://github.com/sonic-net/sonic-platform-daemons
 [submodule "src/sonic-frr/frr"]
 	path = src/sonic-frr/frr
-	url = https://github.com/Azure/sonic-frr.git
+	url = https://github.com/sonic-net/sonic-frr.git
 	branch = frr/7.5
 [submodule "platform/p4/p4-hlir/p4-hlir-v1.1"]
 	path = platform/p4/p4-hlir/p4-hlir-v1.1
@@ -69,7 +69,7 @@
 	url = https://github.com/Mellanox/SAI-Implementation
 [submodule "src/sonic-mgmt-framework"]
 	path = src/sonic-mgmt-framework
-	url = https://github.com/Azure/sonic-mgmt-framework
+	url = https://github.com/sonic-net/sonic-mgmt-framework
 [submodule "src/sonic-telemetry"]
 	path = src/sonic-telemetry
 	url = https://github.com/sonic-net/sonic-gnmi
@@ -78,17 +78,17 @@
 	url = https://github.com/Mellanox/Switch-SDK-drivers
 [submodule "src/sonic-ztp"]
 	path = src/sonic-ztp
-	url = https://github.com/Azure/sonic-ztp
+	url = https://github.com/sonic-net/sonic-ztp
 [submodule "src/sonic-restapi"]
 	path = src/sonic-restapi
-	url = https://github.com/Azure/sonic-restapi.git
+	url = https://github.com/sonic-net/sonic-restapi.git
 	branch = master
 [submodule "src/sonic-mgmt-common"]
 	path = src/sonic-mgmt-common
-	url = https://github.com/Azure/sonic-mgmt-common.git
+	url = https://github.com/sonic-net/sonic-mgmt-common.git
 [submodule "src/linkmgrd"]
 	path = src/linkmgrd
-	url = https://github.com/Azure/sonic-linkmgrd.git
+	url = https://github.com/sonic-net/sonic-linkmgrd.git
 	branch = 202012
 [submodule "src/dhcprelay"]
 	path = src/dhcprelay


### PR DESCRIPTION
Signed-off-by: dprital <drorp@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Change the path of sonic submodules that point to "Azure" to point to "sonic-net"

#### How I did it

Replace "Azure" with "sonic-net" on all relevant paths of sonic submodules

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

