### PR TITLE
[yang-models]: Change name-space from Azure to sonic-net.

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-auto_techsupport.yang
+++ b/src/sonic-yang-models/yang-models/sonic-auto_techsupport.yang
@@ -2,7 +2,7 @@ module sonic-auto_techsupport {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-auto_techsupport";
+    namespace "http://github.com/sonic-net/sonic-auto_techsupport";
     prefix auto_techsupport;
 
     import sonic-types {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-allowed-prefix.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-allowed-prefix.yang
@@ -1,5 +1,5 @@
 module sonic-bgp-allowed-prefix {
-    namespace "http://github.com/Azure/sonic-bgp-allowed-prefix";
+    namespace "http://github.com/sonic-net/sonic-bgp-allowed-prefix";
     prefix bgppre;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
@@ -1,5 +1,5 @@
 module sonic-bgp-common {
-    namespace "http://github.com/Azure/sonic-bgp-common";
+    namespace "http://github.com/sonic-net/sonic-bgp-common";
     prefix bgpcmn;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -1,5 +1,5 @@
 module sonic-bgp-device-global {
-    namespace "http://github.com/Azure/sonic-bgp-device-global";
+    namespace "http://github.com/sonic-net/sonic-bgp-device-global";
     prefix bgp_device_global;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
@@ -1,5 +1,5 @@
 module sonic-bgp-global {
-    namespace "http://github.com/Azure/sonic-bgp-global";
+    namespace "http://github.com/sonic-net/sonic-bgp-global";
     prefix bgpg;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-internal-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-internal-neighbor.yang
@@ -1,5 +1,5 @@
 module sonic-bgp-internal-neighbor {
-    namespace "http://github.com/Azure/sonic-bgp-internal-neighbor";
+    namespace "http://github.com/sonic-net/sonic-bgp-internal-neighbor";
     prefix bgpintnbr;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-monitor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-monitor.yang
@@ -1,5 +1,5 @@
 module sonic-bgp-monitor {
-    namespace "http://github.com/Azure/sonic-bgp-monitor";
+    namespace "http://github.com/sonic-net/sonic-bgp-monitor";
     prefix bgpmon;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -1,5 +1,5 @@
 module sonic-bgp-neighbor {
-    namespace "http://github.com/Azure/sonic-bgp-neighbor";
+    namespace "http://github.com/sonic-net/sonic-bgp-neighbor";
     prefix bgpnbr;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-peergroup.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-peergroup.yang
@@ -1,5 +1,5 @@
 module sonic-bgp-peergroup {
-    namespace "http://github.com/Azure/sonic-bgp-peergroup";
+    namespace "http://github.com/sonic-net/sonic-bgp-peergroup";
     prefix pg;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-peerrange.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-peerrange.yang
@@ -1,5 +1,5 @@
 module sonic-bgp-peerrange {
-    namespace "http://github.com/Azure/sonic-bgp-peerrange";
+    namespace "http://github.com/sonic-net/sonic-bgp-peerrange";
     prefix pr;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-voq-chassis-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-voq-chassis-neighbor.yang
@@ -1,5 +1,5 @@
 module sonic-bgp-voq-chassis-neighbor {
-    namespace "http://github.com/Azure/sonic-bgp-voq-chassis-neighbor";
+    namespace "http://github.com/sonic-net/sonic-bgp-voq-chassis-neighbor";
     prefix bgpintnbr;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
+++ b/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
@@ -2,7 +2,7 @@ module sonic-breakout_cfg {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-breakout_cfg";
+    namespace "http://github.com/sonic-net/sonic-breakout_cfg";
     prefix breakout_cfg;
 
     import sonic-extension {

--- a/src/sonic-yang-models/yang-models/sonic-buffer-pg.yang
+++ b/src/sonic-yang-models/yang-models/sonic-buffer-pg.yang
@@ -1,5 +1,5 @@
 module sonic-buffer-pg {
-    namespace "http://github.com/Azure/sonic-buffer-pg";
+    namespace "http://github.com/sonic-net/sonic-buffer-pg";
     prefix bpg;
 
     yang-version 1.1;

--- a/src/sonic-yang-models/yang-models/sonic-buffer-pool.yang
+++ b/src/sonic-yang-models/yang-models/sonic-buffer-pool.yang
@@ -1,5 +1,5 @@
 module sonic-buffer-pool {
-    namespace "http://github.com/Azure/sonic-buffer-pool";
+    namespace "http://github.com/sonic-net/sonic-buffer-pool";
     prefix bpl;
 
     organization

--- a/src/sonic-yang-models/yang-models/sonic-buffer-port-egress-profile-list.yang
+++ b/src/sonic-yang-models/yang-models/sonic-buffer-port-egress-profile-list.yang
@@ -1,5 +1,5 @@
 module sonic-buffer-port-egress-profile-list {
-    namespace "http://github.com/Azure/sonic-buffer-port-egress-profile-list";
+    namespace "http://github.com/sonic-net/sonic-buffer-port-egress-profile-list";
     prefix bpg;
 
     import sonic-extension {

--- a/src/sonic-yang-models/yang-models/sonic-buffer-port-ingress-profile-list.yang
+++ b/src/sonic-yang-models/yang-models/sonic-buffer-port-ingress-profile-list.yang
@@ -1,5 +1,5 @@
 module sonic-buffer-port-ingress-profile-list {
-    namespace "http://github.com/Azure/sonic-buffer-port-ingress-profile-list";
+    namespace "http://github.com/sonic-net/sonic-buffer-port-ingress-profile-list";
     prefix bpg;
 
     import sonic-extension {

--- a/src/sonic-yang-models/yang-models/sonic-buffer-profile.yang
+++ b/src/sonic-yang-models/yang-models/sonic-buffer-profile.yang
@@ -1,5 +1,5 @@
 module sonic-buffer-profile {
-    namespace "http://github.com/Azure/sonic-buffer-profile";
+    namespace "http://github.com/sonic-net/sonic-buffer-profile";
     prefix bpf;
 
     import sonic-buffer-pool {

--- a/src/sonic-yang-models/yang-models/sonic-buffer-queue.yang
+++ b/src/sonic-yang-models/yang-models/sonic-buffer-queue.yang
@@ -1,5 +1,5 @@
 module sonic-buffer-queue {
-    namespace "http://github.com/Azure/sonic-buffer-queue";
+    namespace "http://github.com/sonic-net/sonic-buffer-queue";
     prefix bqueue;
 
     import sonic-extension {

--- a/src/sonic-yang-models/yang-models/sonic-cable-length.yang
+++ b/src/sonic-yang-models/yang-models/sonic-cable-length.yang
@@ -2,7 +2,7 @@ module sonic-cable-length {
 
     yang-version 1.1;
 
-    namespace  "http://github.com/Azure/sonic-cable-length";
+    namespace  "http://github.com/sonic-net/sonic-cable-length";
 
     prefix cable-length;
 

--- a/src/sonic-yang-models/yang-models/sonic-console.yang
+++ b/src/sonic-yang-models/yang-models/sonic-console.yang
@@ -1,6 +1,6 @@
 module sonic-console {
     yang-version 1.1;
-    namespace "http://github.com/Azure/sonic-console";
+    namespace "http://github.com/sonic-net/sonic-console";
     prefix console;
 
     import sonic-types {

--- a/src/sonic-yang-models/yang-models/sonic-copp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-copp.yang
@@ -2,7 +2,7 @@ module sonic-copp {
 
 	yang-version 1.1;
 
-	namespace "http://github.com/Azure/sonic-copp";
+	namespace "http://github.com/sonic-net/sonic-copp";
 	prefix copp;
 
 	import sonic-types {

--- a/src/sonic-yang-models/yang-models/sonic-crm.yang
+++ b/src/sonic-yang-models/yang-models/sonic-crm.yang
@@ -2,7 +2,7 @@ module sonic-crm {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-crm";
+    namespace "http://github.com/sonic-net/sonic-crm";
     prefix crm;
 
     import sonic-types {

--- a/src/sonic-yang-models/yang-models/sonic-default-lossless-buffer-parameter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-default-lossless-buffer-parameter.yang
@@ -2,7 +2,7 @@ module sonic-default-lossless-buffer-parameter {
 
     yang-version 1.1;
 
-    namespace  "http://github.com/Azure/sonic-default-lossless-buffer-parameter";
+    namespace  "http://github.com/sonic-net/sonic-default-lossless-buffer-parameter";
 
     prefix default-lossless-buffer-parameter;
 

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -2,7 +2,7 @@ module sonic-device_metadata {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-device_metadata";
+    namespace "http://github.com/sonic-net/sonic-device_metadata";
     prefix device_metadata;
 
     import ietf-yang-types {

--- a/src/sonic-yang-models/yang-models/sonic-device_neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_neighbor.yang
@@ -2,7 +2,7 @@ module sonic-device_neighbor {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-device_neighbor";
+    namespace "http://github.com/sonic-net/sonic-device_neighbor";
     prefix device_neighbor;
 
     import ietf-inet-types {

--- a/src/sonic-yang-models/yang-models/sonic-device_neighbor_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_neighbor_metadata.yang
@@ -2,7 +2,7 @@ module sonic-device_neighbor_metadata {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-device_neighbor_metadata";
+    namespace "http://github.com/sonic-net/sonic-device_neighbor_metadata";
     prefix device_neighbor_metadata;
 
     import ietf-yang-types {

--- a/src/sonic-yang-models/yang-models/sonic-dhcp-server.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dhcp-server.yang
@@ -2,7 +2,7 @@ module sonic-dhcp-server {
 
     yang-version 1.1;
 
-    namespace  "http://github.com/Azure/sonic-dhcp-server";
+    namespace  "http://github.com/sonic-net/sonic-dhcp-server";
 
     prefix dhcp-server;
 

--- a/src/sonic-yang-models/yang-models/sonic-dhcpv6-relay.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dhcpv6-relay.yang
@@ -1,6 +1,6 @@
 module sonic-dhcpv6-relay {
 
-	namespace "http://github.com/Azure/sonic-dhcpv6-relay";
+	namespace "http://github.com/sonic-net/sonic-dhcpv6-relay";
 
 	prefix sdhcpv6relay;
 

--- a/src/sonic-yang-models/yang-models/sonic-dot1p-tc-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dot1p-tc-map.yang
@@ -2,7 +2,7 @@ module sonic-dot1p-tc-map {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-dot1p-tc-map";
+    namespace "http://github.com/sonic-net/sonic-dot1p-tc-map";
 
     prefix dot1ptm;
 

--- a/src/sonic-yang-models/yang-models/sonic-dscp-fc-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dscp-fc-map.yang
@@ -2,7 +2,7 @@ module sonic-dscp-fc-map {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-dscp-fc-map";
+    namespace "http://github.com/sonic-net/sonic-dscp-fc-map";
 
     prefix dtm;
 

--- a/src/sonic-yang-models/yang-models/sonic-dscp-tc-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dscp-tc-map.yang
@@ -2,7 +2,7 @@ module sonic-dscp-tc-map {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-dscp-tc-map";
+    namespace "http://github.com/sonic-net/sonic-dscp-tc-map";
 
     prefix dtm;
 

--- a/src/sonic-yang-models/yang-models/sonic-exp-fc-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-exp-fc-map.yang
@@ -2,7 +2,7 @@ module sonic-exp-fc-map {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-exp-fc-map";
+    namespace "http://github.com/sonic-net/sonic-exp-fc-map";
 
     prefix dtm;
 

--- a/src/sonic-yang-models/yang-models/sonic-feature.yang
+++ b/src/sonic-yang-models/yang-models/sonic-feature.yang
@@ -2,7 +2,7 @@ module sonic-feature{
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-feature";
+    namespace "http://github.com/sonic-net/sonic-feature";
     prefix feature;
 
     import sonic-types {

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -2,7 +2,7 @@ module sonic-flex_counter {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-flex_counter";
+    namespace "http://github.com/sonic-net/sonic-flex_counter";
     prefix flex_counter;
 
     import ietf-inet-types {

--- a/src/sonic-yang-models/yang-models/sonic-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-interface.yang
@@ -2,7 +2,7 @@ module sonic-interface {
 
 	yang-version 1.1;
 
-	namespace "http://github.com/Azure/sonic-interface";
+	namespace "http://github.com/sonic-net/sonic-interface";
 	prefix intf;
 
 	import sonic-types {

--- a/src/sonic-yang-models/yang-models/sonic-kdump.yang
+++ b/src/sonic-yang-models/yang-models/sonic-kdump.yang
@@ -1,5 +1,5 @@
 module sonic-kdump {
-    namespace "http://github.com/Azure/sonic-kdump";
+    namespace "http://github.com/sonic-net/sonic-kdump";
     prefix kdump;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-kubernetes_master.yang
+++ b/src/sonic-yang-models/yang-models/sonic-kubernetes_master.yang
@@ -2,7 +2,8 @@ module sonic-kubernetes_master {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-kubernetes_master";
+    namespace "http://github.com/sonic-net/sonic-kubernetes_master";
+
     prefix kubernetes_master;
 
     import ietf-inet-types {

--- a/src/sonic-yang-models/yang-models/sonic-lldp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-lldp.yang
@@ -1,5 +1,5 @@
 module sonic-lldp {
-    namespace "http://github.com/Azure/sonic-lldp";
+    namespace "http://github.com/sonic-net/sonic-lldp";
     prefix slldp;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
@@ -2,7 +2,7 @@ module sonic-loopback-interface {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-loopback-interface";
+    namespace "http://github.com/sonic-net/sonic-loopback-interface";
     prefix lointf;
 
     import sonic-types {

--- a/src/sonic-yang-models/yang-models/sonic-lossless-traffic-pattern.yang
+++ b/src/sonic-yang-models/yang-models/sonic-lossless-traffic-pattern.yang
@@ -2,7 +2,7 @@ module sonic-lossless-traffic-pattern {
 
     yang-version 1.1;
 
-    namespace  "http://github.com/Azure/sonic-lossless-traffic-pattern";
+    namespace  "http://github.com/sonic-net/sonic-lossless-traffic-pattern";
 
     prefix lossless-traffic-pattern;
 

--- a/src/sonic-yang-models/yang-models/sonic-macsec.yang
+++ b/src/sonic-yang-models/yang-models/sonic-macsec.yang
@@ -2,7 +2,7 @@ module sonic-macsec {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-macsec";
+    namespace "http://github.com/sonic-net/sonic-macsec";
 
     prefix macsec;
 

--- a/src/sonic-yang-models/yang-models/sonic-mclag.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mclag.yang
@@ -1,5 +1,5 @@
 module sonic-mclag {
-    namespace "http://github.com/Azure/sonic-mclag";
+    namespace "http://github.com/sonic-net/sonic-mclag";
     prefix smclag;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-mgmt_interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mgmt_interface.yang
@@ -2,7 +2,7 @@ module sonic-mgmt_interface {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-mgmt_interface";
+    namespace "http://github.com/sonic-net/sonic-mgmt_interface";
     prefix mgmtintf;
 
     import sonic-mgmt_port {

--- a/src/sonic-yang-models/yang-models/sonic-mgmt_port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mgmt_port.yang
@@ -2,7 +2,7 @@ module sonic-mgmt_port {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-mgmt_port";
+    namespace "http://github.com/sonic-net/sonic-mgmt_port";
     prefix mgmtprt;
 
     import sonic-types {

--- a/src/sonic-yang-models/yang-models/sonic-mgmt_vrf.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mgmt_vrf.yang
@@ -2,7 +2,7 @@ module sonic-mgmt_vrf {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-mgmt_vrf";
+    namespace "http://github.com/sonic-net/sonic-mgmt_vrf";
     prefix mvrf;
 
     description

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -2,7 +2,7 @@ module sonic-mirror-session {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-mirror-session";
+    namespace "http://github.com/sonic-net/sonic-mirror-session";
     prefix sms;
 
     import ietf-inet-types {

--- a/src/sonic-yang-models/yang-models/sonic-mpls-tc-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mpls-tc-map.yang
@@ -2,7 +2,7 @@ module sonic-mpls-tc-map {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-mpls-tc-map";
+    namespace "http://github.com/sonic-net/sonic-mpls-tc-map";
 
     prefix mpls_tc_map;
 

--- a/src/sonic-yang-models/yang-models/sonic-mux-cable.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mux-cable.yang
@@ -1,5 +1,5 @@
 module sonic-mux-cable {
-    namespace "http://github.com/Azure/sonic-mux-cable";
+    namespace "http://github.com/sonic-net/sonic-mux-cable";
     prefix mux_cable;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-nat.yang
+++ b/src/sonic-yang-models/yang-models/sonic-nat.yang
@@ -1,5 +1,5 @@
 module sonic-nat {
-    namespace "http://github.com/Azure/sonic-nat";
+    namespace "http://github.com/sonic-net/sonic-nat";
     prefix snat;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-ntp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-ntp.yang
@@ -2,7 +2,7 @@ module sonic-ntp {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-system-ntp";
+    namespace "http://github.com/sonic-net/sonic-system-ntp";
     prefix ntp;
 
     import ietf-inet-types {

--- a/src/sonic-yang-models/yang-models/sonic-nvgre-tunnel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-nvgre-tunnel.yang
@@ -2,7 +2,7 @@ module sonic-nvgre-tunnel {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-nvgre-tunnel";
+    namespace "http://github.com/sonic-net/sonic-nvgre-tunnel";
     prefix nvgre;
 
     import ietf-inet-types {

--- a/src/sonic-yang-models/yang-models/sonic-passwh.yang
+++ b/src/sonic-yang-models/yang-models/sonic-passwh.yang
@@ -1,6 +1,6 @@
 module sonic-passwh {
     yang-version 1.1;
-    namespace "http://github.com/Azure/sonic-passwh";
+    namespace "http://github.com/sonic-net/sonic-passwh";
     prefix password;
 
     description "PASSWORD HARDENING YANG Module for SONiC OS";

--- a/src/sonic-yang-models/yang-models/sonic-pbh.yang
+++ b/src/sonic-yang-models/yang-models/sonic-pbh.yang
@@ -2,7 +2,7 @@ module sonic-pbh {
 
 	yang-version 1.1;
 
-	namespace "http://github.com/Azure/sonic-pbh";
+	namespace "http://github.com/sonic-net/sonic-pbh";
 	prefix pbh;
 
 	import ietf-inet-types {

--- a/src/sonic-yang-models/yang-models/sonic-peer-switch.yang
+++ b/src/sonic-yang-models/yang-models/sonic-peer-switch.yang
@@ -1,6 +1,6 @@
 module sonic-peer-switch {
     yang-version 1.1;
-    namespace "http://github.com/Azure/sonic-peer-switch";
+    namespace "http://github.com/sonic-net/sonic-peer-switch";
     prefix peer_switch;
 
     import ietf-inet-types {

--- a/src/sonic-yang-models/yang-models/sonic-pfc-priority-priority-group-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-pfc-priority-priority-group-map.yang
@@ -2,7 +2,7 @@ module sonic-pfc-priority-priority-group-map {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-pfc-priority-priority-group-map";
+    namespace "http://github.com/sonic-net/sonic-pfc-priority-priority-group-map";
 
     prefix pppgm;
 

--- a/src/sonic-yang-models/yang-models/sonic-pfc-priority-queue-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-pfc-priority-queue-map.yang
@@ -2,7 +2,7 @@ module sonic-pfc-priority-queue-map {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-pfc-priority-queue-map";
+    namespace "http://github.com/sonic-net/sonic-pfc-priority-queue-map";
 
     prefix ppqm;
 

--- a/src/sonic-yang-models/yang-models/sonic-pfcwd.yang
+++ b/src/sonic-yang-models/yang-models/sonic-pfcwd.yang
@@ -1,5 +1,5 @@
 module sonic-pfcwd {
-    namespace "http://github.com/Azure/sonic-pfcwd";
+    namespace "http://github.com/sonic-net/sonic-pfcwd";
     prefix sonic-pfcwd;
 
     yang-version 1.1;

--- a/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
@@ -2,7 +2,7 @@ module sonic-port-qos-map {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-port-qos-map";
+    namespace "http://github.com/sonic-net/sonic-port-qos-map";
 
     prefix pqm;
 

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -2,7 +2,7 @@ module sonic-port{
 
 	yang-version 1.1;
 
-	namespace "http://github.com/Azure/sonic-port";
+	namespace "http://github.com/sonic-net/sonic-port";
 	prefix port;
 
 	import sonic-types {

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -2,7 +2,7 @@ module sonic-portchannel {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-portchannel";
+    namespace "http://github.com/sonic-net/sonic-portchannel";
     prefix lag;
 
     import sonic-types {

--- a/src/sonic-yang-models/yang-models/sonic-queue.yang
+++ b/src/sonic-yang-models/yang-models/sonic-queue.yang
@@ -2,7 +2,7 @@ module sonic-queue {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-queue";
+    namespace "http://github.com/sonic-net/sonic-queue";
 
     prefix squeue;
 

--- a/src/sonic-yang-models/yang-models/sonic-restapi.yang
+++ b/src/sonic-yang-models/yang-models/sonic-restapi.yang
@@ -2,7 +2,7 @@ module sonic-restapi {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-restapi";
+    namespace "http://github.com/sonic-net/sonic-restapi";
     prefix restapi;
 
     import ietf-inet-types {

--- a/src/sonic-yang-models/yang-models/sonic-route-common.yang
+++ b/src/sonic-yang-models/yang-models/sonic-route-common.yang
@@ -1,5 +1,5 @@
 module sonic-route-common {
-    namespace "http://github.com/Azure/sonic-route-common";
+    namespace "http://github.com/sonic-net/sonic-route-common";
     prefix rtcmn;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-route-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-route-map.yang
@@ -1,5 +1,5 @@
 module sonic-route-map {
-    namespace "http://github.com/Azure/sonic-route-map";
+    namespace "http://github.com/sonic-net/sonic-route-map";
     prefix rmap;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-routing-policy-sets.yang
+++ b/src/sonic-yang-models/yang-models/sonic-routing-policy-sets.yang
@@ -1,5 +1,5 @@
 module sonic-routing-policy-sets {
-    namespace "http://github.com/Azure/sonic-routing-policy-lists";
+    namespace "http://github.com/sonic-net/sonic-routing-policy-lists";
     prefix rpolsets;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-scheduler.yang
+++ b/src/sonic-yang-models/yang-models/sonic-scheduler.yang
@@ -2,7 +2,7 @@ module sonic-scheduler {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-scheduler";
+    namespace "http://github.com/sonic-net/sonic-scheduler";
 
     prefix sch;
 

--- a/src/sonic-yang-models/yang-models/sonic-sflow.yang
+++ b/src/sonic-yang-models/yang-models/sonic-sflow.yang
@@ -1,6 +1,6 @@
 module sonic-sflow{
 
-    namespace "http://github.com/Azure/sonic-sflow";
+    namespace "http://github.com/sonic-net/sonic-sflow";
     prefix sflow;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -1,5 +1,5 @@
 module sonic-snmp {
-  namespace "http://github.com/Azure/sonic-snmp";
+  namespace "http://github.com/sonic-net/sonic-snmp";
   prefix ssnmp;
   yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-static-route.yang
+++ b/src/sonic-yang-models/yang-models/sonic-static-route.yang
@@ -1,6 +1,6 @@
 module sonic-static-route {
   yang-version 1.1;
-  namespace "http://github.com/Azure/sonic-static-route";
+  namespace "http://github.com/sonic-net/sonic-static-route";
   prefix sroute;
 
   import sonic-vrf {

--- a/src/sonic-yang-models/yang-models/sonic-storm-control.yang
+++ b/src/sonic-yang-models/yang-models/sonic-storm-control.yang
@@ -1,5 +1,5 @@
 module sonic-storm-control {
-    namespace "http://github.com/Azure/sonic-storm-control";
+    namespace "http://github.com/sonic-net/sonic-storm-control";
     yang-version "1";
 
     prefix ssc;

--- a/src/sonic-yang-models/yang-models/sonic-syslog.yang
+++ b/src/sonic-yang-models/yang-models/sonic-syslog.yang
@@ -2,7 +2,7 @@ module sonic-syslog {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-system-syslog";
+    namespace "http://github.com/sonic-net/sonic-system-syslog";
     prefix syslog;
 
     import ietf-inet-types {

--- a/src/sonic-yang-models/yang-models/sonic-system-aaa.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-aaa.yang
@@ -1,5 +1,5 @@
 module sonic-system-aaa {
-    namespace "http://github.com/Azure/sonic-system-aaa";
+    namespace "http://github.com/sonic-net/sonic-system-aaa";
     prefix ssys;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-system-tacacs.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-tacacs.yang
@@ -1,5 +1,5 @@
 module sonic-system-tacacs {
-    namespace "http://github.com/Azure/sonic-system-tacacs";
+    namespace "http://github.com/sonic-net/sonic-system-tacacs";
     prefix ssys;
     yang-version 1.1;
 

--- a/src/sonic-yang-models/yang-models/sonic-tc-priority-group-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tc-priority-group-map.yang
@@ -2,7 +2,7 @@ module sonic-tc-priority-group-map {
     
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-tc-priority-group-map";
+    namespace "http://github.com/sonic-net/sonic-tc-priority-group-map";
 
     prefix tpgm;
 

--- a/src/sonic-yang-models/yang-models/sonic-tc-queue-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tc-queue-map.yang
@@ -2,7 +2,7 @@ module sonic-tc-queue-map {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-tc-queue-map";
+    namespace "http://github.com/sonic-net/sonic-tc-queue-map";
 
     prefix tqm;
 

--- a/src/sonic-yang-models/yang-models/sonic-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-telemetry.yang
@@ -2,7 +2,7 @@ module sonic-telemetry {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-telemetry";
+    namespace "http://github.com/sonic-net/sonic-telemetry";
     prefix telemetry;
 
     import ietf-inet-types {

--- a/src/sonic-yang-models/yang-models/sonic-versions.yang
+++ b/src/sonic-yang-models/yang-models/sonic-versions.yang
@@ -2,7 +2,7 @@ module sonic-versions {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-versions";
+    namespace "http://github.com/sonic-net/sonic-versions";
     prefix versions;
 
 

--- a/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
@@ -2,7 +2,7 @@ module sonic-vlan-sub-interface {
 
     yang-version 1.1;
 
-    namespace  "http://github.com/Azure/sonic-vlan-sub-interface";
+    namespace  "http://github.com/sonic-net/sonic-vlan-sub-interface";
 
     prefix vlan-sub-interface;
 

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -2,7 +2,7 @@ module sonic-vlan {
 
     yang-version 1.1;
 
-	namespace "http://github.com/Azure/sonic-vlan";
+	namespace "http://github.com/sonic-net/sonic-vlan";
 	prefix vlan;
 
 	import ietf-inet-types {

--- a/src/sonic-yang-models/yang-models/sonic-vrf.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vrf.yang
@@ -1,5 +1,5 @@
 module sonic-vrf {
-    namespace "http://github.com/Azure/sonic-vrf";
+    namespace "http://github.com/sonic-net/sonic-vrf";
     prefix vrf;
     
     import sonic-extension {

--- a/src/sonic-yang-models/yang-models/sonic-vxlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vxlan.yang
@@ -1,6 +1,6 @@
 module sonic-vxlan {
     yang-version 1.1;
-    namespace "http://github.com/Azure/sonic-vxlan";
+    namespace "http://github.com/sonic-net/sonic-vxlan";
     prefix svxlan;
 
     import ietf-yang-types {

--- a/src/sonic-yang-models/yang-models/sonic-warm-restart.yang
+++ b/src/sonic-yang-models/yang-models/sonic-warm-restart.yang
@@ -2,7 +2,7 @@ module sonic-warm-restart  {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-warm-restart";
+    namespace "http://github.com/sonic-net/sonic-warm-restart";
     prefix wrm;
 
     description "SONIC WARMRESTART";

--- a/src/sonic-yang-models/yang-models/sonic-wred-profile.yang
+++ b/src/sonic-yang-models/yang-models/sonic-wred-profile.yang
@@ -2,7 +2,7 @@ module sonic-wred-profile {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-wred-profile";
+    namespace "http://github.com/sonic-net/sonic-wred-profile";
 
     prefix wrd;
 

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -7,7 +7,7 @@ module sonic-acl {
 
 	yang-version 1.1;
 
-	namespace "http://github.com/Azure/sonic-acl";
+	namespace "http://github.com/sonic-net/sonic-acl";
 	prefix acl;
 
 	import ietf-inet-types {

--- a/src/sonic-yang-models/yang-templates/sonic-extension.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-extension.yang.j2
@@ -2,7 +2,7 @@ module sonic-extension {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-extension";
+    namespace "http://github.com/sonic-net/sonic-extension";
     prefix sonic-extension;
 
     description "Extension yang Module for SONiC OS";

--- a/src/sonic-yang-models/yang-templates/sonic-policer.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-policer.yang.j2
@@ -7,7 +7,7 @@ module sonic-policer {
 
 	yang-version 1.1;
 
-	namespace "http://github.com/Azure/sonic-policer";
+	namespace "http://github.com/sonic-net/sonic-policer";
 	prefix policer;
 
 	import sonic-types {

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -2,7 +2,7 @@ module sonic-types {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-head";
+    namespace "http://github.com/sonic-net/sonic-head";
     prefix sonic-types;
 
     description "SONiC type for yang Models of SONiC OS";


### PR DESCRIPTION
Changes:
-- Change name-space from Azure to sonic-net.
-- Sort yang list in setup.py for yang-models list.

Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Sonic repo has moved to Linux-foundation.

#### How I did it
[yang-models]: Change name-space from Azure to sonic-net.

#### How to verify it
PR Tests are good enough to verify.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

