### PR TITLE
The user framework module complies with s3ip sysfs specification

### DIFF
--- a/platform/s3ip-sysfs/scripts/s3ip-sysfs.service
+++ b/platform/s3ip-sysfs/scripts/s3ip-sysfs.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=s3ip sysfs service
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/usr/bin/s3ip_sysfs_tool.sh start
+ExecStop=/usr/bin/s3ip_sysfs_tool.sh stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=default.target
+

--- a/platform/s3ip-sysfs/scripts/s3ip_load.py
+++ b/platform/s3ip-sysfs/scripts/s3ip_load.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+# -*- coding: UTF-8 -*- 
+import json
+import os
+
+if __name__ == '__main__':
+    os.system("sudo rm -rf /sys_switch;sudo mkdir -p -m 777 /sys_switch")
+    
+    with open('/etc/s3ip/s3ip_sysfs_conf.json', 'r') as jsonfile:
+        json_string = json.load(jsonfile)
+        for s3ip_sysfs_path in json_string['s3ip_syfs_paths']:
+            #print('path:' + s3ip_sysfs_path['path'])
+            #print('type:' + s3ip_sysfs_path['type'])
+            #print('value:' + s3ip_sysfs_path['value'])
+            
+            if s3ip_sysfs_path['type'] == "string" :
+                (path, file) = os.path.split(s3ip_sysfs_path['path'])
+                #创建文件
+                command = "sudo mkdir -p -m 777 " + path
+                #print(command)
+                os.system(command)
+                command = "sudo echo " +  "\"" + s3ip_sysfs_path['value'] + "\"" + " > " + s3ip_sysfs_path['path']
+                #print(command)
+                os.system(command)
+            elif s3ip_sysfs_path['type'] == "path" :
+                command = "sudo ln -s " + s3ip_sysfs_path['value'] + " " + s3ip_sysfs_path['path']
+                #print(command)
+                os.system(command)
+            else:
+                print('error type:' + s3ip_sysfs_path['type'])
+        os.system("tree -l /sys_switch")
+            

--- a/platform/s3ip-sysfs/scripts/s3ip_sysfs_conf.json
+++ b/platform/s3ip-sysfs/scripts/s3ip_sysfs_conf.json
@@ -4,13 +4,13 @@
       "path": "/sys_switch/temp_sensor",
       "type" : "path",
       "value" : "/sys/s3ip/temp_sensor",
-      "description": "温度传感器信息"
+      "description": "temperature information"
     },
     {
       "path": "/sys_switch/vol_sensor",
       "type" : "path",
       "value" : "/sys/s3ip/vol_sensor",
-      "description": "电压传感器信息"
+      "description": "voltage sensor information"
     },
     {
       "path": "/sys_switch/syseeprom",
@@ -22,55 +22,55 @@
       "path": "/sys_switch/fan",
       "type" : "path",
       "value" : "/sys/s3ip/fan",
-      "description": "风扇信息"
+      "description": "fan information"
     },
     {
       "path": "/sys_switch/psu",
       "type" : "path",
       "value" : "/sys/s3ip/psu",
-      "description": "电源信息"
+      "description": "PSU information"
     },
     {
       "path": "/sys_switch/transceiver",
       "type" : "path",
       "value" : "/sys/s3ip/transceiver",
-      "description": "光模块信息"
+      "description": "transceiver information"
     },
     {
       "path": "/sys_switch/sysled",
       "type" : "path",
       "value" : "/sys/s3ip/sysled",
-      "description": "指示灯信息"
+      "description": "SYS LED information"
     },
     {
       "path": "/sys_switch/fpga",
       "type" : "path",
       "value" : "/sys/s3ip/fpga",
-      "description": "FPGA信息"
+      "description": "FPGA information"
     },
     {
       "path": "/sys_switch/cpld",
       "type" : "path",
       "value" : "/sys/s3ip/cpld",
-      "description": "CPLD信息"
+      "description": "CPLD information"
     },
     {
       "path": "/sys_switch/watchdog",
       "type" : "path",
       "value" : "/sys/s3ip/watchdog",
-      "description": "看门狗信息"
+      "description": "watchdog information"
     },
     {
       "path": "/sys_switch/curr_sensor",
       "type" : "path",
       "value" : "/sys/s3ip/curr_sensor",
-      "description": "电流传感器信息"
+      "description": "current sensor information"
     },
     {
       "path": "/sys_switch/slot",
       "type" : "path",
       "value" : "/sys/s3ip/slot",
-      "description": "子卡信息"
+      "description": "slot information"
     }
   ]
 }

