### PR TITLE
[BFN]: Fix SIGTERM processing

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/psu.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/psu.py
@@ -135,12 +135,16 @@ class Psu(PsuBase):
         :param self.index: An integer, 1-based self.index of the PSU of which to query status
         :return: Boolean, True if PSU is plugged, False if not
         """
+        @cancel_on_sigterm
         def psu_present_get(client):
             return client.pltfm_mgr.pltfm_mgr_pwr_supply_present_get(self.__index)
 
         status = False
         try:
-            status = thrift_try(psu_present_get)
+            status = thrift_try(psu_present_get, attempts=1)
+        except Exception as e:
+            if "Canceling" in str(e):
+                syslog.syslog(syslog.LOG_INFO, "{}".format(e))
         finally:
             return status
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
SIGTERM takes more than 10 seconds to be processed, so psud is stopped by SIGKILL, this causes unexpected behavior since data base is not cleared
#### How I did it
Decorate get_presence api to cancel it on SIGTERM signal in order to avoid long processing.
#### How to verify it
test_pmon_psud_stop_and_start_status
test_pmon_psud_term_and_start_status
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

