### PR TITLE
Update cisco-8000 submodule to v0.120

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202012-v0.117
+ref=202012-v0.120


### PR DESCRIPTION
Why I did it
Fix for fan sensor critical alarms causing some devices to reboot

How I did it
Update cisco-8000 submodule to v0.120

How to verify it

Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

Description for the changelog
