### PR TITLE
[BFN] Added watchdog platform plugin

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
@@ -15,6 +15,7 @@ try:
     from sonic_platform.thermal import chassis_thermals_list_get
     from sonic_platform.platform_utils import file_create
     from sonic_platform.eeprom import Eeprom
+    from sonic_platform.watchdog import Watchdog
 
     from sonic_platform.platform_thrift_client import pltfm_mgr_ready
     from sonic_platform.platform_thrift_client import thrift_try
@@ -49,6 +50,7 @@ class Chassis(ChassisBase):
         self.__thermals = None
         self.__psu_list = None
         self.__sfp_list = None
+        self.__watchdog = None
 
         self.ready = False
         self.phy_port_cur_state = {}
@@ -81,6 +83,16 @@ class Chassis(ChassisBase):
         if self.__tlv_dict_eeprom is None:
             self.__tlv_dict_eeprom = self._eeprom.get_data()
         return self.__tlv_dict_eeprom
+
+    @property
+    def _watchdog(self):
+        if self.__watchdog is None:
+            self.__watchdog = Watchdog()
+        return self.__watchdog
+
+    @_watchdog.setter
+    def _watchdog(self, value):
+        pass
 
     @property
     def _fan_drawer_list(self):

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/watchdog.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/watchdog.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+import syslog
+from sonic_platform_base.watchdog_base import WatchdogBase
+
+class Watchdog(WatchdogBase):
+    def arm(self, seconds):
+        """
+        Arm the hardware watchdog with a timeout of <seconds> seconds.
+        If the watchdog is currently armed, calling this function will
+        simply reset the timer to the provided value. If the underlying
+        hardware does not support the value provided in <seconds>, this
+        method should arm the watchdog with the *next greater* available
+        value.
+        Returns:
+            An integer specifying the *actual* number of seconds the watchdog
+            was armed with. On failure returns -1.
+        """
+        syslog.syslog(syslog.LOG_WARNING, "The watchdog arm operation is not supported in this revision of the plugin!")
+        return -1
+
+    def disarm(self):
+        """
+        Disarm the hardware watchdog
+        Returns:
+            A boolean, True if watchdog is disarmed successfully, False if not
+        """
+        return True
+
+    def is_armed(self):
+        """
+        Retrieves the armed state of the hardware watchdog.
+        Returns:
+            A boolean, True if watchdog is armed, False if not
+        """
+        return False
+
+    def get_remaining_time(self):
+        """
+        If the watchdog is armed, retrieve the number of seconds remaining on
+        the watchdog timer
+        Returns:
+            An integer specifying the number of seconds remaining on thei
+            watchdog timer. If the watchdog is not armed, returns -1.
+        """
+        return -1


### PR DESCRIPTION
Signed-off-by: Andriy Kokhan <andriyx.kokhan@intel.com>

#### Why I did it
Initial implementation of Watchdog platform plugin for BMC-based boards

#### How I did it

#### How to verify it
Run platform_tests/test_reload_config.py
```
platform_tests/test_reload_config.py::test_reload_configuration PASSED   [ 50%]
platform_tests/test_reload_config.py::test_reload_configuration_checks PASSED [100%]
```
#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