--- a/platform/s3ip-sysfs/scripts/s3ip_sysfs_conf.json
+++ b/platform/s3ip-sysfs/scripts/s3ip_sysfs_conf.json
@@ -1,0 +1,76 @@
+{
+  "s3ip_syfs_paths": [
+    {
+      "path": "/sys_switch/temp_sensor",
+      "type" : "path",
+      "value" : "/sys/s3ip/temp_sensor",
+      "description": "温度传感器信息"
+    },
+    {
+      "path": "/sys_switch/vol_sensor",
+      "type" : "path",
+      "value" : "/sys/s3ip/vol_sensor",
+      "description": "电压传感器信息"
+    },
+    {
+      "path": "/sys_switch/syseeprom",
+      "type" : "path",
+      "value" : "/sys/s3ip/syseeprom",
+      "description": "ONIE EEPROM"
+    },
+    {
+      "path": "/sys_switch/fan",
+      "type" : "path",
+      "value" : "/sys/s3ip/fan",
+      "description": "风扇信息"
+    },
+    {
+      "path": "/sys_switch/psu",
+      "type" : "path",
+      "value" : "/sys/s3ip/psu",
+      "description": "电源信息"
+    },
+    {
+      "path": "/sys_switch/transceiver",
+      "type" : "path",
+      "value" : "/sys/s3ip/transceiver",
+      "description": "光模块信息"
+    },
+    {
+      "path": "/sys_switch/sysled",
+      "type" : "path",
+      "value" : "/sys/s3ip/sysled",
+      "description": "指示灯信息"
+    },
+    {
+      "path": "/sys_switch/fpga",
+      "type" : "path",
+      "value" : "/sys/s3ip/fpga",
+      "description": "FPGA信息"
+    },
+    {
+      "path": "/sys_switch/cpld",
+      "type" : "path",
+      "value" : "/sys/s3ip/cpld",
+      "description": "CPLD信息"
+    },
+    {
+      "path": "/sys_switch/watchdog",
+      "type" : "path",
+      "value" : "/sys/s3ip/watchdog",
+      "description": "看门狗信息"
+    },
+    {
+      "path": "/sys_switch/curr_sensor",
+      "type" : "path",
+      "value" : "/sys/s3ip/curr_sensor",
+      "description": "电流传感器信息"
+    },
+    {
+      "path": "/sys_switch/slot",
+      "type" : "path",
+      "value" : "/sys/s3ip/slot",
+      "description": "子卡信息"
+    }
+  ]
+}

--- a/platform/s3ip-sysfs/scripts/s3ip_sysfs_tool.sh
+++ b/platform/s3ip-sysfs/scripts/s3ip_sysfs_tool.sh
@@ -1,0 +1,59 @@
+#! /bin/bash
+
+s3ip_start(){
+        sudo insmod /lib/modules/s3ip/s3ip_sysfs.ko
+        sudo insmod /lib/modules/s3ip/syseeprom_device_driver.ko
+        sudo insmod /lib/modules/s3ip/fan_device_driver.ko
+        sudo insmod /lib/modules/s3ip/cpld_device_driver.ko
+        sudo insmod /lib/modules/s3ip/sysled_device_driver.ko
+        sudo insmod /lib/modules/s3ip/psu_device_driver.ko
+        sudo insmod /lib/modules/s3ip/transceiver_device_driver.ko
+        sudo insmod /lib/modules/s3ip/temp_sensor_device_driver.ko
+        sudo insmod /lib/modules/s3ip/vol_sensor_device_driver.ko
+        sudo insmod /lib/modules/s3ip/fpga_device_driver.ko
+        sudo insmod /lib/modules/s3ip/watchdog_device_driver.ko
+        sudo insmod /lib/modules/s3ip/curr_sensor_device_driver.ko
+        sudo insmod /lib/modules/s3ip/slot_device_driver.ko
+        sudo rm -rf /sys_switch
+        sudo /usr/bin/s3ip_load.py
+        echo "s3ip service start"
+}
+s3ip_stop(){
+        sudo rmmod slot_device_driver
+        sudo rmmod curr_sensor_device_driver
+        sudo rmmod watchdog_device_driver
+        sudo rmmod fpga_device_driver
+        sudo rmmod vol_sensor_device_driver
+        sudo rmmod temp_sensor_device_driver
+        sudo rmmod transceiver_device_driver
+        sudo rmmod psu_device_driver
+        sudo rmmod sysled_device_driver
+        sudo rmmod cpld_device_driver
+        sudo rmmod fan_device_driver
+        sudo rmmod syseeprom_device_driver
+        sudo rmmod s3ip_sysfs
+        sudo rm -rf /sys_switch
+	echo "s3ip service stop"
+
+}
+
+case "$1" in
+    start)
+	s3ip_start
+        ;;
+    stop)
+	s3ip_stop
+	;;
+    status)
+        sudo tree -l /sys_switch
+	;;
+    restart)
+	s3ip_stop
+	s3ip_start
+	;;	
+    *)
+        echo "Usage: $0 {start|stop|status|restart}"
+	exit 1
+esac
+exit 
+


### PR DESCRIPTION
Signed-off-by: tianshangfei <tian_shangfei@163.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The user framework module complies with s3ip sysfs specification

#### How I did it
1、	create a s3ip_sysfs service
2、 the s3ip_sysfs service call the “s3ip_sysfs_tool.sh” to install kernel module and  run s3ip_load.py
3、 s3ip_load.py will parse the s3ip_sysfs_conf.json configuration file and create /sys_switch/ directory

#### How to verify it
A demo driver base on this framework will display the sysfs node wich conform to the s3ip sysfs specification 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

