### PR TITLE
Bugfix #9739: Support when 'bgp_asn' is set to 'None', 'Null', or missing.

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -61,6 +61,7 @@ route-map HIDE_INTERNAL permit 20
 !
 {% endif %}
 !
+{% if (DEVICE_METADATA is defined) and ('localhost' in DEVICE_METADATA) and ('bgp_asn' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['bgp_asn'].lower() != 'none') and (DEVICE_METADATA['localhost']['bgp_asn'].lower() != 'null') %}
 router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 !
 {% block bgp_init %}
@@ -142,6 +143,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
     maximum-paths {{ constants.bgp.maximum_paths.ipv6 | default(64) }}
   exit-address-family
 {% endblock maximum_paths %}
+{% endif %}
 {% endif %}
 !
 ! end of template: bgpd/bgpd.main.conf.j2


### PR DESCRIPTION
bgpd.main.conf.j2: bugfix-9739

* Update bgpd.main.conf.j2 to gracefully handle the bgp configuration cases for when 'bgp_asn' is set to 'None', 'Null', or missing.

Signed-off-by: cchoate54@gmail.com

#### Why I did it
resolves #9739 

#### How I did it
Include a conditional statement to avoid configuring bgp in FRR when 'bgp_asn' is missing or set to 'None' or 'Null'

#### How to verify it
Configure 'bgp_asn' as 'None', 'Null' or have it missing from configurations and verify that /etc/frr/bgpd.conf does not have invalid bgp configurations like 'router bgp None'

#### Description for the changelog
Update bgpd.main.conf.j2 to gracefully handle the bgp configuration cases for when 'bgp_asn' is set to 'None', 'Null', or missing for bugfix 9739.

#### A picture of a cute animal (not mandatory but encouraged)
