### PR TITLE
fix show interface neighbor exp issue

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -260,7 +260,6 @@ def parse_png(png, hname, dpg_ecmp_content = None):
         if child.tag == str(QName(ns, "Devices")):
             for device in child.findall(str(QName(ns, "Device"))):
                 (lo_prefix, lo_prefix_v6, mgmt_prefix, mgmt_prefix_v6, name, hwsku, d_type, deployment_id, cluster, d_subtype) = parse_device(device)
-                # 'lo_addr', 'mgmt_addr', 'type', 'hwsku' are must fields in config db
                 device_data = {'lo_addr': lo_prefix, 'type': d_type, 'mgmt_addr': mgmt_prefix, 'hwsku': hwsku}
                 if cluster != None:
                     device_data['cluster'] = cluster

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -260,23 +260,16 @@ def parse_png(png, hname, dpg_ecmp_content = None):
         if child.tag == str(QName(ns, "Devices")):
             for device in child.findall(str(QName(ns, "Device"))):
                 (lo_prefix, lo_prefix_v6, mgmt_prefix, mgmt_prefix_v6, name, hwsku, d_type, deployment_id, cluster, d_subtype) = parse_device(device)
-                device_data = {}
-                if hwsku != None:
-                    device_data['hwsku'] = hwsku
+                # 'lo_addr', 'mgmt_addr', 'type', 'hwsku' are must fields in config db
+                device_data = {'lo_addr': lo_prefix, 'type': d_type, 'mgmt_addr': mgmt_prefix, 'hwsku': hwsku}
                 if cluster != None:
                     device_data['cluster'] = cluster
                 if deployment_id != None:
                     device_data['deployment_id'] = deployment_id
-                if lo_prefix != None:
-                    device_data['lo_addr'] = lo_prefix
                 if lo_prefix_v6 != None:
                     device_data['lo_addr_v6'] = lo_prefix_v6
-                if mgmt_prefix != None:
-                    device_data['mgmt_addr'] = mgmt_prefix
                 if mgmt_prefix_v6 != None:
                     device_data['mgmt_addr_v6'] = mgmt_prefix_v6
-                if d_type != None:
-                    device_data['type'] = d_type
                 if d_subtype != None:
                     device_data['subtype'] = d_subtype
                 devices[name] = device_data
@@ -403,23 +396,15 @@ def parse_asic_png(png, asic_name, hostname):
         if child.tag == str(QName(ns, "Devices")):
             for device in child.findall(str(QName(ns, "Device"))):
                 (lo_prefix, lo_prefix_v6, mgmt_prefix, mgmt_prefix_v6, name, hwsku, d_type, deployment_id, cluster, _) = parse_device(device)
-                device_data = {}
-                if hwsku != None:
-                    device_data['hwsku'] = hwsku
+                device_data = {'lo_addr': lo_prefix, 'type': d_type, 'mgmt_addr': mgmt_prefix, 'hwsku': hwsku}
                 if cluster != None:
                     device_data['cluster'] = cluster
                 if deployment_id != None:
                     device_data['deployment_id'] = deployment_id
-                if lo_prefix != None:
-                    device_data['lo_addr'] = lo_prefix
                 if lo_prefix_v6 != None:
                     device_data['lo_addr_v6'] = lo_prefix_v6
-                if mgmt_prefix != None:
-                    device_data['mgmt_addr'] = mgmt_prefix
                 if mgmt_prefix_v6 != None:
                     device_data['mgmt_addr_v6'] = mgmt_prefix_v6
-                if d_type != None:
-                    device_data['type'] = d_type
                 devices[name] = device_data
 
     return (neighbors, devices, port_speeds)

--- a/src/sonic-config-engine/tests/test_multinpu_cfggen.py
+++ b/src/sonic-config-engine/tests/test_multinpu_cfggen.py
@@ -252,7 +252,7 @@ class TestMultiNpuCfgGen(TestCase):
         output = json.loads(self.run_script(argument))
         print(output)
         self.assertDictEqual(output, \
-            {'01T2': {'mgmt_addr': '89.139.132.40', 'hwsku': 'VM', 'type': 'SpineRouter'},
+            {'01T2': {'lo_addr': None, 'type': 'SpineRouter', 'mgmt_addr': '89.139.132.40', 'hwsku': 'VM'},
             'ASIC3': {'lo_addr_v6': '::/0', 'mgmt_addr': '0.0.0.0/0', 'hwsku': 'multi-npu-asic', 'lo_addr': '0.0.0.0/0', 'type': 'Asic', 'mgmt_addr_v6': '::/0'},
             'ASIC2': {'lo_addr_v6': '::/0', 'mgmt_addr': '0.0.0.0/0', 'hwsku': 'multi-npu-asic', 'lo_addr': '0.0.0.0/0', 'type': 'Asic', 'mgmt_addr_v6': '::/0'}})
 

--- a/src/sonic-yang-models/yang-models/sonic-device_neighbor_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_neighbor_metadata.yang
@@ -50,6 +50,9 @@ module sonic-device_neighbor_metadata {
                     type union {
                         type inet:ipv4-prefix;
                         type inet:ipv4-address;
+                        type string {
+                            pattern "None";
+                        }
                     }
                 }
 
@@ -68,6 +71,9 @@ module sonic-device_neighbor_metadata {
                     type union {
                         type inet:ipv4-prefix;
                         type inet:ipv4-address;
+                        type string {
+                            pattern "None";
+                        }
                     }
                 }
 


### PR DESCRIPTION
#### Why I did it
With the commit of https://github.com/sonic-net/sonic-buildimage/pull/11894.
device neighbor metadata in config_db.json changed a little bit when "lo_addr"/"mgmt_addr" are None.

![dfa09cf3-b9f5-4da1-b998-ff750ef6ab12](https://user-images.githubusercontent.com/111116206/197200767-cf538999-8cc4-4a93-808d-df7c239de71f.jpg)

CLI parse code for "show interface neighbor expected" is not strong enough to handle None case. 
It always assume 'lo_addr' and 'mgmt_addr' exists, and will finally cause KeyError, show command will not print the information. 

```
for port in natsorted(list(neighbor_dict.keys())):
            try:
                device = neighbor_dict[port]['name']
                body.append([port,
                             device,
                             neighbor_dict[port]['port'],
                             neighbor_metadata_dict[device]['lo_addr'],
                             neighbor_metadata_dict[device]['mgmt_addr'],
                             neighbor_metadata_dict[device]['type']])
            except KeyError:
                pass
```

#### How I did it
Since in code many places don't check the existence of 'lo_addr' and 'mgmt_addr', for safety always add 'lo_addr' and 'mgmt_addr' in minigraph.py   

#### How to verify it
"show interface neighbor expected" with fix image 

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

fixes #12301 
