### PR TITLE
[Arista] Update platform.json for 7260CX3-64

### DIFF
--- a/device/arista/x86_64-arista_7260cx3_64/platform.json
+++ b/device/arista/x86_64-arista_7260cx3_64/platform.json
@@ -1,7 +1,26 @@
 {
     "chassis": {
         "name": "DCS-7260CX3-64",
-        "components": [],
+        "components": [
+            {
+               "name": "Aboot()"
+            },
+            {
+               "name": "Scd(addr=0000:06:00.0)"
+            },
+            {
+               "name": "Scd(addr=0000:ff:0b.3)"
+            },
+            {
+               "name": "Ucd90160(addr=74-004e)"
+            },
+            {
+               "name": "Ucd90120A(addr=83-0034)"
+            },
+            {
+               "name": "RookSysCpld(addr=81-0023)"
+            }
+        ],
         "fans": [],
         "fan_drawers": [
             {
@@ -40,55 +59,59 @@
         "psus": [
             {
                 "name": "psu1",
-                "fans": []
+                "fans": [
+                    {
+                        "name": "psu1/1",
+                        "speed": {
+                            "controllable": false
+                        }
+                    }
+                ]
             },
             {
                 "name": "psu2",
-                "fans": []
+                "fans": [
+                    {
+                        "name": "psu2/1",
+                        "speed": {
+                            "controllable": false
+                        }
+                    }
+                ]
             }
         ],
         "thermals": [
             {
-                "name": "Board sensor"
+                "name": "Board sensor",
+                "controllable": false
             },
             {
-                "name": "PCH temp sensor"
+                "name": "PCH temp sensor",
+                "controllable": false
             },
             {
-                "name": "Physical id 0"
+                "name": "Physical id 0",
+                "controllable": false
             },
             {
-                "name": "CPU core0 temp sensor"
+                "name": "CPU core0 temp sensor",
+                "controllable": false
             },
             {
-                "name": "CPU core1 temp sensor"
+                "name": "CPU core1 temp sensor",
+                "controllable": false
             },
             {
-                "name": "CPU board temp sensor"
+                "name": "CPU board temp sensor",
+                "controllable": false
             },
             {
-                "name": "Back-panel temp sensor"
+                "name": "Back-panel temp sensor",
+                "controllable": false
             },
             {
-                "name": "Front-panel temp sensor"
-            },
-            {
-                "name": "Power supply 1 hotspot sensor"
-            },
-            {
-                "name": "Power supply 1 inlet temp sensor"
-            },
-            {
-                "name": "Power supply 1 exhaust temp sensor"
-            },
-            {
-                "name": "Power supply 2 hotspot sensor"
-            },
-            {
-                "name": "Power supply 2 inlet temp sensor"
-            },
-            {
-                "name": "Power supply 2 exhaust temp sensor"
+                "name": "Front-panel temp sensor",
+                "controllable": false
             }
         ],
         "sfps": [

--- a/device/arista/x86_64-arista_7260cx3_64/platform_components.json
+++ b/device/arista/x86_64-arista_7260cx3_64/platform_components.json
@@ -1,0 +1,14 @@
+{
+    "chassis": {
+        "DCS-7260CX3-64": {
+            "component": {
+                "Aboot()": {},
+                "Scd(addr=0000:06:00.0)": {},
+                "Scd(addr=0000:ff:0b.3)": {},
+                "Ucd90160(addr=74-004e)": {},
+                "Ucd90120A(addr=83-0034)": {},
+                "RookSysCpld(addr=81-0023)": {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Why I did it

Some sonic-mgmt `platform_tests/api` were failing on the 7260CX3-64

#### How I did it

Added the missing metadata in `platform.json` and `platform_components.json`
This is purely test data and does not impact our API implementation.

#### How to verify it

Run `platform_tests/api` and expect 100% passrate.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update platform.json for 7260CX3-64
