### PR TITLE
Fixing #12634

### DIFF
--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
@@ -205,7 +205,7 @@ class PddfSfp(SfpOptoeBase):
                 elif xcvr_id == 0x11 or xcvr_id == 0x0d or xcvr_id == 0x0c:
                     # QSFP28, QSFP+, QSFP
                     # get_power_set() is not defined in the optoe_base class
-                    api = self.get_xcvrd_api()
+                    api = self.get_xcvr_api()
                     power_set = api.get_power_set()
                     power_override = self.get_power_override()
                     # By default the lpmode pin is pulled high as mentioned in the sff community

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
@@ -204,7 +204,9 @@ class PddfSfp(SfpOptoeBase):
                     lpmode = super().get_lpmode()
                 elif xcvr_id == 0x11 or xcvr_id == 0x0d or xcvr_id == 0x0c:
                     # QSFP28, QSFP+, QSFP
-                    power_set = self.get_power_set()
+                    # get_power_set() is not defined in the optoe_base class
+                    api = self.get_xcvrd_api()
+                    power_set = api.get_power_set()
                     power_override = self.get_power_override()
                     # By default the lpmode pin is pulled high as mentioned in the sff community
                     return power_set if power_override else True
@@ -342,9 +344,9 @@ class PddfSfp(SfpOptoeBase):
                 elif xcvr_id == 0x11 or xcvr_id == 0x0d or xcvr_id == 0x0c:
                     # QSFP28, QSFP+, QSFP
                     if lpmode is True:
-                        self.set_power_override(True, True)
+                        status = self.set_power_override(True, True)
                     else:
-                        self.set_power_override(True, False)
+                        status = self.set_power_override(True, False)
 
         return status
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes #12634 

Observing the following error while running 'sfputil show lpmode' command.
AttributeError: 'Sfp' object has no attribute 'get_power_set'

Root Cause: get_power_set() is defined for QSFP28 and QSFP+ i.e. Sff8636 and Sff8634. However, the function is not defined in the optoe_base class.
 
#### How I did it
To use get_power_set(), we need to initialise the 'api' via get_xcvr_api() and then use it to run get_power_set().
  
#### How to verify it
> # sfputil show lpmode 

```
 

root@sonic:/home/admin# sfputil show lpmode

Port         Low-power Mode

-----------  ----------------

Ethernet88   Off

Ethernet96   Off

Ethernet248  Off

Ethernet240  Off

Ethernet32   Off

 

root@sonic:/home/admin# sfputil lpmode on Ethernet240

Enabling low-power mode for port Ethernet240 ... OK

root@sonic:/home/admin#

root@sonic:/home/admin# sfputil show lpmode

Port         Low-power Mode

-----------  ----------------

Ethernet240  On

Ethernet80   Off

..........

 

root@sonic:~# sfputil lpmode off Ethernet240

Disabling low-power mode for port Ethernet240 ... OK

root@sonic:~#

root@sonic:~#

root@sonic:~#

root@sonic:~# sfputil show lpmode

Port         Low-power Mode

-----------  ----------------

...............

Ethernet248  Off

........

Ethernet240  Off

``` 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

