### PR TITLE
Limit reload BCM SDK kmods on syncd start to PikeZ platform

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -30,13 +30,23 @@ function startplatform() {
 
     if [[ x"$sonic_asic_platform" == x"broadcom" ]]; then
         if [[ x"$WARM_BOOT" != x"true" ]]; then
-            is_bcm0=$(ls /sys/class/net | grep bcm0)
-            if [[ "$is_bcm0" == "bcm0" ]]; then
-                debug "stop SDK opennsl-modules ..."
-                /etc/init.d/opennsl-modules stop
-                debug "start SDK opennsl-modules ..."
-                /etc/init.d/opennsl-modules start
-                debug "started SDK opennsl-modules"
+            . /host/machine.conf
+            if [ -n "$aboot_platform" ]; then
+                platform=$aboot_platform
+            elif [ -n "$onie_platform" ]; then
+                platform=$onie_platform
+            else 
+                platform="unknown"
+            fi
+            if [[ x"$platform" == x"x86_64-arista_720dt_48s" ]]; then
+                is_bcm0=$(ls /sys/class/net | grep bcm0)
+                if [[ "$is_bcm0" == "bcm0" ]]; then
+                    debug "stop SDK opennsl-modules ..."
+                    /etc/init.d/opennsl-modules stop
+                    debug "start SDK opennsl-modules ..."
+                    /etc/init.d/opennsl-modules start
+                    debug "started SDK opennsl-modules"
+                fi
             fi
         fi
     fi


### PR DESCRIPTION
Signed-off-by: Michael Li <michael.li@broadcom.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Limiting #12804 changes to PikeZ platform only (Arista-720DT-48S).   Note that this is a short term workaround for this platform until SDK investigation on SDK init failure on docker syncd restart due to DMA issues is resolved.

#### How I did it
Retrieve platform name from /host/machine.conf and only reload SDK kmods on Arista-720DT-48S platform.

#### How to verify it
Steps to reproduce:

1. Run 'docker stop syncd'
2. Wait ~1 minute.
3. Run 'docker ps' to see that syncd is missing.
4. Check logs to see messages below
`pkz403 INFO syncd#supervisord: syncd 0:soc_cmicx_dma_abort: Failed to abort packet DMA in CMC 0 channel 0, check with the design team#015`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

