### PR TITLE
Fix removing of old docker container

### DIFF
--- a/scripts/collect_docker_version_files.sh
+++ b/scripts/collect_docker_version_files.sh
@@ -15,8 +15,8 @@ mkdir -p $TARGET_VERSIONS_PATH
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # Remove the old docker container if existing
-if docker container inspect $DOCKER_IMAGE > /dev/null 2>&1; then
-    docker container rm $DOCKER_IMAGE > /dev/null
+if docker container inspect $DOCKER_CONTAINER > /dev/null 2>&1; then
+    docker container rm $DOCKER_CONTAINER > /dev/null
 fi
 docker create --name $DOCKER_CONTAINER --entrypoint /bin/bash $DOCKER_IMAGE
 docker cp -L $DOCKER_CONTAINER:/etc/os-release $TARGET_VERSIONS_PATH/


### PR DESCRIPTION
#### Why I did it

scripts/collect_docker_version_files.sh doesn't remove existing docker container.
It's possible to get "Error response from daemon: Conflict. The container name ... is already in use by container ...".

#### How I did it

Use $DOCKER_CONTAINER instead of $DOCKER_IMAGE to remove existing docker container.

#### How to verify it

Manually create docker container and run scripts/collect_docker_version_files.sh
Existing container will be successfully removed in this case.

Signed-off-by: Konstantin Vasin <k.vasin@yadro.com>
