### PR TITLE
[TestbedV2] Add dualtor test using TestbedV2. 

### DIFF
--- a/.azure-pipelines/run-test-scheduler-template.yml
+++ b/.azure-pipelines/run-test-scheduler-template.yml
@@ -26,6 +26,10 @@ parameters:
   type: string
   default: ""
 
+- name: COMMON_EXTRA_PARAMS
+  type: string
+  default: ""
+
 steps:
   - script: |
       set -ex
@@ -37,7 +41,7 @@ steps:
       set -ex
       pip install PyYAML
       rm -f new_test_plan_id.txt
-      python ./.azure-pipelines/test_plan.py create -t ${{ parameters.TOPOLOGY }} -o new_test_plan_id.txt --min-worker ${{ parameters.MIN_WORKER }} --max-worker ${{ parameters.MAX_WORKER }} --test-set ${{ parameters.TEST_SET }} --kvm-build-id $(KVM_BUILD_ID) --deploy-mg-extra-params "${{ parameters.DEPLOY_MG_EXTRA_PARAMS }}"
+      python ./.azure-pipelines/test_plan.py create -t ${{ parameters.TOPOLOGY }} -o new_test_plan_id.txt --min-worker ${{ parameters.MIN_WORKER }} --max-worker ${{ parameters.MAX_WORKER }} --test-set ${{ parameters.TEST_SET }} --kvm-build-id $(KVM_BUILD_ID) --deploy-mg-extra-params "${{ parameters.DEPLOY_MG_EXTRA_PARAMS }}" --common-extra-params "${{ parameters.COMMON_EXTRA_PARAMS }}"
       TEST_PLAN_ID=`cat new_test_plan_id.txt`
 
       echo "Created test plan $TEST_PLAN_ID"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -313,3 +313,18 @@ stages:
         ptf_name: ptf_vms6-4
         tbtype: multi-asic-t1-lag-pr
         image: sonic-4asic-vs.img.gz
+
+  - job: dualtor_testbedv2
+      pool:
+        vmImage: 'ubuntu-20.04'
+      displayName: "kvmtest-dualtor-t0 by TestbedV2"
+      timeoutInMinutes: 1080
+      condition: and(succeeded(), eq(variables.BUILD_IMG_RUN_TESTBEDV2_TEST, 'YES'))
+      continueOnError: false
+      steps:
+        - template: .azure-pipelines/run-test-scheduler-template.yml
+          parameters:
+            TOPOLOGY: dualtor
+            MIN_WORKER: 1
+            MAX_WORKER: 1
+            COMMON_EXTRA_PARAMS: "--disable_loganalyzer "

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -315,16 +315,16 @@ stages:
         image: sonic-4asic-vs.img.gz
 
   - job: dualtor_testbedv2
-      pool:
-        vmImage: 'ubuntu-20.04'
-      displayName: "kvmtest-dualtor-t0 by TestbedV2"
-      timeoutInMinutes: 1080
-      condition: and(succeeded(), eq(variables.BUILD_IMG_RUN_TESTBEDV2_TEST, 'YES'))
-      continueOnError: false
-      steps:
-        - template: .azure-pipelines/run-test-scheduler-template.yml
-          parameters:
-            TOPOLOGY: dualtor
-            MIN_WORKER: 1
-            MAX_WORKER: 1
-            COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
+    pool:
+      vmImage: 'ubuntu-20.04'
+    displayName: "kvmtest-dualtor-t0 by TestbedV2"
+    timeoutInMinutes: 1080
+    condition: and(succeeded(), eq(variables.BUILD_IMG_RUN_TESTBEDV2_TEST, 'YES'))
+    continueOnError: false
+    steps:
+      - template: .azure-pipelines/run-test-scheduler-template.yml
+        parameters:
+          TOPOLOGY: dualtor
+          MIN_WORKER: 1
+          MAX_WORKER: 1
+          COMMON_EXTRA_PARAMS: "--disable_loganalyzer "

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -328,3 +328,4 @@ stages:
           MIN_WORKER: 1
           MAX_WORKER: 1
           COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
+          


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Add dualtor test using TestbedV2 in buildimage repo. 

#### Why I did it
Add dualtor test using TestbedV2 in buildimage repo. 

#### How I did it
Add dualtor test using TestbedV2 in buildimage repo. 

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

