### PR TITLE
[Cherry-pick]Remove PYTHON_THRIFT_0_14_1 (#12169)

### DIFF
--- a/rules/thrift_0_14_1.mk
+++ b/rules/thrift_0_14_1.mk
@@ -13,8 +13,5 @@ $(eval $(call add_derived_package,$(LIBTHRIFT_0_14_1),$(LIBTHRIFT_0_14_1_DEV)))
 PYTHON3_THRIFT_0_14_1 = python3-thrift_$(THRIFT_0_14_1_VERSION)_$(CONFIGURED_ARCH).deb
 $(eval $(call add_derived_package,$(LIBTHRIFT_0_14_1),$(PYTHON3_THRIFT_0_14_1)))
 
-PYTHON_THRIFT_0_14_1 = python-thrift_$(THRIFT_0_14_1_VERSION)_$(CONFIGURED_ARCH).deb
-$(eval $(call add_derived_package,$(LIBTHRIFT_0_14_1),$(PYTHON_THRIFT_0_14_1)))
-
 THRIFT_0_14_1_COMPILER = thrift-compiler_$(THRIFT_0_14_1_VERSION)_$(CONFIGURED_ARCH).deb
 $(eval $(call add_derived_package,$(LIBTHRIFT_0_14_1),$(THRIFT_0_14_1_COMPILER)))


### PR DESCRIPTION
#### Why I did it
- cherry pick https://github.com/sonic-net/sonic-buildimage/pull/12169
PYTHON_THRIFT_0_14_1 couldn't be built on the pipeline which caused building docker-saiserverv2 to be failed.
cause the PYTHON_THRIFT_0_14_1 is not built as previous thrift_0.11 for python2.*
for thrift 0.11
https://github.com/sonic-net/sonic-buildimage/blob/master/src/thrift/Makefile#L5
```
THRIFT_VERSION = 0.11.0
THRIFT_VERSION_FULL = $(THRIFT_VERSION)-4

MAIN_TARGET = libthrift-$(THRIFT_VERSION)_$(THRIFT_VERSION_FULL)_$(CONFIGURED_ARCH).deb
DERIVED_TARGETS = libthrift-dev_$(THRIFT_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
		  python-thrift_$(THRIFT_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
		  thrift-compiler_$(THRIFT_VERSION_FULL)_$(CONFIGURED_ARCH).deb
```

For thrift 0.14
https://github.com/sonic-net/sonic-buildimage/blob/master/src/thrift_0_14_1/Makefile#L5
```
THRIFT_VERSION = 0.14.1

MAIN_TARGET = libthrift0_$(THRIFT_VERSION)_$(CONFIGURED_ARCH).deb
DERIVED_TARGETS = libthrift-dev_$(THRIFT_VERSION)_$(CONFIGURED_ARCH).deb \
		  python3-thrift_$(THRIFT_VERSION)_$(CONFIGURED_ARCH).deb \
		  thrift-compiler_$(THRIFT_VERSION)_$(CONFIGURED_ARCH).deb
```
when build this target, there will be an error
```
tar: target/debs/buster/python-thrift_0.14.1_amd64.deb: Cannot stat: No such file or directory
```
Cause no build target depends on ``PYTHON_THRIFT_0_14_1``, remove this target from build

#### How I did it
Remove PYTHON_THRIFT_0_14_1 from rules/thrift_0_14_1.mk.
#### How to verify it
Run pipeline internally and docker-saiserverv2 is built successfully.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

