### PR TITLE
add fix for STATIC_ROUTE_EXPIRY_TIME key not exist

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/static_rt_timer.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/static_rt_timer.py
@@ -16,6 +16,9 @@ class StaticRouteTimer(object):
 
     def set_timer(self):
         """ Check for custom route expiry time in STATIC_ROUTE:EXPIRY_TIME """
+        keys = self.db.keys(self.db.APPL_DB, "STATIC_ROUTE_EXPIRY_TIME")
+        if len(keys) == 0:
+            return
         timer = self.db.get(self.db.APPL_DB, "STATIC_ROUTE_EXPIRY_TIME", "time")
         if timer is not None:
             timer = int(timer)     


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
when key STATIC_ROUTE_EXPIRY_TIME is not exist in APPL_DB, self.db.get(self.db.APPL_DB, "STATIC_ROUTE_EXPIRY_TIME", "time") will rise runtime error, and python thread silent exist.

#### How I did it
Add key check before access it's value

#### How to verify it
Try it on DUT

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

