### PR TITLE
Force xz as compression type when building sonic-build-hooks debs

### DIFF
--- a/src/sonic-build-hooks/Makefile
+++ b/src/sonic-build-hooks/Makefile
@@ -21,7 +21,7 @@ DPKGTOOL = $(shell which dpkg-deb)
 ifeq ($(shell which dpkg-deb),)
 BUILD_COMMAND=docker run --user $(shell id -u):$(shell id -g) --rm -v $(shell pwd):/build debian:buster bash -c 'cd /build; dpkg-deb --build $(TMP_DIR)/$(SONIC_BUILD_HOOKS) $(SONIC_BUILD_HOOKS_TARGET)'
 else
-BUILD_COMMAND=dpkg-deb --build $(TMP_DIR)/$(SONIC_BUILD_HOOKS) $(SONIC_BUILD_HOOKS_TARGET)
+BUILD_COMMAND=dpkg-deb -Zxz --build $(TMP_DIR)/$(SONIC_BUILD_HOOKS) $(SONIC_BUILD_HOOKS_TARGET)
 endif
 
 DEPENDS := $(shell find scripts hooks debian -type f)


### PR DESCRIPTION
Ubuntu 22.04 leverages Zstandard compression to dpkg by default.
Debian doesn't support it yet https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=892664

Fix #12822

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>

