### PR TITLE
[armhf][sonic-installer] Fix an issue of the sonic-installer install after the cleanup

### DIFF
--- a/platform/marvell-armhf/platform.conf
+++ b/platform/marvell-armhf/platform.conf
@@ -118,11 +118,42 @@ prepare_boot_menu() {
         fdt_name_old=""
         sonic_version_2="None"
     else
-        image_dir_old=$(fw_printenv -n image_dir || true)
-        image_name_old=$(fw_printenv -n image_name || true)
-        initrd_name_old=$(fw_printenv -n initrd_name || true)
-        fdt_name_old=$(fw_printenv -n fdt_name || true)
-        sonic_version_2=$(fw_printenv -n sonic_version_1 || true)
+        eval running_version="$(cat /proc/cmdline | sed -n 's/^.*loop=\/*image-\(\S\+\)\/.*$/\1/p')"
+        current_boot_next=$(fw_printenv -n boot_next || true)
+        running_sonic_image=1
+        if [ "$current_boot_next" = "run sonic_image_1" ]; then
+            # boot_next=run sonic_image_1
+            sonic_version_2=$(fw_printenv -n sonic_version_2 || true)
+            if test "${sonic_version_2#*$running_version}" != "$sonic_version_2"
+            then
+                running_sonic_image=2
+            else
+                running_sonic_image=1
+            fi
+        else
+            # boot_next=run sonic_image_2  
+            sonic_version_1=$(fw_printenv -n sonic_version_1 || true)
+            if test "${sonic_version_1#*$running_version}" != "$sonic_version_1"
+            then
+                running_sonic_image=1
+            else
+                running_sonic_image=2
+            fi
+        fi   
+        
+        if [ $running_sonic_image -eq 1 ]; then
+            image_dir_old=$(fw_printenv -n image_dir || true)
+            image_name_old=$(fw_printenv -n image_name || true)
+            initrd_name_old=$(fw_printenv -n initrd_name || true)
+            fdt_name_old=$(fw_printenv -n fdt_name || true)
+            sonic_version_2=$(fw_printenv -n sonic_version_1 || true)
+        else
+            image_dir_old=$(fw_printenv -n image_dir_old || true)
+            image_name_old=$(fw_printenv -n image_name_old || true)
+            initrd_name_old=$(fw_printenv -n initrd_name_old || true)
+            fdt_name_old=$(fw_printenv -n fdt_name_old || true)
+            sonic_version_2=$(fw_printenv -n sonic_version_2 || true)
+        fi
     fi
 
     # Set boot variables


### PR DESCRIPTION
#### Why I did it
When using sonic-installer to set-default and cleanup image or install a third image as the following steps, issues ocur. 
1) (onie-nos-install ) Install first image A
2) (sonic-installer) Install Image B and not reboot it
3) (sonic-installer) set default to back to Image A
4) sudo sonic-installer cleanup
At this time, executing sonic-installer list will throw exception
5) If install an image C, the current running image A been removed unexpected

#### How I did it
When install a image without rebooting, uboot setting is not able to identify which (sonic_version_ sonic_version_2) should be use for the next image installed or cleanup after the set default.  Modified the platform.conf to use the current running image from /proc/cmdline to identify eother sonic_version_ or sonic_version_2 should be used for the new installation.   

This PR work with https://github.com/sonic-net/sonic-utilities/pull/2479

#### How to verify it
Using the following test case to verify it
Case 1:
   1) (onie-nos-install ) Install first image A (SONiC-OS-202012.0-dirty-20221104.031351)
   2) (sonic-installer) Install Image B (SONiC-OS-202205.0-dirty-20221104.050857) and not reboot it 
   3) (sonic-installer) set default to back to Image A
   4) sudo sonic-installer cleanup
   5) execute sonic-installer list, it should list image A as expected
