### PR TITLE
[build][arm64] fix debian source for arm64 bullseye docker image

### DIFF
--- a/scripts/prepare_docker_buildinfo.sh
+++ b/scripts/prepare_docker_buildinfo.sh
@@ -19,7 +19,10 @@ mkdir -p $BUILDINFO_VERSION_PATH
 if [ -z "$DISTRO" ]; then
     DOCKER_BASE_IMAGE=$(grep "^FROM" $DOCKERFILE | head -n 1 | awk '{print $2}')
     DISTRO=$(docker run --rm --entrypoint "" $DOCKER_BASE_IMAGE cat /etc/os-release | grep VERSION_CODENAME | cut -d= -f2)
-    [ -z "$DISTRO" ] && DISTRO=jessie
+    if [ -z "$DISTRO" ]; then
+        DISTRO=$(docker run --rm --entrypoint "" $DOCKER_BASE_IMAGE cat /etc/apt/sources.list | grep deb.debian.org | awk '{print $3}')
+        [ -z "$DISTRO" ] && DISTRO=jessie
+    fi
 fi
 
 if [[ "$IMAGENAME" == docker-base-* ]]; then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
arm64 bullseye docker image source is set to jessie for VERSION_CODENAME is miss.
```
shil@localhost:~/sonic-buildimage$ docker run -it multiarch/debian-debootstrap:arm64-bullseye bash
root@b2e2fea86e2d:/# cat /etc/os-release | grep VERSION_CODENAME | cut -d= -f2
root@b2e2fea86e2d:/# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux bullseye/sid"
NAME="Debian GNU/Linux"
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

#### How I did it
if DISTRO is NULL, find it in /etc/apt/sources.list
```
root@b2e2fea86e2d:/# cat /etc/apt/sources.list | grep deb.debian.org | awk '{print $3}'
bullseye
root@b2e2fea86e2d:/# cat /etc/apt/sources.list
deb http://deb.debian.org/debian bullseye main
root@b2e2fea86e2d:/#
```
#### How to verify it
compile arm64 sonic image

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

