### PR TITLE
[Edgecore][AS7726/PDDF] Enhance sonic_platform feature

### DIFF
--- a/device/accton/x86_64-accton_as7726_32x-r0/pcie.yaml
+++ b/device/accton/x86_64-accton_as7726_32x-r0/pcie.yaml
@@ -1,0 +1,471 @@
+- bus: '00'
+  dev: '00'
+  fn: '0'
+  id: 6f00
+  name: 'Host bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DMI2
+    (rev 03)'
+- bus: '00'
+  dev: '01'
+  fn: '0'
+  id: 6f02
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 1 (rev 03)'
+- bus: '00'
+  dev: '01'
+  fn: '1'
+  id: 6f03
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 1 (rev 03)'
+- bus: '00'
+  dev: '02'
+  fn: '0'
+  id: 6f04
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 2 (rev 03)'
+- bus: '00'
+  dev: '02'
+  fn: '1'
+  id: 6f05
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 2 (rev 03)'
+- bus: '00'
+  dev: '02'
+  fn: '2'
+  id: 6f06
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 2 (rev 03)'
+- bus: '00'
+  dev: '02'
+  fn: '3'
+  id: 6f07
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 2 (rev 03)'
+- bus: '00'
+  dev: '03'
+  fn: '0'
+  id: 6f08
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 3 (rev 03)'
+- bus: '00'
+  dev: '03'
+  fn: '1'
+  id: 6f09
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 3 (rev 03)'
+- bus: '00'
+  dev: '03'
+  fn: '2'
+  id: 6f0a
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 3 (rev 03)'
+- bus: '00'
+  dev: '03'
+  fn: '3'
+  id: 6f0b
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 3 (rev 03)'
+- bus: '00'
+  dev: '05'
+  fn: '0'
+  id: 6f28
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Map/VTd_Misc/System Management (rev 03)'
+- bus: '00'
+  dev: '05'
+  fn: '1'
+  id: 6f29
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D IIO Hot Plug (rev 03)'
+- bus: '00'
+  dev: '05'
+  fn: '2'
+  id: 6f2a
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D IIO RAS/Control Status/Global Errors (rev 03)'
+- bus: '00'
+  dev: '05'
+  fn: '4'
+  id: 6f2c
+  name: 'PIC: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D I/O APIC (rev
+    03)'
+- bus: '00'
+  dev: '14'
+  fn: '0'
+  id: 8c31
+  name: 'USB controller: Intel Corporation 8 Series/C220 Series Chipset Family USB
+    xHCI (rev 05)'
+- bus: '00'
+  dev: '16'
+  fn: '0'
+  id: 8c3a
+  name: 'Communication controller: Intel Corporation 8 Series/C220 Series Chipset
+    Family MEI Controller #1 (rev 04)'
+- bus: '00'
+  dev: '16'
+  fn: '1'
+  id: 8c3b
+  name: 'Communication controller: Intel Corporation 8 Series/C220 Series Chipset
+    Family MEI Controller #2 (rev 04)'
+- bus: '00'
+  dev: 1c
+  fn: '0'
+  id: 8c10
+  name: 'PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express
+    Root Port #1 (rev d5)'
+- bus: '00'
+  dev: 1c
+  fn: '1'
+  id: 8c12
+  name: 'PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express
+    Root Port #2 (rev d5)'
+- bus: '00'
+  dev: 1c
+  fn: '4'
+  id: 8c18
+  name: 'PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express
+    Root Port #5 (rev d5)'
+- bus: '00'
+  dev: 1d
+  fn: '0'
+  id: 8c26
+  name: 'USB controller: Intel Corporation 8 Series/C220 Series Chipset Family USB
+    EHCI #1 (rev 05)'
+- bus: '00'
+  dev: 1f
+  fn: '0'
+  id: 8c54
+  name: 'ISA bridge: Intel Corporation C224 Series Chipset Family Server Standard
+    SKU LPC Controller (rev 05)'
+- bus: '00'
+  dev: 1f
+  fn: '2'
+  id: 8c02
+  name: 'SATA controller: Intel Corporation 8 Series/C220 Series Chipset Family 6-port
+    SATA Controller 1 [AHCI mode] (rev 05)'
+- bus: '00'
+  dev: 1f
+  fn: '3'
+  id: 8c22
+  name: 'SMBus: Intel Corporation 8 Series/C220 Series Chipset Family SMBus Controller
+    (rev 05)'
+- bus: '03'
+  dev: '00'
+  fn: '0'
+  id: 6f50
+  name: 'System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology
+    Register DMA Channel 0'
+- bus: '03'
+  dev: '00'
+  fn: '1'
+  id: 6f51
+  name: 'System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology
+    Register DMA Channel 1'
+- bus: '03'
+  dev: '00'
+  fn: '2'
+  id: 6f52
+  name: 'System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology
+    Register DMA Channel 2'
+- bus: '03'
+  dev: '00'
+  fn: '3'
+  id: 6f53
+  name: 'System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology
+    Register DMA Channel 3'
+- bus: '05'
+  dev: '00'
+  fn: '0'
+  id: 15ab
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection X552 10 GbE Backplane'
+- bus: '05'
+  dev: '00'
+  fn: '1'
+  id: 15ab
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection X552 10 GbE Backplane'
+- bus: '07'
+  dev: '00'
+  fn: '0'
+  id: b870
+  name: 'Ethernet controller: Broadcom Inc. and subsidiaries Device b870 (rev 01)'
+- bus: 0b
+  dev: '00'
+  fn: '0'
+  id: 165f
+  name: 'Ethernet controller: Broadcom Inc. and subsidiaries NetXtreme BCM5720 2-port
+    Gigabit Ethernet PCIe'
+- bus: ff
+  dev: 0b
+  fn: '0'
+  id: 6f81
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D R3 QPI Link 0/1 (rev 03)'
+- bus: ff
+  dev: 0b
+  fn: '1'
+  id: 6f36
+  name: 'Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D R3 QPI Link 0/1 (rev 03)'
+- bus: ff
+  dev: 0b
+  fn: '2'
+  id: 6f37
+  name: 'Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D R3 QPI Link 0/1 (rev 03)'
+- bus: ff
+  dev: 0b
+  fn: '3'
+  id: 6f76
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D R3 QPI Link Debug (rev 03)'
+- bus: ff
+  dev: 0c
+  fn: '0'
+  id: 6fe0
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Caching Agent (rev 03)'
+- bus: ff
+  dev: 0c
+  fn: '1'
+  id: 6fe1
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Caching Agent (rev 03)'
+- bus: ff
+  dev: 0c
+  fn: '2'
+  id: 6fe2
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Caching Agent (rev 03)'
+- bus: ff
+  dev: 0c
+  fn: '3'
+  id: 6fe3
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Caching Agent (rev 03)'
+- bus: ff
+  dev: 0f
+  fn: '0'
+  id: 6ff8
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Caching Agent (rev 03)'
+- bus: ff
+  dev: 0f
+  fn: '4'
+  id: 6ffc
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Caching Agent (rev 03)'
+- bus: ff
+  dev: 0f
+  fn: '5'
+  id: 6ffd
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Caching Agent (rev 03)'
+- bus: ff
+  dev: 0f
+  fn: '6'
+  id: 6ffe
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Caching Agent (rev 03)'
+- bus: ff
+  dev: '10'
+  fn: '0'
+  id: 6f1d
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D R2PCIe Agent (rev 03)'
+- bus: ff
+  dev: '10'
+  fn: '1'
+  id: 6f34
+  name: 'Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D R2PCIe Agent (rev 03)'
+- bus: ff
+  dev: '10'
+  fn: '5'
+  id: 6f1e
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Ubox (rev 03)'
+- bus: ff
+  dev: '10'
+  fn: '6'
+  id: 6f7d
+  name: 'Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Ubox (rev 03)'
+- bus: ff
+  dev: '10'
+  fn: '7'
+  id: 6f1f
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Ubox (rev 03)'
+- bus: ff
+  dev: '12'
+  fn: '0'
+  id: 6fa0
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Home Agent 0 (rev 03)'
+- bus: ff
+  dev: '12'
+  fn: '1'
+  id: 6f30
+  name: 'Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Home Agent 0 (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '0'
+  id: 6fa8
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Target Address/Thermal/RAS (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '1'
+  id: 6f71
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Target Address/Thermal/RAS (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '2'
+  id: 6faa
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel Target Address Decoder (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '3'
+  id: 6fab
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel Target Address Decoder (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '4'
+  id: 6fac
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel Target Address Decoder (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '5'
+  id: 6fad
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel Target Address Decoder (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '6'
+  id: 6fae
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D DDRIO Channel 0/1 Broadcast (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '7'
+  id: 6faf
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D DDRIO Global Broadcast (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '0'
+  id: 6fb0
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 0 Thermal Control (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '1'
+  id: 6fb1
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 1 Thermal Control (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '2'
+  id: 6fb2
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 0 Error (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '3'
+  id: 6fb3
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 1 Error (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '4'
+  id: 6fbc
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D DDRIO Channel 0/1 Interface (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '5'
+  id: 6fbd
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D DDRIO Channel 0/1 Interface (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '6'
+  id: 6fbe
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D DDRIO Channel 0/1 Interface (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '7'
+  id: 6fbf
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D DDRIO Channel 0/1 Interface (rev 03)'
+- bus: ff
+  dev: '15'
+  fn: '0'
+  id: 6fb4
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 2 Thermal Control (rev 03)'
+- bus: ff
+  dev: '15'
+  fn: '1'
+  id: 6fb5
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 3 Thermal Control (rev 03)'
+- bus: ff
+  dev: '15'
+  fn: '2'
+  id: 6fb6
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 2 Error (rev 03)'
+- bus: ff
+  dev: '15'
+  fn: '3'
+  id: 6fb7
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 3 Error (rev 03)'
+- bus: ff
+  dev: 1e
+  fn: '0'
+  id: 6f98
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Power Control Unit (rev 03)'
+- bus: ff
+  dev: 1e
+  fn: '1'
+  id: 6f99
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Power Control Unit (rev 03)'
+- bus: ff
+  dev: 1e
+  fn: '2'
+  id: 6f9a
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Power Control Unit (rev 03)'
+- bus: ff
+  dev: 1e
+  fn: '3'
+  id: 6fc0
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Power Control Unit (rev 03)'
+- bus: ff
+  dev: 1e
+  fn: '4'
+  id: 6f9c
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Power Control Unit (rev 03)'
+- bus: ff
+  dev: 1f
+  fn: '0'
+  id: 6f88
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Power Control Unit (rev 03)'
+- bus: ff
+  dev: 1f
+  fn: '2'
+  id: 6f8a
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Power Control Unit (rev 03)'

--- a/device/accton/x86_64-accton_as7726_32x-r0/pddf/pd-plugin.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/pddf/pd-plugin.json
@@ -61,7 +61,7 @@
 		
         "duty_cycle_to_pwm": "lambda dc: ((dc*100)/625 -1)",
 
-        "pwm_to_duty_cycle": "lambda pwm: (((pwm+1)*625+75)/100)"
+        "pwm_to_duty_cycle": "lambda pwm: (((pwm+1)*625)/100)"
     }
 
 }

--- a/device/accton/x86_64-accton_as7726_32x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/pddf/pddf-device.json
@@ -5,7 +5,7 @@
 		"num_fantrays":6,
 		"num_fans_pertray":2,
 		"num_ports":34,
-		"num_temps":5,
+		"num_temps":7,
 		"pddf_dev_types":
 		{
 			"description":"AS7726 - Below is the list of supported PDDF device types (chip names) for various components. If any component uses some other driver, we will create the client using 'echo <dev-address> <dev-type> > <path>/new_device' method",
@@ -1865,7 +1865,34 @@
 			]
 		}
 	},
-	
+    "TEMP6" :
+    {
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP6"},
+        "dev_attr": { "display_name":"pch_haswell-virtual-0"},
+        "i2c":
+        {
+            "path_info": {"sysfs_base_path": "/sys/class/hwmon/hwmon0"},
+            "attr_list":
+            [
+                { "attr_name": "temp1_input"}
+            ]
+        }
+    },
+    "TEMP7" :
+    {
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP7"},
+        "dev_attr": { "display_name":"coretemp-isa-0000"},
+        "i2c":
+        {
+            "path_info": {"sysfs_base_path": "/sys/class/hwmon/hwmon1"},
+            "attr_list":
+            [
+                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp1_crit"},
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+                { "attr_name": "temp1_input"}
+            ]
+        }
+    },
 	"SYSSTATUS":
 	{
 		"dev_info":{ "device_type":"SYSSTAT", "device_name":"SYSSTATUS"},

--- a/device/accton/x86_64-accton_as7726_32x-r0/pmon_daemon_control.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/pmon_daemon_control.json
@@ -1,5 +1,4 @@
 {
-    "skip_ledd": true,
-    "skip_pcied": true
+    "skip_ledd": true
 }
 

--- a/device/accton/x86_64-accton_as7726_32x-r0/system_health_monitoring_config.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/system_health_monitoring_config.json
@@ -1,0 +1,17 @@
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [
+        "asic",
+        "psu.voltage",
+        "psu.temperature",
+        "PSU1_FAN1.speed",
+        "PSU2_FAN1.speed"
+    ],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "STATUS_LED_COLOR_AMBER",
+        "normal": "STATUS_LED_COLOR_GREEN",
+        "booting": "STATUS_LED_COLOR_OFF"
+    }
+}

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/chassis.py
@@ -8,58 +8,59 @@
 
 try:
     import sys
-    import time
     from sonic_platform_pddf_base.pddf_chassis import PddfChassis
+    from .event import SfpEvent
+    from .helper import APIHelper
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
+NUM_COMPONENT = 6
+HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
+PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
+REBOOT_CAUSE_FILE = "reboot-cause.txt"
 
 class Chassis(PddfChassis):
     """
     PDDF Platform-specific Chassis class
     """
 
+    SYSLED_DEV_NAME = "DIAG_LED"
+
     def __init__(self, pddf_data=None, pddf_plugin_data=None):
         PddfChassis.__init__(self, pddf_data, pddf_plugin_data)
+        self.__initialize_components()
+        self._api_helper = APIHelper()
+        self._sfpevent = SfpEvent(self.get_all_sfps())
+        
+
+    def __initialize_components(self):
+        from sonic_platform.component import Component
+        for index in range(NUM_COMPONENT):
+            component = Component(index)
+            self._component_list.append(component)
 
     # Provide the functions/variables below for which implementation is to be overwritten
-    sfp_change_event_data = {'valid': 0, 'last': 0, 'present': 0}
-    def get_change_event(self, timeout=2000):
-        now = time.time()
-        port_dict = {}
-        change_dict = {}
-        change_dict['sfp'] = port_dict
+    def get_change_event(self, timeout=0):
+        return self._sfpevent.get_sfp_event(timeout)
 
-        if timeout < 1000:
-            timeout = 1000
-        timeout = timeout / float(1000)  # Convert to secs
+    def get_reboot_cause(self):
+        """
+        Retrieves the cause of the previous reboot
 
-        if now < (self.sfp_change_event_data['last'] + timeout) and self.sfp_change_event_data['valid']:
-            return True, change_dict
-        
-        bitmap = 0
-        for i in range(34):
-            modpres = self.get_sfp(i+1).get_presence()
-            if modpres:
-                bitmap = bitmap | (1 << i)
+        Returns:
+            A tuple (string, string) where the first element is a string
+            containing the cause of the previous reboot. This string must be
+            one of the predefined strings in this class. If the first string
+            is "REBOOT_CAUSE_HARDWARE_OTHER", the second string can be used
+            to pass a description of the reboot cause.
+        """
 
-        changed_ports = self.sfp_change_event_data['present'] ^ bitmap
-        if changed_ports:
-            for i in range(34):
-                if (changed_ports & (1 << i)):
-                    if (bitmap & (1 << i)) == 0:
-                        port_dict[i+1] = '0'
-                    else:
-                        port_dict[i+1] = '1'
+        reboot_cause_path = (HOST_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE)
+        sw_reboot_cause = self._api_helper.read_txt_file(
+            reboot_cause_path) or "Unknown"
 
 
-            # Update teh cache dict
-            self.sfp_change_event_data['present'] = bitmap
-            self.sfp_change_event_data['last'] = now
-            self.sfp_change_event_data['valid'] = 1
-            return True, change_dict
-        else:
-            return True, change_dict
+        return ('REBOOT_CAUSE_NON_HARDWARE', sw_reboot_cause)
 
 
     def get_sfp(self, index):
@@ -84,3 +85,19 @@ class Chassis(PddfChassis):
             sys.stderr.write("SFP index {} out of range (1-{})\n".format(
                              index, len(self._sfp_list)))
         return sfp
+  
+    def initizalize_system_led(self):
+        return
+
+    def get_status_led(self):
+        return self.get_system_led(self.SYSLED_DEV_NAME)
+
+    def set_status_led(self, color):
+        return self.set_system_led(self.SYSLED_DEV_NAME, color)
+    
+    def get_port_or_cage_type(self, port):
+        from sonic_platform_base.sfp_base import SfpBase
+        if port in range(1, 32):
+            return SfpBase.SFP_PORT_TYPE_BIT_QSFP | SfpBase.SFP_PORT_TYPE_BIT_QSFP_PLUS | SfpBase.SFP_PORT_TYPE_BIT_QSFP28
+        else:
+            return SfpBase.SFP_PORT_TYPE_BIT_SFP | SfpBase.SFP_PORT_TYPE_BIT_SFP_PLUS

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/helper.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/helper.py
@@ -1,0 +1,117 @@
+import os
+import struct
+import subprocess
+from mmap import *
+from sonic_py_common import device_info
+
+HOST_CHK_CMD = "docker > /dev/null 2>&1"
+EMPTY_STRING = ""
+
+
+class APIHelper():
+
+    def __init__(self):
+        (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
+
+    def is_host(self):
+        return os.system(HOST_CHK_CMD) == 0
+
+    def pci_get_value(self, resource, offset):
+        status = True
+        result = ""
+        try:
+            fd = os.open(resource, os.O_RDWR)
+            mm = mmap(fd, 0)
+            mm.seek(int(offset))
+            read_data_stream = mm.read(4)
+            result = struct.unpack('I', read_data_stream)
+        except Exception:
+            status = False
+        return status, result
+
+    def run_command(self, cmd):
+        status = True
+        result = ""
+        try:
+            p = subprocess.Popen(
+                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            raw_data, err = p.communicate()
+            if err == '':
+                result = raw_data.strip()
+        except Exception:
+            status = False
+        return status, result
+
+    def run_interactive_command(self, cmd):
+        try:
+            os.system(cmd)
+        except Exception:
+            return False
+        return True
+
+    def read_txt_file(self, file_path):
+        try:
+            with open(file_path, 'r', errors='replace') as fd:
+                data = fd.read()
+                return data.strip()
+        except IOError:
+            pass
+        return None
+
+    def write_txt_file(self, file_path, value):
+        try:
+            with open(file_path, 'w') as fd:
+                fd.write(str(value))
+        except IOError:
+            return False
+        return True
+
+    def ipmi_raw(self, netfn, cmd):
+        status = True
+        result = ""
+        try:
+            cmd = "ipmitool raw {} {}".format(str(netfn), str(cmd))
+            p = subprocess.Popen(
+                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            raw_data, err = p.communicate()
+            if err == '':
+                result = raw_data.strip()
+            else:
+                status = False
+        except Exception:
+            status = False
+        return status, result
+
+    def ipmi_fru_id(self, id, key=None):
+        status = True
+        result = ""
+        try:
+            cmd = "ipmitool fru print {}".format(str(
+                id)) if not key else "ipmitool fru print {0} | grep '{1}' ".format(str(id), str(key))
+
+            p = subprocess.Popen(
+                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            raw_data, err = p.communicate()
+            if err == '':
+                result = raw_data.strip()
+            else:
+                status = False
+        except Exception:
+            status = False
+        return status, result
+
+    def ipmi_set_ss_thres(self, id, threshold_key, value):
+        status = True
+        result = ""
+        try:
+            cmd = "ipmitool sensor thresh '{}' {} {}".format(str(id), str(threshold_key), str(value))
+            p = subprocess.Popen(
+                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            raw_data, err = p.communicate()
+            if err == '':
+                result = raw_data.strip()
+            else:
+                status = False
+        except Exception:
+            status = False
+        return status, result

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/pcie.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/pcie.py
@@ -1,0 +1,23 @@
+#############################################################################
+# Edgecore
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the fan status which are available in the platform
+# Base PCIe class
+#############################################################################
+
+import logging
+
+
+try:
+    from sonic_platform.component import Component
+    from sonic_platform_base.sonic_pcie.pcie_common import PcieUtil
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Pcie(PcieUtil):
+    """Edgecore Platform-specific PCIe class"""
+
+    def __init__(self, platform_path):
+        PcieUtil.__init__(self, platform_path)

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/thermal.py
@@ -15,3 +15,9 @@ class Thermal(PddfThermal):
         PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data, is_psu_thermal, psu_index)
 
     # Provide the functions/variables below for which implementation is to be overwritten
+    def get_status(self):
+        get_temp=self.get_temperature()
+
+        if get_temp is not None:
+            return True if get_temp else False
+


### PR DESCRIPTION
Signed-off-by: jostar-yang <jostar_yang@edge-core.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. Support show system-health on pddf platform
2. Base on https://github.com/sonic-net/sonic-buildimage/pull/12904 and  needed code to pass pytest.
3. show platfomr pcieinfo will not show error message
#### How I did it
Add needed code to pddf and sonic_platform.
#### How to verify it
Test show cmd.
root@sonic:/home/admin# show platform fan
  Drawer    LED         FAN    Speed    Direction    Presence    Status          Timestamp
--------  -----  ----------  -------  -----------  ----------  --------  -----------------
Fantray1  green  Fantray1_1      52%      EXHAUST     Present        OK  20220922 14:34:28
Fantray1  green  Fantray1_2      52%      EXHAUST     Present        OK  20220922 14:34:28
Fantray2  green  Fantray2_1      52%      EXHAUST     Present        OK  20220922 14:34:28
Fantray2  green  Fantray2_2      52%      EXHAUST     Present        OK  20220922 14:34:28
Fantray3  green  Fantray3_1      52%      EXHAUST     Present        OK  20220922 14:34:28
Fantray3  green  Fantray3_2      52%      EXHAUST     Present        OK  20220922 14:34:28
Fantray4  green  Fantray4_1      52%      EXHAUST     Present        OK  20220922 14:34:28
Fantray4  green  Fantray4_2      52%      EXHAUST     Present        OK  20220922 14:34:28
     N/A  green   PSU1_FAN1      37%      exhaust     Present        OK  20220922 14:34:28
     N/A  green   PSU2_FAN1      36%      exhaust     Present        OK  20220922 14:34:28

show platform temp
                   Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
-------------------------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
      CpuBoard_temp(0x4B)           30.5       80.0       N/A             N/A            N/A      False  20220922 14:34:28
          FB_1_temp(0x4D)           31         80.0       N/A             N/A            N/A      False  20220922 14:34:28
          FB_2_temp(0x4E)           31         80.0       N/A             N/A            N/A      False  20220922 14:34:28
        MB_MAC_temp(0x48)           36         80.0       N/A             N/A            N/A      False  20220922 14:34:28
 MB_RearCenter_temp(0x49)           39.5       80.0       N/A             N/A            N/A      False  20220922 14:34:28
MB_RightCenter_temp(0x4A)           29         80.0       N/A             N/A            N/A      False  20220922 14:34:28
               PSU1_TEMP1           29          N/A       N/A             N/A            N/A      False  20220922 14:34:28
               PSU2_TEMP1           29          N/A       N/A             N/A            N/A      False  20220922 14:34:28

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

