### PR TITLE
[Build][Bug] Fix apt-get remove version not lock issue

### DIFF
--- a/src/sonic-build-hooks/hooks/apt-get
+++ b/src/sonic-build-hooks/hooks/apt-get
@@ -20,7 +20,7 @@ if [ "$INSTALL" == y ]; then
     [ "$lock_result" == y ] && release_apt_installation_lock
     exit $command_result
 else
-    if [[ "$1" == "purge" || "$@" == *" purge "* ]]; then
+    if [[ " $@ " == *" purge "* || " $@ " == *" remove "* ]]; then
       # When running the purge command, collect the debian versions
       dpkg-query -W -f '${Package}==${Version}\n' >> $POST_VERSION_PATH/purge-versions-deb
       chmod a+wr $POST_VERSION_PATH/purge-versions-deb


### PR DESCRIPTION
Why I did it
Fix apt-get remove/purge version not locked issue when the apt-get options not specified.

How I did it
Add a space character before and after the command line parameters.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

