### PR TITLE
[chassis][Arista] add supervisor to the platform_env.conf

### DIFF
--- a/device/arista/x86_64-arista_7800_sup/platform_env.conf
+++ b/device/arista/x86_64-arista_7800_sup/platform_env.conf
@@ -1,2 +1,3 @@
 usemsi=1
 dmasize=512M
+supervisor=1


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes https://github.com/sonic-net/sonic-buildimage/issues/12614

#### How I did it
In the `container_checker` the database_chassis is added to expected container if device is supervisor
To detect the device is  superviso, add `supervisor=1` to the `platform_env.conf` of 7808 sup platform

#### How to verify it
run `container_checker` monit check

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

)

