### PR TITLE
[sflow]: Unblocked psample_*() function calls  related to BRCM specific procfs for sflow feature's working in ESW platforms

### DIFF
--- a/platform/broadcom/saibcm-modules/sdklt/linux/knetcb/Kbuild
+++ b/platform/broadcom/saibcm-modules/sdklt/linux/knetcb/Kbuild
@@ -17,8 +17,7 @@
 # A copy of the GNU General Public License version 2 (GPLv2) can
 # be found in the LICENSES folder.$
 #
-ifeq ($(BUILD_PSAMPLE),1)
-PSAMPLE_CFLAGS=-DPSAMPLE_SUPPORT
+ifneq ($(CONFIG_PSAMPLE),)
 PSAMPLE_CB_OBJS=psample-cb.o
 endif
 

--- a/platform/broadcom/saibcm-modules/sdklt/linux/knetcb/ngknetcb_main.c
+++ b/platform/broadcom/saibcm-modules/sdklt/linux/knetcb/ngknetcb_main.c
@@ -307,8 +307,8 @@ static struct sk_buff *
 ngknet_rx_cb(struct sk_buff *skb)
 {
     skb = strip_tag_rx_cb(skb);
-#ifdef PSAMPLE_SUPPORT
-    skb = psample_rx_cb(skb); 
+#if IS_ENABLED(CONFIG_PSAMPLE)
+    skb = psample_rx_cb(skb);
 #endif
     return skb;
 }
