### PR TITLE
better solution for STATIC_ROUTE_EXPIRY_TIME check

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/static_rt_timer.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/static_rt_timer.py
@@ -15,17 +15,15 @@ class StaticRouteTimer(object):
     MAX_TIMER     = 1800
 
     def set_timer(self):
-        """ Check for custom route expiry time in STATIC_ROUTE:EXPIRY_TIME """
-        keys = self.db.keys(self.db.APPL_DB, "STATIC_ROUTE_EXPIRY_TIME")
-        if len(keys) == 0:
-            return
+        """ Check for custom route expiry time in STATIC_ROUTE_EXPIRY_TIME """
         timer = self.db.get(self.db.APPL_DB, "STATIC_ROUTE_EXPIRY_TIME", "time")
         if timer is not None:
-            timer = int(timer)     
-            if timer > 0 and timer <= self.MAX_TIMER:
-                self.timer = timer
-                return
-            log_err("Custom static route expiry time of {}s is invalid!".format(timer))
+            if timer.isdigit():
+                timer = int(timer)
+                if timer > 0 and timer <= self.MAX_TIMER:
+                    self.timer = timer
+                    return
+                log_err("Custom static route expiry time of {}s is invalid!".format(timer))
         return
 
     def alarm(self):


### PR DESCRIPTION
#### Why I did it
1. swss-common behavior change between 202012 and master
   https://github.com/sonic-net/sonic-swss-common/commit/e95a4666ad90f13c3675efb9238f273df5232e91
2. This behavior change will cause different return value:
    master:  key not exist, swss-common api will return None.
    202012:  key not exist, swss-common api will return empty string.
3. Based on 1 and 2, modify the original static route expiry code to make the code safe for different kinds of key/value pair in both master and 202012.

#### How I did it
Add protection code when swss-common api return None/"". 

#### How to verify it
apply in bgpcfgd, verify different key/value pair. 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

