### PR TITLE
Add missing flags in qos template file

### DIFF
--- a/device/common/profiles/th2/7260/RDMA-CENTRIC/qos.json.j2
+++ b/device/common/profiles/th2/7260/RDMA-CENTRIC/qos.json.j2
@@ -1,4 +1,5 @@
 {% if ('type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'LeafRouter') %}
+{% set different_dscp_to_tc_map = true %}
 {%- macro generate_dscp_to_tc_map() %}
     "DSCP_TO_TC_MAP": {
         "AZURE": {
@@ -150,6 +151,8 @@
     },
 {%- endmacro %}
 {% elif ('subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR') %}
+{% set different_dscp_to_tc_map = true %}
+{% set different_tc_to_queue_map = true %}
 {%- macro generate_dscp_to_tc_map() %}
     "DSCP_TO_TC_MAP": {
         "AZURE": {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR is to add the missing flags in `device/common/profiles/th2/7260/RDMA-CENTRIC/qos.json.j2`.
The flags are missing by this PR https://github.com/sonic-net/sonic-buildimage/pull/11569

#### How I did it
Add the missing flags
For T1, `different_dscp_to_tc_map = true` is added.
For dualtor, `different_dscp_to_tc_map = true` and `different_tc_to_queue_map = true` are added.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

