### PR TITLE
[dockers] save extension dockers with an image tag

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -439,6 +439,15 @@ export vs_build_prepare_mem=$(VS_PREPARE_MEM)
 ##
 ##     docker-swss:latest <=SAVE/LOAD=> docker-swss-<user>:<tag>
 
+# $(call docker-get-tag,tag)
+# Get the docker tag. For packages it is an image version, for other dockers it stays latest.
+#
+# $(1) => Docker name
+
+define docker-get-tag
+$(shell [ ! -z $(filter $(1).gz,$(SONIC_PACKAGES_LOCAL)) ] && echo $(SONIC_IMAGE_VERSION) || echo latest)
+endef
+
 # $(call docker-image-save,from,to)
 # Sonic docker images are always created with username as extension. During the save operation,
 # it removes the username extension from docker image and saved them as compressed tar file for SONiC image generation.
@@ -451,13 +460,13 @@ define docker-image-save
     @echo "Attempting docker image lock for $(1) save" $(LOG)
     $(call MOD_LOCK,$(1),$(DOCKER_LOCKDIR),$(DOCKER_LOCKFILE_SUFFIX),$(DOCKER_LOCKFILE_TIMEOUT))
     @echo "Obtained docker image lock for $(1) save" $(LOG)
-    @echo "Tagging docker image $(1)-$(DOCKER_USERNAME):$(DOCKER_USERTAG) as $(1):latest" $(LOG)
-    docker tag $(1)-$(DOCKER_USERNAME):$(DOCKER_USERTAG) $(1):latest $(LOG)
-    @echo "Saving docker image $(1):latest" $(LOG)
-        docker save $(1):latest | gzip -c > $(2)
+    @echo "Tagging docker image $(1)-$(DOCKER_USERNAME):$(DOCKER_USERTAG) as $(1):$(call docker-get-tag,$(1))" $(LOG)
+    docker tag $(1)-$(DOCKER_USERNAME):$(DOCKER_USERTAG) $(1):$(call docker-get-tag,$(1)) $(LOG)
+    @echo "Saving docker image $(1):$(call docker-get-tag,$(1))" $(LOG)
+        docker save $(1):$(call docker-get-tag,$(1)) | gzip -c > $(2)
     if [ x$(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD) == x"y" ]; then
-        @echo "Removing docker image $(1):latest" $(LOG)
-        docker rmi -f $(1):latest $(LOG)
+        @echo "Removing docker image $(1):$(call docker-get-tag,$(1))" $(LOG)
+        docker rmi -f $(1):$(call docker-get-tag,$(1)) $(LOG)
     fi
     $(call MOD_UNLOCK,$(1))
     @echo "Released docker image lock for $(1) save" $(LOG)
