### PR TITLE
[logrotate]Fix logrotate firstaction script to reflect correct size

### DIFF
--- a/files/image_config/logrotate/rsyslog.j2
+++ b/files/image_config/logrotate/rsyslog.j2
@@ -50,7 +50,11 @@
         NUM_LOGS_TO_ROTATE=8
 
         # Adjust LOG_FILE_ROTATE_SIZE_KB to reflect the "size" parameter specified above, in kB
+{% if var_log_kb <= 204800 %}
         LOG_FILE_ROTATE_SIZE_KB=1024
+{% else %}
+        LOG_FILE_ROTATE_SIZE_KB=16384
+{% endif %}
 
         # Reserve space for btmp, wtmp, dpkg.log, monit.log, etc., as well as logs that
         # should be disabled, just in case they get created and rotated


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix logrotate firstaction script to reflect correct size. The size was modified to change dynamically based on disk size. However this variable was not updated
https://github.com/sonic-net/sonic-buildimage/pull/9504

#### How I did it
Updated the variable based on disk size

#### How to verify it
Verify in the generated rsyslog file if the variable is correctly generated from jinja template

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

