### PR TITLE
[SFP] Change logging severity when failed to read EEPROM

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -345,7 +345,7 @@ class SFP(NvidiaSFPCommon):
                     raise IOError(f'errno = {os.strerror(ctypes.get_errno())}')
         except (OSError, IOError) as e:
             if log_on_error:
-                logger.log_error(f'Failed to read sfp={self.sdk_index} EEPROM page={page}, page_offset={page_offset}, \
+                logger.log_warning(f'Failed to read sfp={self.sdk_index} EEPROM page={page}, page_offset={page_offset}, \
                     size={num_bytes}, offset={offset}, error = {e}')
             return None
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In order to prevent the [sonic-mgmt/tests/platform_tests/sfp/test_sfputil.py](https://github.com/sonic-net/sonic-mgmt/blob/1224b087efe5635c3bd7c643388a95cd28d80b2b/tests/platform_tests/sfp/test_sfputil.py#L90) test failing on the log analyzer step.

The mentioned test is performing the `sfputil reset EthernetX` for every interface on the SONiC switch, this action will flap the SFP device status (`INSTERTED -> REMOVED -> INSTERTED`).

The SONiC XCVRD daemon will catch this SFP device status change (because it is monitoring the presence status of the cable).
To judge the cable presence status, currently, we are still leveraging to read the first bytes of the EEPROM, and the EEPROM could be not ready at some moment and the SONiC XCVRD daemon will print the error log to Syslog:
```
ERR pmon#xcvrd: Error! Unable to read data for 'xx' port, page 'xx' offset 128, rc = 1, err msg: Sending access register
```

#### How I did it
Change logging severity from `ERR` to `WARNING`

#### How to verify it
Run the [sonic-mgmt/tests/platform_tests/sfp/test_sfputil.py](https://github.com/sonic-net/sonic-mgmt/blob/1224b087efe5635c3bd7c643388a95cd28d80b2b/tests/platform_tests/sfp/test_sfputil.py#L90)

OR much faster way to run the next script on the switch:
```
#!/bin/bash

START=0
END=248

for (( intf=$START; intf<=$END; intf+=8))
do
    sfputil reset Ethernet"${intf}"
done

sfputil show presence
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

