### PR TITLE
[Arista] Fix import error in phy-credo package

### DIFF
--- a/rules/phy-credo.mk
+++ b/rules/phy-credo.mk
@@ -1,3 +1,3 @@
 PHY_CREDO = phy-credo_1.0_amd64.deb
-$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/raw/e89a1696954fd381e1e95edf208cffc97caf15d4/phy/phy-credo_1.0_amd64.deb"
+$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/raw/446f30ccd8626f904d89d5798da7294948e090a6/phy/phy-credo_1.0_amd64.deb"
 SONIC_ONLINE_DEBS += $(PHY_CREDO)


### PR DESCRIPTION
#### Why I did it

A recent migration of `SonicV2Connector` from `swsssdk` to `swsscommon.swsscommon` broke `phy-credo`.

#### How I did it

Change the import path while keeping a fallback on the previous one for 202205

#### How to verify it

`phy-credo.service` no longer fails due to an import error

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix import error in phy-credo package


