### PR TITLE
[Edgecore][PDDF/AS9716] Support QSFP-DD in PDDF

### DIFF
--- a/device/accton/x86_64-accton_as9716_32d-r0/pddf/pd-plugin.json
+++ b/device/accton/x86_64-accton_as9716_32d-r0/pddf/pd-plugin.json
@@ -7,7 +7,7 @@
            "i2c":
            {
                "valmap-SFP28": {"1":true, "0":false },
-               "valmap-QSFP28": {"1":true, "0":false}
+               "valmap-QSFP-DD": {"1":true, "0":false}
            }
         }
     },

--- a/device/accton/x86_64-accton_as9716_32d-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as9716_32d-r0/pddf/pddf-device.json
@@ -114,7 +114,7 @@
         "i2c":
         {
             "topo_info": { "parent_bus":"0x0", "dev_addr":"0x77", "dev_type":"pca9548"},
-            "dev_attr": { "virt_bus":"0x1"},
+            "dev_attr": { "virt_bus":"0x1", "idle_state":"-2"},
              "channel":
             [
                 { "chn":"0", "dev":"MUX2" },
@@ -134,7 +134,7 @@
         "i2c":
         {
             "topo_info": { "parent_bus":"0x1", "dev_addr":"0x72", "dev_type":"pca9548"},
-            "dev_attr": { "virt_bus":"0x9"},
+            "dev_attr": { "virt_bus":"0x9", "idle_state":"-2"},
             "channel":
             [
                 { "chn":"0", "dev":"PSU2" },
@@ -165,7 +165,6 @@
             "attr_list": 
             [  
                 { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x3", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
-                { "attr_name":"psu_model_name", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"12" },
                 { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x3", "attr_mask":"0x4", "attr_cmpval":"0x4", "attr_len":"1"},
                 { "attr_name":"psu_mfr_id", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
                 { "attr_name":"psu_fan_dir", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
@@ -186,6 +185,7 @@
             "topo_info":{ "parent_bus":"0xa", "dev_addr":"0x51", "dev_type":"psu_eeprom"}, 
             "attr_list": 
             [  
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x51", "attr_devtype":"eeprom", "attr_offset":"0x20", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"11" },
                 { "attr_name":"psu_serial_num", "attr_devaddr":"0x51", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"20" }
             ]
         }
@@ -214,7 +214,6 @@
             "attr_list": 
             [  
                 { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x3", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
-                { "attr_name":"psu_model_name", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"12" },
                 { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x3", "attr_mask":"0x8", "attr_cmpval":"0x8", "attr_len":"1"},
                 { "attr_name":"psu_mfr_id", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
                 { "attr_name":"psu_fan_dir", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
@@ -235,6 +234,7 @@
             "topo_info":{ "parent_bus":"0x9", "dev_addr":"0x50", "dev_type":"psu_eeprom"}, 
             "attr_list": 
             [  
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x20", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"11" },
                 { "attr_name":"psu_serial_num", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"20" }
             ]
         }
@@ -245,7 +245,7 @@
         "i2c":
         {
             "topo_info": { "parent_bus":"0x1", "dev_addr":"0x76", "dev_type":"pca9548"},
-            "dev_attr": { "virt_bus":"0x11"},
+            "dev_attr": { "virt_bus":"0x11", "idle_state":"-2"},
             "channel":
             [
                 { "chn":"0", "dev":"FAN-CTRL" },
@@ -487,7 +487,7 @@
         "i2c":
         {
             "topo_info": { "parent_bus":"0x2", "dev_addr":"0x72", "dev_type":"pca9548"},
-            "dev_attr": { "virt_bus":"0x19"},
+            "dev_attr": { "virt_bus":"0x19", "idle_state":"-2"},
             "channel":
             [
                 { "chn":"0", "dev":"PORT1" },
@@ -507,7 +507,7 @@
         "i2c":
         {
             "topo_info": { "parent_bus":"0x2", "dev_addr":"0x73", "dev_type":"pca9548"},
-            "dev_attr": { "virt_bus":"0x21"},
+            "dev_attr": { "virt_bus":"0x21", "idle_state":"-2"},
             "channel":
             [
                 { "chn":"0", "dev":"PORT9" },
@@ -527,7 +527,7 @@
         "i2c":
         {
             "topo_info": { "parent_bus":"0x2", "dev_addr":"0x74", "dev_type":"pca9548"},
-            "dev_attr": { "virt_bus":"0x29"},
+            "dev_attr": { "virt_bus":"0x29", "idle_state":"-2"},
             "channel":
             [
                 { "chn":"0", "dev":"PORT17" },
@@ -547,7 +547,7 @@
         "i2c":
         {
             "topo_info": { "parent_bus":"0x2", "dev_addr":"0x75", "dev_type":"pca9548"},
-            "dev_attr": { "virt_bus":"0x31"},
+            "dev_attr": { "virt_bus":"0x31", "idle_state":"-2"},
             "channel":
             [
                 { "chn":"0", "dev":"PORT25" },
@@ -567,7 +567,7 @@
         "i2c":
         {
             "topo_info": { "parent_bus":"0x2", "dev_addr":"0x76", "dev_type":"pca9548"},
-            "dev_attr": { "virt_bus":"0x39"},
+            "dev_attr": { "virt_bus":"0x39", "idle_state":"-2"},
             "channel":
             [
                 { "chn":"0", "dev":"PORT33" },
@@ -577,7 +577,7 @@
     },
     "PORT1":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT1", "device_parent":"MUX4"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT1", "device_parent":"MUX4"},
         "dev_attr": { "dev_idx":"1"},
         "i2c":
         {
@@ -593,7 +593,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT1-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT1"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x19", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x19", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -616,7 +616,7 @@
     },
     "PORT2":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT2", "device_parent":"MUX4"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT2", "device_parent":"MUX4"},
         "dev_attr": { "dev_idx":"2"},
         "i2c":
         {
@@ -632,7 +632,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT2-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT2"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x1a", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x1a", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -655,7 +655,7 @@
     },    
     "PORT3":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT3", "device_parent":"MUX4"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT3", "device_parent":"MUX4"},
         "dev_attr": { "dev_idx":"3"},
         "i2c":
         {
@@ -671,7 +671,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT3-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT3"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x1b", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x1b", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -694,7 +694,7 @@
     },
     "PORT4":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT4", "device_parent":"MUX4"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT4", "device_parent":"MUX4"},
         "dev_attr": { "dev_idx":"4"},
         "i2c":
         {
@@ -710,7 +710,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT4-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT4"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x1c", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x1c", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -733,7 +733,7 @@
     },
     "PORT5":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT5", "device_parent":"MUX4"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT5", "device_parent":"MUX4"},
         "dev_attr": { "dev_idx":"5"},
         "i2c":
         {
@@ -749,7 +749,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT5-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT5"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x1d", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x1d", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -772,7 +772,7 @@
     },
     "PORT6":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT6", "device_parent":"MUX4"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT6", "device_parent":"MUX4"},
         "dev_attr": { "dev_idx":"6"},
         "i2c":
         {
@@ -788,7 +788,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT6-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT6"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x1e", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x1e", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -811,7 +811,7 @@
     },
     "PORT7":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT7", "device_parent":"MUX4"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT7", "device_parent":"MUX4"},
         "dev_attr": { "dev_idx":"7"},
         "i2c":
         {
@@ -827,7 +827,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT7-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT7"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x1f", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x1f", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -850,7 +850,7 @@
     },
     "PORT8":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT8", "device_parent":"MUX4"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT8", "device_parent":"MUX4"},
         "dev_attr": { "dev_idx":"8"},
         "i2c":
         {
@@ -866,7 +866,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT8-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT8"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x20", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x20", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -887,17 +887,10 @@
             ]
         }
     },
-    
-    
-    
-    
-    
-    
-    
-    
+
     "PORT9":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT9", "device_parent":"MUX5"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT9", "device_parent":"MUX5"},
         "dev_attr": { "dev_idx":"9"},
         "i2c":
         {
@@ -913,7 +906,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT9-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT9"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x21", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x21", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -936,7 +929,7 @@
     },
     "PORT10":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT10", "device_parent":"MUX5"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT10", "device_parent":"MUX5"},
         "dev_attr": { "dev_idx":"10"},
         "i2c":
         {
@@ -952,7 +945,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT2-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT10"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x22", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x22", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -975,7 +968,7 @@
     },    
     "PORT11":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT11", "device_parent":"MUX5"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT11", "device_parent":"MUX5"},
         "dev_attr": { "dev_idx":"11"},
         "i2c":
         {
@@ -991,7 +984,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT11-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT11"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x23", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x23", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1014,7 +1007,7 @@
     },
     "PORT12":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT12", "device_parent":"MUX5"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT12", "device_parent":"MUX5"},
         "dev_attr": { "dev_idx":"12"},
         "i2c":
         {
@@ -1030,7 +1023,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT12-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT12"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x24", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x24", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1053,7 +1046,7 @@
     },
     "PORT13":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT13", "device_parent":"MUX5"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT13", "device_parent":"MUX5"},
         "dev_attr": { "dev_idx":"13"},
         "i2c":
         {
@@ -1069,7 +1062,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT13-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT13"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x25", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x25", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1092,7 +1085,7 @@
     },
     "PORT14":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT14", "device_parent":"MUX5"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT14", "device_parent":"MUX5"},
         "dev_attr": { "dev_idx":"14"},
         "i2c":
         {
@@ -1108,7 +1101,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT14-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT14"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x26", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x26", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1131,7 +1124,7 @@
     },
     "PORT15":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT15", "device_parent":"MUX5"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT15", "device_parent":"MUX5"},
         "dev_attr": { "dev_idx":"15"},
         "i2c":
         {
@@ -1147,7 +1140,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT15-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT15"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x27", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x27", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1170,7 +1163,7 @@
     },
     "PORT16":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT16", "device_parent":"MUX5"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT16", "device_parent":"MUX5"},
         "dev_attr": { "dev_idx":"16"},
         "i2c":
         {
@@ -1186,7 +1179,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT16-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT16"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x28", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x28", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1212,7 +1205,7 @@
     
     "PORT17":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT17", "device_parent":"MUX6"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT17", "device_parent":"MUX6"},
         "dev_attr": { "dev_idx":"17"},
         "i2c":
         {
@@ -1228,7 +1221,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT17-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT17"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x29", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x29", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1251,7 +1244,7 @@
     },
     "PORT18":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT18", "device_parent":"MUX6"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT18", "device_parent":"MUX6"},
         "dev_attr": { "dev_idx":"18"},
         "i2c":
         {
@@ -1267,7 +1260,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT18-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT18"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x2a", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x2a", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1290,7 +1283,7 @@
     },    
     "PORT19":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT19", "device_parent":"MUX6"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT19", "device_parent":"MUX6"},
         "dev_attr": { "dev_idx":"19"},
         "i2c":
         {
@@ -1306,7 +1299,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT19-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT19"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x2b", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x2b", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1329,7 +1322,7 @@
     },
     "PORT20":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT20", "device_parent":"MUX6"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT20", "device_parent":"MUX6"},
         "dev_attr": { "dev_idx":"20"},
         "i2c":
         {
@@ -1345,7 +1338,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT20-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT20"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x2c", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x2c", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1368,7 +1361,7 @@
     },
     "PORT21":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT21", "device_parent":"MUX6"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT21", "device_parent":"MUX6"},
         "dev_attr": { "dev_idx":"21"},
         "i2c":
         {
@@ -1384,7 +1377,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT21-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT21"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x2d", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x2d", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1407,7 +1400,7 @@
     },
     "PORT22":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT22", "device_parent":"MUX6"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT22", "device_parent":"MUX6"},
         "dev_attr": { "dev_idx":"22"},
         "i2c":
         {
@@ -1423,7 +1416,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT22-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT22"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x2e", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x2e", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1446,7 +1439,7 @@
     },
     "PORT23":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT23", "device_parent":"MUX6"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT23", "device_parent":"MUX6"},
         "dev_attr": { "dev_idx":"23"},
         "i2c":
         {
@@ -1462,7 +1455,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT23-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT23"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x2f", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x2f", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1485,7 +1478,7 @@
     },
     "PORT24":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT24", "device_parent":"MUX6"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT24", "device_parent":"MUX6"},
         "dev_attr": { "dev_idx":"24"},
         "i2c":
         {
@@ -1501,7 +1494,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT24-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT24"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x30", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x30", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1526,7 +1519,7 @@
     
     "PORT25":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT25", "device_parent":"MUX7"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT25", "device_parent":"MUX7"},
         "dev_attr": { "dev_idx":"25"},
         "i2c":
         {
@@ -1542,7 +1535,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT25-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT25"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x31", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x31", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1565,7 +1558,7 @@
     },
     "PORT26":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT26", "device_parent":"MUX7"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT26", "device_parent":"MUX7"},
         "dev_attr": { "dev_idx":"26"},
         "i2c":
         {
@@ -1581,7 +1574,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT26-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT26"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x32", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x32", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1604,7 +1597,7 @@
     },    
     "PORT27":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT27", "device_parent":"MUX7"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT27", "device_parent":"MUX7"},
         "dev_attr": { "dev_idx":"27"},
         "i2c":
         {
@@ -1620,7 +1613,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT27-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT27"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x33", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x33", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1643,7 +1636,7 @@
     },
     "PORT28":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT28", "device_parent":"MUX7"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT28", "device_parent":"MUX7"},
         "dev_attr": { "dev_idx":"28"},
         "i2c":
         {
@@ -1659,7 +1652,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT28-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT28"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x34", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x34", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1682,7 +1675,7 @@
     },
     "PORT29":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT29", "device_parent":"MUX7"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT29", "device_parent":"MUX7"},
         "dev_attr": { "dev_idx":"29"},
         "i2c":
         {
@@ -1698,7 +1691,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT29-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT29"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x35", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x35", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1721,7 +1714,7 @@
     },
     "PORT30":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT30", "device_parent":"MUX7"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT30", "device_parent":"MUX7"},
         "dev_attr": { "dev_idx":"30"},
         "i2c":
         {
@@ -1737,7 +1730,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT30-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT30"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x36", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x36", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1760,7 +1753,7 @@
     },
     "PORT31":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT31", "device_parent":"MUX7"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT31", "device_parent":"MUX7"},
         "dev_attr": { "dev_idx":"31"},
         "i2c":
         {
@@ -1776,7 +1769,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT31-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT31"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x37", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x37", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1799,7 +1792,7 @@
     },
     "PORT32":
     {
-        "dev_info": { "device_type":"QSFP28", "device_name":"PORT32", "device_parent":"MUX7"},
+        "dev_info": { "device_type":"QSFP-DD", "device_name":"PORT32", "device_parent":"MUX7"},
         "dev_attr": { "dev_idx":"32"},
         "i2c":
         {
@@ -1815,7 +1808,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT32-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT32"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x38", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x38", "dev_addr":"0x50", "dev_type":"optoe3"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1854,7 +1847,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT33-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT33"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x39", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x39", "dev_addr":"0x50", "dev_type":"optoe2"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}
@@ -1894,7 +1887,7 @@
         "dev_info": { "device_type":"", "device_name":"PORT34-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT34"},
         "i2c":
         {
-            "topo_info": { "parent_bus":"0x3a", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "topo_info": { "parent_bus":"0x3a", "dev_addr":"0x50", "dev_type":"optoe2"},
             "attr_list":
             [
                 { "attr_name":"eeprom"}


### PR DESCRIPTION
Signed-off-by: jostar-yang <jostar_yang@edge-core.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support QSFP-DD in PDDF on as9716-32d platform
#### How I did it
1. Change from "QSFP28" to "QSFP-DD" in pddf-device.json
2. Change from "optoe1" to "optoe3" in pddf-device.json
#### How to verify it
Insert 400G transceiver Test sfputil show eeprom. Port eeprom can be dump correctly.
Ethernet248: SFP EEPROM detected
        Active App Selection Host Lane 1: 1
        Active App Selection Host Lane 2: 1
        Active App Selection Host Lane 3: 1
        Active App Selection Host Lane 4: 1
        Active App Selection Host Lane 5: 1
        Active App Selection Host Lane 6: 1
        Active App Selection Host Lane 7: 1
        Active App Selection Host Lane 8: 1
        Active Firmware Version: 1.9
        Application Advertisement: {1: {'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)', 'module_media_interface_id': '400ZR, DWDM, amplified', 'media_lane_count': 1, 'host_lane_count': 8, 'host_lane_assignment_options': 1}}
        CMIS Revision: 5.0
        Connector: LC
        Encoding: N/A
        Extended Identifier: Power Class 8 (19.0W Max)
        Extended RateSelect Compliance: N/A
        Hardware Revision: 0.0
        Host Electrical Interface: 400GAUI-8 C2M (Annex 120E)
        Host Lane Assignment Options: 1
        Host Lane Count: 8
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware Version: 1.9
        Length Cable Assembly(m): 0.0
        Media Interface Code: 400ZR, DWDM, amplified
        Media Interface Technology: C-band tunable laser
        Media Lane Assignment Options: 1
        Media Lane Count: 1
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: sm_media_interface
        Supported Max Laser Frequency: 196100GHz
        Supported Max TX Power: -8.0dBm
        Supported Min Laser Frequency: 191300GHz
        Supported Min TX Power: -15.0dBm
        Vendor Date Code(YYYY-MM-DD Lot): 2022-05-23 00
        Vendor Name: NeoPhotonics
        Vendor OUI: 00-15-06
        Vendor PN: QDDZR400100C1000
        Vendor Rev: 00
        Vendor SN: EVT2122019

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
-->Some customer need this feature
#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

