### PR TITLE
[201811][DX010] enable LPM

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t0.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t0.config.bcm
@@ -14,6 +14,7 @@ l2xmsg_mode=1
 l2_mem_entries=8192
 l3_mem_entries=8192
 l3_alpm_enable=2
+lpm_scaling_enable=0
 ipv6_lpm_128b_enable=1
 mmu_lossless=0
 

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t1.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t1.config.bcm
@@ -14,6 +14,7 @@ l2xmsg_mode=1
 l2_mem_entries=8192
 l3_mem_entries=8192
 l3_alpm_enable=2
+lpm_scaling_enable=0
 ipv6_lpm_128b_enable=1
 mmu_lossless=0
 

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/th-seastone-dx010-48x50G+8x100G.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/th-seastone-dx010-48x50G+8x100G.config.bcm
@@ -6,6 +6,9 @@ phy_ext_rom_boot=0
 fpem_mem_entries=32768 
 l2xmsg_mode=1 
 oversubscribe_mode=1 
+l3_alpm_enable=2
+lpm_scaling_enable=0
+ipv6_lpm_128b_enable=1
 pbmp_xport_xe=0xcccc44cc33113333044cccccc66666622
 
 


### PR DESCRIPTION
#### Why I did it
DX010 didn't have LPM enabled. Which could cause device to crash when tcam is full.

#### How I did it
Enable LPM.

#### How to verify it
Check crm after enabling.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

