### PR TITLE
[build] Add `PLATFORM_CHECK` to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ endef
 .PHONY: $(PLATFORM_PATH)
 
 $(PLATFORM_PATH):
-	@echo "+++ Cheking $@ +++"
+	@echo "+++ Checking $@ +++"
 	$(PLATFORM_CHECKOUT_CMD)
 
 configure : $(PLATFORM_PATH)

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ PLATFORM_PATH := platform/$(if $(PLATFORM),$(PLATFORM),$(CONFIGURED_PLATFORM))
 PLATFORM_CHECKOUT := platform/checkout
 PLATFORM_CHECKOUT_FILE := $(PLATFORM_CHECKOUT)/$(PLATFORM).ini
 PLATFORM_CHECKOUT_CMD := $(shell if [ -f $(PLATFORM_CHECKOUT_FILE) ]; then PLATFORM_PATH=$(PLATFORM_PATH) j2 $(PLATFORM_CHECKOUT)/template.j2 $(PLATFORM_CHECKOUT_FILE); fi)
+PLATFORM_CHECK := @ls platform | grep -q -w $(PLATFORM) || (echo "ERROR: Specified platform is not supported."; exit 1)
 
 %::
 	@echo "+++ --- Making $@ --- +++"
@@ -90,6 +91,7 @@ $(PLATFORM_PATH):
 	$(PLATFORM_CHECKOUT_CMD)
 
 configure : $(PLATFORM_PATH)
+	$(PLATFORM_CHECK)
 	$(call make_work, $@)
 
 clean reset showtag docker-cleanup sonic-slave-build sonic-slave-bash :


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The current behavior is that it take a long time before it can be informed to the user that an unsupported platform is specified in the command-line argument while executing command `make configure PLATFORM={}`. 

- sonic-slave image is uselessly downloaded.
- A lot of unnecessary steps are performed 

### Current behavior
![image](https://user-images.githubusercontent.com/88161975/195915310-0974df2a-8c6e-4d4b-ab08-e323a3006481.png)

### New behavior
![image](https://user-images.githubusercontent.com/88161975/195915678-0bc7ab88-d865-4bd8-afa8-4b65d337dc72.png)


With this change, the feedback is provided immediately without executing unnecessary steps. 

#### How I did it
The directories under `sonic-buildimage/platform` represent the currently supported platforms. The platform provided in command-line is checked against the directory names inside `sonic-buildimage/platform` folder. If it is not an exact match, an error is thrown.

#### How to verify it
Run command `make configure PLATFORM={}`. Test with sample values for platforms such as vs, broadcom etc..


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

