### PR TITLE
Add dhcp6relay dualtor option

### DIFF
--- a/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
@@ -12,6 +12,8 @@
 {% set _dummy = relay_for_ipv6.update({'flag': False}) %}
 [program:dhcp6relay]
 command=/usr/sbin/dhcp6relay
+{#- Dual ToR Option #}
+{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %} -d {% endif -%}
 priority=3
 autostart=false
 autorestart=false

--- a/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
@@ -13,7 +13,7 @@
 [program:dhcp6relay]
 command=/usr/sbin/dhcp6relay
 {#- Dual ToR Option #}
-{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %} -d {% endif -%}
+{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %} -d{% endif %}
 
 priority=3
 autostart=false

--- a/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
@@ -14,6 +14,7 @@
 command=/usr/sbin/dhcp6relay
 {#- Dual ToR Option #}
 {% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %} -d {% endif -%}
+
 priority=3
 autostart=false
 autorestart=false


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add dual tor option for dhcp6relay in dual tor mode as per PR https://github.com/sonic-net/sonic-dhcp-relay/pull/10
Option listed in dhcp6relay code:
https://github.com/sonic-net/sonic-dhcp-relay/blob/9c3b73837f768b3220d68ed01030d204c650d476/src/main.cpp#L17

#### How I did it
Add "-d" when subtype is 'DualToR"

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

