### PR TITLE
[FRR]Adding patch to fix enhanced capability turned on for interface

### DIFF
--- a/src/sonic-frr/patch/0011-bgpd-enhanced-capability-is-always-turned-on-for-int.patch
+++ b/src/sonic-frr/patch/0011-bgpd-enhanced-capability-is-always-turned-on-for-int.patch
@@ -1,0 +1,36 @@
+From 4db4fc1bf0599f79067bfd62aa435be8e161d81e Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Tue, 3 May 2022 12:51:21 -0400
+Subject: [PATCH] bgpd: enhanced capability is always turned on for interface
+ based peers
+
+FRR is displaying that the peer enhanced capability command is not
+turned on when the interface is part of a peer group.  Saving the
+config and then reloading actually turns it off.
+
+Fix the code so that FRR does not display the enhanced capability
+for interface based peers.
+
+Fixes: #11108
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+---
+ bgpd/bgp_vty.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/bgpd/bgp_vty.c b/bgpd/bgp_vty.c
+index 4df2abef8..6fcce239b 100644
+--- a/bgpd/bgp_vty.c
++++ b/bgpd/bgp_vty.c
+@@ -16586,7 +16586,8 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
+ 
+ 	/* capability extended-nexthop */
+ 	if (peergroup_flag_check(peer, PEER_FLAG_CAPABILITY_ENHE)) {
+-		if (CHECK_FLAG(peer->flags_invert, PEER_FLAG_CAPABILITY_ENHE))
++		if (CHECK_FLAG(peer->flags_invert, PEER_FLAG_CAPABILITY_ENHE) &&
++		    !peer->conf_if)
+ 			vty_out(vty,
+ 				" no neighbor %s capability extended-nexthop\n",
+ 				addr);
+-- 
+2.17.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -10,3 +10,4 @@ Disable-ipv6-src-address-test-in-pceplib.patch
 cross-compile-changes.patch
 0009-ignore-route-from-default-table.patch
 0010-zebra-Note-when-the-netlink-DUMP-command-is-interrup.patch
+0011-bgpd-enhanced-capability-is-always-turned-on-for-int.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixing issue  https://github.com/FRRouting/frr/issues/11108
For interface based peers with peer-groups, "no neighbor capability extended-nexthop" gets added by default. This will result in IPv4 routes not having ipv6 next hops.

#### How I did it
Porting the commit https://github.com/FRRouting/frr/commit/8e89adc1edfb4200843e1cbbff1404172bebd9e5 to FRR 8.2.2 which fixes the issue

#### How to verify it
Load FRR and verify if the "no neighbor capability extended-nexthop" not gets added for interfaces associated with peer-groups


### Before fix
```
show running-config
Building configuration...

Current configuration:
!
frr version 8.2.2
frr defaults traditional
hostname r-lionfish-16
no service integrated-vtysh-config
!
router bgp 65001
 no bgp suppress-duplicates
 neighbor PEER_V6 peer-group
 neighbor PEER_V6 remote-as internal
 neighbor PEER_V6 capability extended-nexthop
 neighbor Ethernet116 interface peer-group PEER_V6
 no neighbor Ethernet116 capability extended-nexthop
 !
 address-family ipv4 unicast
  redistribute connected
 exit-address-family
 !
exit

```
### After fix
```
show running-config
Building configuration...

Current configuration:
!
frr version 8.2.2
frr defaults traditional
hostname r-lionfish-16
no service integrated-vtysh-config
!
router bgp 65001
 no bgp suppress-duplicates
 neighbor PEER_V6 peer-group
 neighbor PEER_V6 remote-as internal
 neighbor PEER_V6 capability extended-nexthop
 neighbor Ethernet116 interface peer-group PEER_V6
 !
 address-family ipv4 unicast
  redistribute connected
 exit-address-family
 !
exit

```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