```
admin@sonic:~$ sudo sonic-installer list
Current: SONiC-OS-202012.0-dirty-20221104.031351
Next: SONiC-OS-202012.0-dirty-20221104.031351
Available: 
SONiC-OS-202012.0-dirty-20221104.031351
```
           
Case 2:
   6) sonic-installer install an image C (SONIC-OS-202205.0-dirty-20221104.050348)
   7) sonic-installer list. It should lis image as expected
```
admin@sonic:~$ sudo sonic-installer list
Current: SONiC-OS-202012.0-dirty-20221104.031351
Next: SONIC-OS-202205.0-dirty-20221104.050348
Available: 
SONiC-OS-202012.0-dirty-20221104.031351
SONIC-OS-202205.0-dirty-20221104.050348
```
Case 3:
8) reboot the system.
9) sonic-installer list 
```
admin@sonic:~$ sudo sonic-installer list
Current: SONIC-OS-202205.0-dirty-20221104.050348
Next: SONIC-OS-202205.0-dirty-20221104.050348
Available: 
SONiC-OS-202012.0-dirty-20221104.031351
SONIC-OS-202205.0-dirty-20221104.050348
```
Case 4
   10) sonic-installer install the image A.
   11) it should be indicated that the image has been installed and just set to default.
```
admin@ixs-7215-pizza9:~$ sudo sonic-installer install /tmp/sonic-marvell-armhf.bin
New image will be installed, continue? [y/N]: y
Image SONiC-OS-202012.0-dirty-20221104.031351 is already installed. Setting it as default...
Command: /usr/bin/fw_setenv boot_next "run sonic_image_2"

Command: sync;sync;sync

Command: sleep 3

Done
```
case 5:
  12 execute sonic-installer list
```
Current: SONIC-OS-202205.0-dirty-20221104.050348
Next: SONiC-OS-202012.0-dirty-20221104.031351
Available: 
SONiC-OS-202012.0-dirty-20221104.031351
SONIC-OS-202205.0-dirty-20221104.050348
```
Case 6:
 13) reboot the device
 14) and sonic-installer list
```
admin@sonic:~$ sudo sonic-installer list
Current: SONiC-OS-202012.0-dirty-20221104.031351
Next: SONiC-OS-202012.0-dirty-20221104.031351
Available: 
SONiC-OS-202012.0-dirty-20221104.031351
SONIC-OS-202205.0-dirty-20221104.050348
```
Case 7:
  15) sonic-installer set-default to image C (SONIC-OS-202205.0-dirty-20221104.050348)
  16) sonic-installer list 
```
Current: SONiC-OS-202012.0-dirty-20221104.031351
Next: SONIC-OS-202205.0-dirty-20221104.050348
Available: 
SONiC-OS-202012.0-dirty-20221104.031351
SONIC-OS-202205.0-dirty-20221104.050348
```
Case 8:
    17) reboot the device 
    18)  sonic-installer list
```
Current: SONIC-OS-202205.0-dirty-20221104.050348
Next: SONIC-OS-202205.0-dirty-20221104.050348
Available: 
SONiC-OS-202012.0-dirty-20221104.031351
SONIC-OS-202205.0-dirty-20221104.050348
```
Case 9: 
 19) install image B (SONiC-OS-202205.0-dirty-20221104.050857)
 20) sonic-installer list
```
Current: SONIC-OS-202205.0-dirty-20221104.050348
Next:  SONiC-OS-202205.0-dirty-20221104.050857
Available: 
SONiC-OS-202205.0-dirty-20221104.050857
SONIC-OS-202205.0-dirty-20221104.050348
```
Case 10:
 21) reboot the device
22) sonic-installer list
```
Current: SONiC-OS-202205.0-dirty-20221104.050857
Next:  SONiC-OS-202205.0-dirty-20221104.050857
Available: 
SONiC-OS-202205.0-dirty-20221104.050857
SONIC-OS-202205.0-dirty-20221104.050348
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

