### PR TITLE
[cherry-pick][201911] Fix dhcp option buffer issue

### DIFF
--- a/src/isc-dhcp/patch/0014-Fix-dhcrelay-agent-option-buffer-pointer-logic.patch
+++ b/src/isc-dhcp/patch/0014-Fix-dhcrelay-agent-option-buffer-pointer-logic.patch
@@ -1,0 +1,53 @@
+From 0a2f9a62bceb90b0d30461add2e25c4ce7a24547 Mon Sep 17 00:00:00 2001
+From: Thomas Markwalder <tmark@isc.org>
+Date: Fri, 20 Dec 2019 10:11:54 -0500
+Subject: [PATCH] [#71] Fix dhcrelay agent option buffer pointer logic
+
+relay/dhcrelay.c
+    strip_relay_agent_options()
+    strip_relay_agent_options()
+    - corrected buffer pointer logic
+
+---
+ relay/dhcrelay.c | 18 ++++++++++++++----
+ 1 file changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/relay/dhcrelay.c b/relay/dhcrelay.c
+index 896e1e2e..980dacae 100644
+--- a/relay/dhcrelay.c
++++ b/relay/dhcrelay.c
+@@ -1238,8 +1238,13 @@ strip_relay_agent_options(struct interface_info *in,
+ 				return (0);
+ 
+ 			if (sp != op) {
+-				memmove(sp, op, op[1] + 2);
+-				sp += op[1] + 2;
++				size_t mlen = op[1] + 2;
++				memmove(sp, op, mlen);
++				sp += mlen;
++				if (sp > max) {
++					return (0);
++				}
++
+ 				op = nextop;
+ 			} else
+ 				op = sp = nextop;
+@@ -1620,8 +1620,13 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
+ 			end_pad = NULL;
+ 
+ 			if (sp != op) {
+-				memmove(sp, op, op[1] + 2);
+-				sp += op[1] + 2;
++				size_t mlen = op[1] + 2;
++				memmove(sp, op, mlen);
++				sp += mlen;
++				if (sp > max) {
++					return (0);
++				}
++
+ 				op = nextop;
+ 			} else
+ 				op = sp = nextop;
+-- 
+2.17.1
+

--- a/src/isc-dhcp/patch/0014-Fix-dhcrelay-agent-option-buffer-pointer-logic.patch
+++ b/src/isc-dhcp/patch/0014-Fix-dhcrelay-agent-option-buffer-pointer-logic.patch
@@ -16,7 +16,7 @@ diff --git a/relay/dhcrelay.c b/relay/dhcrelay.c
 index 896e1e2e..980dacae 100644
 --- a/relay/dhcrelay.c
 +++ b/relay/dhcrelay.c
-@@ -1238,8 +1238,13 @@ strip_relay_agent_options(struct interface_info *in,
+@@ -1065,8 +1065,13 @@ strip_relay_agent_options(struct interface_info *in,
  				return (0);
  
  			if (sp != op) {
@@ -32,7 +32,7 @@ index 896e1e2e..980dacae 100644
  				op = nextop;
  			} else
  				op = sp = nextop;
-@@ -1620,8 +1620,13 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
+@@ -1168,8 +1168,13 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
  			end_pad = NULL;
  
  			if (sp != op) {

--- a/src/isc-dhcp/patch/series
+++ b/src/isc-dhcp/patch/series
@@ -12,3 +12,4 @@
 0011-interface-name-maxlen-crash.patch
 0012-Don-t-skip-down-interfaces-when-discovering-interfac.patch
 0013-add-option-si-to-support-using-src-intf-ip-in-relay.patch
+0014-Fix-dhcrelay-agent-option-buffer-pointer-logic.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Signed-off-by: Gang Lv [ganglv@microsoft.com](mailto:ganglv@microsoft.com)

#### Why I did it
#12033 

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

