### PR TITLE
[TACACS] Send remote address in TACACS authorization package.

### DIFF
--- a/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
+++ b/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
@@ -1,0 +1,88 @@
+From aec0ad4da85b0edbfa45f6deab1c0abbeecd4bbb Mon Sep 17 00:00:00 2001
+From: liuh-80 <liuh@microsoft.com>
+Date: Wed, 28 Sep 2022 17:12:18 +0800
+Subject: [PATCH] Send remote address in TACACS+ authorization message.
+
+---
+ nss_tacplus.c | 53 ++++++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 52 insertions(+), 1 deletion(-)
+
+diff --git a/nss_tacplus.c b/nss_tacplus.c
+index 2de00a6..00b0d17 100644
+--- a/nss_tacplus.c
++++ b/nss_tacplus.c
+@@ -33,6 +33,7 @@
+ #include <ctype.h>
+ #include <netdb.h>
+ #include <nss.h>
++#include <limits.h>
+ 
+ #include <libtac/libtac.h>
+ 
+@@ -717,6 +718,44 @@ connect_tacacs(struct tac_attrib **attr, int srvr)
+     return fd;
+ }
+ 
++/*
++ * Get current SSH session remote address from environment variable
++ */
++void get_remote_address(char* dst, socklen_t size)
++{
++    memset(dst, 0, size);
++    char format[32];
++    snprintf(format, sizeof(format), "%%%ds", (int)(size-1));
++
++    // SSHD will create environment variable SSH_CONNECTION after user session created.
++    const char* ssh_connection = getenv("SSH_CONNECTION");
++    if (ssh_connection != NULL) {
++        // The first part of $SSH_CONNECTION is client IP address
++        sscanf(ssh_connection , format, dst);
++        if(debug) {
++            syslog(LOG_DEBUG, "%s: remote address=%s, SSH_CONNECTION=%s", nssname, ssh_connection, dst);
++        }
++        return;
++    }
++
++    if(debug) {
++        syslog(LOG_DEBUG, "%s: can't get environment variable SSH_CONNECTION, errno=%d", nssname, errno);
++    }
++
++    // Before user session created, SSHD will create environment variable SSH_REMOTE_IP.
++    const char* ssh_remote_ip = getenv("SSH_REMOTE_IP");
++    if (ssh_remote_ip != NULL) {
++        snprintf (dst , size, "%s", ssh_remote_ip);
++        if(debug) {
++            syslog(LOG_DEBUG, "%s: remote address=%s", nssname, dst);
++        }
++        return;
++    }
++
++    if(debug) {
++        syslog(LOG_DEBUG, "%s: can't get environment variable SSH_REMOTE_IP, errno=%d", nssname, errno);
++    }
++}
+ 
+ /*
+  * lookup the user on a TACACS server.  Returns 0 on successful lookup, else 1
+@@ -735,6 +778,9 @@ lookup_tacacs_user(struct pwbuf *pb)
+     int ret = 1, done = 0;
+     struct tac_attrib *attr;
+     int tac_fd, srvr;
++    char remote_addr[INET6_ADDRSTRLEN + 1];
++
++    get_remote_address(remote_addr, sizeof(remote_addr));
+ 
+     for(srvr=0; srvr < tac_srv_no && !done; srvr++) {
+         arep.msg = NULL;
+@@ -748,7 +796,7 @@ lookup_tacacs_user(struct pwbuf *pb)
+                     tac_ntop(tac_srv[srvr].addr->ai_addr) : "unknown", tac_fd);
+             continue;
+         }
+-        ret = tac_author_send(tac_fd, pb->name, "", "", attr);
++        ret = tac_author_send(tac_fd, pb->name, "", remote_addr, attr);
+         if(ret < 0) {
+             if(debug)
+                 syslog(LOG_WARNING, "%s: TACACS+ server %s send failed (%d) for"
+-- 
+2.37.1.windows.1
+

--- a/src/tacacs/nss/patch/series
+++ b/src/tacacs/nss/patch/series
@@ -7,3 +7,4 @@
 0007-Add-support-for-TACACS-source-address.patch
 0008-do-not-create-or-modify-local-user-if-there-is-no-pr.patch
 0009-fix-compile-error-strncpy.patch
+0010-Send-remote-address-in-TACACS-authorization-message.patch


### PR DESCRIPTION
Send remote address in TACACS authorization package.

#### Why I did it
TACACS not send remote address in authorization package.

#### How I did it
Read remote address from SSH_CONNECTION or SSH_REMOTE_IP and send in TACACS authorization package.

#### How to verify it
Pass all E2E test.
New E2E test case to cover this change.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
Send remote address in TACACS authorization package.

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

