### PR TITLE
[TestbedV2][202205] Support passing the instance numbers of a testplan.

### DIFF
--- a/.azure-pipelines/run-test-scheduler-template.yml
+++ b/.azure-pipelines/run-test-scheduler-template.yml
@@ -11,12 +11,12 @@ parameters:
   default: 36000
 
 - name: MIN_WORKER
-  type: number
+  type: string
   default: 1
 
 - name: MAX_WORKER
-  type: number
-  default: 2
+  type: string
+  default: 1
 
 - name: TEST_SET
   type: string

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,8 +176,8 @@ stages:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:
         TOPOLOGY: t0
-        MIN_WORKER: 2
-        MAX_WORKER: 3
+        MIN_WORKER: $(T0_INSTANCE_NUM)
+        MAX_WORKER: $(T0_INSTANCE_NUM)
         MGMT_BRANCH: 202205
 
   - job: t0_2vlans_testbedv2
@@ -192,7 +192,8 @@ stages:
       parameters:
         TOPOLOGY: t0
         TEST_SET: t0-2vlans
-        MAX_WORKER: 1
+        MIN_WORKER: $(T0_2VLANS_INSTANCE_NUM)
+        MAX_WORKER: $(T0_2VLANS_INSTANCE_NUM)
         DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
         MGMT_BRANCH: 202205
 
@@ -252,8 +253,8 @@ stages:
     - template: .azure-pipelines/run-test-scheduler-template.yml
       parameters:
         TOPOLOGY: t1-lag
-        MIN_WORKER: 2
-        MAX_WORKER: 3
+        MIN_WORKER: $(T1_LAG_INSTANCE_NUM)
+        MAX_WORKER: $(T1_LAG_INSTANCE_NUM)
         MGMT_BRANCH: 202205
 
   - job:
@@ -309,8 +310,8 @@ stages:
       - template: .azure-pipelines/run-test-scheduler-template.yml
         parameters:
           TOPOLOGY: t0-64-32
-          MIN_WORKER: 1
-          MAX_WORKER: 2
+          MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
+          MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
           TEST_SET: t0-sonic
           COMMON_EXTRA_PARAMS: "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"
           VM_TYPE: vsonic
@@ -328,7 +329,7 @@ stages:
       - template: .azure-pipelines/run-test-scheduler-template.yml
         parameters:
           TOPOLOGY: dualtor
-          MIN_WORKER: 1
-          MAX_WORKER: 1
+          MIN_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
+          MAX_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
           COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
           MGMT_BRANCH: 202205


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Previously, we hard code the min and max numbers of instance in a plan. In this pr, we support passing the instance numbers of a testplan.

#### Why I did it
Previously, we hard code the min and max numbers of instance in a plan. In this pr, we support passing the instance numbers of a testplan.

#### How I did it
Use a variable to set the instance number.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

