### PR TITLE
[device][Quanta] Hide datapath ports in config.bcm files to prevent SAI from initializing them

### DIFF
--- a/device/quanta/x86_64-quanta_ix7_rglbmc-r0/Quanta-IX7-32X/td3-ix7-32x100G.config.bcm
+++ b/device/quanta/x86_64-quanta_ix7_rglbmc-r0/Quanta-IX7-32X/td3-ix7-32x100G.config.bcm
@@ -69,8 +69,10 @@ portmap_123=121:100
 portmap_127=125:100
 
 # datapath port -- merlin core
-portmap_66=129:10:m
-portmap_130=128:10:m
+#Hide these to prevent SAI from initializing them...they are physically not on system
+#front panel
+#portmap_66=129:10:m
+#portmap_130=128:10:m
 
 # loopback port
 portmap_65=130:10

--- a/device/quanta/x86_64-quanta_ix8_rglbmc-r0/Quanta-IX8-56X/td3-ix8-48x25G+8x100G.config.bcm
+++ b/device/quanta/x86_64-quanta_ix8_rglbmc-r0/Quanta-IX8-56X/td3-ix8-48x25G+8x100G.config.bcm
@@ -90,8 +90,10 @@ portmap_123=121:100
 portmap_127=125:100
 
 # datapath port -- MerlinCore
-portmap_66=129:10:m
-portmap_130=128:10:m
+#Hide these to prevent SAI from initializing them...they are physically not on system
+#front panel
+#portmap_66=129:10:m
+#portmap_130=128:10:m
 
 # loopback port
 portmap_65=130:10

--- a/device/quanta/x86_64-quanta_ix8c_bwde-r0/Quanta-IX8C-56X/td3-ix8c-48x25G+8x100G.config.bcm
+++ b/device/quanta/x86_64-quanta_ix8c_bwde-r0/Quanta-IX8C-56X/td3-ix8c-48x25G+8x100G.config.bcm
@@ -90,8 +90,10 @@ portmap_123=121:100
 portmap_127=125:100
 
 # datapath port -- MerlinCore
-portmap_66=129:10:m
-portmap_130=128:10:m
+#Hide these to prevent SAI from initializing them...they are physically not on system
+#front panel
+#portmap_66=129:10:m
+#portmap_130=128:10:m
 
 # loopback port
 portmap_65=130:10

--- a/device/quanta/x86_64-quanta_ix9_bwde-r0/Quanta-IX9-32X/th3-ix9-32x400G.config.bcm
+++ b/device/quanta/x86_64-quanta_ix9_bwde-r0/Quanta-IX9-32X/th3-ix9-32x400G.config.bcm
@@ -56,8 +56,10 @@ portmap_148=241:400
 portmap_152=249:400
 
 # datapath port
-portmap_38=257:10
-portmap_118=258:10
+#Hide these to prevent SAI from initializing them...they are physically not on system
+#front panel
+#portmap_38=257:10
+#portmap_118=258:10
 
 # loopback port
 portmap_19=260:10


### PR DESCRIPTION
Signed-off-by: roberthong-qct <10606901@qcttw.com>

#### Why I did it
The legacy datapath port settings in config.bcm files make SAI initilization fail:
ERR syncd#syncd: :- processEvent: failed to execute api: remove, key: SAI_OBJECT_TYPE_PORT:oid:0x1000000000012, status: SAI_STATUS_NOT_SUPPORTED

#### How I did it
Remove the settings from Quanta config.bcm files

#### How to verify it
1. Install 201911 branch image on Quanta devices
2. Boot up and syncd will run without relavant error logs

#### Which release branch to backport (provide reason below if selected)
It's for 201911 only

#### Description for the changelog
Fix SAI initilization issues by modifying config.bcm files for Quanta devices.

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

