### PR TITLE
Seastone: fix platform fan psu and temperature issues

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/fan.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/fan.py
@@ -97,7 +97,7 @@ class Fan(FanBase):
 
     def __get_gpio_base(self):
         for r in os.listdir(GPIO_DIR):
-            label_path = os.path.join(GPIO_DIR, r, "label")
+            label_path = os.path.join(GPIO_DIR, r, "device/name")
             if "gpiochip" in r and GPIO_LABEL in \
                     self._api_helper.read_txt_file(label_path):
                 return int(r[8:], 10)

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/psu.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/psu.py
@@ -69,7 +69,7 @@ class Psu(PsuBase):
 
     def __get_gpio_base(self):
         for r in os.listdir(GPIO_DIR):
-            label_path = os.path.join(GPIO_DIR, r, "label")
+            label_path = os.path.join(GPIO_DIR, r, "device/name")
             if "gpiochip" in r and GPIO_LABEL in self._api_helper.read_txt_file(label_path):
                 return int(r[8:], 10)
         return 216  # Reserve


### PR DESCRIPTION
#### Why I did it
Fix multiple seastone platform issues caused by sonic kernel upgrade.

#### How I did it
Get gpio base id with new label path in gpio sys fs.

#### How to verify it
After the change, show platform fan/psustatus/temperature works well.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

