### PR TITLE
[Restapi Yang] Fix issue with multiple certs

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/restapi.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/restapi.json
@@ -9,5 +9,8 @@
     },
     "RESTAPI_TABLE_WITH_VALID_CONFIG": {
         "desc": "RESTAPI TABLE WITH VALID CONFIG."
+    },
+    "RESTAPI_TABLE_WITH_MULTIPLE_CERTS": {
+        "desc": "RESTAPI TABLE WITH MULTIPLE CERTS."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/restapi.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/restapi.json
@@ -34,5 +34,17 @@
                 }
             }
         }
+    },
+    "RESTAPI_TABLE_WITH_MULTIPLE_CERTS": {
+        "sonic-restapi:sonic-restapi": {
+            "sonic-restapi:RESTAPI": {
+                "certs": {
+                    "ca_crt": "/etc/sonic/credentials/ame_root.pem",
+                    "server_crt": "/etc/sonic/credentials/restapiserver.crt",
+                    "server_key": "/etc/sonic/credentials/restapiserver.key",
+                    "client_crt_cname": "client.sonic.net,clientds.prod.net"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-restapi.yang
+++ b/src/sonic-yang-models/yang-models/sonic-restapi.yang
@@ -45,7 +45,7 @@ module sonic-restapi {
 
                 leaf client_crt_cname {
                     type string {
-                        pattern '([a-zA-Z0-9_\-\.]+)';
+                        pattern '([a-zA-Z0-9_,\-\.]+)';
                     }
                     description "Client cert name.";
                 }

--- a/src/sonic-yang-models/yang-models/sonic-restapi.yang
+++ b/src/sonic-yang-models/yang-models/sonic-restapi.yang
@@ -45,7 +45,7 @@ module sonic-restapi {
 
                 leaf client_crt_cname {
                     type string {
-                        pattern '([a-zA-Z0-9_,\-\.]+)';
+                        pattern '([a-zA-Z0-9_\-\.]+,)*([a-zA-Z0-9_\-\.]+)';
                     }
                     description "Client cert name.";
                 }


### PR DESCRIPTION
#### Why I did it
Fix for multiple names in client cert name

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

