### PR TITLE
[build] Fix rare failure case about dpkg frontend lock

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -774,7 +774,7 @@ else
 	        { sudo cp -rf tmp/usr/lib/python3/dist-packages/* $(VIRTENV_LIB_CROSS_PYTHON3)/python3.*/site-packages/ 2>/dev/null || true;} && break
 endif
 	        sleep 1
-	        [[ $i == 100 ]] && { sudo lsof /var/lib/dpkg/lock-frontend; ps aux; exit 1; }
+	        [ $i -eq 100 ] && { sudo lsof /var/lib/dpkg/lock-frontend; ps aux; exit 1; }
 	    done
 	$(FOOTER)
 

--- a/slave.mk
+++ b/slave.mk
@@ -764,7 +764,14 @@ $(SONIC_INSTALL_DEBS) : $(DEBS_PATH)/%-install : .platform $$(addsuffix -install
 		# put a lock here because dpkg does not allow installing packages in parallel
 		if mkdir $(DEBS_PATH)/dpkg_lock &> /dev/null; then
 ifneq ($(CROSS_BUILD_ENVIRON),y)
-			{ sudo DEBIAN_FRONTEND=noninteractive dpkg -i $(DEBS_PATH)/$* $(LOG) && rm -d $(DEBS_PATH)/dpkg_lock && break; } || { set +e; rm -d $(DEBS_PATH)/dpkg_lock; sudo lsof /var/lib/dpkg/lock-frontend; ps aux; exit 1 ; }
+			# apt-get install inside sonic-slave may conflict with dpkg -i
+			# add retry here
+			for (( i=1; i<=10; i++))
+			do
+			    sudo DEBIAN_FRONTEND=noninteractive dpkg -i $(DEBS_PATH)/$* $(LOG) && rm -d $(DEBS_PATH)/dpkg_lock && break 2
+			    sleep 1
+			done
+			rm -d $(DEBS_PATH)/dpkg_lock; sudo lsof /var/lib/dpkg/lock-frontend; ps aux; exit 1 ; }
 else
 			# Relocate debian packages python libraries to the cross python virtual env location
 			{ sudo DEBIAN_FRONTEND=noninteractive dpkg -i $(if $(findstring $(LINUX_HEADERS),$*),--force-depends) $(DEBS_PATH)/$* $(LOG) && \

--- a/slave.mk
+++ b/slave.mk
@@ -757,33 +757,25 @@ SONIC_INSTALL_DEBS = $(addsuffix -install,$(addprefix $(DEBS_PATH)/, \
 $(SONIC_INSTALL_DEBS) : $(DEBS_PATH)/%-install : .platform $$(addsuffix -install,$$(addprefix $(DEBS_PATH)/,$$($$*_DEPENDS))) $(DEBS_PATH)/$$*
 	$(HEADER)
 	[ -f $(DEBS_PATH)/$* ] || { echo $(DEBS_PATH)/$* does not exist $(LOG) && false $(LOG) }
-	while true; do
-		# wait for conflicted packages to be uninstalled
-		$(foreach deb, $($*_CONFLICT_DEBS), \
-			{ while dpkg -s $(firstword $(subst _, ,$(basename $(deb)))) | grep "^Version: $(word 2, $(subst _, ,$(basename $(deb))))" &> /dev/null; do echo "waiting for $(deb) to be uninstalled" $(LOG); sleep 1; done } )
-		# put a lock here because dpkg does not allow installing packages in parallel
-		if mkdir $(DEBS_PATH)/dpkg_lock &> /dev/null; then
-
-		    # apt-get install inside sonic-slave may conflict with dpkg -i
-		    # add retry here
-		    for (( i=1; i<=10; i++))
-		    do
+	# wait for conflicted packages to be uninstalled
+	$(foreach deb, $($*_CONFLICT_DEBS), \
+	    { while dpkg -s $(firstword $(subst _, ,$(basename $(deb)))) | grep "^Version: $(word 2, $(subst _, ,$(basename $(deb))))" &> /dev/null; do echo "waiting for $(deb) to be uninstalled" $(LOG); sleep 1; done } )
+	    # apt-get install inside sonic-slave may conflict with dpkg -i
+	    # add retry here
+	    for (( i=1; i<=100; i++))
+	    do
 ifneq ($(CROSS_BUILD_ENVIRON),y)
-		        sudo DEBIAN_FRONTEND=noninteractive dpkg -i $(DEBS_PATH)/$* $(LOG) && rm -d $(DEBS_PATH)/dpkg_lock && break 2
+	        sudo DEBIAN_FRONTEND=noninteractive dpkg -i $(DEBS_PATH)/$* $(LOG) && break
 else
-		        # Relocate debian packages python libraries to the cross python virtual env location
-		        sudo DEBIAN_FRONTEND=noninteractive dpkg -i $(if $(findstring $(LINUX_HEADERS),$*),--force-depends) $(DEBS_PATH)/$* $(LOG) && \
-		        { rm -rf tmp && mkdir tmp && dpkg -x $(DEBS_PATH)/$* tmp; } && \
-		        { sudo cp -rf tmp/usr/lib/python2*/dist-packages/* $(VIRTENV_LIB_CROSS_PYTHON2)/python2*/site-packages/ 2>/dev/null || true ;} && \
-		        { sudo cp -rf tmp/usr/lib/python3/dist-packages/* $(VIRTENV_LIB_CROSS_PYTHON3)/python3.*/site-packages/ 2>/dev/null || true;} && \
-		        rm -d $(DEBS_PATH)/dpkg_lock && break 2
+	        # Relocate debian packages python libraries to the cross python virtual env location
+	        sudo DEBIAN_FRONTEND=noninteractive dpkg -i $(if $(findstring $(LINUX_HEADERS),$*),--force-depends) $(DEBS_PATH)/$* $(LOG) && \
+	        { rm -rf tmp && mkdir tmp && dpkg -x $(DEBS_PATH)/$* tmp; } && \
+	        { sudo cp -rf tmp/usr/lib/python2*/dist-packages/* $(VIRTENV_LIB_CROSS_PYTHON2)/python2*/site-packages/ 2>/dev/null || true ;} && \
+	        { sudo cp -rf tmp/usr/lib/python3/dist-packages/* $(VIRTENV_LIB_CROSS_PYTHON3)/python3.*/site-packages/ 2>/dev/null || true;} && break
 endif
-		        sleep 1
-		    done
-		    set +e; rm -d $(DEBS_PATH)/dpkg_lock; sudo lsof /var/lib/dpkg/lock-frontend; ps aux; exit 1
-		fi
-		sleep 10
-	done
+	        sleep 1
+            [[ $i == 100 ]] && { sudo lsof /var/lib/dpkg/lock-frontend; ps aux; exit 1; }
+	    done
 	$(FOOTER)
 
 

--- a/slave.mk
+++ b/slave.mk
@@ -771,7 +771,7 @@ ifneq ($(CROSS_BUILD_ENVIRON),y)
 			    sudo DEBIAN_FRONTEND=noninteractive dpkg -i $(DEBS_PATH)/$* $(LOG) && rm -d $(DEBS_PATH)/dpkg_lock && break 2
 			    sleep 1
 			done
-			rm -d $(DEBS_PATH)/dpkg_lock; sudo lsof /var/lib/dpkg/lock-frontend; ps aux; exit 1 ; }
+			rm -d $(DEBS_PATH)/dpkg_lock; sudo lsof /var/lib/dpkg/lock-frontend; ps aux; exit 1
 else
 			# Relocate debian packages python libraries to the cross python virtual env location
 			{ sudo DEBIAN_FRONTEND=noninteractive dpkg -i $(if $(findstring $(LINUX_HEADERS),$*),--force-depends) $(DEBS_PATH)/$* $(LOG) && \

--- a/slave.mk
+++ b/slave.mk
@@ -780,7 +780,7 @@ else
 endif
 			    sleep 1
 			done
-			rm -d $(DEBS_PATH)/dpkg_lock; sudo lsof /var/lib/dpkg/lock-frontend; ps aux; exit 1
+			set +e; rm -d $(DEBS_PATH)/dpkg_lock; sudo lsof /var/lib/dpkg/lock-frontend; ps aux; exit 1
 		fi
 		sleep 10
 	done

--- a/slave.mk
+++ b/slave.mk
@@ -774,7 +774,7 @@ else
 	        { sudo cp -rf tmp/usr/lib/python3/dist-packages/* $(VIRTENV_LIB_CROSS_PYTHON3)/python3.*/site-packages/ 2>/dev/null || true;} && break
 endif
 	        sleep 1
-            [[ $i == 100 ]] && { sudo lsof /var/lib/dpkg/lock-frontend; ps aux; exit 1; }
+	        [[ $i == 100 ]] && { sudo lsof /var/lib/dpkg/lock-frontend; ps aux; exit 1; }
 	    done
 	$(FOOTER)
 

--- a/slave.mk
+++ b/slave.mk
@@ -764,23 +764,23 @@ $(SONIC_INSTALL_DEBS) : $(DEBS_PATH)/%-install : .platform $$(addsuffix -install
 		# put a lock here because dpkg does not allow installing packages in parallel
 		if mkdir $(DEBS_PATH)/dpkg_lock &> /dev/null; then
 
-			# apt-get install inside sonic-slave may conflict with dpkg -i
-			# add retry here
-			for (( i=1; i<=10; i++))
-			do
+		    # apt-get install inside sonic-slave may conflict with dpkg -i
+		    # add retry here
+		    for (( i=1; i<=10; i++))
+		    do
 ifneq ($(CROSS_BUILD_ENVIRON),y)
-			    sudo DEBIAN_FRONTEND=noninteractive dpkg -i $(DEBS_PATH)/$* $(LOG) && rm -d $(DEBS_PATH)/dpkg_lock && break 2
+		        sudo DEBIAN_FRONTEND=noninteractive dpkg -i $(DEBS_PATH)/$* $(LOG) && rm -d $(DEBS_PATH)/dpkg_lock && break 2
 else
-			    # Relocate debian packages python libraries to the cross python virtual env location
-			    sudo DEBIAN_FRONTEND=noninteractive dpkg -i $(if $(findstring $(LINUX_HEADERS),$*),--force-depends) $(DEBS_PATH)/$* $(LOG) && \
-			    { rm -rf tmp && mkdir tmp && dpkg -x $(DEBS_PATH)/$* tmp; } && \
-			    { sudo cp -rf tmp/usr/lib/python2*/dist-packages/* $(VIRTENV_LIB_CROSS_PYTHON2)/python2*/site-packages/ 2>/dev/null || true ;} && \
-			    { sudo cp -rf tmp/usr/lib/python3/dist-packages/* $(VIRTENV_LIB_CROSS_PYTHON3)/python3.*/site-packages/ 2>/dev/null || true;} && \
-			    rm -d $(DEBS_PATH)/dpkg_lock && break 2
+		        # Relocate debian packages python libraries to the cross python virtual env location
+		        sudo DEBIAN_FRONTEND=noninteractive dpkg -i $(if $(findstring $(LINUX_HEADERS),$*),--force-depends) $(DEBS_PATH)/$* $(LOG) && \
+		        { rm -rf tmp && mkdir tmp && dpkg -x $(DEBS_PATH)/$* tmp; } && \
+		        { sudo cp -rf tmp/usr/lib/python2*/dist-packages/* $(VIRTENV_LIB_CROSS_PYTHON2)/python2*/site-packages/ 2>/dev/null || true ;} && \
+		        { sudo cp -rf tmp/usr/lib/python3/dist-packages/* $(VIRTENV_LIB_CROSS_PYTHON3)/python3.*/site-packages/ 2>/dev/null || true;} && \
+		        rm -d $(DEBS_PATH)/dpkg_lock && break 2
 endif
-			    sleep 1
-			done
-			set +e; rm -d $(DEBS_PATH)/dpkg_lock; sudo lsof /var/lib/dpkg/lock-frontend; ps aux; exit 1
+		        sleep 1
+		    done
+		    set +e; rm -d $(DEBS_PATH)/dpkg_lock; sudo lsof /var/lib/dpkg/lock-frontend; ps aux; exit 1
 		fi
 		sleep 10
 	done


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
There are some rare failure cases about dpkg frontend lock.
The conflict is:
1. Command 'dpkg -i' in docker-sonic-slave for target *-install
2. Command 'apt-get install' in docker build, such as target/docker-base-buster.gz.
#### How I did it
Add retry when running dpkg -i in docker-sonic-slave.
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

