### PR TITLE
[201911] [Systemd] Upgrade systemd to fix timer elapsed issue

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -188,15 +188,6 @@ if [[ $CONFIGURED_ARCH == amd64 ]]; then
     sudo cp $files_path/ixgbe.ko $FILESYSTEM_ROOT/lib/modules/${LINUX_KERNEL_VERSION}-amd64/kernel/drivers/net/ethernet/intel/ixgbe/ixgbe.ko
 fi
 
-## On 201911, Upgrade systemd to fix timer elapse issue: https://github.com/systemd/systemd/issues/6680
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT curl -o /tmp/libsystemd0_241-5~bpo9+1_${CONFIGURED_ARCH}.deb -fsSL \
-    http://http.us.debian.org/debian/pool/main/s/systemd/libsystemd0_241-5~bpo9+1_${CONFIGURED_ARCH}.deb
-sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install -f /tmp/libsystemd0_241-5~bpo9+1_${CONFIGURED_ARCH}.deb
-
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT curl -o /tmp/systemd_241-5~bpo9+1_${CONFIGURED_ARCH}.deb -fsSL \
-    http://http.us.debian.org/debian/pool/main/s/systemd/systemd_241-5~bpo9+1_${CONFIGURED_ARCH}.deb
-sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install -f /tmp/systemd_241-5~bpo9+1_${CONFIGURED_ARCH}.deb
-
 ## Install docker
 echo '[INFO] Install docker'
 ## Install apparmor utils since they're missing and apparmor is enabled in the kernel
@@ -343,7 +334,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT bash -c "find /usr/share/i18n/locales/ ! -na
 # Install certain fundamental packages from stretch-backports in order to get
 # more up-to-date (but potentially less stable) versions
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y -t stretch-backports install \
-    picocom
+    picocom libsystemd0 systemd
 
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y download \

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -188,6 +188,15 @@ if [[ $CONFIGURED_ARCH == amd64 ]]; then
     sudo cp $files_path/ixgbe.ko $FILESYSTEM_ROOT/lib/modules/${LINUX_KERNEL_VERSION}-amd64/kernel/drivers/net/ethernet/intel/ixgbe/ixgbe.ko
 fi
 
+## On 201911, Upgrade systemd to fix timer elapse issue: https://github.com/systemd/systemd/issues/6680
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT curl -o /tmp/libsystemd0_241-5~bpo9+1_${CONFIGURED_ARCH}.deb -fsSL \
+    http://http.us.debian.org/debian/pool/main/s/systemd/libsystemd0_241-5~bpo9+1_${CONFIGURED_ARCH}.deb
+sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install -f /tmp/libsystemd0_241-5~bpo9+1_${CONFIGURED_ARCH}.deb
+
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT curl -o /tmp/systemd_241-5~bpo9+1_${CONFIGURED_ARCH}.deb -fsSL \
+    http://http.us.debian.org/debian/pool/main/s/systemd/systemd_241-5~bpo9+1_${CONFIGURED_ARCH}.deb
+sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install -f /tmp/systemd_241-5~bpo9+1_${CONFIGURED_ARCH}.deb
+
 ## Install docker
 echo '[INFO] Install docker'
 ## Install apparmor utils since they're missing and apparmor is enabled in the kernel


### PR DESCRIPTION
Upgrade systemd to fix timer elapsed issue.

#### Why I did it
On 201911 release, snmp.timer become elapsed status and snmp.service will not be trigger by snmp.timer:

● snmp.service - SNMP container
Loaded: loaded (/usr/lib/systemd/system/snmp.service; static; vendor preset: enabled)
Active: inactive (dead)
● snmp.timer - Delays snmp container until SONiC has started
Loaded: loaded (/usr/lib/systemd/system/snmp.timer; enabled; vendor preset: enabled)
Active: active (elapsed) since Wed 2022-08-03 18:12:59 UTC; 2 months 17 days ago

This issue caused by systemd bug: https://github.com/systemd/systemd/pull/10778/files

This issue can be reproduce with following steps:
1. reboot system.
2. continusly run following commands till  timer elapsed:
systemctl status snmp.timer
sudo systemctl daemon-reload

#### How I did it
Install latest version systemd from offical backport source.

#### How to verify it
Pass all test case.
Manually check reproduce steps, verify the issue fixed.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
Upgrade systemd to fix timer elapsed issue.

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

