### PR TITLE
Fix syncd autorestart sequence

### DIFF
--- a/files/build_templates/per_namespace/syncd.service.j2
+++ b/files/build_templates/per_namespace/syncd.service.j2
@@ -30,6 +30,7 @@ ExecStop=/usr/local/bin/syncd.sh stop{% if multi_instance == 'true' %} %i{% endi
 {% if sonic_asic_platform == 'mellanox' %}
 TimeoutStartSec=480
 {% endif %}
+RestartSec=30
 
 [Install]
 WantedBy=sonic.target


### PR DESCRIPTION
Signed-off-by: Oleksandr Kolomeiets <oleksandrx.kolomeiets@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
After stopping syncd process (docker exec -it syncd kill 20), syncd service restarts without swss service restarting:
1. Syncd stopped
2. Syncd started
3. Swss stopped
4. Swss started

#### How I did it
Added delay before syncd restart.

#### How to verify it
Stop syncd process (docker exec -it syncd kill 20).
Syncd service starts after swss service:
1. Syncd stopped
2. Swss stopped
3. Swss started
4. Syncd started

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
Fix syncd autorestart sequence.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

