### PR TITLE
[202012] [Mellanox] [SFP Platform API] Fix DOM support capability issues on QSFP and CMIS cables

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -411,6 +411,26 @@ class SFP(SfpBase):
             # in this case we treat it as the default type according to the SKU
             self.sfp_type = sfp_type
 
+    def _is_qsfp_copper(self):
+        # This function read the specification compliance byte and
+        # ext specification compliance byte to judge whether the cable is copper or not.
+        # It is only designed for SFF 8636 cables, SFF 8472 and CMIS cables don't apply.
+
+        # copper cables defined in SFF8024 "Extended Specification Compliance Codes"
+        copper_ext_specification_list = ['08', '0b', '0c', '0d', '19', '30', '32', '40']
+
+        offset = PAGE00_HIGH_MEMORY_OFFSET
+        qsfp_specification_raw = self._read_eeprom_specific_bytes(offset + XCVR_COMPLIANCE_CODE_OFFSET, 1)
+        qsfp_specification = int(qsfp_specification_raw[0], 16)
+        # The 4th bit of the specification complaince byte(131) indicate a 40GBASE-CR4 copper cable
+        if qsfp_specification & 0x8:
+            return True
+
+        qsfp_ext_specification_raw = self._read_eeprom_specific_bytes(offset + XCVR_EXT_SPECIFICATION_COMPLIANCE_OFFSET, XCVR_EXT_SPECIFICATION_COMPLIANCE_WIDTH)
+        if qsfp_ext_specification_raw[0] in copper_ext_specification_list:
+            return True
+
+        return False
 
     def _dom_capability_detect(self):
         if not self.get_presence():
@@ -424,6 +444,16 @@ class SFP(SfpBase):
             return
 
         if self.sfp_type == QSFP_TYPE:
+            if self._is_qsfp_copper():
+                self.dom_supported = False
+                self.dom_temp_supported = False
+                self.dom_volt_supported = False
+                self.dom_rx_power_supported = False
+                self.dom_tx_power_supported = False
+                self.calibration = 0
+                self.qsfp_page3_available = False
+                return
+
             self.calibration = 1
             sfpi_obj = sff8436InterfaceId()
             if sfpi_obj is None:
@@ -478,11 +508,11 @@ class SFP(SfpBase):
             # two types of QSFP-DD cable types supported: Copper and Optical.
             qsfp_dom_capability_raw = self._read_eeprom_specific_bytes((offset + XCVR_DOM_CAPABILITY_OFFSET_QSFP_DD), XCVR_DOM_CAPABILITY_WIDTH_QSFP_DD)
             if qsfp_dom_capability_raw is not None:
-                self.dom_temp_supported = True
-                self.dom_volt_supported = True
                 dom_capability = sfpi_obj.parse_dom_capability(qsfp_dom_capability_raw, 0)
                 if dom_capability['data']['Flat_MEM']['value'] == 'Off':
                     self.dom_supported = True
+                    self.dom_temp_supported = True
+                    self.dom_volt_supported = True
                     self.second_application_list = True
                     self.dom_rx_power_supported = True
                     self.dom_tx_power_supported = True
@@ -491,6 +521,8 @@ class SFP(SfpBase):
                     self.dom_rx_tx_power_bias_supported = True
                 else:
                     self.dom_supported = False
+                    self.dom_temp_supported = False
+                    self.dom_volt_supported = False
                     self.second_application_list = False
                     self.dom_rx_power_supported = False
                     self.dom_tx_power_supported = False


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. For QSFP cables(SFF 8636), if the cable is only compliant with some old revision(e.g. lower than 0x08), in these revisions some of the DOM support status bits are not defined yet, so the DOM support status of the cable is also 'unknown', currently will treat this case as DOM support status 'supported', but for copper cables, it never can support DOM, copper cables should be ruled out in this case.
2. For CMIS cable, there is a bug in determining the DOM support status, the temperature and voltage support statuses are always set to true, this is not correct, they shall be determined in the same way as other DOM capability support statuses.

#### How I did it
1. Add a function to judge whether a QSFP cable is a copper cable or not, it judges from the specification compliance bytes and ext specification compliance byte.
2. CMIS cable temperature and voltage DOM support status shall be judged in the same way as other capabilities.
#### How to verify it
Verify the platform API and 'show interface transceiver eeprom -d' command on various types of CMIS and QSFP cables to make sure the output is as expected.


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog

#### A picture of a cute animal (not mandatory but encouraged)

