### PR TITLE
[Build] fix md5sum calculation of web packages if transient error

### DIFF
--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -63,7 +63,8 @@ check_version_control()
 get_url_version()
 {
     local package_url=$1
-    /usr/bin/curl -Lks $package_url | md5sum | cut -d' ' -f1
+    set -o pipefail
+    /usr/bin/curl -Lfks --retry 5 $package_url | md5sum | cut -d' ' -f1
 }
 
 check_if_url_exist()
@@ -127,14 +128,14 @@ download_packages()
                     filenames[$version_filename]=$filename
                     real_version=$version
                 else
-                    real_version=$(get_url_version $url)
+                    real_version=$(get_url_version $url) || { echo "get_url_version $url failed"; exit 1; }
                     if [ "$real_version" != "$version" ]; then
                         echo "Failed to verify url: $url, real hash value: $real_version, expected value: $version_filename" 1>&2
                        exit 1
                     fi
                 fi
             else
-                real_version=$(get_url_version $url)
+                real_version=$(get_url_version $url) || { echo "get_url_version $url failed"; exit 1; }
             fi
 
             echo "$url==$real_version" >> ${BUILD_WEB_VERSION_FILE}


### PR DESCRIPTION
Fix #12279

#### Why I did it

Curl can fail when we calculate md5sum of web package.
E.g. if server responsed with 503 error.
But we don't validate this and pass any output from curl directly to md5sum.
After that we save incorrect md5 hash to versions-web file.

#### How I did it

1. use option --retry 5 for transient errors (default value is 0)
2. use option -f for curl and set -o pipefail for shell to detect errors
3. stop build if curl failed

Signed-off-by: Konstantin Vasin <k.vasin@yadro.com>
