### PR TITLE
[Arista] Enable ipv6 128b lpm on 720DT-48S

### DIFF
--- a/device/arista/x86_64-arista_720dt_48s/td3x2-a720dt-48s-flex.config.bcm
+++ b/device/arista/x86_64-arista_720dt_48s/td3x2-a720dt-48s-flex.config.bcm
@@ -10,6 +10,7 @@ dma_desc_timeout_usec.0=15000000
 fpem_mem_entries.0=0
 higig2_hdr_mode.0=1
 ifp_inports_support_enable.0=1
+ipv6_lpm_128b_enable.0=1
 l2xmsg_mode.0=1
 l2_mem_entries.0=65536
 l3_mem_entries.0=32768


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Added to allow test_crm_route to pass; the test tries to add a /126 ipv6 route and this change is required in order for the count of available routes to be updated correctly.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

