### PR TITLE
Add missing system_ref_core_clock_khz in Arista-7800R3A-36D2-C36 and Arista-7800R3A-36D2-C72

### DIFF
--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1,4 +1,5 @@
 soc_family=BCM8885X
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1,4 +1,5 @@
 soc_family=BCM8885X
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 


### PR DESCRIPTION
`system_ref_core_clock_khz` was missing in Arista-7800R3A-36D2-C36 and Arista-7800R3A-36D2-C72 for ASIC1.