### PR TITLE
[sonic-ctrmgrd] Replace os.system and remove subprocess with shell=True

### DIFF
--- a/src/sonic-ctrmgrd/ctrmgr/container_startup.py
+++ b/src/sonic-ctrmgrd/ctrmgr/container_startup.py
@@ -120,7 +120,6 @@ def get_docker_id():
     cmd3 = ['cut', '-f1', '-d', '/']
     cmd4 = ['rev']
     _, output = getstatusoutput_noshell_pipe(cmd0, cmd1, cmd2, cmd3, cmd4)
-    # output = proc.communicate()[0].decode("utf-8")
     return output.strip()[:12]
 
 

--- a/src/sonic-ctrmgrd/ctrmgr/container_startup.py
+++ b/src/sonic-ctrmgrd/ctrmgr/container_startup.py
@@ -4,11 +4,11 @@ import argparse
 import datetime
 import inspect
 import json
-import subprocess
 import syslog
 import time
 
 from swsscommon import swsscommon
+from sonic_py_common.general import getstatusoutput_noshell_pipe
 
 # DB field names
 SET_OWNER = "set_owner"
@@ -114,9 +114,13 @@ def get_docker_id():
     # Read the container-id
     # Note: This script runs inside the context of container
     #
-    cmd = 'cat /proc/self/cgroup | grep -e ":memory:" | rev | cut -f1 -d\'/\' | rev'
-    proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
-    output = proc.communicate()[0].decode("utf-8")
+    cmd0 = ['cat', '/proc/self/cgroup']
+    cmd1 = ['grep', '-e', ":memory:"]
+    cmd2 = ['rev']
+    cmd3 = ['cut', '-f1', '-d', '/']
+    cmd4 = ['rev']
+    _, output = getstatusoutput_noshell_pipe(cmd0, cmd1, cmd2, cmd3, cmd4)
+    # output = proc.communicate()[0].decode("utf-8")
     return output.strip()[:12]
 
 

--- a/src/sonic-ctrmgrd/ctrmgr/ctrmgr_iptables.py
+++ b/src/sonic-ctrmgrd/ctrmgr/ctrmgr_iptables.py
@@ -105,8 +105,8 @@ def iptable_proxy_rule_upd(ip_str, port = SQUID_PORT):
     while True:
         num += 1
 
-        cmd = "sudo iptables -t nat -n -L OUTPUT {}".format(num)
-        proc = subprocess.run(cmd, shell=True, capture_output=True)
+        cmd = ["sudo", "iptables", "-t", "nat", "-n", "-L", "OUTPUT", str(num)]
+        proc = subprocess.run(cmd, shell=False, capture_output=True)
         check_proc(proc)
 
         if not proc.stdout:
@@ -119,16 +119,15 @@ def iptable_proxy_rule_upd(ip_str, port = SQUID_PORT):
                 found = True
             else:
                 # Duplicate or different IP - delete it
-                cmd = "sudo iptables -t nat -D OUTPUT {}".format(num)
-                proc = subprocess.run(cmd, shell=True, capture_output=True)
+                cmd = ["sudo", "iptables", "-t", "nat", "-D", "OUTPUT", str(num)]
+                proc = subprocess.run(cmd, shell=False, capture_output=True)
                 check_proc(proc)
                 # Decrement number to accommodate deleted rule
                 num -= 1
 
     if destination and not found:
-        cmd = "sudo iptables -t nat -A OUTPUT -p tcp -d {} --dport {} -j DNAT --to-destination {}".format(
-                DST_IP, DST_PORT, destination)
-        proc = subprocess.run(cmd, shell=True, capture_output=True)
+        cmd = ["sudo", "iptables", "-t", "nat", "-A", "OUTPUT", "-p", "tcp", "-d", DST_IP, "--dport", DST_PORT, "-j", "DNAT", "--to-destination", destination]
+        proc = subprocess.run(cmd, shell=False, capture_output=True)
 
         check_proc(proc)
 

--- a/src/sonic-ctrmgrd/ctrmgr/ctrmgrd.py
+++ b/src/sonic-ctrmgrd/ctrmgr/ctrmgrd.py
@@ -6,7 +6,7 @@ import json
 import os
 import sys
 import syslog
