### PR TITLE
[system-health] Led color shall be controlled by configuration when system is booting

### DIFF
--- a/src/system-health/health_checker/config.py
+++ b/src/system-health/health_checker/config.py
@@ -20,7 +20,7 @@ class Config(object):
     DEFAULT_LED_CONFIG = {
         'fault': 'red',
         'normal': 'green',
-        'booting': 'orange_blink'
+        'booting': 'red'
     }
 
     # System health configuration file name

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -425,7 +425,7 @@ def test_config():
 
     assert config.get_led_color('fault') == 'red'
     assert config.get_led_color('normal') == 'green'
-    assert config.get_led_color('booting') == 'orange_blink'
+    assert config.get_led_color('booting') == 'red'
 
     config._last_mtime  = 1
     config._config_file = 'notExistFile'

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -498,10 +498,10 @@ def test_manager(mock_hw_info, mock_service_info, mock_udc_info):
     assert stat['Internal']['UserDefinedChecker - some check']['status'] == 'Not OK'
 
     chassis.set_status_led.side_effect = NotImplementedError()
-    manager._set_system_led(chassis, manager.config, 'normal')
+    manager._set_system_led(chassis)
 
     chassis.set_status_led.side_effect = RuntimeError()
-    manager._set_system_led(chassis, manager.config, 'normal')
+    manager._set_system_led(chassis)
 
 def test_utils():
     output = utils.run_command('some invalid command')
@@ -568,7 +568,7 @@ def test_get_app_ready_status(mock_config_db, mock_run, mock_docker_client):
             'has_global_scope': 'True',
             'has_per_asic_scope': 'False',
             'check_up_status': 'True'
-        },   
+        },
         'snmp': {
             'state': 'enabled',
             'has_global_scope': 'True',
@@ -659,10 +659,10 @@ def test_get_all_system_status_not_ok():
     result = sysmon.get_all_system_status()
     print("result:{}".format(result))
     assert result == 'DOWN'
-    
+
 def test_post_unit_status():
     sysmon = Sysmonitor()
-    sysmon.post_unit_status("mock_bgp", 'OK', 'Down', 'mock reason', '-') 
+    sysmon.post_unit_status("mock_bgp", 'OK', 'Down', 'mock reason', '-')
     result = swsscommon.SonicV2Connector.get_all(MockConnector, 0, 'ALL_SERVICE_STATUS|mock_bgp')
     print(result)
     assert result['service_status'] == 'OK'
@@ -671,7 +671,7 @@ def test_post_unit_status():
 
 def test_post_system_status():
     sysmon = Sysmonitor()
-    sysmon.post_system_status("UP") 
+    sysmon.post_system_status("UP")
     result = swsscommon.SonicV2Connector.get(MockConnector, 0, "SYSTEM_READY|SYSTEM_STATE", 'Status')
     print("post system status result:{}".format(result))
     assert result == "UP"
@@ -689,7 +689,7 @@ def test_publish_system_status():
 @patch('health_checker.sysmonitor.Sysmonitor.publish_system_status', test_publish_system_status())
 def test_update_system_status():
     sysmon = Sysmonitor()
-    sysmon.update_system_status() 
+    sysmon.update_system_status()
     result = swsscommon.SonicV2Connector.get(MockConnector, 0, "SYSTEM_READY|SYSTEM_STATE", 'Status')
     assert result == "UP"
 


### PR DESCRIPTION
HLD: https://github.com/sonic-net/SONiC/pull/1106
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently, system status LED is always red during booting stage. User cannot tell if it is a real issue or system is under initialization. This HLD change introduces a booting stage for the system health daemon and allow user to configure the system status led color for booting state.

#### How I did it
Led color is determined by system status and uptime.

#### How to verify it
Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

