### PR TITLE
[Build] set apt Acquire::Retries to 3 for bullseye

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -110,7 +110,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT mount
 ## Pointing apt to public apt mirrors and getting latest packages, needed for latest security updates
 scripts/build_mirror_config.sh files/apt $CONFIGURED_ARCH $IMAGE_DISTRO 
 sudo cp files/apt/sources.list.$CONFIGURED_ARCH $FILESYSTEM_ROOT/etc/apt/sources.list
-sudo cp files/apt/apt.conf.d/{81norecommends,apt-{clean,gzip-indexes,no-languages},no-check-valid-until} $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
+sudo cp files/apt/apt.conf.d/{81norecommends,apt-{clean,gzip-indexes,no-languages},no-check-valid-until,apt-multiple-retries} $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
 
 ## Note: set lang to prevent locale warnings in your chroot
 sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y update

--- a/dockers/docker-base-bullseye/Dockerfile.j2
+++ b/dockers/docker-base-bullseye/Dockerfile.j2
@@ -30,6 +30,7 @@ COPY ["dpkg_01_drop", "/etc/dpkg/dpkg.cfg.d/01_drop"]
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]
 COPY ["no_install_recommend_suggest", "/etc/apt/apt.conf.d"]
 COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
+COPY ["apt-multiple-retries", "/etc/apt/apt.conf.d"]
 
 # Update apt cache and
 # pre-install fundamental packages

--- a/dockers/docker-base-bullseye/apt-multiple-retries
+++ b/dockers/docker-base-bullseye/apt-multiple-retries
@@ -1,0 +1,4 @@
+# Instruct apt to retry downloads on failures
+# This is required only for bullseye.
+
+Acquire::Retries "3";

--- a/files/apt/apt.conf.d/apt-multiple-retries
+++ b/files/apt/apt.conf.d/apt-multiple-retries
@@ -1,0 +1,4 @@
+# Instruct apt to retry downloads on failures
+# This is required only for bullseye.
+
+Acquire::Retries "3";

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -22,6 +22,7 @@ FROM {{ prefix }}debian:bullseye
 MAINTAINER gulv@microsoft.com
 
 COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
+COPY ["apt-multiple-retries", "/etc/apt/apt.conf.d/"]
 
 {%- if CROSS_BUILD_ENVIRON != "y" %}
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]

--- a/sonic-slave-bullseye/apt-multiple-retries
+++ b/sonic-slave-bullseye/apt-multiple-retries
@@ -1,0 +1,4 @@
+# Instruct apt to retry downloads on failures
+# This is required only for bullseye.
+
+Acquire::Retries "3";


### PR DESCRIPTION
#### Why I did it

There were some changes in apt source code in version 2.1.9.
As a result apt used in bullseye (2.2.4) is intolerant to network issues.
This was fixed in https://salsa.debian.org/apt-team/apt/-/commit/10631550f1f9788bdfd64d2434237a1448ab0626 Already fixed version is used in bookworm (2.5.4)
And not yet affected version is used in buster (1.8.2.3)

#### How I did it

Set Acquire::Retries to 3 for sonic-slave-bullseye, docker-base-bullseye and final Debian image.

Ref: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1876035

Signed-off-by: Konstantin Vasin <k.vasin@yadro.com>


