### PR TITLE
[build]: increase raw image disk size to 4GB

### DIFF
--- a/onie-image-arm64.conf
+++ b/onie-image-arm64.conf
@@ -37,7 +37,7 @@ OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin
 OUTPUT_RAW_IMAGE=target/sonic-$TARGET_MACHINE.raw
 
 ## Raw image size in MB
-RAW_IMAGE_DISK_SIZE=3072
+RAW_IMAGE_DISK_SIZE=4096
 
 ## Output file name for kvm image
 OUTPUT_KVM_IMAGE=target/sonic-$TARGET_MACHINE.img

--- a/onie-image-armhf.conf
+++ b/onie-image-armhf.conf
@@ -37,7 +37,7 @@ OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin
 OUTPUT_RAW_IMAGE=target/sonic-$TARGET_MACHINE.raw
 
 ## Raw image size in MB
-RAW_IMAGE_DISK_SIZE=3072
+RAW_IMAGE_DISK_SIZE=4096
 
 ## Output file name for kvm image
 OUTPUT_KVM_IMAGE=target/sonic-$TARGET_MACHINE.img

--- a/onie-image.conf
+++ b/onie-image.conf
@@ -37,7 +37,7 @@ OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin
 OUTPUT_RAW_IMAGE=target/sonic-$TARGET_MACHINE.raw
 
 ## Raw image size in MB
-RAW_IMAGE_DISK_SIZE=3072
+RAW_IMAGE_DISK_SIZE=4096
 
 ## Output file name for kvm image
 OUTPUT_KVM_IMAGE=target/sonic-$TARGET_MACHINE.img


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
3GB disk size is not enough for broadcom raw image.
#### How I did it
Increase from 3GB to 4GB
#### How to verify it
Creating SONiC raw partition : target/sonic-broadcom.raw of size 3072 MB
+ fallocate -l 3072M target/sonic-broadcom.raw
+ sudo mount proc /proc -t proc
+ sudo chmod a+x target/sonic-broadcom.bin.tmp
+ sudo ./target/sonic-broadcom.bin.tmp
Verifying image checksum ... OK.
Preparing image archive ... OK.
Installing SONiC in BUILD
ONIE Installer: platform: x86_64-broadcom-r0
onie_platform: 
mke2fs 1.46.2 (28-Feb-2021)
Discarding device blocks:   4096/786432             done                            
Creating filesystem with 786432 4k blocks and 196608 inodes
Filesystem UUID: 7a5d7ab4-efb6-4a59-8c9c-f8b9b069e49a
Superblock backups stored on blocks: 
	32768, 98304, 163840, 229376, 294912

Allocating group tables:  0/24     done                            
Writing inode tables:  0/24     done                            
Creating journal (16384 blocks): done
Writing superblocks and filesystem accounting information:  0/24     done

Mounting /sonic/target/sonic-broadcom.raw on build_raw_image_mnt...
Installing SONiC to build_raw_image_mnt/image-master.184171-5281f6c3f
Archive:  fs.zip
   creating: build_raw_image_mnt/image-master.184171-5281f6c3f/boot/
  inflating: build_raw_image_mnt/image-master.184171-5281f6c3f/boot/vmlinuz-5.10.0-18-2-amd64  
  inflating: build_raw_image_mnt/image-master.184171-5281f6c3f/boot/config-5.10.0-18-2-amd64  
  inflating: build_raw_image_mnt/image-master.184171-5281f6c3f/boot/initrd.img-5.10.0-18-2-amd64  
  inflating: build_raw_image_mnt/image-master.184171-5281f6c3f/boot/System.map-5.10.0-18-2-amd64  
 extracting: build_raw_image_mnt/image-master.184171-5281f6c3f/fs.squashfs  
tar: ./overlay2/54533b48c3b9902bdd86047014e479ee3289441ef6c7d9f7a8a80212bf5872bd/diff/usr/local/bin/p4rt_read: Wrote only 3584 of 10240 bytes
tar: ./overlay2/54533b48c3b9902bdd86047014e479ee3289441ef6c7d9f7a8a80212bf5872bd/diff/usr/local/bin/p4rt_set_forwarding_pipeline: Cannot write: No space left on device

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

