### PR TITLE
[Pipeline]Fix the issue that test job and checkout code job can't be cancelled

### DIFF
--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -36,7 +36,7 @@ jobs:
         displayName: "Set cache options"
       - checkout: self
         submodules: recursive
-        condition: eq(variables.SKIP_CHECKOUT, '') 
+        condition: and(succeeded(), eq(variables.SKIP_CHECKOUT, ''))
         displayName: 'Checkout code'
       - script: |
           BRANCH_NAME=$(Build.SourceBranchName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ stages:
 
 - stage: Test
   dependsOn: BuildVS
-  condition: and(ne(stageDependencies.BuildVS.outputs['vs.SetVar.SKIP_VSTEST'], 'YES'), in(dependencies.BuildVS.result, 'Succeeded', 'SucceededWithIssues'))
+  condition: and(succeeded(), and(ne(stageDependencies.BuildVS.outputs['vs.SetVar.SKIP_VSTEST'], 'YES'), in(dependencies.BuildVS.result, 'Succeeded', 'SucceededWithIssues')))
   variables:
   - name: inventory
     value: veos_vtb


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Now, checkout code step and KVM test job can't be cancelled even though the whole build is cancelled.
That's because by using Azure Pipeline Conditions, we customized the running condition, and we need to react to the Cancel action explicitly by asserting 'succeeded'
https://learn.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#succeeded
https://learn.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml#ive-got-a-conditional-step-that-runs-even-when-a-job-is-canceled-how-do-i-manage-to-cancel-all-jobs-at-once


#### How I did it
Assert 'succeeded' condition explicitly.
#### How to verify it
Verified by cancelling and rerunning the azure pipeline.
#### Which release branch to backport (provide reason below if selected)