### PR TITLE
[Arista] Remove pcie device monitoring for 7260CX3-64

### DIFF
--- a/device/arista/x86_64-arista_7260cx3_64/pcie.yaml
+++ b/device/arista/x86_64-arista_7260cx3_64/pcie.yaml
@@ -100,12 +100,6 @@
   id: 8c24
   name: 'Signal processing controller: Intel Corporation 8 Series Chipset Family Thermal
     Management Controller (rev 05)'
-- bus: '01'
-  dev: '00'
-  fn: '0'
-  id: '1682'
-  name: 'Ethernet controller: Broadcom Limited NetXtreme BCM57762 Gigabit Ethernet
-    PCIe (rev 20)'
 - bus: '02'
   dev: '00'
   fn: '0'


### PR DESCRIPTION
#### Why I did it

On some products from this line one of the management NIC might be unpopulated.
On such products this leads to errors from `pcied` and `pcie-check.sh`

#### How I did it

Remove this PCIe device from `pcie.yaml`

#### How to verify it

Run `pcieutil check` on the 2 hardware variants and validate that it passes.
Restart `pcied` and make sure that there is no more error logs in the syslog.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Remove pcie device monitoring for 7260CX3-64
