### PR TITLE
[Arista] Remove pcie device monitoring for 7260CX3-64

### DIFF
--- a/device/arista/x86_64-arista_7260cx3_64/pcie.yaml
+++ b/device/arista/x86_64-arista_7260cx3_64/pcie.yaml
@@ -100,12 +100,6 @@
   id: 8c24
   name: 'Signal processing controller: Intel Corporation 8 Series Chipset Family Thermal
     Management Controller (rev 05)'
-- bus: '01'
-  dev: '00'
-  fn: '0'
-  id: '1682'
-  name: 'Ethernet controller: Broadcom Limited NetXtreme BCM57762 Gigabit Ethernet
-    PCIe (rev 20)'
 - bus: '02'
   dev: '00'
   fn: '0'


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

On some products from this line one of the management NIC might be unpopulated.
On such products this leads to errors from `pcied` and `pcie-check.sh`

#### How I did it

Remove this PCIe device from `pcie.yaml`

#### How to verify it

Run `pcieutil check` on the 2 hardware variants and validate that it passes.
Restart `pcied` and make sure that there is no more error logs in the syslog.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Remove pcie device monitoring for 7260CX3-64
