### PR TITLE
[Arista] update sensors.conf to ignore sensors

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32s/sensors.conf
+++ b/device/arista/x86_64-arista_7050_qx32s/sensors.conf
@@ -11,6 +11,9 @@ bus "i2c-7" "SCD 0000:02:00.0 SMBus master 0 bus 5"
 chip "k10temp-pci-00c3"
     label temp1 "Cpu temp sensor"
 
+chip "fam15h_power-pci-00c4"
+    ignore power1
+
 chip "max6658-i2c-2-4c"
     label temp1 "Board temp sensor"
     set temp1_max 55
@@ -34,7 +37,13 @@ chip "pmbus-i2c-6-58"
     label temp2 "Power supply 1 inlet temp sensor"
     label temp3 "Power supply 1 sensor"
 
+    ignore fan2
+    ignore fan3
+
 chip "pmbus-i2c-5-58"
     label temp1 "Power supply 2 hotspot sensor"
     label temp2 "Power supply 2 inlet temp sensor"
     label temp3 "Power supply 2 sensor"
+
+    ignore fan2
+    ignore fan3

--- a/device/arista/x86_64-arista_7050cx3_32s/sensors.conf
+++ b/device/arista/x86_64-arista_7050cx3_32s/sensors.conf
@@ -10,6 +10,9 @@ bus "i2c-14" "SCD 0000:02:00.0 SMBus master 1 bus 4"
 chip "k10temp-pci-00c3"
     label temp1 "Cpu temp sensor"
 
+chip "fam15h_power-pci-00c4"
+    ignore power1
+
 chip "max6658-i2c-2-4c"
     label temp1 "Cpu board temp sensor"
     set temp1_max 75
@@ -33,7 +36,13 @@ chip "pmbus-i2c-13-58"
     label temp2 "Power supply 1 inlet temp sensor"
     label temp3 "Power supply 1 sensor"
 
+    ignore fan2
+    ignore fan3
+
 chip "pmbus-i2c-14-58"
     label temp1 "Power supply 2 hotspot sensor"
     label temp2 "Power supply 2 inlet temp sensor"
     label temp3 "Power supply 2 sensor"
+
+    ignore fan2
+    ignore fan3

--- a/device/arista/x86_64-arista_7060_cx32s/sensors.conf
+++ b/device/arista/x86_64-arista_7060_cx32s/sensors.conf
@@ -11,6 +11,9 @@ bus "i2c-7" "SCD 0000:02:00.0 SMBus master 0 bus 5"
 chip "k10temp-pci-00c3"
     label temp1 "Cpu temp sensor"
 
+chip "fam15h_power-pci-00c4"
+    ignore power1
+
 chip "max6697-i2c-2-1a"
     label temp1 "Board sensor"
     set temp1_max 95
@@ -45,7 +48,13 @@ chip "pmbus-i2c-6-58"
     label temp2 "Power supply 1 inlet temp sensor"
     label temp3 "Power supply 1 exhaust temp sensor"
 
+    ignore fan2
+    ignore fan3
+
 chip "pmbus-i2c-5-58"
     label temp1 "Power supply 2 hotspot sensor"
     label temp2 "Power supply 2 inlet temp sensor"
     label temp3 "Power supply 2 exhaust temp sensor"
+
+    ignore fan2
+    ignore fan3


### PR DESCRIPTION
#### Why I did it

The sensors and sensord processes were reporting data on unused sensors.
This lead to `ALARM` messages or erroneous values that could be misinterpreted.

#### How I did it

Ignore the affected sensors in the sensors.conf

#### How to verify it

Check that there are no longer `ALARM` messages from `sensord` in the syslog or in the output of `sensors`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update sensors.conf to ignore sensors on Arista platforms

