### PR TITLE
[202205] Cherry-pick sonic-host-services/pull/19 into 202205

### DIFF
--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -11,7 +11,7 @@ import signal
 import re
 import jinja2
 from sonic_py_common import device_info
-from swsscommon.swsscommon import ConfigDBConnector, DBConnector, Table
+from swsscommon.swsscommon import ConfigDBConnector, DBConnector, Table, SonicDBConfig
 
 # FILE
 PAM_AUTH_CONF = "/etc/pam.d/common-auth-sonic"
@@ -199,6 +199,21 @@ class FeatureHandler(object):
         self._cached_config = {}
         self.is_multi_npu = device_info.is_multi_npu()
         self._device_running_config = device_info.get_device_runtime_metadata()
+        self.ns_cfg_db = {}
+        self.ns_feature_state_tbl = {}
+
+        # Initlaize Global config that loads all database*.json
+        if self.is_multi_npu:
+            SonicDBConfig.initializeGlobalConfig()
+            namespaces = device_info.get_namespaces()
+            for ns in namespaces:
+                #Connect to ConfigDB in each namespace
+                self.ns_cfg_db[ns] = ConfigDBConnector(namespace=ns)
+                self.ns_cfg_db[ns].connect(wait_for_init=True, retry_on=True)
+
+                #Connect to stateDB in each namespace
+                db_conn = DBConnector(STATE_DB, 0, False, ns);
+                self.ns_feature_state_tbl[ns] = Table(db_conn, 'FEATURE')
 
     def handler(self, feature_name, op, feature_cfg):
         if not feature_cfg:
@@ -246,7 +261,6 @@ class FeatureHandler(object):
             device_config = {}
             device_config.update(self._device_config)
             device_config.update(self._device_running_config)
-
             feature = Feature(feature_name, feature_table[feature_name], device_config)
 
             self._cached_config.setdefault(feature_name, feature)
@@ -333,6 +347,10 @@ class FeatureHandler(object):
                         self.set_feature_state(feature, self.FEATURE_STATE_FAILED)
                         return
         self._config_db.mod_entry('FEATURE', feature_config.name, {'has_per_asic_scope': str(feature_config.has_per_asic_scope)})
