### PR TITLE
[centec][arm64] fix tsingma bsp compile error

### DIFF
--- a/platform/centec-arm64/tsingma-bsp/src/ctc_wdt/ctc_wdt.c
+++ b/platform/centec-arm64/tsingma-bsp/src/ctc_wdt/ctc_wdt.c
@@ -345,14 +345,14 @@ err:
 	return ret;
 }
 
-static int ctc_wdt_remove(struct amba_device *adev)
+static void ctc_wdt_remove(struct amba_device *adev)
 {
 	struct ctc_wdt *wdt = amba_get_drvdata(adev);
 
 	watchdog_unregister_device(&wdt->wdd);
 	watchdog_set_drvdata(&wdt->wdd, NULL);
 
-	return 0;
+	return;
 }
 
 static int __maybe_unused ctc_wdt_suspend(struct device *dev)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fix centec arm64 tsingma bsp compile error caused by linux kernel api change

#### How I did it
fix centec arm64 tsingma bsp compile error caused by linux kernel api change

#### How to verify it
compile centec arm64 image and verify on centec arm64 E530 series device

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

