### PR TITLE
Adding PDDF common framework enhancements.

### DIFF
--- a/platform/pddf/i2c/modules/include/pddf_psu_api.h
+++ b/platform/pddf/i2c/modules/include/pddf_psu_api.h
@@ -24,18 +24,8 @@ extern void get_psu_duplicate_sysfs(int idx, char *str);
 extern ssize_t psu_show_default(struct device *dev, struct device_attribute *da, char *buf);
 extern ssize_t psu_store_default(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
 
-extern int sonic_i2c_get_psu_present_default(void *client, PSU_DATA_ATTR *adata, void *data);
-extern int sonic_i2c_get_psu_power_good_default(void *client, PSU_DATA_ATTR *adata, void *data);
-extern int sonic_i2c_get_psu_model_name_default(void *client, PSU_DATA_ATTR *adata, void *data);
-extern int sonic_i2c_get_psu_mfr_id_default(void *client, PSU_DATA_ATTR *adata, void *data);
-extern int sonic_i2c_get_psu_serial_num_default(void *client, PSU_DATA_ATTR *adata, void *data);
-extern int sonic_i2c_get_psu_fan_dir_default(void *client, PSU_DATA_ATTR *adata, void *data);
-extern int sonic_i2c_get_psu_v_out_default(void *client, PSU_DATA_ATTR *adata, void *data);
-extern int sonic_i2c_get_psu_i_out_default(void *client, PSU_DATA_ATTR *adata, void *data);
-extern int sonic_i2c_get_psu_p_out_default(void *client, PSU_DATA_ATTR *adata, void *data);
-extern int sonic_i2c_get_psu_fan1_speed_rpm_default(void *client, PSU_DATA_ATTR *adata, void *data);
-extern int sonic_i2c_get_psu_temp1_input_default(void *client, PSU_DATA_ATTR *adata, void *data);
-extern int sonic_i2c_get_psu_v_in_default(void *client, PSU_DATA_ATTR *adata, void *data);
-extern int sonic_i2c_get_psu_i_in_default(void *client, PSU_DATA_ATTR *adata, void *data);
+extern int sonic_i2c_get_psu_byte_default(void *client, PSU_DATA_ATTR *adata, void *data);
+extern int sonic_i2c_get_psu_block_default(void *client, PSU_DATA_ATTR *adata, void *data);
+extern int sonic_i2c_get_psu_word_default(void *client, PSU_DATA_ATTR *adata, void *data);
 
 #endif

--- a/platform/pddf/i2c/modules/include/pddf_psu_driver.h
+++ b/platform/pddf/i2c/modules/include/pddf_psu_driver.h
@@ -27,12 +27,17 @@ enum psu_sysfs_attributes {
 	PSU_SERIAL_NUM,
 	PSU_FAN_DIR,
     PSU_V_OUT,
+    PSU_V_OUT_MIN,
+    PSU_V_OUT_MAX,
     PSU_I_OUT,
     PSU_P_OUT, /* This is in micro watts to comply with lm-sensors */
+    PSU_P_OUT_MAX,
     PSU_FAN1_SPEED,
     PSU_TEMP1_INPUT,
+    PSU_TEMP1_HIGH_THRESHOLD,
     PSU_V_IN,
     PSU_I_IN,
+	PSU_P_IN,
 	PSU_ATTR_MAX
 };
 

--- a/platform/pddf/i2c/modules/psu/driver/pddf_psu_driver.c
+++ b/platform/pddf/i2c/modules/psu/driver/pddf_psu_driver.c
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  *
- * A pddf kernel module driver for PSU 
+ * A pddf kernel module driver for PSU
  */
 
 #include <linux/kernel.h>
@@ -53,45 +53,59 @@ struct pddf_ops_t pddf_psu_ops = {
 EXPORT_SYMBOL(pddf_psu_ops);
 
 
-PSU_SYSFS_ATTR_DATA access_psu_present = {PSU_PRESENT, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_present_default, NULL, NULL, NULL, NULL, NULL};
+PSU_SYSFS_ATTR_DATA access_psu_present = {PSU_PRESENT, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_byte_default, NULL, NULL, NULL, NULL, NULL};
 EXPORT_SYMBOL(access_psu_present);
 
-PSU_SYSFS_ATTR_DATA access_psu_model_name = {PSU_MODEL_NAME, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_model_name_default, NULL, NULL, NULL, NULL, NULL};
+PSU_SYSFS_ATTR_DATA access_psu_model_name = {PSU_MODEL_NAME, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_block_default, NULL, NULL, NULL, NULL, NULL};
 EXPORT_SYMBOL(access_psu_model_name);
 
-PSU_SYSFS_ATTR_DATA access_psu_power_good = {PSU_POWER_GOOD, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_power_good_default, NULL, NULL, NULL, NULL, NULL};
+PSU_SYSFS_ATTR_DATA access_psu_power_good = {PSU_POWER_GOOD, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_byte_default, NULL, NULL, NULL, NULL, NULL};
 EXPORT_SYMBOL(access_psu_power_good);
 
-PSU_SYSFS_ATTR_DATA access_psu_mfr_id = {PSU_MFR_ID, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_mfr_id_default, NULL, NULL, NULL, NULL, NULL};
+PSU_SYSFS_ATTR_DATA access_psu_mfr_id = {PSU_MFR_ID, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_block_default, NULL, NULL, NULL, NULL, NULL};
 EXPORT_SYMBOL(access_psu_mfr_id);
 
-PSU_SYSFS_ATTR_DATA access_psu_serial_num = {PSU_SERIAL_NUM, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_serial_num_default, NULL, NULL, NULL, NULL, NULL};
+PSU_SYSFS_ATTR_DATA access_psu_serial_num = {PSU_SERIAL_NUM, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_block_default, NULL, NULL, NULL, NULL, NULL};
 EXPORT_SYMBOL(access_psu_serial_num);
 
-PSU_SYSFS_ATTR_DATA access_psu_fan_dir = {PSU_FAN_DIR, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_fan_dir_default, NULL, NULL, NULL, NULL, NULL};
+PSU_SYSFS_ATTR_DATA access_psu_fan_dir = {PSU_FAN_DIR, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_block_default, NULL, NULL, NULL, NULL, NULL};
 EXPORT_SYMBOL(access_psu_fan_dir);
 
-PSU_SYSFS_ATTR_DATA access_psu_v_out = {PSU_V_OUT, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_v_out_default, NULL, NULL, NULL, NULL, NULL};
+PSU_SYSFS_ATTR_DATA access_psu_v_out = {PSU_V_OUT, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_word_default, NULL, NULL, NULL, NULL, NULL};
 EXPORT_SYMBOL(access_psu_v_out);
 
-PSU_SYSFS_ATTR_DATA access_psu_i_out = {PSU_I_OUT, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_i_out_default, NULL, NULL, NULL, NULL, NULL};
+PSU_SYSFS_ATTR_DATA access_psu_v_out_min = {PSU_V_OUT_MIN, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_word_default, NULL, NULL, NULL, NULL, NULL};
+EXPORT_SYMBOL(access_psu_v_out_min);
+
+PSU_SYSFS_ATTR_DATA access_psu_v_out_max = {PSU_V_OUT_MAX, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_word_default, NULL, NULL, NULL, NULL, NULL};
+EXPORT_SYMBOL(access_psu_v_out_max);
+
+PSU_SYSFS_ATTR_DATA access_psu_i_out = {PSU_I_OUT, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_word_default, NULL, NULL, NULL, NULL, NULL};
 EXPORT_SYMBOL(access_psu_i_out);
 
-PSU_SYSFS_ATTR_DATA access_psu_p_out = {PSU_P_OUT, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_p_out_default, NULL, NULL, NULL, NULL, NULL};
+PSU_SYSFS_ATTR_DATA access_psu_p_out = {PSU_P_OUT, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_word_default, NULL, NULL, NULL, NULL, NULL};
 EXPORT_SYMBOL(access_psu_p_out);
 
-PSU_SYSFS_ATTR_DATA access_psu_fan1_speed_rpm = {PSU_FAN1_SPEED, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_fan1_speed_rpm_default, NULL, NULL, NULL, NULL, NULL};
+PSU_SYSFS_ATTR_DATA access_psu_p_out_max = {PSU_P_OUT_MAX, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_word_default, NULL, NULL, NULL, NULL, NULL};
+EXPORT_SYMBOL(access_psu_p_out_max);
+
+PSU_SYSFS_ATTR_DATA access_psu_fan1_speed_rpm = {PSU_FAN1_SPEED, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_word_default, NULL, NULL, NULL, NULL, NULL};
 EXPORT_SYMBOL(access_psu_fan1_speed_rpm);
 
-PSU_SYSFS_ATTR_DATA access_psu_temp1_input = {PSU_TEMP1_INPUT, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_temp1_input_default, NULL, NULL, NULL, NULL, NULL};
+PSU_SYSFS_ATTR_DATA access_psu_temp1_input = {PSU_TEMP1_INPUT, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_word_default, NULL, NULL, NULL, NULL, NULL};
 EXPORT_SYMBOL(access_psu_temp1_input);
 
-PSU_SYSFS_ATTR_DATA access_psu_v_in = {PSU_V_IN, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_v_in_default, NULL, NULL, NULL, NULL, NULL};
+PSU_SYSFS_ATTR_DATA access_psu_temp1_high_threshold = {PSU_TEMP1_HIGH_THRESHOLD, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_word_default, NULL, NULL, NULL, NULL, NULL};
+EXPORT_SYMBOL(access_psu_temp1_high_threshold);
+
+PSU_SYSFS_ATTR_DATA access_psu_v_in = {PSU_V_IN, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_word_default, NULL, NULL, NULL, NULL, NULL};
 EXPORT_SYMBOL(access_psu_v_in);
 
-PSU_SYSFS_ATTR_DATA access_psu_i_in = {PSU_I_IN, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_i_in_default, NULL, NULL, NULL, NULL, NULL};
+PSU_SYSFS_ATTR_DATA access_psu_i_in = {PSU_I_IN, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_word_default, NULL, NULL, NULL, NULL, NULL};
 EXPORT_SYMBOL(access_psu_i_in);
 
+PSU_SYSFS_ATTR_DATA access_psu_p_in = {PSU_P_IN, S_IRUGO, psu_show_default, NULL, sonic_i2c_get_psu_word_default, NULL, NULL, NULL, NULL, NULL};
+EXPORT_SYMBOL(access_psu_p_in);
 
 PSU_SYSFS_ATTR_DATA_ENTRY psu_sysfs_attr_data_tbl[]=
 {
@@ -102,12 +116,17 @@ PSU_SYSFS_ATTR_DATA_ENTRY psu_sysfs_attr_data_tbl[]=
 	{ "psu_serial_num" , &access_psu_serial_num},
 	{ "psu_fan_dir" , &access_psu_fan_dir},
 	{ "psu_v_out" , &access_psu_v_out},
+	{ "psu_v_out_min" , &access_psu_v_out_min},
+	{ "psu_v_out_max" , &access_psu_v_out_max},
 	{ "psu_i_out" , &access_psu_i_out},
 	{ "psu_p_out" , &access_psu_p_out},
+	{ "psu_p_out_max" , &access_psu_p_out_max},
 	{ "psu_fan1_speed_rpm" , &access_psu_fan1_speed_rpm},
 	{ "psu_temp1_input" , &access_psu_temp1_input},
-    { "psu_v_in" , &access_psu_v_in},
-    { "psu_i_in" , &access_psu_i_in}
+	{ "psu_temp1_high_threshold" , &access_psu_temp1_high_threshold},
+	{ "psu_v_in" , &access_psu_v_in},
+	{ "psu_i_in" , &access_psu_i_in},
+	{ "psu_p_in" , &access_psu_p_in}
 };
 
 void *get_psu_access_data(char *name)
@@ -232,7 +251,7 @@ static int psu_probe(struct i2c_client *client,
 
     dev_info(&client->dev, "%s: psu '%s'\n",
          dev_name(data->hwmon_dev), client->name);
-    
+
 	/* Add a support for post probe function */
     if (pddf_psu_ops.post_probe)
     {
@@ -293,7 +312,7 @@ static int psu_remove(struct i2c_client *client)
 		printk(KERN_DEBUG "%s: Freeing platform data\n", __FUNCTION__);
 		kfree(platdata);
 	}
-    
+
 	if (pddf_psu_ops.post_remove)
     {
         ret = (pddf_psu_ops.post_remove)(client);

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_psu.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_psu.py
@@ -11,9 +11,17 @@
 # - psu_serial_num
 # - psu_fan_dir
 # - psu_v_out
+# - psu_v_out_min
+# - psu_v_out_max
 # - psu_i_out
 # - psu_p_out
+# - psu_p_out_max
 # - psu_fan1_speed_rpm
+# - psu_temp1_input
+# - psu_temp1_high_threshold
+# - psu_v_in
+# - psu_i_in
+# - psu_p_in
 #############################################################################
 
 
@@ -129,6 +137,10 @@ class PddfPsu(PsuBase):
 
         serial = output['status']
 
+        # strip_non_ascii
+        stripped = (c for c in serial if 0 < ord(c) < 127)
+        serial = ''.join(stripped)
+
         return serial.rstrip('\n')
 
     def get_status(self):
@@ -167,6 +179,10 @@ class PddfPsu(PsuBase):
             return None
 
         mfr = output['status']
+
+        # strip_non_ascii
+        stripped = (c for c in mfr if 0 < ord(c) < 127)
+        mfr = ''.join(stripped)
 
         return mfr.rstrip('\n')
 
@@ -318,6 +334,116 @@ class PddfPsu(PsuBase):
 
         # current in mA
         return float(i_in)/1000
+
+    def get_input_power(self):
+        """
+        Retrieves current energy supplied to the PSU
+        Returns:
+            A float number, the power in watts, e.g. 302.6
+        """
+        device = "PSU{}".format(self.psu_index)
+        output = self.pddf_obj.get_attr_name_output(device, "psu_p_in")
+        if not output:
+            return 0.0
+
+        p_in = output['status']
+
+        # power is returned in micro watts
+        return float(p_in)/1000000
+
+    def get_temperature_high_threshold(self):
+        """
+        Retrieves the high threshold temperature of PSU
+        Returns:
+            A float number, the high threshold temperature of PSU in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        device = "PSU{}".format(self.psu_index)
+        output = self.pddf_obj.get_attr_name_output(device, "psu_temp1_high_threshold")
+        if not output:
+            return 0.0
+
+        temp_high_thresh = output['status']
+        return float(temp_high_thresh)/1000
+
+    def get_voltage_high_threshold(self):
+        """
+        Retrieves the high threshold PSU voltage output
+        Returns:
+            A float number, the high threshold output voltage in volts,
+            e.g. 12.1
+        """
+        device = "PSU{}".format(self.psu_index)
+        output = self.pddf_obj.get_attr_name_output(device, "psu_v_out_max")
+        if not output:
+            return 0.0
+
+        v_out_max = output['status']
+        return float(v_out_max)/1000
+
+    def get_voltage_low_threshold(self):
+        """
+        Retrieves the low threshold PSU voltage output
+        Returns:
+            A float number, the low threshold output voltage in volts,
+            e.g. 12.1
+        """
+        device = "PSU{}".format(self.psu_index)
+        output = self.pddf_obj.get_attr_name_output(device, "psu_v_out_min")
+        if not output:
+            return 0.0
+
+        v_out_min = output['status']
+        return float(v_out_min)/1000
+
+    def get_maximum_supplied_power(self):
+        """
+        Retrieves the maximum supplied power by PSU
+        Returns:
+            A float number, the maximum power output in Watts.
+            e.g. 1200.1
+        """
+        device = "PSU{}".format(self.psu_index)
+        output = self.pddf_obj.get_attr_name_output(device, "psu_p_out_max")
+        if not output:
+            return 0.0
+
+        p_out_max = output['status']
+        # max power is in milliwatts
+        return float(p_out_max)/1000
+
+    def get_temperature(self):
+        """
+        Retrieves current temperature reading from PSU
+        Returns:
+            A float number of current temperature in Celsius up to nearest thousandth
+            of one degree Celsius, e.g. 30.125
+        """
+        device = "PSU{}".format(self.psu_index)
+        output = self.pddf_obj.get_attr_name_output(device, "psu_temp1_input")
+        if not output:
+            return 0.0
+
+        temperature = output['status']
+
+        return float(temperature)/1000
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device.
+        Returns:
+            integer: The 1-based relative physical position in parent
+            device or -1 if cannot determine the position
+        """
+        return self.psu_index
+
+    def is_replaceable(self):
+        """
+        Indicate whether PSU is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return True
 
     def dump_sysfs(self):
         return self.pddf_obj.cli_dump_dsysfs('psu')

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_psu.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_psu.py
@@ -412,22 +412,6 @@ class PddfPsu(PsuBase):
         # max power is in milliwatts
         return float(p_out_max)/1000
 
-    def get_temperature(self):
-        """
-        Retrieves current temperature reading from PSU
-        Returns:
-            A float number of current temperature in Celsius up to nearest thousandth
-            of one degree Celsius, e.g. 30.125
-        """
-        device = "PSU{}".format(self.psu_index)
-        output = self.pddf_obj.get_attr_name_output(device, "psu_temp1_input")
-        if not output:
-            return 0.0
-
-        temperature = output['status']
-
-        return float(temperature)/1000
-
     def get_position_in_parent(self):
         """
         Retrieves 1-based relative physical position in parent device.

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
@@ -40,6 +40,7 @@ class PddfSfp(SfpOptoeBase):
             print("Invalid port index %d" % index)
             return
 
+	# 1-based port index
         self.port_index = index+1
         self.device = 'PORT{}'.format(self.port_index)
         self.sfp_type = self.pddf_obj.get_device_type(self.device)
@@ -347,6 +348,23 @@ class PddfSfp(SfpOptoeBase):
                         self.set_power_override(True, False)
 
         return status
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device.
+        Returns:
+            integer: The 1-based relative physical position in parent
+            device or -1 if cannot determine the position
+        """
+        return self.port_index
+
+    def is_replaceable(self):
+        """
+        Indicate whether the SFP is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return True
 
     def dump_sysfs(self):
         return self.pddf_obj.cli_dump_dsysfs('xcvr')

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
@@ -406,19 +406,25 @@ class PddfApi():
 
         for attr in attr_list:
             if attr_name == attr['attr_name'] or attr_name == 'all':
-                path = self.show_device_sysfs(dev, ops)+"/%d-00%x/" % (int(dev['i2c']['topo_info']['parent_bus'], 0),
-                                                                       int(dev['i2c']['topo_info']['dev_addr'], 0))
                 if 'drv_attr_name' in attr.keys():
                     real_name = attr['drv_attr_name']
                 else:
                     real_name = attr['attr_name']
 
-                if (os.path.exists(path)):
-                    full_path = glob.glob(path + 'hwmon/hwmon*/' + real_name)[0]
-                    dsysfs_path = full_path
-                    if dsysfs_path not in self.data_sysfs_obj[KEY]:
-                        self.data_sysfs_obj[KEY].append(dsysfs_path)
-                    ret.append(full_path)
+                if 'topo_info' in dev['i2c']:
+                    path = self.show_device_sysfs(dev, ops)+"/%d-00%x/" % (int(dev['i2c']['topo_info']['parent_bus'], 0),
+                            int(dev['i2c']['topo_info']['dev_addr'], 0))
+                    if (os.path.exists(path)):
+                        full_path = glob.glob(path + 'hwmon/hwmon*/' + real_name)[0]
+                elif 'path_info' in dev['i2c']:
+                    path = dev['i2c']['path_info']['sysfs_base_path']
+                    if (os.path.exists(path)):
+                        full_path = "/".join([path, real_name])
+
+                dsysfs_path = full_path
+                if dsysfs_path not in self.data_sysfs_obj[KEY]:
+                    self.data_sysfs_obj[KEY].append(dsysfs_path)
+                ret.append(full_path)
         return ret
 
     def show_attr_sysstatus_device(self, dev, ops):


### PR DESCRIPTION
1) Consolidating multiple read functions in a PSU driver on the basis of byte, word or block read, 
2) Enhancing PDDF parsing script support for CPU and PCH temperature reading, 
3) Adding missing methods in PDDF common APIs

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- PSU driver changes are to optimize the code and increase the code coverage
- PDDF parser script enhancements to accommodate the CPU and PCH temp reading using hwmon device path
- Some of the new APIs were missing from the PDDF common platform classes
 
#### How I did it
Added code changes and verified them on AS7816 adn AS7726 platforms.

#### How to verify it
*AS7816*
```
root@sonic:/home/admin# show platform summary
Platform: x86_64-accton_as7816_64x-r0
HwSKU: Accton-AS7816-64X
ASIC: broadcom
ASIC Count: 1
Serial Number: AAA1903AAEV
Model Number: FP3AT7664000A
Hardware Revision: N/A
root@sonic:/home/admin#
root@sonic:/home/admin# show platform psustatus
PSU    Model     Serial              HW Rev      Voltage (V)    Current (A)    Power (W)  Status    LED
-----  --------  ------------------  --------  -------------  -------------  -----------  --------  -----
PSU 1                                N/A                0.00           0.00         0.00  NOT OK    off
PSU 2  YM-2851F  SA070U461830013847  N/A               12.03          20.88       251.00  OK        green
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# show platform fan
  Drawer    LED         FAN    Speed    Direction    Presence    Status          Timestamp
--------  -----  ----------  -------  -----------  ----------  --------  -----------------
Fantray1  green  Fantray1_1      52%      EXHAUST     Present        OK  20221129 09:30:17
Fantray1  green  Fantray1_2      52%      EXHAUST     Present        OK  20221129 09:30:17
Fantray2  green  Fantray2_1      52%      EXHAUST     Present        OK  20221129 09:30:17
Fantray2  green  Fantray2_2      52%      EXHAUST     Present        OK  20221129 09:30:17
Fantray3  green  Fantray3_1      52%      EXHAUST     Present        OK  20221129 09:30:17
Fantray3  green  Fantray3_2      52%      EXHAUST     Present        OK  20221129 09:30:17
Fantray4  green  Fantray4_1      52%      EXHAUST     Present        OK  20221129 09:30:17
Fantray4  green  Fantray4_2      52%      EXHAUST     Present        OK  20221129 09:30:17
     N/A    off   PSU1_FAN1       0%      exhaust     Present    Not OK  20221129 09:30:18
     N/A  green   PSU2_FAN1      78%      exhaust     Present        OK  20221129 09:30:18
root@sonic:/home/admin#
root@sonic:/home/admin# show platform temperature
                   Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
-------------------------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
      CpuBoard_temp(0x4B)           26.5       80.0       N/A             N/A            N/A      False  20221129 09:30:18
          FB_1_temp(0x4D)           28         80.0       N/A             N/A            N/A      False  20221129 09:30:18
          FB_2_temp(0x4E)           28         80.0       N/A             N/A            N/A      False  20221129 09:30:18
        MB_MAC_temp(0x48)           31.5       80.0       N/A             N/A            N/A      False  20221129 09:30:18
 MB_RearCenter_temp(0x49)           35         80.0       N/A             N/A            N/A      False  20221129 09:30:18
MB_RightCenter_temp(0x4A)           26.5       80.0       N/A             N/A            N/A      False  20221129 09:30:18
               PSU1_TEMP1            0          N/A       N/A             N/A            N/A      False  20221129 09:30:19
               PSU2_TEMP1           25          N/A       N/A             N/A            N/A      False  20221129 09:30:19
root@sonic:/home/admin#
root@sonic:/home/admin# pddf_psuutil mfrinfo
PSU    Status    Manufacturer ID    Model     Serial              Fan Airflow Direction
-----  --------  -----------------  --------  ------------------  -----------------------
PSU1   NOT OK                                                     exhaust
PSU2   OK        3Y POWER           YM-2851F  SA070U461830013847  exhaust
root@sonic:/home/admin# pddf_psuutil seninfo
PSU    Status      Output Voltage (V)    Output Current (A)    Output Power (W)    Temperature1 (C)    Fan1 Speed (RPM)
-----  --------  --------------------  --------------------  ------------------  ------------------  ------------------
PSU1   NOT OK                    0.00                  0.00                0.00                0.00                   0
PSU2   OK                       12.05                 20.97              253.00               25.00               14096
root@sonic:/home/admin# pddf_fanutil getspeed
FAN           SPEED (RPM)
----------  -------------
Fantray1_1           9897
Fantray1_2           7961
Fantray2_1           9897
Fantray2_2           8138
Fantray3_1           9897
Fantray3_2           8138
Fantray4_1           9897
Fantray4_2           7961
root@sonic:/home/admin# pddf_fanutil direction
FAN         Direction
----------  -----------
Fantray1_1  Exhaust
Fantray1_2  Exhaust
Fantray2_1  Exhaust
Fantray2_2  Exhaust
Fantray3_1  Exhaust
Fantray3_2  Exhaust
Fantray4_1  Exhaust
Fantray4_2  Exhaust
root@sonic:/home/admin# pddf_thermalutil gettemp
Temp Sensor                Label           Value
-------------------------  --------------  -------
FB_1_temp(0x4D)            lm75-i2c-17-4d  temp1	 +28.0 C (high = +80.0 C)
FB_2_temp(0x4E)            lm75-i2c-17-4e  temp1	 +28.0 C (high = +80.0 C)
MB_MAC_temp(0x48)          lm75-i2c-18-48  temp1	 +31.5 C (high = +80.0 C)
MB_RearCenter_temp(0x49)   lm75-i2c-18-49  temp1	 +34.5 C (high = +80.0 C)
MB_RightCenter_temp(0x4A)  lm75-i2c-18-4a  temp1	 +27.0 C (high = +80.0 C)
CpuBoard_temp(0x4B)        lm75-i2c-18-4b  temp1	 +26.5 C (high = +80.0 C)
root@sonic:/home/admin#
root@sonic:/home/admin# python3
Python 3.9.2 (default, Feb 28 2021, 17:03:44)
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sonic_platform
>>> ch = sonic_platform.platform.Platform().get_chassis()
>>> p1 = ch.get_psu(0)
>>> p2 = ch.get_psu(1)
>>> p2.get_position_in_parent()
2
>>> p1.get_position_in_parent()
1
>>> p1.is_replaceable()
True
>>> p2.is_replaceable()
True
>>>
root@sonic:/home/admin#
```




*AS7726*
```
root@sonic:/home/admin# show platform summary
Platform: x86_64-accton_as7726_32x-r0
HwSKU: Accton-AS7726-32X
ASIC: broadcom
ASIC Count: 1
Serial Number: 772632X1911067
Model Number: FP3ZZ7632074A
Hardware Revision: N/A
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# show platform psustatus
PSU    Model     Serial              HW Rev      Voltage (V)    Current (A)    Power (W)  Status    LED
-----  --------  ------------------  --------  -------------  -------------  -----------  --------  -----
PSU 1  N/A       N/A                 N/A                0.00           0.00         0.00  NOT OK    off
PSU 2  YM-2651Y  SA070V581905000496  N/A               12.16          11.00       133.00  OK        green
root@sonic:/home/admin# show platform fan
  Drawer    LED         FAN    Speed    Direction    Presence    Status          Timestamp
--------  -----  ----------  -------  -----------  ----------  --------  -----------------
Fantray1  green  Fantray1_1      38%      EXHAUST     Present        OK  20221129 09:31:05
Fantray1  green  Fantray1_2      38%      EXHAUST     Present        OK  20221129 09:31:05
Fantray2  green  Fantray2_1      38%      EXHAUST     Present        OK  20221129 09:31:05
Fantray2  green  Fantray2_2      38%      EXHAUST     Present        OK  20221129 09:31:05
Fantray3  green  Fantray3_1      38%      EXHAUST     Present        OK  20221129 09:31:05
Fantray3  green  Fantray3_2      38%      EXHAUST     Present        OK  20221129 09:31:05
Fantray4  green  Fantray4_1      38%      EXHAUST     Present        OK  20221129 09:31:05
Fantray4  green  Fantray4_2      38%      EXHAUST     Present        OK  20221129 09:31:05
Fantray5  green  Fantray5_1      38%      EXHAUST     Present        OK  20221129 09:31:05
Fantray5  green  Fantray5_2      38%      EXHAUST     Present        OK  20221129 09:31:05
Fantray6  green  Fantray6_1      38%      EXHAUST     Present        OK  20221129 09:31:05
Fantray6  green  Fantray6_2      38%      EXHAUST     Present        OK  20221129 09:31:05
     N/A    off   PSU1_FAN1       0%                  Present    Not OK  20221129 09:31:06
     N/A  green   PSU2_FAN1      23%      EXHAUST     Present        OK  20221129 09:31:06
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# show platform temperature
                  Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
------------------------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
           CB_temp(0x4B)           36.5       80.0       N/A             N/A            N/A      False  20221129 09:31:06
           FB_temp(0x4C)           34.5       80.0       N/A             N/A            N/A      False  20221129 09:31:06
  MB_FrontMAC_temp(0x49)           34         80.0       N/A             N/A            N/A      False  20221129 09:31:06
MB_LeftCenter_temp(0x4A)           34.5       80.0       N/A             N/A            N/A      False  20221129 09:31:06
   MB_RearMAC_temp(0x48)           36.5       80.0       N/A             N/A            N/A      False  20221129 09:31:06
              PSU1_TEMP1            0          N/A       N/A             N/A            N/A      False  20221129 09:31:07
              PSU2_TEMP1           40          N/A       N/A             N/A            N/A      False  20221129 09:31:07
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# pddf_psuutil mfrinfo
PSU    Status    Manufacturer ID    Model     Serial              Fan Airflow Direction
-----  --------  -----------------  --------  ------------------  -----------------------
PSU1   NOT OK                       N/A       N/A
PSU2   OK        3Y POWER           YM-2651Y  SA070V581905000496  EXHAUST
root@sonic:/home/admin#
root@sonic:/home/admin# pddf_psuutil seninfo
PSU    Status      Output Voltage (V)    Output Current (A)    Output Power (W)    Temperature1 (C)    Fan1 Speed (RPM)
-----  --------  --------------------  --------------------  ------------------  ------------------  ------------------
PSU1   NOT OK                    0.00                  0.00                0.00                0.00                   0
PSU2   OK                       12.14                 11.09              135.00               34.00               25792
root@sonic:/home/admin# pddf_thermalutil gettemp
Temp Sensor               Label           Value
------------------------  --------------  -------
FB_temp(0x4C)             lm75-i2c-54-4c  temp1	 +31.5 C (high = +80.0 C)
MB_RearMAC_temp(0x48)     lm75-i2c-55-48  temp1	 +36.0 C (high = +80.0 C)
MB_FrontMAC_temp(0x49)    lm75-i2c-55-49  temp1	 +34.0 C (high = +80.0 C)
MB_LeftCenter_temp(0x4A)  lm75-i2c-55-4a  temp1	 +34.5 C (high = +80.0 C)
CB_temp(0x4B)             lm75-i2c-55-4b  temp1	 +35.0 C (high = +80.0 C)
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# show environment
lm75-i2c-55-4a
Adapter: i2c-2-mux (chan_id 6)
MB_LeftCenter_temp:  +34.5 C  (high = +80.0 C, hyst = +75.0 C)

lm75-i2c-55-49
Adapter: i2c-2-mux (chan_id 6)
MB_FrontMAC_temp:  +34.0 C  (high = +80.0 C, hyst = +75.0 C)

fan_ctrl-i2c-54-66
Adapter: i2c-2-mux (chan_id 5)
Fantray1 Front: 10000 RPM
Fantray1 Rear:  8400 RPM
Fantray2 Front: 10000 RPM
Fantray2 Rear:  8400 RPM
Fantray3 Front: 10000 RPM
Fantray3 Rear:  8400 RPM
Fantray4 Front: 10000 RPM
Fantray4 Rear:  8400 RPM
Fantray5 Front: 10100 RPM
Fantray5 Rear:  8500 RPM
Fantray6 Front: 10100 RPM
Fantray6 Rear:  8600 RPM

lm75-i2c-55-4b
Adapter: i2c-2-mux (chan_id 6)
CB_temp:      +34.5 C  (high = +80.0 C, hyst = +75.0 C)

pch_haswell-virtual-0
Adapter: Virtual device
temp1:        +40.5 C

lm75-i2c-55-48
Adapter: i2c-2-mux (chan_id 6)
MB_RearMAC_temp:  +36.0 C  (high = +80.0 C, hyst = +75.0 C)

lm75-i2c-54-4c
Adapter: i2c-2-mux (chan_id 5)
FB_temp:      +31.0 C  (high = +80.0 C, hyst = +75.0 C)

psu_pmbus-i2c-50-5b
Adapter: i2c-2-mux (chan_id 1)
PSU 1 Voltage:       0.00 V
PSU 1 Fan:            0 RPM
PSU 1 Temperature:   +0.0 C
PSU 1 Power:         0.00 W
PSU 1 Current:       0.00 A

coretemp-isa-0000
Adapter: ISA adapter
Package id 0:  +45.0 C  (high = +82.0 C, crit = +104.0 C)
Core 0:        +45.0 C  (high = +82.0 C, crit = +104.0 C)
Core 1:        +45.0 C  (high = +82.0 C, crit = +104.0 C)
Core 2:        +45.0 C  (high = +82.0 C, crit = +104.0 C)
Core 3:        +45.0 C  (high = +82.0 C, crit = +104.0 C)

psu_pmbus-i2c-49-58
Adapter: i2c-2-mux (chan_id 0)
PSU 2 Voltage:      12.17 V
PSU 2 Fan:         25696 RPM
PSU 2 Temperature:  +34.0 C
PSU 2 Power:       134.00 W
PSU 2 Current:      11.09 A

root@sonic:/home/admin#
root@sonic:/home/admin#
```


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

