### PR TITLE
[sonic-yang-mgmt] Replace subprocess using with shell=True

### DIFF
--- a/src/sonic-yang-mgmt/tests/test_cfghelp.py
+++ b/src/sonic-yang-mgmt/tests/test_cfghelp.py
@@ -1,7 +1,7 @@
 import json
 import subprocess
 import os
-
+from shlex import join
 from unittest import TestCase
 
 output1="""\
@@ -126,7 +126,7 @@ class TestCfgHelp(TestCase):
         self.script_file = os.path.join(self.test_dir, '..', 'sonic-cfg-help')
 
     def run_script(self, argument):
-        print('\n    Running sonic-cfg-help ', argument)
+        print('\n    Running sonic-cfg-help ' + join(argument))
         output = subprocess.check_output([self.script_file] + argument)
 
         output = output.decode()

--- a/src/sonic-yang-mgmt/tests/test_cfghelp.py
+++ b/src/sonic-yang-mgmt/tests/test_cfghelp.py
@@ -126,8 +126,8 @@ class TestCfgHelp(TestCase):
         self.script_file = os.path.join(self.test_dir, '..', 'sonic-cfg-help')
 
     def run_script(self, argument):
-        print('\n    Running sonic-cfg-help ' + argument)
-        output = subprocess.check_output(self.script_file + ' ' + argument, shell=True)
+        print('\n    Running sonic-cfg-help ', argument)
+        output = subprocess.check_output([self.script_file] + argument)
 
         output = output.decode()
 
@@ -139,32 +139,32 @@ class TestCfgHelp(TestCase):
         return output
 
     def test_dummy_run(self):
-        argument = ''
+        argument = []
         output = self.run_script(argument)
         self.assertEqual(output, output1)
 
     def test_single_table(self):
-        argument = '-t AUTO_TECHSUPPORT'
+        argument = ['-t', 'AUTO_TECHSUPPORT']
         output = self.run_script(argument)
         self.assertEqual(output, techsupport_table_output)
 
     def test_single_field(self):
-        argument = '-t AUTO_TECHSUPPORT -f state'
+        argument = ['-t', 'AUTO_TECHSUPPORT', '-f', 'state']
         output = self.run_script(argument)
         self.assertEqual(output, techsupport_table_field_output)
 
     def test_leaf_list(self):
-        argument = '-t PORTCHANNEL -f members'
+        argument = ['-t', 'PORTCHANNEL', '-f', 'members']
         output = self.run_script(argument)
         self.assertEqual(output, portchannel_table_field_output)
 
     def test_leaf_list_map(self):
-        argument = '-t DSCP_TO_TC_MAP'
+        argument = ['-t', 'DSCP_TO_TC_MAP']
         output = self.run_script(argument)
         self.maxDiff = None
         self.assertEqual(output, dscp_to_tc_table_field_output)
 
     def test_when_condition(self):
-        argument = '-t ACL_RULE -f ICMP_TYPE'
+        argument = ['-t', 'ACL_RULE', '-f', 'ICMP_TYPE']
         output = self.run_script(argument)
         self.assertEqual(output, acl_rule_table_field_output)

--- a/src/sonic-yang-mgmt/tests/test_cfghelp.py
+++ b/src/sonic-yang-mgmt/tests/test_cfghelp.py
@@ -1,7 +1,6 @@
 import json
 import subprocess
 import os
-from shlex import join
 from unittest import TestCase
 
 output1="""\
@@ -126,7 +125,7 @@ class TestCfgHelp(TestCase):
         self.script_file = os.path.join(self.test_dir, '..', 'sonic-cfg-help')
 
     def run_script(self, argument):
-        print('\n    Running sonic-cfg-help ' + join(argument))
+        print('\n    Running sonic-cfg-help ' + ' '.join(argument))
         output = subprocess.check_output([self.script_file] + argument)
 
         output = output.decode()


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`subprocess` is used with `shell=True`, which is very dangerous for shell injection.
#### How I did it
remove `shell=True`, use `shell=False`
#### How to verify it
Pass UT
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

