### PR TITLE
Add yang model definition for VOQ_INBAND_INTERFACE (#12306)

### DIFF
--- a/src/sonic-config-engine/tests/sample-voq-graph.xml
+++ b/src/sonic-config-engine/tests/sample-voq-graph.xml
@@ -51,11 +51,6 @@
       <IPInterfaces/>
       <VoqInbandInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
         <a:VoqInbandInterface>
-          <Name>Vlan3094</Name>
-          <Type>Vlan</Type>
-          <a:PrefixStr>1.1.1.1/24</a:PrefixStr>
-        </a:VoqInbandInterface>
-        <a:VoqInbandInterface>
           <Name>Ethernet-IB0</Name>
           <Type>port</Type>
           <a:PrefixStr>2.2.2.2/32</a:PrefixStr>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -905,19 +905,6 @@ class TestCfgGen(TestCase):
             utils.to_dict("{'lanes': '6,7', 'fec': 'rs', 'alias': 'Ethernet1/1', 'index': '1', 'role': 'Ext', 'speed': '100000', 'macsec': 'macsec-profile', 'description': 'Ethernet1/1', 'mtu': '9100', 'tpid': '0x8100', 'pfc_asym': 'off'}")
         )
 
-    def test_minigraph_voq_inband_interface_vlan(self):
-        argument = "-j {} -m {} -p {} --var-json VOQ_INBAND_INTERFACE".format(self.macsec_profile, self.sample_graph_voq, self.voq_port_config)
-        output = self.run_script(argument)
-        output_dict = utils.to_dict(output.strip())
-        self.assertDictEqual(
-            output_dict['Vlan3094'],
-            {'inband_type': 'Vlan'}
-        )
-        self.assertDictEqual(
-            output_dict['Vlan3094|1.1.1.1/24'],
-            {}
-        )
-
     def test_minigraph_voq_inband_interface_port(self):
         argument = "-j {} -m {} -p {} --var-json VOQ_INBAND_INTERFACE".format(self.macsec_profile, self.sample_graph_voq, self.voq_port_config)
         output = self.run_script(argument)

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -50,6 +50,7 @@ Table of Contents
          * [Versions](#versions)  
          * [VLAN](#vlan)   
          * [VLAN_MEMBER](#vlan_member)  
+         * [VOQ Inband Interface](#voq-inband-interface) 
          * [Virtual router](#virtual-router)  
          * [WRED_PROFILE](#wred_profile)  
          * [PASSWORD_HARDENING](#password_hardening)
@@ -1467,6 +1468,20 @@ channel name as object key, and tagging mode as attributes.
 		"tagging_mode": "tagged"
 	}
   }
+}
+```
+
+### VOQ INBAND INTERFACE
+
+VOQ_INBAND_INTERFACE holds the name of the inband system port dedicated for cpu communication. At this time, only inband_type of "port" is supported
+
+```
+"VOQ_INBAND_INTERFACE": {
+    "Ethernet-IB0": {
+	   "inband_type": "port"
+	},
+	"Ethernet-IB0|3.3.3.1/32": {},
+    "Ethernet-IB0|3333::3:5/128": {}
 }
 ```
 

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -134,6 +134,7 @@ setup(
                          './yang-models/sonic-types.yang',
                          './yang-models/sonic-versions.yang',
                          './yang-models/sonic-vlan.yang',
+                         './yang-models/sonic-voq-inband-interface.yang',
                          './yang-models/sonic-vrf.yang',
                          './yang-models/sonic-mclag.yang',
                          './yang-models/sonic-vlan-sub-interface.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1805,6 +1805,14 @@
             }
         },
 
+        "VOQ_INBAND_INTERFACE": {
+            "Ethernet-IB0": {
+               "inband_type": "port"
+            },
+            "Ethernet-IB0|3.3.3.1/32": {},
+            "Ethernet-IB0|3333::3:5/128": {}
+        },
+
         "PASSW_HARDENING": {
             "POLICIES": {
                 "state": "enabled",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/voq-inband-interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/voq-inband-interface.json
@@ -1,0 +1,25 @@
+{
+    "VOQ_INBAND_INTERFACE_TEST": {
+        "desc": "Configure voq inband interface"
+    },
+    "VOQ_INBAND_INTERFACE_WRONG_PATTERN_FOR_INTERFACE_NAME_TEST": {
+        "desc": "Configure incorrect interface name in VOQ_INBAND_INTERFACE table",
+        "eStrKey" : "Pattern",
+        "eStr": ["Ethernet-IB[0-9]+"]
+    },
+    "VOQ_INBAND_INTERFACE_DEFAULT_INBAND_TYPE_TEST": {
+        "desc": "Configure voq_inband_interface with default inband type"
+    },
+    "VOQ_INBAND_INTERFACE_INVALID_INBAND_TYPE_TEST": {
+        "desc": "Configure incorrect inband type",
+        "eStrKey": "Pattern"
+    },
+    "VOQ_INBAND_INTERFACE_IP_PREFIX_PORT_NON_EXISTING_LEAF_TEST": {
+        "desc": "Configure ip prefix on voq-inband-interface with non-existing reference",
+        "eStrKey": "LeafRef"
+    },
+    "VOQ_INBAND_INTERFACE_IP_PREFIX_EMPTY_STRING_TEST": {
+        "desc": "Configure ip prefix voq-inband-interface with empty ip prefix",
+        "eStrKey": "InvalidValue"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/voq-inband-interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/voq-inband-interface.json
@@ -1,0 +1,121 @@
+{
+    "VOQ_INBAND_INTERFACE_TEST": {
+        "sonic-voq-inband-interface:sonic-voq-inband-interface" : {
+            "sonic-voq-inband-interface:VOQ_INBAND_INTERFACE": {
+                "VOQ_INBAND_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet-IB0",
+                        "inband_type": "port"
+                    }
+                ],
+                "VOQ_INBAND_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "name": "Ethernet-IB0",
+                        "ip-prefix": "3.3.3.1/32"
+                    },
+                    {
+                        "name": "Ethernet-IB0",
+                        "ip-prefix": "3333::3:5/128"
+                    }
+                ]
+            }
+        }
+    },
+    "VOQ_INBAND_INTERFACE_WRONG_PATTERN_FOR_INTERFACE_NAME_TEST": {
+        "sonic-voq-inband-interface:sonic-voq-inband-interface" : {
+            "sonic-voq-inband-interface:VOQ_INBAND_INTERFACE": {
+                "VOQ_INBAND_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet-0IB",
+                        "inband_type": "port"
+                    }
+                ],
+                "VOQ_INBAND_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "name": "Ethernet-0IB",
+                        "ip-prefix": "3.3.3.1/32"
+                    },
+                    {
+                        "name": "Ethernet-0IB",
+                        "ip-prefix": "3333::3:5/128"
+                    }
+                ]
+            }
+        }
+    },
+    "VOQ_INBAND_INTERFACE_DEFAULT_INBAND_TYPE_TEST": {
+        "sonic-voq-inband-interface:sonic-voq-inband-interface" : {
+            "sonic-voq-inband-interface:VOQ_INBAND_INTERFACE": {
+                "VOQ_INBAND_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet-IB0"                        
+                    }
+                ],
+                "VOQ_INBAND_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "name": "Ethernet-IB0",
+                        "ip-prefix": "3.3.3.1/32"
+                    }
+                ]
+            }
+        }
+    },
+    "VOQ_INBAND_INTERFACE_INVALID_INBAND_TYPE_TEST": {
+        "sonic-voq-inband-interface:sonic-voq-inband-interface" : {
+            "sonic-voq-inband-interface:VOQ_INBAND_INTERFACE": {
+                "VOQ_INBAND_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet-IB0",
+                        "inband_type": "System-port"
+                    }
+                ],
+                "VOQ_INBAND_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "name": "Ethernet-IB0",
+                        "ip-prefix": "3.3.3.1/32"
+                    }
+                ]
+            }
+        }
+    },
+    "VOQ_INBAND_INTERFACE_IP_PREFIX_PORT_NON_EXISTING_LEAF_TEST": {
+        "sonic-voq-inband-interface:sonic-voq-inband-interface" : {
+            "sonic-voq-inband-interface:VOQ_INBAND_INTERFACE": {
+                "VOQ_INBAND_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet-IB0",
+                        "inband_type": "port"
+                    }
+                ],
+                "VOQ_INBAND_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "name": "Ethernet-IB0",
+                        "ip-prefix": "3.3.3.1/32"
+                    },
+                    {
+                        "name": "Ethernet-IB1",
+                        "ip-prefix": "3333::3:5/128"
+                    }
+                ]
+            }
+        }
+    },
+    "VOQ_INBAND_INTERFACE_IP_PREFIX_EMPTY_STRING_TEST": {
+        "sonic-voq-inband-interface:sonic-voq-inband-interface" : {
+            "sonic-voq-inband-interface:VOQ_INBAND_INTERFACE": {
+                "VOQ_INBAND_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet-IB0",
+                        "inband_type": "port"
+                    }
+                ],
+                "VOQ_INBAND_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "name": "Ethernet-IB0",
+                        "ip-prefix": ""
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-voq-inband-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-voq-inband-interface.yang
@@ -1,0 +1,56 @@
+module sonic-voq-inband-interface {
+    namespace "http://github.com/sonic-net/sonic-voq-inband-interface";
+    prefix voq-inband-intf;
+    yang-version 1.1;    
+
+    import sonic-types {
+        prefix stypes;
+    }
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "SONIC BGP Internal Neighbor for voq chassis platforms";
+
+    revision 2022-10-06 {
+        description
+            "Initial revision.";
+    }
+
+    container sonic-voq-inband-interface {
+        container VOQ_INBAND_INTERFACE {
+            description "VOQ inband interface in VOQ Chassis";
+            list VOQ_INBAND_INTERFACE_LIST {
+                key "name";
+                leaf name {
+                    type string {
+                        pattern "Ethernet-IB[0-9]+";
+                    }
+                }
+                leaf inband_type {
+                    description "Type of inband interface";
+                    type string {
+                        pattern "port|Port";                        
+                    }
+                    default "port";                    
+                }
+            }
+            list VOQ_INBAND_INTERFACE_IPPREFIX_LIST {
+                description "Prefix for VOQ_INBAND_INTERFACE";
+                key "name ip-prefix";
+                leaf name {
+                    type leafref {
+                        path "../../VOQ_INBAND_INTERFACE_LIST/name";
+                    }
+                }
+                leaf ip-prefix {
+                    type stypes:sonic-ip-prefix;
+                }
+            }
+        }
+    }  
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Cherry-pick https://github.com/sonic-net/sonic-buildimage/pull/12306 to 202205 branch 

#### Why I did it
Add yang model definition for VOQ_INBAND_INTERFACE defined and implemented for VOQ chassis. HLD for voq-inband-interface is included in https://github.com/sonic-net/SONiC/blob/master/doc/voq/voq_hld.md

#### How I did it
Added yang model definition, unit tests, sample config and documentation for the table

#### How to verify it
1. Validated config tree generation using "pyang -Vf tree -p /usr/local/share/yang/modules/ietf ./yang-models/sonic-voq-inband-interface.yang"

2. Built the below python-wheels to validate unit tests and other changes
target/python-wheels/bullseye/sonic_yang_mgmt-1.0-py3-none-any.whl 
target/python-wheels/bullseye/sonic_yang_models-1.0-py3-none-any.whl 
target/python-wheels/bullseye/sonic_config_engine-1.0-py3-none-any.whl

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
https://github.com/Azure/sonic-buildimage/blob/6fd7eab250ac54e9fedb68fc5248fdef2ba0adf6/src/sonic-yang-models/doc/Configuration.md#voq-inband-interface

#### A picture of a cute animal (not mandatory but encouraged)


