### PR TITLE
[Build] Update SLAVE_BASE_TAG and DPKG cache if Debian mirrors were changed

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -70,6 +70,7 @@ SONIC_COMMON_FILES_LIST :=  $(if $(wildcard cache.skip.common),, .platform slave
 SONIC_COMMON_FLAGS_LIST :=  $(CONFIGURED_PLATFORM) \
                             $(CONFIGURED_ARCH) \
                             $(BLDENV) \
+                            $(MIRROR_URLS) $(MIRROR_SECURITY_URLS) \
                             $(SONIC_DEBUGGING_ON) \
                             $(SONIC_PROFILING_ON) $(SONIC_ENABLE_SYNCD_RPC)
 SONIC_COMMON_DPKG_LIST  :=  debian/control debian/changelog debian/rules \

--- a/Makefile.work
+++ b/Makefile.work
@@ -207,6 +207,7 @@ $(shell $(PREPARE_DOCKER) )
 # Add the versions in the tag, if the version change, need to rebuild the slave
 SLAVE_BASE_TAG = $(shell \
 	cat $(SLAVE_DIR)/Dockerfile \
+		$(SLAVE_DIR)/sources.list.* \
 		$(SLAVE_DIR)/buildinfo/versions/versions-* \
 		src/sonic-build-hooks/hooks/* 2>/dev/null \
 	| sha1sum \


### PR DESCRIPTION
#### Why I did it

After #12557 sources.lists are generated.
So we need to recalculate SLAVE_BASE_TAG if mirrors were changed.
Also we need to rebuild DPKG cache in this case.

#### How I did it

1. Use generated sources.list for SLAVE_BASE_TAG
2. Add MIRROR_URLS and MIRROR_SECURITY_URLS to SONIC_COMMON_FLAGS_LIST

Signed-off-by: Konstantin Vasin k.vasin@yadro.com


