### PR TITLE
[dhcpv6_relay] Fix dependency of dhcp-mon on VLAN with only v6 cfg is provided

### DIFF
--- a/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
@@ -32,7 +32,7 @@ dhcpmon-{{ vlan_name }}
 {% endif %}
 {# Check DHCPv6 agents #}
 {% if DHCP_RELAY and vlan_name in DHCP_RELAY and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
-{% for dhcpv6_server in VLAN[vlan_name]['dhcpv6_servers'] %}
+{% for dhcpv6_server in DHCP_RELAY[vlan_name]['dhcpv6_servers'] %}
 {% if dhcpv6_server | ipv6 %}
 {% set _dummy = relay_for_ipv6.update({'flag': True}) %}
 {% endif %}


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

1. config vlan add 100
2. config vlan member add Ethernet0
3. config interface ip add Vlan100 <ip_addr>
4. config load 
```
{
        "DHCP_RELAY" :{
                "Vlan100" : {
                        "dhcpv6_servers" : ["fc02:2000::2"]
                }
        }
}
```
5. Systemctl restart dhcp_relay

####  Behavior Seec
1. dhcp_relay container doesn't start with the following log
```
Dec  8 21:19:47.779998 sonic  INFO dockerd[572]: time="2022-12-08T21:19:47.779415981+02:00" level=error msg="Error setting up exec command in container dhcp_relay: Container 4a64823d9a9a3617f5fdb8f9b54a10e6ebf003df1c3dafeea1606ca38a9ae0d8 is not running"
```

2. Happened because of the wrong jinja formatting of supervisord.conf file which results in:

```
root@sonic:/home/admin# sonic-cfggen -d -t docker-dhcp-relay.supervisord.conf.j2
..............
..............

[group:dhcp-relay]
programs=dhcp6relay

[program:dhcp6relay]
command=/usr/sbin/dhcp6relay
priority=3
autostart=false
autorestart=false
stdout_logfile=syslog
stderr_logfile=syslog
dependent_startup=true
dependent_startup_wait_for=start:exited

[group:dhcpmon]
programs=dhcpmon-Vlan100

<missing [program:dhcp6relay] section for dhcpmon>

root@sonic:/home/admin#
```

With this change, the formatting is proper and the container starts as expected even without VLAN|<id> dhcp6_servers field
```
[group:dhcp-relay]
programs=dhcp6relay

[program:dhcp6relay]
command=/usr/sbin/dhcp6relay
priority=3
autostart=false
autorestart=false
stdout_logfile=syslog
stderr_logfile=syslog
dependent_startup=true
dependent_startup_wait_for=start:exited

[group:dhcpmon]
programs=dhcpmon-Vlan100

[program:dhcpmon-Vlan100]
command=/usr/sbin/dhcpmon -id Vlan100 -iu Ethernet236 -im eth0
priority=4
autostart=false
autorestart=false
stdout_logfile=syslog
stderr_logfile=syslog
dependent_startup=true
dependent_startup_wait_for=
```




#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

