### PR TITLE
[YANG MODEL] Add vni to vrf yang file

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-vrf.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vrf.yang
@@ -43,6 +43,12 @@ module sonic-vrf {
                         "Enable/disable fallback feature which is useful for specified VRF user to access internet through global/main route.";
                 }
 
+                leaf vni {
+                    type uint32 {
+                        range 1..16777215;
+                    }
+                }
+
             } /* end of list VRF_LISt */
         } /* end of container VRf */
     } /* end of container sonic-vrf */


### PR DESCRIPTION

#### Why I did it
Fail to breakout interface when there is VRF-VNI mapping.
Apply breakout setting on interface, there are error messages as below.

sonicyang(6):Note: Below table(s) have no YANG models: RESTSERVER, SNMP, SNMPCOMMUNITY, VXLANEVPNNVO, VXLANTUNNEL, VXLANTUNNELMAP, XCVRDLOG sonicyang(3):All Keys are not parsed in VRF
dictkeys(['Vrf01']) sonicyang(3):exceptionList:["'vni'"]
sonicyang(3):Data Loading Failed:All Keys are not parsed in VRF dictkeys(['Vrf01'])
Data Loading Failed
All Keys are not parsed in VRF
dict_keys(['Vrf01'])
ConfigMgmt Class creation failed
Failed to break out Port. Error: Failed to load the config. Error: ConfigMgmtDPB Class creation failed

#### How I did it
Add vni to vrf yang file
#### How to verify it
Add VRF-VNI mapping and apply breakout setting on interface, breakout process got successfully completed.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

