### PR TITLE
[chassis] update the asic_status.py to read from CHASSIS_FABRIC_ASIC_INFO_TABLE

### DIFF
--- a/dockers/docker-orchagent/docker-init.j2
+++ b/dockers/docker-orchagent/docker-init.j2
@@ -52,7 +52,7 @@ USE_PCI_ID_IN_CHASSIS_STATE_DB=/usr/share/sonic/platform/use_pci_id_chassis
 ASIC_ID="asic$NAMESPACE_ID"
 if [ -f "$USE_PCI_ID_IN_CHASSIS_STATE_DB" ]; then
     while true; do
-        PCI_ID=$(sonic-db-cli -s CHASSIS_STATE_DB HGET "CHASSIS_ASIC_TABLE|$ASIC_ID" asic_pci_address)
+        PCI_ID=$(sonic-db-cli -s CHASSIS_STATE_DB HGET "CHASSIS_FABRIC_ASIC_INFO_TABLE|$ASIC_ID" asic_pci_address)
         if [ -z "$PCI_ID" ]; then
             sleep 3
         else

--- a/dockers/docker-orchagent/docker-init.j2
+++ b/dockers/docker-orchagent/docker-init.j2
@@ -52,7 +52,7 @@ fi
 IS_SUPERVISOR=/etc/sonic/chassisdb.conf
 USE_PCI_ID_IN_CHASSIS_STATE_DB=/usr/share/sonic/platform/use_pci_id_chassis
 ASIC_ID="asic$NAMESPACE_ID"
-if [-f "$IS_SUPERVISOR"]; then 
+if [ -f "$IS_SUPERVISOR" ]; then 
     if [ -f "$USE_PCI_ID_IN_CHASSIS_STATE_DB" ]; then
         while true; do
             PCI_ID=$(sonic-db-cli -s CHASSIS_STATE_DB HGET "CHASSIS_FABRIC_ASIC_TABLE|$ASIC_ID" asic_pci_address)

--- a/dockers/docker-orchagent/docker-init.j2
+++ b/dockers/docker-orchagent/docker-init.j2
@@ -4,6 +4,7 @@ mkdir -p /etc/swss/config.d/
 mkdir -p /etc/supervisor/
 mkdir -p /etc/supervisor/conf.d/
 
+
 CFGGEN_PARAMS=" \
     -d \
 {% if ENABLE_ASAN == "y" %}
@@ -48,21 +49,24 @@ if [ "$SUBTYPE" == "DualToR" ]; then
     cp /usr/share/sonic/templates/tunnel_packet_handler.conf /etc/supervisor/conf.d/
 fi
 
+IS_SUPERVISOR=/etc/sonic/chassisdb.conf
 USE_PCI_ID_IN_CHASSIS_STATE_DB=/usr/share/sonic/platform/use_pci_id_chassis
 ASIC_ID="asic$NAMESPACE_ID"
