### PR TITLE
[202205][Arista] Mark thermals as not controllable for 7050CX3-32S platform

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/platform.json
+++ b/device/arista/x86_64-arista_7050cx3_32s/platform.json
@@ -79,19 +79,24 @@
         ],
         "thermals": [
             {
-                "name": "Cpu temp sensor"
+                "name": "Cpu temp sensor",
+                "controllable": false
             },
             {
-                "name": "Cpu board temp sensor"
+                "name": "Cpu board temp sensor",
+                "controllable": false
             },
             {
-                "name": "Back-panel temp sensor"
+                "name": "Back-panel temp sensor",
+                "controllable": false
             },
             {
-                "name": "Board temp sensor"
+                "name": "Board temp sensor",
+                "controllable": false
             },
             {
-                "name": "Front-panel temp sensor"
+                "name": "Front-panel temp sensor",
+                "controllable": false
             }
         ],
         "sfps": [


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The platform_tests.api.test_thermal::test_set_low_threshold testcase fails because by default the thermals on this platform are not controllable via the API.

#### How I did it
Mark thermals as not controllable in platform.json

#### How to verify it
Verified that testcase is skipped instead of failing

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

