### PR TITLE
Fix variable in systemd not initialized issue

### DIFF
--- a/src/systemd-sonic-generator/systemd-sonic-generator.c
+++ b/src/systemd-sonic-generator/systemd-sonic-generator.c
@@ -516,7 +516,7 @@ int get_num_of_asic() {
     FILE *fp;
     char *line = NULL;
     char* token;
-    char* platform;
+    char* platform = NULL;
     char* saveptr;
     size_t len = 0;
     ssize_t nread;


### PR DESCRIPTION
#### Why I did it
The variable is not initialized in src/systemd-sonic-generator/systemd-sonic-generator.c. I fixed this one.

#### How I did it
Assure pointer is initialized to NULL when defined and before use.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

