### PR TITLE
[FRR] import FRR patch: zebra: Note when the netlink DUMP command is interrupted

### DIFF
--- a/src/sonic-frr/patch/0010-zebra-Note-when-the-netlink-DUMP-command-is-interrup.patch
+++ b/src/sonic-frr/patch/0010-zebra-Note-when-the-netlink-DUMP-command-is-interrup.patch
@@ -1,0 +1,45 @@
+From 8f10590a85669f300d2706d5ef1e560cdbaaf0f8 Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Fri, 25 Mar 2022 19:08:14 -0400
+Subject: [PATCH 10/10] zebra: Note when the netlink DUMP command is
+ interrupted
+
+There exists code paths in the linux kernel where a dump command
+will be interrupted( I am not sure I understand what this really
+means ) and the data sent back from the kernel is wrong or incomplete.
+
+At this point in time I am not 100% certain what should be done, but
+let's start noticing that this has happened so we can formulate a plan
+or allow the end operator to know bad stuff is a foot at the circle K.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+---
+ zebra/kernel_netlink.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/zebra/kernel_netlink.c b/zebra/kernel_netlink.c
+index ccafc8f0c..9dc597fad 100644
+--- a/zebra/kernel_netlink.c
++++ b/zebra/kernel_netlink.c
+@@ -972,6 +972,18 @@ int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
+ 					return err;
+ 			}
+ 
++			/*
++			 * What is the right thing to do?  The kernel
++			 * is telling us that the dump request was interrupted
++			 * and we more than likely are out of luck and have
++			 * missed data from the kernel.  At this point in time
++			 * lets just note that this is happening.
++			 */
++			if (h->nlmsg_flags & NLM_F_DUMP_INTR)
++				flog_err(
++					EC_ZEBRA_NETLINK_BAD_SEQUENCE,
++					"netlink recvmsg: The Dump request was interrupted");
++
+ 			/* OK we got netlink message. */
+ 			if (IS_ZEBRA_DEBUG_KERNEL)
+ 				zlog_debug(
+-- 
+2.17.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -9,3 +9,4 @@
 Disable-ipv6-src-address-test-in-pceplib.patch
 cross-compile-changes.patch
 0009-ignore-route-from-default-table.patch
+0010-zebra-Note-when-the-netlink-DUMP-command-is-interrup.patch


### PR DESCRIPTION
#### Why I did it
There is an outstanding FRR issue #12380. This seems to be a known issue but without good fix so far. The root cause is around zebra and kernel netlink interaction. The failure was previously not noticed by zebra.

#### How I did it
Port the patch that would make the issue obvious.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