@@ -324,7 +324,7 @@ static int
 ngknet_netif_create_cb(struct net_device *dev)
 {
     int retv = 0;
-#ifdef PSAMPLE_SUPPORT
+#if IS_ENABLED(CONFIG_PSAMPLE)
     retv = psample_netif_create_cb(dev); 
 #endif
     return retv;
@@ -334,7 +334,7 @@ static int
 ngknet_netif_destroy_cb(struct net_device *dev)
 {
     int retv = 0;
-#ifdef PSAMPLE_SUPPORT
+#if IS_ENABLED(CONFIG_PSAMPLE)
     retv = psample_netif_destroy_cb(dev); 
 #endif
     return retv;
@@ -431,7 +431,7 @@ ngknetcb_init_module(void)
     ngknet_rx_cb_register(ngknet_rx_cb);
     ngknet_tx_cb_register(ngknet_tx_cb);
 
-#ifdef PSAMPLE_SUPPORT
+#if IS_ENABLED(CONFIG_PSAMPLE)
     psample_init();
 #endif
 
@@ -446,7 +446,7 @@ ngknetcb_exit_module(void)
     ngknet_netif_create_cb_unregister(ngknet_netif_create_cb);
     ngknet_netif_destroy_cb_unregister(ngknet_netif_destroy_cb);
 
-#ifdef PSAMPLE_SUPPORT
+#if IS_ENABLED(CONFIG_PSAMPLE)
     psample_cleanup();
 #endif
 

--- a/platform/broadcom/saibcm-modules/sdklt/linux/knetcb/psample-cb.h
+++ b/platform/broadcom/saibcm-modules/sdklt/linux/knetcb/psample-cb.h
@@ -24,7 +24,6 @@
 #include <lkm/lkm.h>
 #include <linux/netdevice.h>
 
-//#define PSAMPLE_SUPPORT 1  // TODO: MLI@BRCM - Add this as part of conditional in Makefile
 #define PSAMPLE_CB_NAME "psample"
 
 extern int

--- a/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/knet-cb/knet-cb.c
+++ b/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/knet-cb/knet-cb.c
@@ -46,7 +46,7 @@
 #include <linux/if_vlan.h>
 
 /* Enable sflow sampling using psample */
-#ifdef PSAMPLE_SUPPORT
+#if IS_ENABLED(CONFIG_PSAMPLE)
 #include "psample-cb.h"
 #endif
 
@@ -334,7 +334,7 @@ knet_filter_cb(uint8_t * pkt, int size, int dev_no, void *meta,
                      int chan, kcom_filter_t *kf)
 {
     /* check for filter callback handler */
-#ifdef PSAMPLE_SUPPORT
+#if IS_ENABLED(CONFIG_PSAMPLE)
     if (strncmp(kf->desc, PSAMPLE_CB_NAME, strlen(PSAMPLE_CB_NAME)) == 0) {
         return psample_filter_cb (pkt, size, dev_no, meta, chan, kf);
     }
@@ -346,7 +346,7 @@ static int
 knet_netif_create_cb(int unit, kcom_netif_t *netif, uint16 spa, struct net_device *dev)
 {
     int retv = 0;
-#ifdef PSAMPLE_SUPPORT
+#if IS_ENABLED(CONFIG_PSAMPLE)
     retv = psample_netif_create_cb(unit, netif, spa, dev);
 #endif
     return retv;
@@ -356,7 +356,7 @@ static int
 knet_netif_destroy_cb(int unit, kcom_netif_t *netif, uint16 spa, struct net_device *dev)
 {
     int retv = 0;
-#ifdef PSAMPLE_SUPPORT
+#if IS_ENABLED(CONFIG_PSAMPLE)
     retv = psample_netif_destroy_cb(unit, netif, spa, dev);
 #endif
     return retv;
@@ -367,7 +367,7 @@ knet_filter_cb(uint8_t * pkt, int size, int dev_no, void *meta,
                      int chan, kcom_filter_t *kf)
 {
     /* check for filter callback handler */
-#ifdef PSAMPLE_SUPPORT
+#if IS_ENABLED(CONFIG_PSAMPLE)
     if (strncmp(kf->desc, PSAMPLE_CB_NAME, KCOM_FILTER_DESC_MAX) == 0) {
         return psample_filter_cb (pkt, size, dev_no, meta, chan, kf);
     }
@@ -379,7 +379,7 @@ static int
 knet_netif_create_cb(int unit, kcom_netif_t *netif, struct net_device *dev)
 {
     int retv = 0;
-#ifdef PSAMPLE_SUPPORT
+#if IS_ENABLED(CONFIG_PSAMPLE)
     retv = psample_netif_create_cb(unit, netif, dev);
 #endif
     return retv;
@@ -389,7 +389,7 @@ static int
 knet_netif_destroy_cb(int unit, kcom_netif_t *netif, struct net_device *dev)
 {
     int retv = 0;
-#ifdef PSAMPLE_SUPPORT
+#if IS_ENABLED(CONFIG_PSAMPLE)
     retv = psample_netif_destroy_cb(unit, netif, dev);
 #endif
     return retv;
@@ -427,7 +427,7 @@ _cleanup(void)
     bkn_netif_create_cb_unregister(knet_netif_create_cb);
     bkn_netif_destroy_cb_unregister(knet_netif_destroy_cb);
 
-#ifdef PSAMPLE_SUPPORT
+#if IS_ENABLED(CONFIG_PSAMPLE)
     psample_cleanup();
 #endif
     return 0;
@@ -445,7 +445,7 @@ _init(void)
         bkn_tx_skb_cb_register(strip_tag_tx_cb);
     }
 
-#ifdef PSAMPLE_SUPPORT
+#if IS_ENABLED(CONFIG_PSAMPLE)
     psample_init();
 #endif
     bkn_filter_cb_register(knet_filter_cb);


### PR DESCRIPTION
Fixed sflow feature code breakage in BRCM ESW platform.

*Replaced BRCM SDK's psample support flag(PSAMPLE_SUPPORT) with linux kernel psample module support config flag(CONFIG_PSAMPLE) in saibcm-modules. 
*Replaced BUILD_PSAMPLE conditioanl check with CONFIG_PSAMPLE to build psample callback library(psample-cb.o), only if psample config is enabled in linux kernel. 
*Cleaned up PSAMPLE_SUPPORT related commented code.

Signed-off-by: haris@celestica.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
SFLOW configuration(config sflow enable) causes swss docker to exit in Broadcom Td3-X2 family chipset platform. Reason is as part of the sflow configuration, Broadcom tries to open the file /proc/bcm/knet_cb/psample/rate and it got failed since the file doesn't exists. psample-cb.o object file is responsible for loading '/proc/bcm/knet-cb/psample/rate' file. And this object file is not included due to BUILD_PSAMPLE=1 flag is removed in the recent [commit.](https://github.com/sonic-net/sonic-buildimage/commit/8bc8b96c4a69cdb4357131b713bd6a2f916d7833)
#### How I did it
Unblocked psample_*() function calls in BRCM ESW platforms for proper functionality of sflow feature.
*Replaced BRCM SDK's psample support flag(PSAMPLE_SUPPORT) with linux kernel psample module support config flag(CONFIG_PSAMPLE) in saibcm-modules.
*Replaced BUILD_PSAMPLE conditioanl check with CONFIG_PSAMPLE to build psample callback library(psample-cb.o), only if psample config is enabled in linux kernel.
*Cleaned up PSAMPLE_SUPPORT related commented code.
#### How to verify it
1. Check psample module is insmoded by default by using 'lsmod | grep psample' command.  pass
2. Check required procfs such as (debug, map, rate,  size,  stats) are created under /proc/bcm/knet-cb/psample/ folder.  pass
3. Enable sflow feature by using 'config feature state sflow enabled' command. pass
4. Check sflow docker is instantiated by using 'docker ps' command. pass
5. Check sflow config(config sflow enable) doesnt stop swss docker. pass
6. Check COUNTER and FLOW samples are being received at the configured collector interface. pass
7. Change sflow attributes(global and interface specific) and verify the config changes are affecting samples count or not. pass
8. Check sflow functionality after cold reboot. pass 
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
Replaced BRCM SDK psample support flag with kernel psample config flag to unblock the creation of BRCM specific procfs for sflow feature's working in ESW platforms. It fixes [Issue#12810](https://github.com/sonic-net/sonic-buildimage/issues/12810)

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
[saibcm-modules][sflow] 

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

