### PR TITLE
[202012] Add lossy scheduler for queue 7

### DIFF
--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -334,7 +334,7 @@
 {# DSCP 48 is mapped to QUEUE 7 in macro generate_dscp_to_tc_map #}
 {% if (generate_dscp_to_tc_map is defined) and tunnel_qos_remap_enable %}
         "{{ port }}|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
 {% endif %}
 {% endfor %}

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -231,6 +231,7 @@
         "global": {
             "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]"
         }{% if PORT_ACTIVE %},{% endif %}
+
 {% endif %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}": {
@@ -330,6 +331,12 @@
         "{{ port }}|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
+{# DSCP 48 is mapped to QUEUE 7 in macro generate_dscp_to_tc_map #}
+{% if (generate_dscp_to_tc_map is defined) and tunnel_qos_remap_enable %}
+        "{{ port }}|7": {
+            "scheduler": "scheduler.0"
+        },
+{% endif %}
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|6": {

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-arista7050cx3-dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-arista7050cx3-dualtor.json
@@ -1050,98 +1050,194 @@
         "Ethernet0|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet0|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet4|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet4|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet8|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet12|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet12|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet16|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet20|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet20|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet24|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet28|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet28|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet32|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet36|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet36|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet40|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet44|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet44|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet48|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet52|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet52|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet56|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet60|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet60|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet64|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet64|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet68|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet68|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet72|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet72|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet76|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet76|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet80|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet80|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet84|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet84|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet88|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet88|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet92|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet92|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet96|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet96|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet100|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet100|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet104|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet104|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet108|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet108|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet112|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet112|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet116|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet116|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet120|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet120|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet124|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet124|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet0|6": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-arista7050cx3-dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-arista7050cx3-dualtor.json
@@ -1051,193 +1051,193 @@
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet0|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet4|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet4|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet8|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet8|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet12|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet12|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet16|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet16|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet20|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet20|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet24|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet24|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet28|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet28|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet32|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet32|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet36|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet36|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet40|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet40|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet44|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet44|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet48|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet48|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet52|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet52|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet56|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet56|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet60|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet60|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet64|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet64|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet68|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet68|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet72|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet72|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet76|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet76|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet80|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet80|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet84|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet84|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet88|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet88|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet92|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet92|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet96|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet96|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet100|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet100|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet104|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet104|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet108|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet108|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet112|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet112|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet116|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet116|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet120|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet120|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet124|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet124|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet0|6": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-arista7260-dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-arista7260-dualtor.json
@@ -1850,194 +1850,386 @@
         "Ethernet0|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+         "Ethernet0|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet4|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet4|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet8|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet12|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet12|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet16|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet20|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet20|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet24|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet28|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet28|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet32|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet36|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet36|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet40|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet44|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet44|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet48|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet52|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet52|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet56|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet60|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet60|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet64|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet64|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet68|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet68|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet72|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet72|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet76|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet76|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet80|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet80|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet84|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet84|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet88|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet88|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet92|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet92|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet96|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet96|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet100|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet100|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet104|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet104|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet108|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet108|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet112|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet112|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet116|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet116|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet120|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet120|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet124|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet124|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet128|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet128|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet132|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet132|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet136|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet136|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet140|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet140|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet144|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet144|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet148|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet148|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet152|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet152|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet156|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet156|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet160|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet160|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet164|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet164|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet168|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet168|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet172|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet172|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet176|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet176|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet180|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet180|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet184|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet184|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet188|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet188|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet192|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet192|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet196|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet196|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet200|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet200|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet204|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet204|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet208|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet208|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet212|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet212|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet216|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet216|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet220|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet220|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet224|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet224|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet228|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet228|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet232|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet232|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet236|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet236|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet240|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet240|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet244|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet244|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet248|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet248|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet252|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet252|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet0|6": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-arista7260-dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-arista7260-dualtor.json
@@ -1851,385 +1851,385 @@
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
          "Ethernet0|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet4|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet4|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet8|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet8|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet12|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet12|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet16|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet16|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet20|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet20|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet24|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet24|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet28|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet28|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet32|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet32|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet36|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet36|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet40|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet40|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet44|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet44|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet48|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet48|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet52|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet52|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet56|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet56|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet60|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet60|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet64|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet64|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet68|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet68|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet72|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet72|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet76|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet76|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet80|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet80|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet84|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet84|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet88|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet88|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet92|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet92|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet96|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet96|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet100|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet100|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet104|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet104|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet108|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet108|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet112|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet112|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet116|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet116|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet120|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet120|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet124|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet124|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet128|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet128|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet132|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet132|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet136|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet136|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet140|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet140|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet144|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet144|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet148|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet148|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet152|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet152|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet156|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet156|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet160|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet160|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet164|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet164|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet168|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet168|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet172|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet172|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet176|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet176|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet180|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet180|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet184|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet184|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet188|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet188|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet192|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet192|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet196|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet196|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet200|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet200|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet204|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet204|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet208|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet208|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet212|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet212|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet216|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet216|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet220|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet220|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet224|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet224|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet228|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet228|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet232|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet232|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet236|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet236|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet240|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet240|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet244|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet244|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet248|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet248|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet252|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet252|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet0|6": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-arista7260-t1.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-arista7260-t1.json
@@ -926,169 +926,169 @@
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet0|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet4|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet4|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet16|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet16|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet20|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet20|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet64|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet64|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet68|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet68|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet80|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet80|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet84|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet84|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet136|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet136|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet144|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet144|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet148|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet148|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet152|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet152|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet156|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet156|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet168|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet168|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet176|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet176|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet180|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet180|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet184|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet184|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet188|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet188|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet200|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet200|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet208|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet208|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet212|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet212|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet216|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet216|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet220|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet220|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet232|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet232|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet240|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet240|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet244|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet244|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet248|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet248|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet252|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
         "Ethernet252|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet0|6": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-arista7260-t1.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-arista7260-t1.json
@@ -925,86 +925,170 @@
         "Ethernet0|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet0|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet4|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet4|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet16|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet20|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet20|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet64|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet64|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet68|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet68|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet80|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet80|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet84|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet84|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet136|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet136|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet144|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet144|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet148|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet148|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet152|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet152|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet156|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet156|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet168|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet168|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet176|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet176|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet180|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet180|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet184|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet184|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet188|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet188|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet200|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet200|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet208|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet208|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet212|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet212|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet216|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet216|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet220|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet220|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet232|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet232|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet240|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet240|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet244|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet244|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet248|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet248|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet252|5": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet252|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet0|6": {
             "scheduler"   : "[SCHEDULER|scheduler.0]"

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-mellanox4600c-c64.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-mellanox4600c-c64.json
@@ -923,86 +923,170 @@
         "Ethernet0|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet0|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet4|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet4|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet16|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet20|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet20|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet64|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet64|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet68|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet68|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet80|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet80|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet84|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet84|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet136|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet136|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet144|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet144|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet148|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet148|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet152|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet152|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet156|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet156|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet168|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet168|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet176|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet176|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet180|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet180|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet184|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet184|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet188|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet188|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet200|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet200|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet208|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet208|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet212|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet212|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet216|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet216|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet220|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet220|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet232|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet232|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet240|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet240|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet244|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet244|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet248|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
+        "Ethernet248|7": {
+            "scheduler": "scheduler.0"
+        },
         "Ethernet252|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet252|7": {
+            "scheduler": "scheduler.0"
         },
         "Ethernet0|6": {
             "scheduler": "[SCHEDULER|scheduler.0]"

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-mellanox4600c-c64.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-mellanox4600c-c64.json
@@ -924,169 +924,169 @@
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet0|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet4|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet4|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet16|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet16|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet20|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet20|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet64|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet64|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet68|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet68|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet80|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet80|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet84|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet84|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet136|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet136|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet144|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet144|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet148|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet148|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet152|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet152|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet156|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet156|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet168|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet168|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet176|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet176|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet180|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet180|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet184|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet184|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet188|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet188|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet200|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet200|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet208|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet208|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet212|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet212|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet216|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet216|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet220|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet220|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet232|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet232|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet240|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet240|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet244|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet244|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet248|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet248|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet252|5": {
             "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet252|7": {
-            "scheduler": "scheduler.0"
+            "scheduler": "[SCHEDULER|scheduler.0]"
         },
         "Ethernet0|6": {
             "scheduler": "[SCHEDULER|scheduler.0]"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR is to cherry-pick https://github.com/sonic-net/sonic-buildimage/pull/12596 into `202012` branch after resolving conflicts
This PR is to add scheduler for Queue 7 for all ports if `tunnel_qos_remap_enable` is `True`.
PR https://github.com/sonic-net/sonic-buildimage/pull/10176 update the default `DSCP_TO_TC_MAP` to map DSCP 48 to TC 7, and TC 7 is mapped to Queue 7. However, the scheduler for Queue  7 is missing.
This PR fixed the issue by adding lossy scheduler for Queue 7.
Thanks @stephenxs  reporting this issue.

#### How I did it
This PR fixed the issue by adding lossy scheduler for Queue 7.

#### How to verify it
1. Verified by UT.
2. Verified by wrr test in sonic-mgmt.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
This PR is to add scheduler for Queue 7 for all ports if `tunnel_qos_remap_enable` is `True`.

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)