-
+import subprocess
 from collections import defaultdict
 from ctrmgr.ctrmgr_iptables import iptable_proxy_rule_upd
 
@@ -119,7 +119,7 @@ def ts_now():
 
 def is_systemd_active(feat):
     if not UNIT_TESTING:
-        status = os.system('systemctl is-active --quiet {}'.format(feat))
+        status = subprocess.call(['systemctl', 'is-active', '--quiet', str(feat)])
     else:
         status = UNIT_TESTING_ACTIVE
     log_debug("system status for {}: {}".format(feat, str(status)))
@@ -129,7 +129,7 @@ def is_systemd_active(feat):
 def restart_systemd_service(server, feat, owner):
     log_debug("Restart service {} to owner:{}".format(feat, owner))
     if not UNIT_TESTING:
-        status = os.system("systemctl restart {}".format(feat))
+        status = subprocess.call(["systemctl", "restart", str(feat)])
     else:
         server.mod_db_entry(STATE_DB_NAME,
                 FEATURE_TABLE, feat, {"restart": "true"})

--- a/src/sonic-ctrmgrd/tests/ctrmgr_iptables_test.py
+++ b/src/sonic-ctrmgrd/tests/ctrmgr_iptables_test.py
@@ -103,30 +103,31 @@ class proc:
 
 
 def mock_subproc_run(cmd, shell, capture_output):
-    cmd_prefix = "sudo iptables -t nat "
-    list_cmd = "{}-n -L OUTPUT ".format(cmd_prefix)
-    del_cmd = "{}-D OUTPUT ".format(cmd_prefix)
-    ins_cmd = "{}-A OUTPUT -p tcp -d ".format(cmd_prefix)
+    list_cmd = ["sudo", "iptables", "-t", "nat", "-n", "-L", "OUTPUT"]
+    del_cmd = ["sudo", "iptables", "-t", "nat", "-D", "OUTPUT"]
+    ins_cmd = ["sudo", "iptables", "-t", "nat", "-A", "OUTPUT", "-p", "tcp", "-d"]
 
-    assert shell
+    assert shell == False
     
     print("cmd={}".format(cmd))
-    if cmd.startswith(list_cmd):
-        num = int(cmd[len(list_cmd):])
-        out = current_rules[num] if len(current_rules) > num else ""
-        return proc(0, out, "")
+    if list_cmd == cmd[:len(list_cmd)]:
+        if len(cmd) == len(list_cmd) + 1:
+            num = int(cmd[len(list_cmd)])
+            out = current_rules[num] if len(current_rules) > num else ""
+            return proc(0, out, "")
 
-    if cmd.startswith(del_cmd):
-        num = int(cmd[len(del_cmd):])
-        if num >= len(current_rules):
-            print("delete num={} is greater than len={}".format(num, len(current_rules)))
-            print("current_rules = {}".format(current_rules))
-            assert False
-        del current_rules[num]
-        return proc(0, "", "")
+    if del_cmd == cmd[:len(del_cmd)]:
+        if len(cmd) == len(del_cmd) + 1:
+            num = int(cmd[len(del_cmd)])
+            if num >= len(current_rules):
+                print("delete num={} is greater than len={}".format(num, len(current_rules)))
+                print("current_rules = {}".format(current_rules))
+                assert False
+            del current_rules[num]
+            return proc(0, "", "")
 
-    if cmd.startswith(ins_cmd):
-        l = cmd.split()
+    if ins_cmd == cmd[:len(ins_cmd)]:
+        l = cmd
         assert len(l) == 16
         rule = "DNAT tcp -- 0.0.0.0/0 {} tcp dpt:{} to:{}".format(l[9], l[11], l[-1])
         current_rules.append(rule)


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`subprocess.Popen()` and `subprocess.run()` is used with `shell=True`, which is very dangerous for shell injection.
`os` - not secure against maliciously constructed input and dangerous if used to evaluate dynamic content
#### How I did it
Replace `os` by `subprocess`, remove `shell=True`
#### How to verify it
Passed UT
Tested in DUT
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

