### PR TITLE
[build] use real wget for SAI_FLAGS

### DIFF
--- a/platform/broadcom/sai.dep
+++ b/platform/broadcom/sai.dep
@@ -4,7 +4,7 @@ SPATH       := $($(BRCM_XGS_SAI)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) platform/broadcom/sai.mk platform/broadcom/sai.dep
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 # Get the Latest HTTP Header and calculate the SHA value as it is a softlink that always points to LATEST_INT_OCP_SAI_X.X.X
-SAI_FLAGS   := $(shell wget --spider --server-response $($(BRCM_XGS_SAI)_URL) $($(BRCM_XGS_SAI_DEV)_URL)  2>&1 \
+SAI_FLAGS   := $(shell SKIP_BUILD_HOOK=y wget --spider --server-response $($(BRCM_XGS_SAI)_URL) $($(BRCM_XGS_SAI_DEV)_URL)  2>&1 \
 			   | grep -Ev -- '--|Date:|x-ms-request-id'|sha256sum|awk '{print $$1}' )
 
 $(BRCM_XGS_SAI)_CACHE_MODE  := GIT_CONTENT_SHA


### PR DESCRIPTION

#### Why I did it

We download libsaibcm.deb every time when we use make to build.
That's because we use build hook but not real wget to get hash for SAI_FLAGS.
As a result we also call curl for libsaibcm.deb inside of function download_packages.

#### How I did it

Add SKIP_BUILD_HOOK=y to use real wget instead of build hook.

#### How to verify it

I redirected all requests to proxy to log them (1st column is timing).

Without fix (curl, curl , wget):

1668034736.348  0 CONNECT sonicstorage.blob.core.windows.net:443
1668034831.997  40064209 GET https://sonicstorage.blob.core.windows.net/public/sai/bcmsai/REL_7.0/7.1.17.4/libsaibcm_7.1.17.4_amd64.deb
1668034832.601  0 CONNECT sonicstorage.blob.core.windows.net:443
1668034833.212  113911 GET https://sonicstorage.blob.core.windows.net/public/sai/bcmsai/REL_7.0/7.1.17.4/libsaibcm-dev_7.1.17.4_amd64.deb
1668034833.831  0 CONNECT sonicstorage.blob.core.windows.net:443
1668034834.030  549 HEAD https://sonicstorage.blob.core.windows.net/public/sai/bcmsai/REL_7.0/7.1.17.4/libsaibcm_7.1.17.4_amd64.deb
1668034834.235  547 HEAD https://sonicstorage.blob.core.windows.net/public/sai/bcmsai/REL_7.0/7.1.17.4/libsaibcm-dev_7.1.17.4_amd64.deb

Fixed version (only wget):

1668034973.199  0 CONNECT sonicstorage.blob.core.windows.net:443
1668034973.339  549 HEAD https://sonicstorage.blob.core.windows.net/public/sai/bcmsai/REL_7.0/7.1.17.4/libsaibcm_7.1.17.4_amd64.deb
1668034973.501  547 HEAD https://sonicstorage.blob.core.windows.net/public/sai/bcmsai/REL_7.0/7.1.17.4/libsaibcm-dev_7.1.17.4_amd64.deb


Signed-off-by: Konstantin Vasin <k.vasin@yadro.com>