### PR TITLE
Reload BCM SDK kmods on syncd start to handle syncd restart issues

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -28,6 +28,19 @@ function startplatform() {
         debug "Firmware update procedure ended"
     fi
 
+    if [[ x"$sonic_asic_platform" == x"broadcom" ]]; then
+        if [[ x"$WARM_BOOT" != x"true" ]]; then
+            is_bcm0=$(ls /sys/class/net | grep bcm0)
+            if [[ "$is_bcm0" == "bcm0" ]]; then
+                debug "stop SDK opennsl-modules ..."
+                /etc/init.d/opennsl-modules stop
+                debug "start SDK opennsl-modules ..."
+                /etc/init.d/opennsl-modules start
+                debug "started SDK opennsl-modules"
+            fi
+        fi
+    fi
+
     if [[ x"$sonic_asic_platform" == x"barefoot" ]]; then
         is_usb0=$(ls /sys/class/net | grep usb0)
         if [[ "$is_usb0" == "usb0" ]]; then


### PR DESCRIPTION
Signed-off-by: Michael Li <michael.li@broadcom.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
There is an issue on the Arista PikeZ platform (using T3.X2: BCM56274) while running SONiC. If the 'syncd' container in SONiC is restarted, the expected behaviour is that syncd will automatically restart/recover; however it does not and always fails at create_switch due to BCM SDK kmod DMA operation cancellation getting stuck.

`
Sep 16 22:19:44.855125 pkz208 ERR syncd#syncd: [none] SAI_API_SWITCH:platform_process_command:428 Platform command "init soc" failed, rc = -1.
Sep 16 22:19:44.855206 pkz208 INFO syncd#supervisord: syncd CMIC_CMC0_PKTDMA_CH4_DESC_COUNT_REQ:0x33#015
Sep 16 22:19:44.855264 pkz208 CRIT syncd#syncd: [none] SAI_API_SWITCH:platformInit:1909 initialization command "init soc" failed, rc = -1 (Internal error).
Sep 16 22:19:44.855403 pkz208 CRIT syncd#syncd: [none] SAI_API_SWITCH:sai_driver_init:642 Error initializing driver, rc = -1.
...
Sep 16 22:19:44.855891 pkz208 CRIT syncd#syncd: [none] SAI_API_SWITCH:brcm_sai_create_switch:1173 initializing SDK failed with error Operation failed (0xfffffff5).
`

Reloading the BCM SDK kmods allows the switch init to continue properly.

#### How I did it
If BCM SDK kmods are loaded, unload and load them again on syncd docker start script.

#### How to verify it
Steps to reproduce:

1. In SONiC, run 'docker ps' to see current running containers; 'syncd' should be present.
2. Run 'docker stop syncd'
3. Wait ~1 minute.
4. Run 'docker ps' to see that syncd is missing.
5. Check logs to see messages similar to the above.

#### Which release branch to backport (provide reason below if selected)
202205
202205 is the community branch used for PikeZ platform 

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

