### PR TITLE
[centec][arm64] support multi-platform device tree

### DIFF
--- a/platform/centec-arm64/platform.conf
+++ b/platform/centec-arm64/platform.conf
@@ -19,7 +19,7 @@ bootloader_menu_config() {
         fw_setenv -f linuxargs "${extra_cmdline_linux}"
         fw_setenv -f nos_bootcmd "test -n \$boot_once && setenv do_boot_once \$boot_once && setenv boot_once && saveenv && run do_boot_once; run boot_next"
 
-        fw_setenv -f sonic_image_1 "ext4load mmc 0:1 \$loadaddr \$sonic_dir_1/boot/sonic_arm64.fit && setenv bootargs quiet console=\$consoledev,\$baudrate root=/dev/mmcblk0p1 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=\$sonic_dir_1/fs.squashfs systemd.unified_cgroup_hierarchy=0 \${linuxargs} && bootm \$loadaddr"
+        fw_setenv -f sonic_image_1 "ext4load mmc 0:1 \$loadaddr \$sonic_dir_1/boot/sonic_arm64.fit && setenv bootargs quiet console=\$consoledev,\$baudrate root=/dev/mmcblk0p1 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=\$sonic_dir_1/fs.squashfs systemd.unified_cgroup_hierarchy=0 \${linuxargs} && bootm \$loadaddr#\$onie_platform"
         fw_setenv -f sonic_image_2 "NONE"
         fw_setenv -f sonic_dir_1 $image_dir
         fw_setenv -f sonic_dir_2 "NONE"
@@ -41,7 +41,7 @@ bootloader_menu_config() {
         fw_setenv linuxargs "${extra_cmdline_linux}"
         fw_setenv nos_bootcmd "test -n \$boot_once && setenv do_boot_once \$boot_once && setenv boot_once && saveenv && run do_boot_once; run boot_next"
 
-        fw_setenv sonic_image_$idx "ext4load mmc 0:1 \$loadaddr \$sonic_dir_$idx/boot/sonic_arm64.fit && setenv bootargs quiet console=\$consoledev,\$baudrate root=/dev/mmcblk0p1 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=\$sonic_dir_$idx/fs.squashfs systemd.unified_cgroup_hierarchy=0 \${linuxargs} && bootm \$loadaddr"
+        fw_setenv sonic_image_$idx "ext4load mmc 0:1 \$loadaddr \$sonic_dir_$idx/boot/sonic_arm64.fit && setenv bootargs quiet console=\$consoledev,\$baudrate root=/dev/mmcblk0p1 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=\$sonic_dir_$idx/fs.squashfs systemd.unified_cgroup_hierarchy=0 \${linuxargs} && bootm \$loadaddr#\$onie_platform"
         fw_setenv sonic_dir_$idx $image_dir
         fw_setenv sonic_version_$idx `echo $image_dir | sed "s/^image-/SONiC-OS-/g"`
 

--- a/platform/centec-arm64/sonic_fit.its
+++ b/platform/centec-arm64/sonic_fit.its
@@ -50,13 +50,34 @@
 		};
 	};
 	configurations {
-		default = "e530-ctc5236";
+		default = "arm64-centec_e530_24x2c-r0";
 					
-		e530-ctc5236 {			
-			description = "config for tm_ctc5236";			
-			kernel = "kernel_ctc";			
-			ramdisk = "initramfs";			
-			fdt = "ctc_fdt";		
+		arm64-centec_e530_24x2c-r0 {
+			description = "config for arm64-centec_e530_24x2c-r0";
+			kernel = "kernel_ctc";
+			ramdisk = "initramfs";
+			fdt = "ctc_fdt";
+			};
+
+		arm64-centec_e530_24x2q-r0 {
+			description = "config for arm64-centec_e530_24x2q-r0";
+			kernel = "kernel_ctc";
+			ramdisk = "initramfs";
+			fdt = "ctc_fdt";
+			};
+
+		arm64-centec_e530_48s4x-r0 {
+			description = "config for arm64-centec_e530_48s4x-r0";
+			kernel = "kernel_ctc";
+			ramdisk = "initramfs";
+			fdt = "ctc_fdt";
+			};
+
+		arm64-centec_e530_48t4x_p-r0 {
+			description = "config for arm64-centec_e530_48t4x_p-r0";
+			kernel = "kernel_ctc";
+			ramdisk = "initramfs";
+			fdt = "ctc_fdt";
 			};
 	};
 };


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
support multi-platform device tree for default dtb may not suitable on all vender hardware designs.

#### How I did it
use onie_platform variable to load device tree blob

#### How to verify it
build centec arm64 image and verify it on centec e530-24x2c board

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

