### PR TITLE
Revert "[build] don't require passwordless sudo (Closes #11292)"

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -241,8 +241,7 @@ endif
 DOCKER_LOCKFILE_SAVE := $(DOCKER_LOCKDIR)/docker_save.lock
 $(shell mkdir -m 0777 -p $(DOCKER_LOCKDIR))
 $(shell [ -f $(DOCKER_LOCKFILE_SAVE) ] || (touch $(DOCKER_LOCKFILE_SAVE) && chmod 0777 $(DOCKER_LOCKFILE_SAVE)))
-$(docker run --rm -v $(DOCKER_ROOT)\:/mount alpine sh -c 'rm -rf /mount/')
-$(mkdir -p $(DOCKER_ROOT))
+$(shell sudo rm -rf $(DOCKER_ROOT) && mkdir -p $(DOCKER_ROOT))
 
 ifeq ($(DOCKER_BUILDER_MOUNT),)
 override DOCKER_BUILDER_MOUNT := "$(PWD):/sonic"


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#11417

This docker image `alpine` is unnecessary dependency.