### PR TITLE
[submodule]Update SAI SDK URL from package storage to public

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,5 +1,5 @@
 LIBSAIBCM_XGS_VERSION = 4.3.7.1-6
-LIBSAIBCM_BRANCH_NAME = REL_PRE_4.3.5.2
+LIBSAIBCM_BRANCH_NAME = REL_4.3.5.2
 LIBSAIBCM_XGS_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/bcmsai/$(LIBSAIBCM_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)"
 
 BRCM_SAI = libsaibcm_$(LIBSAIBCM_XGS_VERSION)_amd64.deb
@@ -8,11 +8,6 @@ BRCM_SAI_DEV = libsaibcm-dev_$(LIBSAIBCM_XGS_VERSION)_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
 $(BRCM_SAI_DEV)_URL = "$(LIBSAIBCM_XGS_URL_PREFIX)/$(BRCM_SAI_DEV)"
 
-BRCM_SAI_DBG = libsaibcm-dbg_3.5.2.3_amd64.deb
-$(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DBG)))
-$(BRCM_SAI_DBG)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/libsaibcm-dbg_3.5.2.3_amd64.deb?sv=2015-04-05&sr=b&sig=02XfkVdPH4RF85%2B0LG%2BFA5g22tUgEXKIlF2IpZLflIk%3D&se=2033-04-16T16%3A32%3A54Z&sp=r"
-
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)
 $(eval $(call add_conflict_package,$(BRCM_SAI_DEV),$(LIBSAIVS_DEV)))
-$(BRCM_SAI_DBG)_DEPENDS += $(BRCM_SAI)

--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,18 @@
-BRCM_SAI = libsaibcm_4.3.7.1-6_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.3/202012/libsaibcm_4.3.7.1-6_amd64.deb?sv=2021-04-10&st=2022-10-25T06%3A49%3A16Z&se=2037-10-26T06%3A49%3A00Z&sr=b&sp=r&sig=NceGVsZ%2BG9DwI7t82bdQRsXSI5ewZdvx6rtEx8KTB74%3D"
-BRCM_SAI_DEV = libsaibcm-dev_4.3.7.1-6_amd64.deb
+LIBSAIBCM_XGS_VERSION = 4.3.7.1-6
+LIBSAIBCM_BRANCH_NAME = REL_PRE_4.3.5.2
+LIBSAIBCM_XGS_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/bcmsai/$(LIBSAIBCM_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)"
+
+BRCM_SAI = libsaibcm_$(LIBSAIBCM_XGS_VERSION)_amd64.deb
+$(BRCM_SAI)_URL = "$(LIBSAIBCM_XGS_URL_PREFIX)/$(BRCM_SAI)"
+BRCM_SAI_DEV = libsaibcm-dev_$(LIBSAIBCM_XGS_VERSION)_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.3/202012/libsaibcm-dev_4.3.7.1-6_amd64.deb?sv=2021-04-10&st=2022-10-25T06%3A50%3A50Z&se=2037-10-26T06%3A50%3A00Z&sr=b&sp=r&sig=bW8ORoQqQl0SGhWSge8C2KH1FcnELM5wxEZ1lMWgH6w%3D"
+$(BRCM_SAI_DEV)_URL = "$(LIBSAIBCM_XGS_URL_PREFIX)/$(BRCM_SAI_DEV)"
+
+BRCM_SAI_DBG = libsaibcm-dbg_3.5.2.3_amd64.deb
+$(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DBG)))
+$(BRCM_SAI_DBG)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/libsaibcm-dbg_3.5.2.3_amd64.deb?sv=2015-04-05&sr=b&sig=02XfkVdPH4RF85%2B0LG%2BFA5g22tUgEXKIlF2IpZLflIk%3D&se=2033-04-16T16%3A32%3A54Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)
 $(eval $(call add_conflict_package,$(BRCM_SAI_DEV),$(LIBSAIVS_DEV)))
+$(BRCM_SAI_DBG)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION


Signed-off-by: richardyu-ms <richard.yu@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In order to make the sai update easier, change the URL pattern to a more unified format, which can be update automated latter.


#### How I did it
use the public URL instead of the package url
#### How to verify it

Pipeline test
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

