### PR TITLE
[BFN]: Implement getting psu related sensors in sonic_platform directly from BMC

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -38,8 +38,8 @@ RUN apt-get update &&   \
 RUN pip3 install grpcio==1.39.0 \
         grpcio-tools==1.39.0
 
-# Barefoot platform vendors' sonic_platform packages import the Python 'thrift' library
-RUN pip3 install thrift==0.13.0
+# Barefoot platform vendors' sonic_platform packages import these Python libraries
+RUN pip3 install thrift==0.13.0 netifaces
 
 {% if docker_platform_monitor_debs.strip() -%}
 # Copy locally-built Debian package dependencies

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/bfn_extensions/psu_sensors.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/bfn_extensions/psu_sensors.py
@@ -79,8 +79,8 @@ def get_psu_metrics():
 
     http_address = "http://[%s%%%s]:8080" % (link_local_address, link_local_interface)
     args = "/api/sys/bmc/sensors/%20-A%20-u%20"
-    output = Popen("curl " + http_address + args, \
-                    shell=True, stdout=PIPE, stderr=DEVNULL).stdout.read()
+    cmd = "curl " + http_address + args
+    output = Popen(cmd.split(), stdout=PIPE, stderr=DEVNULL).stdout.read()
     output = json.loads(output.decode())["Information"]["Description"][0].strip()
     sections = output.split("\n\n")
 

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/bfn_extensions/psu_sensors.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/bfn_extensions/psu_sensors.py
@@ -1,4 +1,4 @@
-# from netifaces import ifaddresses, AF_INET6
+from netifaces import ifaddresses, AF_INET6
 from subprocess import Popen, PIPE, DEVNULL
 import json
 import os
@@ -70,8 +70,6 @@ def get_link_local_interface():
                 return os.listdir(concrete_ether_net)[0]
 
 def get_link_local_address(link_local_interface):
-    # netifaces is not available in pmon, currently resolving this
-    return 'fe80::ff:fe00:1'
     for addr in ifaddresses(link_local_interface)[AF_INET6]:
         address = addr['addr'].split('%')[0]
         # according to rfc4291 this ipv6 address is used for link local connection

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/bfn_extensions/psu_sensors.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/bfn_extensions/psu_sensors.py
@@ -1,0 +1,127 @@
+# from netifaces import ifaddresses, AF_INET6
+from subprocess import Popen, PIPE, DEVNULL
+import json
+import os
+
+psu_drivers = {
+    1 : "psu_driver-i2c-7-5a",
+    2 : "psu_driver-i2c-7-59"
+}
+
+class Metric(object):
+
+    def __init__(self, sensor_id, sensor_key, value, label):
+        self._value = self.parse_value(value)
+        self._sensor_id = sensor_id
+        self._sensor_key = sensor_key
+        self._label = label
+
+    @classmethod
+    def parse_value(cls, value):
+        parse = getattr(cls, "parse")
+        return parse(value)
+
+    # For debug purposes
+    def __repr__(self):
+        return "%s, %s: %s %s [%s]" % (
+            self._sensor_id,
+            self._sensor_key,
+            self._value,
+            getattr(self, "unit", "?"),
+            self._label)
+
+class Temperature(Metric):
+    parse = float
+    unit = "°C"
+
+class FanRpm(Metric):
+    parse = float
+    unit = "RPM"
+
+class FanFault(Metric):
+    parse = float
+
+class Voltage(Metric):
+    parse = float
+    unit = "V"
+
+class Power(Metric):
+    parse = float
+    unit = "W"
+
+class Current(Metric):
+    parse = float
+    unit = "A"
+
+def get_metric_value(metrics, name):
+    sensor_id, sensor_key = name.split("_")
+    for metric in metrics:
+        if metric._sensor_id == sensor_id and metric._sensor_key == sensor_key:
+            return metric._value
+    return None
+
+def get_link_local_interface():
+    cdc_ether_path = "/sys/bus/usb/drivers/cdc_ether"
+    for ether in os.listdir(cdc_ether_path):
+        concrete_ether = os.path.join(cdc_ether_path, ether)
+        if os.path.isdir(concrete_ether):
+            concrete_ether_net = os.path.join(concrete_ether, 'net')
+            if os.path.exists(concrete_ether_net):
+                return os.listdir(concrete_ether_net)[0]
+
+def get_link_local_address(link_local_interface):
+    # netifaces is not available in pmon, currently resolving this
+    return 'fe80::ff:fe00:1'
+    for addr in ifaddresses(link_local_interface)[AF_INET6]:
+        address = addr['addr'].split('%')[0]
+        # according to rfc4291 this ipv6 address is used for link local connection
+        if address.startswith('fe80:'):
+            # first address is taken for BMC and second for this host
+            return address[:-1] + '1'
+    return None
+
+def get_psu_metrics(index):
+    link_local_interface = get_link_local_interface()
+    link_local_address = get_link_local_address(link_local_interface)
+
+    http_address = "http://[%s%%%s]:8080" % (link_local_address, link_local_interface)
+    args = "/api/sys/bmc/sensors/%20-A%20-u%20" + psu_drivers[index]
+    output = Popen("curl " + http_address + args, \
+                    shell=True, stdout=PIPE, stderr=DEVNULL).stdout.read()
+    output = json.loads(output.decode())
+    fields = output["Information"]["Description"][0].strip().split("\n")
+
+    metrics = []
+    label = None
+    for field in fields[1:]:
+        if field.startswith("  "):
+            field = field.replace("  ", "")
+            field_key, field_value = field.split(": ")
+            if "_" in field_key:
+                sensor_id, sensor_key = field_key.split("_", 1)
+                if sensor_key == "input":
+                    if sensor_id.startswith("temp"):
+                        metrics.append(
+                            Temperature(sensor_id, sensor_key, field_value, label=label))
+                    elif sensor_id.startswith("in"):
+                        metrics.append(
+                            Voltage(sensor_id, sensor_key, field_value, label=label))
+                    elif sensor_id.startswith("power"):
+                        metrics.append(
+                            Power(sensor_id, sensor_key, field_value, label=label))
+                    elif sensor_id.startswith("curr"):
+                        metrics.append(
+                            Current(sensor_id, sensor_key, field_value, label=label))
+                    elif sensor_id.startswith("fan"):
+                        metrics.append(
+                            FanRpm(sensor_id, sensor_key, field_value, label=label))
+                elif sensor_key == "fault":
+                    if sensor_id.startswith("fan"):
+                        metrics.append(
+                            FanFault(sensor_id, sensor_key, field_value, label=label))
+        elif field.startswith("ERROR"):
+            syslog.syslog(syslog.LOG_INFO, field)
+        else:
+            label = field[:-1]  # strip off trailing ":" character
+
+    return metrics

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/psu.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/psu.py
@@ -153,9 +153,6 @@ class Psu(PsuBase):
         """
         return get_metric_value(self.__sensors_get(self.__index), "curr1_input")
 
-    def g(self):
-        return self.__sensors_get(self.__index)
-
     def get_power(self):
         """
         Retrieves current energy supplied by PSU


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Platform interface doesn't provide all sensors and using it isn't effective
#### How I did it
Request sensors via http from BMC server and parse the result
#### How to verify it
Related daemon in pmon populates redis db, run this command to view the contents
```
show platform psustatus
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

