### PR TITLE
[Cherry-pick] Add build target to build thrift 0.14.1 for python2

### DIFF
--- a/rules/thrift_0_14_1.mk
+++ b/rules/thrift_0_14_1.mk
@@ -13,5 +13,8 @@ $(eval $(call add_derived_package,$(LIBTHRIFT_0_14_1),$(LIBTHRIFT_0_14_1_DEV)))
 PYTHON3_THRIFT_0_14_1 = python3-thrift_$(THRIFT_0_14_1_VERSION)_$(CONFIGURED_ARCH).deb
 $(eval $(call add_derived_package,$(LIBTHRIFT_0_14_1),$(PYTHON3_THRIFT_0_14_1)))
 
+PYTHON_THRIFT_0_14_1 = python-thrift_$(THRIFT_0_14_1_VERSION)_$(CONFIGURED_ARCH).deb
+$(eval $(call add_derived_package,$(LIBTHRIFT_0_14_1),$(PYTHON_THRIFT_0_14_1)))
+
 THRIFT_0_14_1_COMPILER = thrift-compiler_$(THRIFT_0_14_1_VERSION)_$(CONFIGURED_ARCH).deb
 $(eval $(call add_derived_package,$(LIBTHRIFT_0_14_1),$(THRIFT_0_14_1_COMPILER)))

--- a/src/thrift_0_14_1/Makefile
+++ b/src/thrift_0_14_1/Makefile
@@ -7,6 +7,7 @@ THRIFT_VERSION = 0.14.1
 MAIN_TARGET = libthrift0_$(THRIFT_VERSION)_$(CONFIGURED_ARCH).deb
 DERIVED_TARGETS = libthrift-dev_$(THRIFT_VERSION)_$(CONFIGURED_ARCH).deb \
 		  python3-thrift_$(THRIFT_VERSION)_$(CONFIGURED_ARCH).deb \
+		  python-thrift_$(THRIFT_VERSION)_$(CONFIGURED_ARCH).deb \
 		  thrift-compiler_$(THRIFT_VERSION)_$(CONFIGURED_ARCH).deb
 
 THRIFT_LINK_PRE = https://archive.apache.org/dist/thrift


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR is a cherry-pick of #12790 and a revert of #12169 to add build target to help build thrift 0.14.1 for python2.

PYTHON_THRIFT_0_14_1 couldn't be built on the pipeline which caused some building targets to fail, like docker-saiserverv2.
In order to make the thrift 0.14.1 can be used by other build targets and prepare for the latter upgrade from thrift 0.11 to 0.14.1. Add this target.

#### How I did it
Cherry-pick #12790 from master to 202205 and re-add the target PYTHON_THRIFT_0_14_1.

#### How to verify it
Local docker build.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>