### PR TITLE
[sonic-bgpcfgd] Replace getstatusoutput function

### DIFF
--- a/src/sonic-bgpcfgd/bgpmon/bgpmon.py
+++ b/src/sonic-bgpcfgd/bgpmon/bgpmon.py
@@ -23,12 +23,12 @@ Description: bgpmon.py -- populating bgp related information in stateDB.
     is a need to perform update or the peer is stale to be removed from the
     state DB
 """
-import subprocess
 import json
 import os
 import syslog
 from swsscommon import swsscommon
 import time
+from sonic_py_common.general import getstatusoutput_noshell
 
 PIPE_BATCH_MAX_COUNT = 50
 
@@ -72,8 +72,8 @@ class BgpStateGet:
 
     # Get a new snapshot of BGP neighbors and store them in the "new" location
     def get_all_neigh_states(self):
-        cmd = "vtysh -c 'show bgp summary json'"
-        rc, output = subprocess.getstatusoutput(cmd)
+        cmd = ["vtysh", "-c", 'show bgp summary json']
+        rc, output = getstatusoutput_noshell(cmd)
         if rc:
             syslog.syslog(syslog.LOG_ERR, "*ERROR* Failed with rc:{} when execute: {}".format(rc, cmd))
             return


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`getstatusoutput()` function from `subprocess` module has shell injection issue because it includes `shell=True` in the implementation
#### How I did it
Use `getstatusoutput_noshell()` from sonic_py_common library
#### How to verify it
Tested in DUT
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

