### PR TITLE
Enable k8s feature

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -165,7 +165,7 @@ INCLUDE_MACSEC = y
 
 # INCLUDE_KUBERNETES - if set to y kubernetes packages are installed to be able to
 # run as worker node in kubernetes cluster.
-INCLUDE_KUBERNETES = n
+INCLUDE_KUBERNETES = y
 
 KUBE_DOCKER_PROXY = http://172.16.1.1:3128/
 
@@ -174,9 +174,9 @@ KUBE_DOCKER_PROXY = http://172.16.1.1:3128/
 # These are Used *only* when INCLUDE_KUBERNETES=y
 # NOTE: As a worker node it has to run version compatible to kubernetes master.
 #
-KUBERNETES_VERSION = 1.21.1
+KUBERNETES_VERSION = 1.22.2
 KUBERNETES_CNI_VERSION = 0.8.7
-K8s_GCR_IO_PAUSE_VERSION = 3.4.1
+K8s_GCR_IO_PAUSE_VERSION = 3.5
 
 # SONIC_ENABLE_IMAGE_SIGNATURE - enable image signature
 # To not use the auto-generated self-signed certificate, the required files to sign the image as below:


### PR DESCRIPTION
Signed-off-by: Yun Li <yunli1@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Plan to pilot k8s feature on 202205 branch, so enable k8s feature in this PR so that k8s feature related code could be built in sonic image on 202205 branch.
#### How I did it
Set INCLUDE_KUBERNETES = y
#### How to verify it
Inside sonic, execute command "systemctl status ctrmgrd.service" to verify.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

