### PR TITLE
Create a clean_docker_images Makefile profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,3 +89,6 @@ clean reset showtag sonic-slave-build sonic-slave-bash :
 # Freeze the versions, see more detail options: scripts/versions_manager.py freeze -h
 freeze:
 	@scripts/versions_manager.py freeze $(FREEZE_VERSION_OPTIONS)
+
+clean_docker_images:
+	./clean_docker_images.sh

--- a/clean_docker_images.sh
+++ b/clean_docker_images.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+DOCKER_CMD=docker
+if [ ! `which $DOCKER_CMD` ]
+then  echo "no docker command available" >&2
+    exit 1
+fi
+#if "docker ps" cannot be run without error, prepend sudo
+if ( ! $DOCKER_CMD ps >/dev/null 2>&1 );then
+    echo "docker command only usable as root, using sudo" >&2
+    DOCKER_CMD="sudo docker"
+fi
+
+
+IMAGES_LIST=$($DOCKER_CMD image ls "sonic*" | sed 's/  */\t/g' | cut -f3 | tail -n +2)
+
+if [ -z $IMAGES_LIST ]; then
+    echo "No docker image to delete"
+    exit 0
+fi
+
+echo -n "Run '$DOCKER_CMD image rm -f $(echo $IMAGES_LIST) ' (y/n)?"
+initial_stty_cfg=$(stty -g)
+stty raw -echo
+answer=$( while ! head -c 1 | grep -i '[yn]' ;do true ;done )
+stty $initial_stty_cfg
+if echo "$answer" | grep -iq "^y" ;then
+    $DOCKER_CMD image rm -f $(echo $IMAGES_LIST)
+else
+    echo "Nothing done"
+    exit 0
+fi
+echo -n "Run '$DOCKER_CMD image prune -af' (y/n)?"
+initial_stty_cfg=$(stty -g)
+stty raw -echo
+answer=$( while ! head -c 1 | grep -i '[yn]' ;do true ;done )
+stty $initial_stty_cfg
+if echo "$answer" | grep -iq "^y" ;then
+    $DOCKER_CMD image prune -af
+fi


### PR DESCRIPTION
SONiC image build process generates several docker images. They consume a lot of space disk that can be reclaimed once the SONiC image has been built.
Moreover, many of these docker images will not be reused at next build.

- create a shell script to detect docker images generated during build (with a blob pattern) to delete them and reclaim space disk
- declare in the Make a profile "clean_image" that points to this script

Signed-off-by: Guillaume Lambert <guillaume.lambert@orange.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

