### PR TITLE
Add media_settings.json for x86_64-arista_7800r3a_36d2_lc 

### DIFF
--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/media_settings.json
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/media_settings.json
@@ -1,0 +1,5044 @@
+{
+    "PORT_MEDIA_SETTINGS": {
+        "1": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x55", 
+                    "lane2": "0x50", 
+                    "lane3": "0x4b"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x19", 
+                    "lane2": "-0x17", 
+                    "lane3": "-0x15"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x7", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x4"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x8d", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x90", 
+                    "lane4": "0x89", 
+                    "lane5": "0x8d", 
+                    "lane6": "0x94", 
+                    "lane7": "0x88"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x1", 
+                    "lane4": "-0xc", 
+                    "lane5": "-0x5", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0xe"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "-0x2", 
+                    "lane2": "-0x2", 
+                    "lane3": "-0x3", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "0x0", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x3", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x1", 
+                    "lane7": "-0x4"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0x10", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x11", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0xe"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x3", 
+                    "lane2": "0x3", 
+                    "lane3": "0x2", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x2", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x55", 
+                    "lane2": "0x50", 
+                    "lane3": "0x4b"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x19", 
+                    "lane2": "-0x17", 
+                    "lane3": "-0x15"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x7", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x4"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "2": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x4b", 
+                    "lane1": "0x4b", 
+                    "lane2": "0x4e", 
+                    "lane3": "0x4e"
+                }, 
+                "post1": {
+                    "lane0": "-0x14", 
+                    "lane1": "-0x14", 
+                    "lane2": "-0x16", 
+                    "lane3": "-0x16"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x8d", 
+                    "lane1": "0x8d", 
+                    "lane2": "0x89", 
+                    "lane3": "0x8d", 
+                    "lane4": "0x8d", 
+                    "lane5": "0x84", 
+                    "lane6": "0x8d", 
+                    "lane7": "0x8d"
+                }, 
+                "post1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0xc", 
+                    "lane3": "-0x5", 
+                    "lane4": "-0x8", 
+                    "lane5": "-0xa", 
+                    "lane6": "-0x5", 
+                    "lane7": "-0x8"
+                }, 
+                "post2": {
+                    "lane0": "-0x2", 
+                    "lane1": "-0x3", 
+                    "lane2": "0x0", 
+                    "lane3": "-0x2", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x2", 
+                    "lane6": "-0x2", 
+                    "lane7": "-0x3"
+                }, 
+                "post3": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x1", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xf", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0xf", 
+                    "lane5": "-0x14", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0xf"
+                }, 
+                "pre2": {
+                    "lane0": "0x3", 
+                    "lane1": "0x2", 
+                    "lane2": "0x2", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x4b", 
+                    "lane1": "0x4b", 
+                    "lane2": "0x4e", 
+                    "lane3": "0x4e"
+                }, 
+                "post1": {
+                    "lane0": "-0x14", 
+                    "lane1": "-0x14", 
+                    "lane2": "-0x16", 
+                    "lane3": "-0x16"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "3": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x50", 
+                    "lane1": "0x50", 
+                    "lane2": "0x55", 
+                    "lane3": "0x55"
+                }, 
+                "post1": {
+                    "lane0": "-0x17", 
+                    "lane1": "-0x17", 
+                    "lane2": "-0x19", 
+                    "lane3": "-0x19"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x7"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x89", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x94", 
+                    "lane5": "0x88", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0xc", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "0x0", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x4", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x2", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x50", 
+                    "lane1": "0x50", 
+                    "lane2": "0x55", 
+                    "lane3": "0x55"
+                }, 
+                "post1": {
+                    "lane0": "-0x17", 
+                    "lane1": "-0x17", 
+                    "lane2": "-0x19", 
+                    "lane3": "-0x19"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x7"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "4": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x89", 
+                    "lane1": "0x8d", 
+                    "lane2": "0x8d", 
+                    "lane3": "0x8d", 
+                    "lane4": "0x89", 
+                    "lane5": "0x8d", 
+                    "lane6": "0x8d", 
+                    "lane7": "0x8d"
+                }, 
+                "post1": {
+                    "lane0": "-0xc", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x5", 
+                    "lane4": "-0xc", 
+                    "lane5": "-0x8", 
+                    "lane6": "-0x8", 
+                    "lane7": "-0x5"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "-0x2", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x2"
+                }, 
+                "post3": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x3", 
+                    "lane2": "-0x1", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x1", 
+                    "lane6": "-0x1", 
+                    "lane7": "-0x3"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0x10", 
+                    "lane2": "-0xf", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0xf", 
+                    "lane6": "-0xf", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x3", 
+                    "lane2": "0x2", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x2", 
+                    "lane6": "0x2", 
+                    "lane7": "0x3"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "5": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x89", 
+                    "lane2": "0x88", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x88", 
+                    "lane5": "0x8b", 
+                    "lane6": "0x88", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xc", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x7", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "0x0", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x3", 
+                    "lane2": "-0x4", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x4", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x4", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0x10", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x2", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x2", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "6": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x94", 
+                    "lane5": "0x88", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "0x0", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x4", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x2", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "7": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x88", 
+                    "lane4": "0x94", 
+                    "lane5": "0x8b", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x88"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0xe", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x7", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0xe"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "0x0", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x4", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x4"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0xe", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0xe"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x2", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "8": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x94", 
+                    "lane2": "0x88", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x88", 
+                    "lane5": "0x8b", 
+                    "lane6": "0x88", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x3", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x7", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "0x0", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x1", 
+                    "lane2": "-0x4", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x4", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x4", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0x10", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x2", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x2", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "9": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x94", 
+                    "lane5": "0x88", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "0x0", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x4", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x2", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "10": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x55", 
+                    "lane1": "0x4e", 
+                    "lane2": "0x4b", 
+                    "lane3": "0x53"
+                }, 
+                "post1": {
+                    "lane0": "-0x15", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x14", 
+                    "lane3": "-0x16"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x6", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x94", 
+                    "lane5": "0x88", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "0x0", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x4", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x2", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x55", 
+                    "lane1": "0x4e", 
+                    "lane2": "0x4b", 
+                    "lane3": "0x53"
+                }, 
+                "post1": {
+                    "lane0": "-0x15", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x14", 
+                    "lane3": "-0x16"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x6", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "11": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x4b", 
+                    "lane1": "0x4b", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x15", 
+                    "lane1": "-0x15", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x4", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x94", 
+                    "lane2": "0x88", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x88", 
+                    "lane5": "0x8b", 
+                    "lane6": "0x88", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x3", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x7", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "0x0", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x1", 
+                    "lane2": "-0x4", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x4", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x4", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0x10", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x2", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x2", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x4b", 
+                    "lane1": "0x4b", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x15", 
+                    "lane1": "-0x15", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x4", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "12": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x55", 
+                    "lane1": "0x53", 
+                    "lane2": "0x55", 
+                    "lane3": "0x53"
+                }, 
+                "post1": {
+                    "lane0": "-0x15", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x15", 
+                    "lane3": "-0x16"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x6", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x6", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x88", 
+                    "lane4": "0x94", 
+                    "lane5": "0x8b", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x88"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0xe", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x7", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0xe"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "0x0", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x4", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x4"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0xe", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0xe"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x2", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x55", 
+                    "lane1": "0x53", 
+                    "lane2": "0x55", 
+                    "lane3": "0x53"
+                }, 
+                "post1": {
+                    "lane0": "-0x15", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x15", 
+                    "lane3": "-0x16"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x6", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x6", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "13": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x4e", 
+                    "lane1": "0x4e", 
+                    "lane2": "0x53", 
+                    "lane3": "0x4b"
+                }, 
+                "post1": {
+                    "lane0": "-0x16", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x16", 
+                    "lane3": "-0x14"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x94", 
+                    "lane5": "0x88", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "0x0", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x4", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x2", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x4e", 
+                    "lane1": "0x4e", 
+                    "lane2": "0x53", 
+                    "lane3": "0x4b"
+                }, 
+                "post1": {
+                    "lane0": "-0x16", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x16", 
+                    "lane3": "-0x14"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "14": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x55", 
+                    "lane1": "0x55", 
+                    "lane2": "0x4b", 
+                    "lane3": "0x50"
+                }, 
+                "post1": {
+                    "lane0": "-0x19", 
+                    "lane1": "-0x19", 
+                    "lane2": "-0x15", 
+                    "lane3": "-0x17"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x7", 
+                    "lane1": "-0x7", 
+                    "lane2": "-0x4", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x94", 
+                    "lane2": "0x88", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x88", 
+                    "lane5": "0x8b", 
+                    "lane6": "0x88", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x3", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x7", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "0x0", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x1", 
+                    "lane2": "-0x4", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x4", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x4", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0x10", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x2", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x2", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x55", 
+                    "lane1": "0x55", 
+                    "lane2": "0x4b", 
+                    "lane3": "0x50"
+                }, 
+                "post1": {
+                    "lane0": "-0x19", 
+                    "lane1": "-0x19", 
+                    "lane2": "-0x15", 
+                    "lane3": "-0x17"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x7", 
+                    "lane1": "-0x7", 
+                    "lane2": "-0x4", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "15": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x4e", 
+                    "lane1": "0x53", 
+                    "lane2": "0x55", 
+                    "lane3": "0x53"
+                }, 
+                "post1": {
+                    "lane0": "-0x16", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x15", 
+                    "lane3": "-0x16"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x6", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x86", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x8d", 
+                    "lane4": "0x94", 
+                    "lane5": "0x8b", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x88"
+                }, 
+                "post1": {
+                    "lane0": "-0xc", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x5", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x7", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0xe"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x4"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0xe"
+                }, 
+                "pre2": {
+                    "lane0": "0x3", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x4e", 
+                    "lane1": "0x53", 
+                    "lane2": "0x55", 
+                    "lane3": "0x53"
+                }, 
+                "post1": {
+                    "lane0": "-0x16", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x15", 
+                    "lane3": "-0x16"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x6", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "16": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x55", 
+                    "lane1": "0x4b", 
+                    "lane2": "0x59", 
+                    "lane3": "0x50"
+                }, 
+                "post1": {
+                    "lane0": "-0x19", 
+                    "lane1": "-0x15", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x17"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x7", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x94", 
+                    "lane5": "0x88", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "0x0", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x4", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x2", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x55", 
+                    "lane1": "0x4b", 
+                    "lane2": "0x59", 
+                    "lane3": "0x50"
+                }, 
+                "post1": {
+                    "lane0": "-0x19", 
+                    "lane1": "-0x15", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x17"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x7", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "17": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x53", 
+                    "lane1": "0x53", 
+                    "lane2": "0x55", 
+                    "lane3": "0x55"
+                }, 
+                "post1": {
+                    "lane0": "-0x16", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x15", 
+                    "lane3": "-0x15"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x6", 
+                    "lane3": "-0x6"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x8d", 
+                    "lane1": "0x90", 
+                    "lane2": "0x89", 
+                    "lane3": "0x88", 
+                    "lane4": "0x8b", 
+                    "lane5": "0x89", 
+                    "lane6": "0x8d", 
+                    "lane7": "0x90"
+                }, 
+                "post1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x1", 
+                    "lane2": "-0xc", 
+                    "lane3": "-0xe", 
+                    "lane4": "-0x7", 
+                    "lane5": "-0xc", 
+                    "lane6": "-0x5", 
+                    "lane7": "-0x1"
+                }, 
+                "post2": {
+                    "lane0": "-0x2", 
+                    "lane1": "-0x3", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0", 
+                    "lane4": "-0x2", 
+                    "lane5": "0x0", 
+                    "lane6": "-0x2", 
+                    "lane7": "-0x3"
+                }, 
+                "post3": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x3", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x4", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x3"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0x11", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0xe", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x11"
+                }, 
+                "pre2": {
+                    "lane0": "0x3", 
+                    "lane1": "0x2", 
+                    "lane2": "0x2", 
+                    "lane3": "0x2", 
+                    "lane4": "0x3", 
+                    "lane5": "0x2", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x53", 
+                    "lane1": "0x53", 
+                    "lane2": "0x55", 
+                    "lane3": "0x55"
+                }, 
+                "post1": {
+                    "lane0": "-0x16", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x15", 
+                    "lane3": "-0x15"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x6", 
+                    "lane3": "-0x6"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "18": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x4b", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x4b"
+                }, 
+                "post1": {
+                    "lane0": "-0x15", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x15"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x4", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x4"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x89", 
+                    "lane1": "0x8d", 
+                    "lane2": "0x8d", 
+                    "lane3": "0x8d", 
+                    "lane4": "0x89", 
+                    "lane5": "0x8d", 
+                    "lane6": "0x89", 
+                    "lane7": "0x8d"
+                }, 
+                "post1": {
+                    "lane0": "-0xc", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8", 
+                    "lane4": "-0xc", 
+                    "lane5": "-0x5", 
+                    "lane6": "-0xc", 
+                    "lane7": "-0x5"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "-0x2", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "0x0", 
+                    "lane7": "-0x2"
+                }, 
+                "post3": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x3", 
+                    "lane2": "-0x1", 
+                    "lane3": "-0x1", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x3"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0x10", 
+                    "lane2": "-0xf", 
+                    "lane3": "-0xf", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x3", 
+                    "lane2": "0x2", 
+                    "lane3": "0x2", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x2", 
+                    "lane7": "0x3"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x4b", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x4b"
+                }, 
+                "post1": {
+                    "lane0": "-0x15", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x15"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x4", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x4"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "19": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x55", 
+                    "lane1": "0x55", 
+                    "lane2": "0x50", 
+                    "lane3": "0x50"
+                }, 
+                "post1": {
+                    "lane0": "-0x19", 
+                    "lane1": "-0x19", 
+                    "lane2": "-0x17", 
+                    "lane3": "-0x17"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x7", 
+                    "lane1": "-0x7", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x89", 
+                    "lane1": "0x8d", 
+                    "lane2": "0x90", 
+                    "lane3": "0x90", 
+                    "lane4": "0x89", 
+                    "lane5": "0x8d", 
+                    "lane6": "0x89", 
+                    "lane7": "0x8d"
+                }, 
+                "post1": {
+                    "lane0": "-0xc", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x1", 
+                    "lane3": "-0x1", 
+                    "lane4": "-0xc", 
+                    "lane5": "-0x5", 
+                    "lane6": "-0xc", 
+                    "lane7": "-0x5"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "-0x2", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "0x0", 
+                    "lane7": "-0x2"
+                }, 
+                "post3": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x3", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x3"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0x10", 
+                    "lane2": "-0x11", 
+                    "lane3": "-0x11", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x3", 
+                    "lane2": "0x2", 
+                    "lane3": "0x2", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x2", 
+                    "lane7": "0x3"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x55", 
+                    "lane1": "0x55", 
+                    "lane2": "0x50", 
+                    "lane3": "0x50"
+                }, 
+                "post1": {
+                    "lane0": "-0x19", 
+                    "lane1": "-0x19", 
+                    "lane2": "-0x17", 
+                    "lane3": "-0x17"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x7", 
+                    "lane1": "-0x7", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "20": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x4b", 
+                    "lane1": "0x4b", 
+                    "lane2": "0x4e", 
+                    "lane3": "0x4e"
+                }, 
+                "post1": {
+                    "lane0": "-0x14", 
+                    "lane1": "-0x14", 
+                    "lane2": "-0x16", 
+                    "lane3": "-0x16"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x8d", 
+                    "lane1": "0x8d", 
+                    "lane2": "0x89", 
+                    "lane3": "0x8d", 
+                    "lane4": "0x8d", 
+                    "lane5": "0x89", 
+                    "lane6": "0x8d", 
+                    "lane7": "0x8d"
+                }, 
+                "post1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0xc", 
+                    "lane3": "-0x5", 
+                    "lane4": "-0x8", 
+                    "lane5": "-0xc", 
+                    "lane6": "-0x5", 
+                    "lane7": "-0x8"
+                }, 
+                "post2": {
+                    "lane0": "-0x2", 
+                    "lane1": "-0x3", 
+                    "lane2": "0x0", 
+                    "lane3": "-0x2", 
+                    "lane4": "-0x3", 
+                    "lane5": "0x0", 
+                    "lane6": "-0x2", 
+                    "lane7": "-0x3"
+                }, 
+                "post3": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x1", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xf", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0xf", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0xf"
+                }, 
+                "pre2": {
+                    "lane0": "0x3", 
+                    "lane1": "0x2", 
+                    "lane2": "0x2", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x2", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x4b", 
+                    "lane1": "0x4b", 
+                    "lane2": "0x4e", 
+                    "lane3": "0x4e"
+                }, 
+                "post1": {
+                    "lane0": "-0x14", 
+                    "lane1": "-0x14", 
+                    "lane2": "-0x16", 
+                    "lane3": "-0x16"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "21": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x50", 
+                    "lane1": "0x50", 
+                    "lane2": "0x55", 
+                    "lane3": "0x55"
+                }, 
+                "post1": {
+                    "lane0": "-0x17", 
+                    "lane1": "-0x17", 
+                    "lane2": "-0x19", 
+                    "lane3": "-0x19"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x7"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x94", 
+                    "lane5": "0x88", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x89"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0xc"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "0x0", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x4", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x3"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x2", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x50", 
+                    "lane1": "0x50", 
+                    "lane2": "0x55", 
+                    "lane3": "0x55"
+                }, 
+                "post1": {
+                    "lane0": "-0x17", 
+                    "lane1": "-0x17", 
+                    "lane2": "-0x19", 
+                    "lane3": "-0x19"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x7"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "22": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x89", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x88", 
+                    "lane4": "0x94", 
+                    "lane5": "0x8b", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x88"
+                }, 
+                "post1": {
+                    "lane0": "-0xc", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0xe", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x7", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0xe"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "0x0", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x4", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x4"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0xe", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0xe"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x2", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "23": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x94", 
+                    "lane2": "0x88", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x88", 
+                    "lane5": "0x8b", 
+                    "lane6": "0x88", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x3", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x7", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "0x0", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x1", 
+                    "lane2": "-0x4", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x4", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x4", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0x10", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x2", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x2", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "24": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x94", 
+                    "lane5": "0x88", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "0x0", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x4", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x2", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "25": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x88", 
+                    "lane4": "0x94", 
+                    "lane5": "0x8b", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x88"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0xe", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x7", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0xe"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "0x0", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x4", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x4"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0xe", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0xe"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x2", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "26": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x94", 
+                    "lane2": "0x88", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x88", 
+                    "lane5": "0x8b", 
+                    "lane6": "0x88", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x3", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x7", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "0x0", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x1", 
+                    "lane2": "-0x4", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x4", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x4", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0x10", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x2", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x2", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "27": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x94", 
+                    "lane5": "0x88", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "0x0", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x4", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x2", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x59", 
+                    "lane1": "0x59", 
+                    "lane2": "0x59", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x1d", 
+                    "lane1": "-0x1d", 
+                    "lane2": "-0x1d", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x8", 
+                    "lane1": "-0x8", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "28": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x4e", 
+                    "lane1": "0x4e", 
+                    "lane2": "0x4b", 
+                    "lane3": "0x4b"
+                }, 
+                "post1": {
+                    "lane0": "-0x16", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x14", 
+                    "lane3": "-0x14"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x94", 
+                    "lane5": "0x88", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "0x0", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x4", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x2", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x4e", 
+                    "lane1": "0x4e", 
+                    "lane2": "0x4b", 
+                    "lane3": "0x4b"
+                }, 
+                "post1": {
+                    "lane0": "-0x16", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x14", 
+                    "lane3": "-0x14"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "29": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x4b", 
+                    "lane1": "0x50", 
+                    "lane2": "0x55", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x15", 
+                    "lane1": "-0x17", 
+                    "lane2": "-0x19", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x4", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x94", 
+                    "lane2": "0x88", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x88", 
+                    "lane5": "0x8b", 
+                    "lane6": "0x88", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x3", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x7", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "0x0", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x1", 
+                    "lane2": "-0x4", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x4", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x4", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0x10", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x2", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x2", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x4b", 
+                    "lane1": "0x50", 
+                    "lane2": "0x55", 
+                    "lane3": "0x59"
+                }, 
+                "post1": {
+                    "lane0": "-0x15", 
+                    "lane1": "-0x17", 
+                    "lane2": "-0x19", 
+                    "lane3": "-0x1d"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x4", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x8"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "30": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x4e", 
+                    "lane1": "0x53", 
+                    "lane2": "0x4e", 
+                    "lane3": "0x4b"
+                }, 
+                "post1": {
+                    "lane0": "-0x16", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x16", 
+                    "lane3": "-0x14"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x88", 
+                    "lane4": "0x94", 
+                    "lane5": "0x8b", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x88"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0xe", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x7", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0xe"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "0x0", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x4", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x4"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0xe", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0xe"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x2", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x4e", 
+                    "lane1": "0x53", 
+                    "lane2": "0x4e", 
+                    "lane3": "0x4b"
+                }, 
+                "post1": {
+                    "lane0": "-0x16", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x16", 
+                    "lane3": "-0x14"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "31": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x4e", 
+                    "lane1": "0x4e", 
+                    "lane2": "0x4b", 
+                    "lane3": "0x4b"
+                }, 
+                "post1": {
+                    "lane0": "-0x16", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x14", 
+                    "lane3": "-0x14"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x94", 
+                    "lane5": "0x88", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "0x0", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x4", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0xe", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x2", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x4e", 
+                    "lane1": "0x4e", 
+                    "lane2": "0x4b", 
+                    "lane3": "0x4b"
+                }, 
+                "post1": {
+                    "lane0": "-0x16", 
+                    "lane1": "-0x16", 
+                    "lane2": "-0x14", 
+                    "lane3": "-0x14"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "32": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x55", 
+                    "lane1": "0x55", 
+                    "lane2": "0x50", 
+                    "lane3": "0x50"
+                }, 
+                "post1": {
+                    "lane0": "-0x19", 
+                    "lane1": "-0x19", 
+                    "lane2": "-0x17", 
+                    "lane3": "-0x17"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x7", 
+                    "lane1": "-0x7", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x94", 
+                    "lane2": "0x88", 
+                    "lane3": "0x8b", 
+                    "lane4": "0x88", 
+                    "lane5": "0x8b", 
+                    "lane6": "0x88", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x3", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x7", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x7", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "-0x2", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "0x0", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x1", 
+                    "lane2": "-0x4", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x4", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x4", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0x10", 
+                    "lane2": "-0xe", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0xe", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0xe", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x2", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x2", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x55", 
+                    "lane1": "0x55", 
+                    "lane2": "0x50", 
+                    "lane3": "0x50"
+                }, 
+                "post1": {
+                    "lane0": "-0x19", 
+                    "lane1": "-0x19", 
+                    "lane2": "-0x17", 
+                    "lane3": "-0x17"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x7", 
+                    "lane1": "-0x7", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "33": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x4e", 
+                    "lane1": "0x4b", 
+                    "lane2": "0x4e", 
+                    "lane3": "0x4b"
+                }, 
+                "post1": {
+                    "lane0": "-0x16", 
+                    "lane1": "-0x14", 
+                    "lane2": "-0x16", 
+                    "lane3": "-0x14"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x94", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x88", 
+                    "lane4": "0x94", 
+                    "lane5": "0x8b", 
+                    "lane6": "0x8b", 
+                    "lane7": "0x88"
+                }, 
+                "post1": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0xe", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x7", 
+                    "lane6": "-0x7", 
+                    "lane7": "-0xe"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "0x0", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "-0x2", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x1", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x4", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x4"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0xe", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0xe"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x2", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x4e", 
+                    "lane1": "0x4b", 
+                    "lane2": "0x4e", 
+                    "lane3": "0x4b"
+                }, 
+                "post1": {
+                    "lane0": "-0x16", 
+                    "lane1": "-0x14", 
+                    "lane2": "-0x16", 
+                    "lane3": "-0x14"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "34": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x55", 
+                    "lane1": "0x50", 
+                    "lane2": "0x55", 
+                    "lane3": "0x50"
+                }, 
+                "post1": {
+                    "lane0": "-0x19", 
+                    "lane1": "-0x17", 
+                    "lane2": "-0x19", 
+                    "lane3": "-0x17"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x7", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x89", 
+                    "lane1": "0x88", 
+                    "lane2": "0x8b", 
+                    "lane3": "0x8d", 
+                    "lane4": "0x94", 
+                    "lane5": "0x8d", 
+                    "lane6": "0x81", 
+                    "lane7": "0x94"
+                }, 
+                "post1": {
+                    "lane0": "-0xc", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x8", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x5", 
+                    "lane6": "-0xf", 
+                    "lane7": "-0x3"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "-0x2", 
+                    "lane3": "-0x3", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "-0x3", 
+                    "lane7": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x4", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x1", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x2", 
+                    "lane7": "-0x1"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0xe", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0xf", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0x12", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x2", 
+                    "lane2": "0x3", 
+                    "lane3": "0x2", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x55", 
+                    "lane1": "0x50", 
+                    "lane2": "0x55", 
+                    "lane3": "0x50"
+                }, 
+                "post1": {
+                    "lane0": "-0x19", 
+                    "lane1": "-0x17", 
+                    "lane2": "-0x19", 
+                    "lane3": "-0x17"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x7", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "35": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x4b", 
+                    "lane1": "0x4b", 
+                    "lane2": "0x4e", 
+                    "lane3": "0x4e"
+                }, 
+                "post1": {
+                    "lane0": "-0x14", 
+                    "lane1": "-0x14", 
+                    "lane2": "-0x16", 
+                    "lane3": "-0x16"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x8d", 
+                    "lane1": "0x90", 
+                    "lane2": "0x89", 
+                    "lane3": "0x8d", 
+                    "lane4": "0x90", 
+                    "lane5": "0x89", 
+                    "lane6": "0x8d", 
+                    "lane7": "0x90"
+                }, 
+                "post1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x1", 
+                    "lane2": "-0xc", 
+                    "lane3": "-0x5", 
+                    "lane4": "-0x1", 
+                    "lane5": "-0xc", 
+                    "lane6": "-0x5", 
+                    "lane7": "-0x1"
+                }, 
+                "post2": {
+                    "lane0": "-0x2", 
+                    "lane1": "-0x3", 
+                    "lane2": "0x0", 
+                    "lane3": "-0x2", 
+                    "lane4": "-0x3", 
+                    "lane5": "0x0", 
+                    "lane6": "-0x2", 
+                    "lane7": "-0x3"
+                }, 
+                "post3": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x3", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x3"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0x11", 
+                    "lane2": "-0x10", 
+                    "lane3": "-0x10", 
+                    "lane4": "-0x11", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x11"
+                }, 
+                "pre2": {
+                    "lane0": "0x3", 
+                    "lane1": "0x2", 
+                    "lane2": "0x2", 
+                    "lane3": "0x3", 
+                    "lane4": "0x2", 
+                    "lane5": "0x2", 
+                    "lane6": "0x3", 
+                    "lane7": "0x2"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x4b", 
+                    "lane1": "0x4b", 
+                    "lane2": "0x4e", 
+                    "lane3": "0x4e"
+                }, 
+                "post1": {
+                    "lane0": "-0x14", 
+                    "lane1": "-0x14", 
+                    "lane2": "-0x16", 
+                    "lane3": "-0x16"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x5", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }, 
+        "36": {
+            "QSFP28-Extended-*": {
+                "main": {
+                    "lane0": "0x50", 
+                    "lane1": "0x55", 
+                    "lane2": "0x55", 
+                    "lane3": "0x50"
+                }, 
+                "post1": {
+                    "lane0": "-0x17", 
+                    "lane1": "-0x19", 
+                    "lane2": "-0x19", 
+                    "lane3": "-0x17"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x7", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }, 
+            "QSFP-DD-sm_media_interface": {
+                "main": {
+                    "lane0": "0x89", 
+                    "lane1": "0x8d", 
+                    "lane2": "0x8d", 
+                    "lane3": "0x8d", 
+                    "lane4": "0x89", 
+                    "lane5": "0x8d", 
+                    "lane6": "0x89", 
+                    "lane7": "0x8d"
+                }, 
+                "post1": {
+                    "lane0": "-0xc", 
+                    "lane1": "-0x5", 
+                    "lane2": "-0x8", 
+                    "lane3": "-0x8", 
+                    "lane4": "-0xc", 
+                    "lane5": "-0x5", 
+                    "lane6": "-0xc", 
+                    "lane7": "-0x5"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "-0x2", 
+                    "lane2": "-0x3", 
+                    "lane3": "-0x3", 
+                    "lane4": "0x0", 
+                    "lane5": "-0x2", 
+                    "lane6": "0x0", 
+                    "lane7": "-0x2"
+                }, 
+                "post3": {
+                    "lane0": "-0x3", 
+                    "lane1": "-0x3", 
+                    "lane2": "-0x1", 
+                    "lane3": "-0x1", 
+                    "lane4": "-0x3", 
+                    "lane5": "-0x3", 
+                    "lane6": "-0x3", 
+                    "lane7": "-0x3"
+                }, 
+                "pre1": {
+                    "lane0": "-0x10", 
+                    "lane1": "-0x10", 
+                    "lane2": "-0xf", 
+                    "lane3": "-0xf", 
+                    "lane4": "-0x10", 
+                    "lane5": "-0x10", 
+                    "lane6": "-0x10", 
+                    "lane7": "-0x10"
+                }, 
+                "pre2": {
+                    "lane0": "0x2", 
+                    "lane1": "0x3", 
+                    "lane2": "0x2", 
+                    "lane3": "0x2", 
+                    "lane4": "0x2", 
+                    "lane5": "0x3", 
+                    "lane6": "0x2", 
+                    "lane7": "0x3"
+                }
+            }, 
+            "Default": {
+                "main": {
+                    "lane0": "0x50", 
+                    "lane1": "0x55", 
+                    "lane2": "0x55", 
+                    "lane3": "0x50"
+                }, 
+                "post1": {
+                    "lane0": "-0x17", 
+                    "lane1": "-0x19", 
+                    "lane2": "-0x19", 
+                    "lane3": "-0x17"
+                }, 
+                "post2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "post3": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }, 
+                "pre1": {
+                    "lane0": "-0x5", 
+                    "lane1": "-0x7", 
+                    "lane2": "-0x7", 
+                    "lane3": "-0x5"
+                }, 
+                "pre2": {
+                    "lane0": "0x0", 
+                    "lane1": "0x0", 
+                    "lane2": "0x0", 
+                    "lane3": "0x0"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Why I did it
TX FIR tuning should be done based on the type of inserted transceiver

#### How I did it
Add media_settings.json which contains the tuning data for 100G optic and 400G optic.

#### How to verify it
Tested against x86_64-arista_7800r3a_36d2_lc

#### Description for the changelog
Add media_settings.json for x86_64-arista_7800r3a_36d2_lc