### PR TITLE
[BGPCfgD] Support for Static Route Expiry

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -3,6 +3,7 @@ import signal
 import sys
 import syslog
 import traceback
+import threading
 
 from swsscommon import swsscommon
 
@@ -19,6 +20,7 @@ from .managers_setsrc import ZebraSetSrc
 from .managers_static_rt import StaticRouteMgr
 from .managers_rm import RouteMapMgr
 from .managers_device_global import DeviceGlobalCfgMgr
+from .static_rt_timer import StaticRouteTimer
 from .runner import Runner, signal_handler
 from .template import TemplateFabric
 from .utils import read_constants
@@ -28,6 +30,9 @@ from .vars import g_debug
 
 def do_work():
     """ Main function """
+    st_rt_timer = StaticRouteTimer()
+    thr = threading.Thread(target = st_rt_timer.run)
+    thr.start()
     frr = FRR(["bgpd", "zebra", "staticd"])
     frr.wait_for_daemons(seconds=20)
     #
@@ -72,6 +77,7 @@ def do_work():
     for mgr in managers:
         runner.add_manager(mgr)
     runner.run()
+    thr.join()
 
 
 def main():

--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -67,6 +67,7 @@ def do_work():
         BBRMgr(common_objs, "CONFIG_DB", "BGP_BBR"),
         # Static Route Managers
         StaticRouteMgr(common_objs, "CONFIG_DB", "STATIC_ROUTE"),
+        StaticRouteMgr(common_objs, "APPL_DB", "STATIC_ROUTE"),
         # Route Advertisement Managers
         AdvertiseRouteMgr(common_objs, "STATE_DB", swsscommon.STATE_ADVERTISE_NETWORK_TABLE_NAME),
         RouteMapMgr(common_objs, "APPL_DB", swsscommon.APP_BGP_PROFILE_TABLE_NAME),

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
@@ -97,10 +97,12 @@ class StaticRouteMgr(Manager):
         :param key: key to split
         :return: vrf name extracted from the key, ip prefix extracted from the key
         """
-        if '|' not in key:
-            return 'default', key
-        else:
+        if '|' in key:
             return tuple(key.split('|', 1))
+        elif ':' in key:
+            return tuple(key.split(':', 1))
+        else:
+            return 'default', key
 
     def static_route_commands(self, ip_nh_set, cur_nh_set, ip_prefix, vrf, route_tag, cur_route_tag):
         op_cmd_list = {}

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
@@ -97,12 +97,17 @@ class StaticRouteMgr(Manager):
         :param key: key to split
         :return: vrf name extracted from the key, ip prefix extracted from the key
         """
-        if '|' in key:
-            return tuple(key.split('|', 1))
-        elif ':' in key:
-            return tuple(key.split(':', 1))
-        else:
+
+        if '|' not in key:
             return 'default', key
+        else:
+            return tuple(key.split('|', 1))
+        # if '|' in key:
+        #     return tuple(key.split('|', 1))
+        # elif ':' in key:
+        #     return tuple(key.split(':', 1))
+        # else:
+        #     return 'default', key
 
     def static_route_commands(self, ip_nh_set, cur_nh_set, ip_prefix, vrf, route_tag, cur_route_tag):
         op_cmd_list = {}

--- a/src/sonic-bgpcfgd/bgpcfgd/static_rt_timer.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/static_rt_timer.py
@@ -1,11 +1,11 @@
 from .log import log_err, log_info, log_debug
-from swsssdk import SonicV2Connector
+from swsscommon import swsscommon
 import time
 
 class StaticRouteTimer(object):
     """ This class checks the static routes and deletes those entries that have not been refreshed """
     def __init__(self):
-        self.db = SonicV2Connector()
+        self.db = swsscommon.SonicV2Connector()
         self.db.connect(self.db.APPL_DB)
         self.timer = None
         self.start = None

--- a/src/sonic-bgpcfgd/bgpcfgd/static_rt_timer.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/static_rt_timer.py
@@ -8,6 +8,7 @@ class StaticRouteTimer(object):
         self.db = SonicV2Connector()
         self.db.connect(self.db.APPL_DB)
         self.timer = None
+        self.start = None
 
     DEFAULT_TIMER = 180
     MAX_TIMER     = 1800
@@ -21,7 +22,6 @@ class StaticRouteTimer(object):
                 self.timer = timer
                 return
             log_err("Custom static route expiry time of {}s is invalid!".format(timer))
-        self.timer = self.DEFAULT_TIMER
         return
 
     def alarm(self):
@@ -37,11 +37,17 @@ class StaticRouteTimer(object):
                 else:
                     self.db.delete(self.db.APPL_DB, sr)
                     log_debug("Static route {}:{} deleted".format(val[0], val[1]))
+        self.start = time.time()
         return
 
     def run(self):
         while True:
             self.set_timer()
             log_debug("Static route expiry set to {}s".format(self.timer))