+
+        # sync has_per_asic_scope to CONFIG_DB in namespaces in multi-asic platform
+        for ns, db in self.ns_cfg_db.items():
+            db.mod_entry('FEATURE', feature_config.name, {'has_per_asic_scope': str(feature_config.has_per_asic_scope)})
     
     def update_systemd_config(self, feature_config):
         """Updates `Restart=` field in feature's systemd configuration file
@@ -459,9 +477,16 @@ class FeatureHandler(object):
     def resync_feature_state(self, feature):
         self._config_db.mod_entry('FEATURE', feature.name, {'state': feature.state})
 
+        # resync the feature state to CONFIG_DB in namespaces in multi-asic platform
+        for ns, db in self.ns_cfg_db.items():
+            db.mod_entry('FEATURE', feature.name, {'state': feature.state})
+
     def set_feature_state(self, feature, state):
         self._feature_state_table.set(feature.name, [('state', state)])
 
+        # Update the feature state to STATE_DB in namespaces in multi-asic platform
+        for ns, tbl in self.ns_feature_state_tbl.items():
+            tbl.set(feature.name, [('state', state)])
 
 class Iptables(object):
     def __init__(self):

--- a/src/sonic-host-services/tests/common/mock_configdb.py
+++ b/src/sonic-host-services/tests/common/mock_configdb.py
@@ -57,5 +57,5 @@ class MockConfigDb(object):
 
 
 class MockDBConnector():
-    def __init__(self, db, val):
+    def __init__(self, db, val, tcpFlag=False, name=None):
         pass

--- a/src/sonic-host-services/tests/hostcfgd/test_vectors.py
+++ b/src/sonic-host-services/tests/hostcfgd/test_vectors.py
@@ -1030,6 +1030,141 @@ HOSTCFGD_TEST_VECTOR = [
             },
         },
     ],
+    [
+        "Chassis_LineCard_VOQ_multinpu",
+        {
+            "num_npu": 2,
+            "device_runtime_metadata": {
+                "DEVICE_RUNTIME_METADATA": {
+                    "CHASSIS_METADATA": {
+                        "module_type": "linecard",
+                        "chassis_type": "voq"
+                        },
+                    "ETHERNET_PORTS_PRESENT":True,
+                    "MACSEC_SUPPORTED":True
+                    }
+                },
+            "config_db": {
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "type": "SpineRouter",
+                    }
+                },
+                "KDUMP": {
+                    "config": {
+                        "enabled": "false",
+                        "num_dumps": "3",
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                    }
+                },
+                "FEATURE": {
+                    "bgp": {
+                        "state": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}",
+                        "has_timer": "False",
+                        "has_global_scope": "False",
+                        "has_per_asic_scope": "True",
+                        "auto_restart": "enabled",
+                        "high_mem_alert": "disabled"
+                    },
+                    "teamd": {
+                        "state": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] %}disabled{% else %}enabled{% endif %}",
+                        "has_timer": "False",
+                        "has_global_scope": "False",
+                        "has_per_asic_scope": "True",
+                        "auto_restart": "enabled",
+                        "high_mem_alert": "disabled"
+                    },
+                    "lldp": {
+                        "state": "enabled",
+                        "has_timer": "False",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}False{% else %}True{% endif %}",
+                        "auto_restart": "enabled",
+                        "high_mem_alert": "disabled"
+                    },
+                    "macsec": {
+                        "state": "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and DEVICE_RUNTIME_METADATA['MACSEC_SUPPORTED'] %}enabled{% else %}disabled{% endif %}",
+                        "has_timer": "False",
+                        "has_global_scope": "False",
+                        "has_per_asic_scope": "True",
+                        "auto_restart": "enabled",
+                        "high_mem_alert": "disabled"
+                    }
+                },
+            },
+            "expected_config_db": {
+                "FEATURE": {
+                    "bgp": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "False",
+                        "has_per_asic_scope": "True",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "state": "enabled"
+                    },
+                    "teamd": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "False",
+                        "has_per_asic_scope": "True",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "state": "enabled"
+                    },
+                    "lldp": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "state": "enabled"
+                    },
+                    "macsec": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "False",
+                        "has_per_asic_scope": "True",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "state": "enabled"
+                    }
+                },
+            },
+            "enable_feature_subprocess_calls": [
+                call('sudo systemctl unmask bgp@0.service', shell=True),
+                call('sudo systemctl enable bgp@0.service', shell=True),
+                call('sudo systemctl start bgp@0.service', shell=True),
+                call('sudo systemctl unmask bgp@1.service', shell=True),
+                call('sudo systemctl enable bgp@1.service', shell=True),
+                call('sudo systemctl start bgp@1.service', shell=True),
+                call('sudo systemctl unmask teamd@0.service', shell=True),
+                call('sudo systemctl enable teamd@0.service', shell=True),
+                call('sudo systemctl start teamd@0.service', shell=True),
+                call('sudo systemctl unmask teamd@1.service', shell=True),
+                call('sudo systemctl enable teamd@1.service', shell=True),
+                call('sudo systemctl start teamd@1.service', shell=True),
+                call('sudo systemctl unmask lldp.service', shell=True),
+                call('sudo systemctl enable lldp.service', shell=True),
+                call('sudo systemctl start lldp.service', shell=True),
+                call('sudo systemctl unmask lldp@0.service', shell=True),
+                call('sudo systemctl enable lldp@0.service', shell=True),
+                call('sudo systemctl start lldp@0.service', shell=True),
+                call('sudo systemctl unmask lldp@1.service', shell=True),
+                call('sudo systemctl enable lldp@1.service', shell=True),
+                call('sudo systemctl start lldp@1.service', shell=True),
+                call('sudo systemctl unmask macsec@0.service', shell=True),
+                call('sudo systemctl enable macsec@0.service', shell=True),
+                call('sudo systemctl start macsec@0.service', shell=True),
+                call('sudo systemctl unmask macsec@1.service', shell=True),
+                call('sudo systemctl enable macsec@1.service', shell=True),
+                call('sudo systemctl start macsec@1.service', shell=True)
+            ],
+            "daemon_reload_subprocess_call": [
+                call("sudo systemctl daemon-reload", shell=True),
+            ],
+            "popen_attributes": {
+                'communicate.return_value': ('output', 'error')
+            },
+        },
+    ]
  
 ]
 


### PR DESCRIPTION
#### Why I did it
Cherry-pick [sonic-host-services/pull/19](https://github.com/sonic-net/sonic-host-services/pull/19) into 202205

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

