### PR TITLE
Remove LOGLEVEL DB since is no longer used

### DIFF
--- a/dockers/docker-database/database_config.json.j2
+++ b/dockers/docker-database/database_config.json.j2
@@ -29,11 +29,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/dockers/docker-database/database_config.json.j2
+++ b/dockers/docker-database/database_config.json.j2
@@ -29,6 +29,11 @@
             "separator": ":",
             "instance" : "redis"
         },
+        "LOGLEVEL_DB" : {
+            "id" : 3,
+            "separator": ":",
+            "instance" : "redis"
+        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/platform/vs/docker-sonic-vs/database_config.json
+++ b/platform/vs/docker-sonic-vs/database_config.json
@@ -28,11 +28,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/src/sonic-config-engine/tests/mock_tables/asic0/database_config.json
+++ b/src/sonic-config-engine/tests/mock_tables/asic0/database_config.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/src/sonic-config-engine/tests/mock_tables/asic1/database_config.json
+++ b/src/sonic-config-engine/tests/mock_tables/asic1/database_config.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/src/sonic-config-engine/tests/mock_tables/asic2/database_config.json
+++ b/src/sonic-config-engine/tests/mock_tables/asic2/database_config.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/src/sonic-config-engine/tests/mock_tables/asic3/database_config.json
+++ b/src/sonic-config-engine/tests/mock_tables/asic3/database_config.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/src/sonic-config-engine/tests/mock_tables/database_config.json
+++ b/src/sonic-config-engine/tests/mock_tables/database_config.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/src/sonic-eventd/tests/redis_multi_db_ut_config/database_config.json
+++ b/src/sonic-eventd/tests/redis_multi_db_ut_config/database_config.json
@@ -42,11 +42,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/src/sonic-eventd/tests/redis_multi_db_ut_config/database_config0.json
+++ b/src/sonic-eventd/tests/redis_multi_db_ut_config/database_config0.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/src/sonic-eventd/tests/redis_multi_db_ut_config/database_config1.json
+++ b/src/sonic-eventd/tests/redis_multi_db_ut_config/database_config1.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/src/sonic-py-common/sonic_py_common/sonic_db_dump_load.py
+++ b/src/sonic-py-common/sonic_py_common/sonic_db_dump_load.py
@@ -113,7 +113,7 @@ def sonic_db_dump_load():
         parser.add_option('-A', '--use-expireat', help='use EXPIREAT rather than TTL/EXPIRE', action='store_true')
     else:
         parser.add_option('-l', '--load', help='load data into redis (default is to dump data from redis)', action='store_true')
-        parser.add_option('-n', '--dbname', help='dump DATABASE (APPL_DB/ASIC_DB/COUNTERS_DB/LOGLEVEL_DB/CONFIG_DB...)')
+        parser.add_option('-n', '--dbname', help='dump DATABASE (APPL_DB/ASIC_DB/COUNTERS_DB/CONFIG_DB...)')
         parser.add_option('-t', '--conntype', help='indicate redis connection type (tcp[default] or unix_socket)', default='tcp')
         parser.add_option('-k', '--keys', help='dump only keys matching specified glob-style pattern')
         parser.add_option('-o', '--output', help='write to OUTPUT instead of stdout (dump mode only)')


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
This PR is part of the following HLD:
Persistent loglevel HLD: https://github.com/sonic-net/SONiC/pull/1041

#### Why I did it
After the Logger tables moved from the LOGLEVEL_DB to the CONFIG_DB and the jinja2_cache was deleted the LOGLEVEL_DB is not in use.
#### How I did it
Removed the LOGLEVEL_DB from the SONiC code

#### How to verify it
All tests were passed

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