@@ -1026,6 +1035,7 @@ $(addprefix $(TARGET_PATH)/, $(DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .platform
 			-t $(DOCKER_IMAGE_REF) $($*.gz_PATH) $(LOG)
 		if [ x$(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD) == x"y" ]; then docker tag $(DOCKER_IMAGE_REF) $*; fi
 		scripts/collect_docker_version_files.sh $(DOCKER_IMAGE_REF) $(TARGET_PATH)
+		if [ ! -z $(filter $*.gz,$(SONIC_PACKAGES_LOCAL)) ]; then docker tag $(DOCKER_IMAGE_REF) $*:$(SONIC_IMAGE_VERSION); fi
 		$(call docker-image-save,$*,$@)
 		# Clean up
 		if [ -f $($*.gz_PATH).patch/series ]; then pushd $($*.gz_PATH) && quilt pop -a -f; [ -d .pc ] && rm -rf .pc; popd; fi
@@ -1079,6 +1089,7 @@ $(addprefix $(TARGET_PATH)/, $(DOCKER_DBG_IMAGES)) : $(TARGET_PATH)/%-$(DBG_IMAG
 			-t $(DOCKER_DBG_IMAGE_REF) $($*.gz_PATH) $(LOG)
 		if [ x$(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD) == x"y" ]; then docker tag $(DOCKER_IMAGE_REF) $*; fi
 		scripts/collect_docker_version_files.sh $(DOCKER_DBG_IMAGE_REF) $(TARGET_PATH)
+		if [ ! -z $(filter $*.gz,$(SONIC_PACKAGES_LOCAL)) ]; then docker tag $(DOCKER_IMAGE_REF) $*:$(SONIC_IMAGE_VERSION); fi
 		$(call docker-image-save,$*-$(DBG_IMAGE_MARK),$@)
 		# Clean up
 		docker rmi -f $(DOCKER_IMAGE_REF) &> /dev/null || true


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

**FIXES**: https://github.com/sonic-net/sonic-buildimage/issues/11521

#### Why I did it

When build SONiC dockers, SONiC build system tags all of them with ```latest``` tag. This is Ok for all built-in dockers because we will also tag them with image version tag in ```sonic_debian_extension.j2``` script. On the other hand, some of these dockers are SONiC packages and they are installed by ```sonic-package-manager``` which creates a only one tag whcih is recorded in the corresponding .gz file. This leads to having these dockers tagged only with ```latest``` tag. This change saves the tag as an image version string in .gz file, so that these dockers have version identification in their tag.

#### How I did it

I modified slave.mk to save the version tag instead of latest tag.

#### How to verify it

I verified this change by running ```show version```:

```
SONiC Software Version: SONiC.HEAD.2016-2998c3f40
Distribution: Debian 11.5
Kernel: 5.10.0-18-2-amd64
Build commit: 2998c3f40
Build date: Thu Nov 24 17:12:09 UTC 2022
Built by: sw-r2d2-bot@r-build-sonic-ci03-241

Platform: x86_64-mlnx_msn4600c-r0
HwSKU: Mellanox-SN4600C-C64
ASIC: mellanox
ASIC Count: 1
Serial Number: MT2023X22082
Model Number: MSN4600-CS2FO
Hardware Revision: A1
Uptime: 10:06:31 up 2 min,  1 user,  load average: 2.48, 1.14, 0.44
Date: Fri 25 Nov 2022 10:06:31

Docker images:
REPOSITORY                    TAG                   IMAGE ID       SIZE
docker-orchagent              HEAD.2016-2998c3f40   760e3ac32730   525MB
docker-orchagent              latest                760e3ac32730   525MB
docker-fpm-frr                HEAD.2016-2998c3f40   a914f8582dff   536MB
docker-fpm-frr                latest                a914f8582dff   536MB
docker-teamd                  HEAD.2016-2998c3f40   23c5bb16ddac   506MB
docker-teamd                  latest                23c5bb16ddac   506MB
docker-macsec                 HEAD.2016-2998c3f40   b04d8bd19248   509MB
docker-syncd-mlnx             HEAD.2016-2998c3f40   6bbf6e4b8a3a   910MB
docker-syncd-mlnx             latest                6bbf6e4b8a3a   910MB
docker-platform-monitor       HEAD.2016-2998c3f40   9bcae580c5b0   917MB
docker-platform-monitor       latest                9bcae580c5b0   917MB
docker-sonic-telemetry        HEAD.2016-2998c3f40   7802fb621402   784MB
docker-sonic-telemetry        latest                7802fb621402   784MB
docker-snmp                   HEAD.2016-2998c3f40   af6493bb9b92   536MB
docker-snmp                   latest                af6493bb9b92   536MB
docker-lldp                   HEAD.2016-2998c3f40   9b098dd5d539   532MB
docker-lldp                   latest                9b098dd5d539   532MB
docker-dhcp-relay             HEAD.2016-2998c3f40   8dd189f905f9   500MB
docker-sonic-p4rt             HEAD.2016-2998c3f40   cecba3819cb3   572MB
docker-sonic-p4rt             latest                cecba3819cb3   572MB
docker-mux                    HEAD.2016-2998c3f40   314b433cdc12   539MB
docker-mux                    latest                314b433cdc12   539MB
docker-database               HEAD.2016-2998c3f40   cf751891dd80   490MB
docker-database               latest                cf751891dd80   490MB
docker-router-advertiser      HEAD.2016-2998c3f40   1c726d4fed44   490MB
docker-router-advertiser      latest                1c726d4fed44   490MB
docker-eventd                 HEAD.2016-2998c3f40   f907d689a556   490MB
docker-eventd                 latest                f907d689a556   490MB
docker-sonic-mgmt-framework   HEAD.2016-2998c3f40   76a2a9a9e6c6   609MB
docker-sonic-mgmt-framework   latest                76a2a9a9e6c6   609MB
docker-nat                    HEAD.2016-2998c3f40   4305aed622f5   478MB
docker-nat                    latest                4305aed622f5   478MB
docker-sflow                  HEAD.2016-2998c3f40   f53036301efb   476MB
docker-sflow                  latest                f53036301efb   476MB
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

