### PR TITLE
Added libpci and pciutils to the pmon docker

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -27,6 +27,7 @@ RUN apt-get update &&   \
         python3-jsonschema \
         libpci3         \
         iputils-ping    \
+        pciutils        \
 # smartmontools version should match the installed smartmontools in sonic_debian_extension build template
         smartmontools=7.2-1
 
@@ -40,6 +41,9 @@ RUN pip3 install grpcio==1.39.0 \
 
 # Barefoot platform vendors' sonic_platform packages import the Python 'thrift' library
 RUN pip3 install thrift==0.13.0
+
+# We install the libpci module in order to be able to do PCI transactions
+RUN pip3 install libpci
 
 {% if docker_platform_monitor_debs.strip() -%}
 # Copy locally-built Debian package dependencies


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This is part of a corresponding change to the pcie daemon that enables it to verify PCI peripherals on a platform against a preconfigured YAML file, and enables the pcied daemon to call the system commands needed for PCI peripheral verification

#### How I did it
Adding aforementioned libraries to the Dockerfile.j2 file

#### How to verify it
run 'which setpci' from the pmon docker - would show the path of the binary

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Modified pmon's Dockerfile.j2 to include pciutils and libpci libraries.

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