-            time.sleep(self.timer)
-            self.alarm()
+            if self.timer:
+                time.sleep(self.timer)
+                self.alarm()
+            else:
+                time.sleep(1)
+                if time.time() - self.start == self.DEFAULT_TIMER:
+                    self.alarm()

--- a/src/sonic-bgpcfgd/bgpcfgd/static_rt_timer.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/static_rt_timer.py
@@ -11,6 +11,7 @@ class StaticRouteTimer(object):
         self.start = None
 
     DEFAULT_TIMER = 180
+    DEFAULT_SLEEP = 60
     MAX_TIMER     = 1800
 
     def set_timer(self):
@@ -49,6 +50,6 @@ class StaticRouteTimer(object):
                 time.sleep(self.timer)
                 self.alarm()
             else:
-                time.sleep(1)
+                time.sleep(self.DEFAULT_SLEEP)
                 if time.time() - self.start >= self.DEFAULT_TIMER:
                     self.alarm()

--- a/src/sonic-bgpcfgd/bgpcfgd/static_rt_timer.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/static_rt_timer.py
@@ -1,4 +1,4 @@
-from .log import log_err, log_debug
+from .log import log_err, log_info, log_debug
 from swsssdk import SonicV2Connector
 import time
 
@@ -15,7 +15,7 @@ class StaticRouteTimer(object):
 
     def set_timer(self):
         """ Check for custom route expiry time in STATIC_ROUTE:EXPIRY_TIME """
-        timer = self.db.get(self.db.APPL_DB, "STATIC_ROUTE:EXPIRY_TIME", "time")
+        timer = self.db.get(self.db.APPL_DB, "STATIC_ROUTE_EXPIRY_TIME", "time")
         if timer is not None:
             timer = int(timer)     
             if timer > 0 and timer <= self.MAX_TIMER:
@@ -41,13 +41,14 @@ class StaticRouteTimer(object):
         return
 
     def run(self):
+        self.start = time.time()
         while True:
             self.set_timer()
-            log_debug("Static route expiry set to {}s".format(self.timer))
             if self.timer:
+                log_info("Static route expiry set to {}s".format(self.timer))
                 time.sleep(self.timer)
                 self.alarm()
             else:
                 time.sleep(1)
-                if time.time() - self.start == self.DEFAULT_TIMER:
+                if time.time() - self.start >= self.DEFAULT_TIMER:
                     self.alarm()

--- a/src/sonic-bgpcfgd/bgpcfgd/static_rt_timer.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/static_rt_timer.py
@@ -1,0 +1,47 @@
+from .log import log_err, log_debug
+from swsssdk import SonicV2Connector
+import time
+
+class StaticRouteTimer(object):
+    """ This class checks the static routes and deletes those entries that have not been refreshed """
+    def __init__(self):
+        self.db = SonicV2Connector()
+        self.db.connect(self.db.APPL_DB)
+        self.timer = None
+
+    DEFAULT_TIMER = 180
+    MAX_TIMER     = 1800
+
+    def set_timer(self):
+        """ Check for custom route expiry time in STATIC_ROUTE:EXPIRY_TIME """
+        timer = self.db.get(self.db.APPL_DB, "STATIC_ROUTE:EXPIRY_TIME", "time")
+        if timer is not None:
+            timer = int(timer)     
+            if timer > 0 and timer <= self.MAX_TIMER:
+                self.timer = timer
+                return
+            log_err("Custom static route expiry time of {}s is invalid!".format(timer))
+        self.timer = self.DEFAULT_TIMER
+        return
+
+    def alarm(self):
+        """ Clear unrefreshed static routes """
+        static_routes = self.db.keys(self.db.APPL_DB, "STATIC_ROUTE:*:*")
+        if static_routes is not None:
+            for sr in static_routes:
+                refresh = self.db.get(self.db.APPL_DB, sr, "refresh")
+                val = sr.split(":")
+                if refresh == "true":
+                    self.db.set(self.db.APPL_DB, sr, "refresh", "false")
+                    log_debug("Refresh status of static route {}:{} is set to false".format(val[0], val[1]))
+                else:
+                    self.db.delete(self.db.APPL_DB, sr)
+                    log_debug("Static route {}:{} deleted".format(val[0], val[1]))
+        return
+
+    def run(self):
+        while True:
+            self.set_timer()
+            log_debug("Static route expiry set to {}s".format(self.timer))
+            time.sleep(self.timer)
+            self.alarm()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
This is to resubmit https://github.com/sonic-net/sonic-buildimage/pull/11743, original PR always failed with pipeline, suspect old code base issue.

#### Why I did it
Modify BgpCfgD to support static route expiry

#### How I did it
Add a new class StaticRouteTimer to monitor old and unrefreshed static routes in APP DB and remove them

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

