### PR TITLE
[tunnel_pkt_handler]: Skip nonexistent intfs

### DIFF
--- a/dockers/docker-orchagent/tunnel_packet_handler.py
+++ b/dockers/docker-orchagent/tunnel_packet_handler.py
@@ -16,6 +16,7 @@ from swsscommon.swsscommon import ConfigDBConnector, SonicV2Connector
 from sonic_py_common import logger as log
 
 from pyroute2 import IPRoute
+from pyroute2.netlink.exceptions import NetlinkError
 from scapy.layers.inet import IP
 from scapy.layers.inet6 import IPv6
 from scapy.sendrecv import AsyncSniffer
@@ -115,7 +116,14 @@ class TunnelPacketHandler(object):
         portchannel_intf_names = [name for name, _ in self.portchannel_intfs]
         link_statuses = []
         for intf in portchannel_intf_names:
-            status = self.netlink_api.link("get", ifname=intf)
+            try:
+                status = self.netlink_api.link("get", ifname=intf)
+            except NetlinkError:
+                # Continue if we find a non-existent interface since we don't
+                # need to listen on it while it's down/not created. Once it comes up,
+                # we will get another netlink message which will trigger this check again
+                logger.log_notice("Skipping non-existent interface {}".format(intf))
+                continue
             link_statuses.append(status[0])
         up_portchannels = []
 


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Sometimes the process will try to get the status of non-existent portchannel interfaces

#### How I did it
Skip the interface status check if the interface does not exist. In the future, when the interface is created/comes up this check will be triggered again.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

