### PR TITLE
DellEMC: Add platform_env.conf for Z9432F platform

### DIFF
--- a/device/dell/x86_64-dellemc_z9432f_c3758-r0/platform_env.conf
+++ b/device/dell/x86_64-dellemc_z9432f_c3758-r0/platform_env.conf
@@ -1,0 +1,2 @@
+SYNCD_SHM_SIZE=256m
+is_ltsw_chip=1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
DellEMC: Add platform_env.conf for Z9432F platform

#### How I did it
Added the platform specific non-default values.

#### How to verify it
Based on the value of is_ltsw_chip in platform_en.conf the knet driver will be loaded.
[Unit_Test_Z9432F.txt](https://github.com/sonic-net/sonic-buildimage/files/10188101/Unit_Test_Z9432F.txt)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