-if [ -f "$USE_PCI_ID_IN_CHASSIS_STATE_DB" ]; then
-    while true; do
-        PCI_ID=$(sonic-db-cli -s CHASSIS_STATE_DB HGET "CHASSIS_FABRIC_ASIC_INFO_TABLE|$ASIC_ID" asic_pci_address)
-        if [ -z "$PCI_ID" ]; then
-            sleep 3
-        else
-            # Update asic_id in CONFIG_DB, which is used by orchagent and fed to syncd
-            if [[ $PCI_ID == ????:??:??.? ]]; then
-                sonic-db-cli CONFIG_DB HSET 'DEVICE_METADATA|localhost' 'asic_id' ${PCI_ID#*:}
-                break
+if [-f "$IS_SUPERVISOR"]; then 
+    if [ -f "$USE_PCI_ID_IN_CHASSIS_STATE_DB" ]; then
+        while true; do
+            PCI_ID=$(sonic-db-cli -s CHASSIS_STATE_DB HGET "CHASSIS_FABRIC_ASIC_INFO_TABLE|$ASIC_ID" asic_pci_address)
+            if [ -z "$PCI_ID" ]; then
+                sleep 3
+            else
+                # Update asic_id in CONFIG_DB, which is used by orchagent and fed to syncd
+                if [[ $PCI_ID == ????:??:??.? ]]; then
+                    sonic-db-cli CONFIG_DB HSET 'DEVICE_METADATA|localhost' 'asic_id' ${PCI_ID#*:}
+                    break
+                fi
             fi
-        fi
-    done
+        done
+    fi
 fi
 
 exec /usr/local/bin/supervisord

--- a/dockers/docker-orchagent/docker-init.j2
+++ b/dockers/docker-orchagent/docker-init.j2
@@ -55,7 +55,7 @@ ASIC_ID="asic$NAMESPACE_ID"
 if [-f "$IS_SUPERVISOR"]; then 
     if [ -f "$USE_PCI_ID_IN_CHASSIS_STATE_DB" ]; then
         while true; do
-            PCI_ID=$(sonic-db-cli -s CHASSIS_STATE_DB HGET "CHASSIS_FABRIC_ASIC_INFO_TABLE|$ASIC_ID" asic_pci_address)
+            PCI_ID=$(sonic-db-cli -s CHASSIS_STATE_DB HGET "CHASSIS_FABRIC_ASIC_TABLE|$ASIC_ID" asic_pci_address)
             if [ -z "$PCI_ID" ]; then
                 sleep 3
             else

--- a/files/scripts/asic_status.py
+++ b/files/scripts/asic_status.py
@@ -17,7 +17,7 @@ except ImportError as e:
 # Constants ====================================================================
 #
 SYSLOG_IDENTIFIER = 'asic_status.py'
-CHASSIS_ASIC_INFO_TABLE = 'CHASSIS_ASIC_TABLE'
+CHASSIS_ASIC_INFO_TABLE = 'CHASSIS_FABRIC_ASIC_INFO_TABLE'
 SELECT_TIMEOUT_MSECS = 5000
 
 def main():

--- a/files/scripts/asic_status.py
+++ b/files/scripts/asic_status.py
@@ -17,7 +17,7 @@ except ImportError as e:
 # Constants ====================================================================
 #
 SYSLOG_IDENTIFIER = 'asic_status.py'
-CHASSIS_ASIC_INFO_TABLE = 'CHASSIS_FABRIC_ASIC_INFO_TABLE'
+CHASSIS_FABRIC_ASIC_INFO_TABLE = 'CHASSIS_FABRIC_ASIC_INFO_TABLE'
 SELECT_TIMEOUT_MSECS = 5000
 
 def main():
@@ -40,7 +40,7 @@ def main():
     state_db = daemon_base.db_connect("CHASSIS_STATE_DB")
 
     sel = swsscommon.Select()
-    sst = swsscommon.SubscriberStateTable(state_db, CHASSIS_ASIC_INFO_TABLE)
+    sst = swsscommon.SubscriberStateTable(state_db, CHASSIS_FABRIC_ASIC_INFO_TABLE)
     sel.addSelectable(sst)
 
     while True:

--- a/files/scripts/asic_status.py
+++ b/files/scripts/asic_status.py
@@ -17,7 +17,7 @@ except ImportError as e:
 # Constants ====================================================================
 #
 SYSLOG_IDENTIFIER = 'asic_status.py'
-CHASSIS_FABRIC_ASIC_INFO_TABLE = 'CHASSIS_FABRIC_ASIC_INFO_TABLE'
+CHASSIS_FABRIC_ASIC_INFO_TABLE = 'CHASSIS_FABRIC_ASIC_TABLE'
 SELECT_TIMEOUT_MSECS = 5000
 
 def main():

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -26,7 +26,7 @@ NEIGH_DEVICE_METADATA_CFG_DB_TABLE = 'DEVICE_NEIGHBOR_METADATA'
 DEFAULT_NAMESPACE = ''
 PORT_ROLE = 'role'
 CHASSIS_STATE_DB='CHASSIS_STATE_DB'
-CHASSIS_ASIC_INFO_TABLE='CHASSIS_ASIC_TABLE'
+CHASSIS_FABRIC_ASIC_INFO_TABLE='CHASSIS_FABRIC_ASIC_TABLE'
 
 # Dictionary to cache config_db connection handle per namespace
 # to prevent duplicate connections from being opened
@@ -479,7 +479,7 @@ def get_asic_presence_list():
             # Get asic list from CHASSIS_ASIC_TABLE which lists only the asics
             # present based on Fabric card detection by the platform.
             db = swsscommon.DBConnector(CHASSIS_STATE_DB, 0, True)
-            asic_table = swsscommon.Table(db, CHASSIS_ASIC_INFO_TABLE)
+            asic_table = swsscommon.Table(db, CHASSIS_FABRIC_ASIC_INFO_TABLE)
             if asic_table:
                 asics_presence_list = list(asic_table.getKeys())
                 for asic in asics_presence_list:


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes https://github.com/sonic-net/sonic-buildimage/issues/12575 and https://github.com/sonic-net/sonic-buildimage/issues/12575

#### How I did it
In the PR https://github.com/sonic-net/sonic-platform-daemons/pull/311 `chassisd` updates to `CHASSIS_FABRIC_ASIC_INFO` with the fabric asic info.
Updating the `asic_status.py` to read from the correct table.

#### How to verify it
test on chassis

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

