### PR TITLE
[DellEMC] Fixing 'show interface status' break in DellEMC platforms

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/chassis.py
@@ -123,11 +123,11 @@ class Chassis(ChassisBase):
 
         for port_num in range(self.PORT_START, (self.PORT_END + 1)):
             # sfp get uses zero-indexing, but port numbers start from 1
-            presence = self.get_sfp(port_num-1).get_presence()
-            if presence:
-                self._global_port_pres_dict[port_num] = '1'
-            else:
-                self._global_port_pres_dict[port_num] = '0'
+            #presence = self.get_sfp(port_num-1).get_presence()
+            #if presence:
+            #    self._global_port_pres_dict[port_num] = '1'
+            #else:
+            self._global_port_pres_dict[port_num] = '0'
 
         self.LOCATOR_LED_ON = self.STATUS_LED_COLOR_BLUE_BLINK
         self.LOCATOR_LED_OFF = self.STATUS_LED_COLOR_OFF

--- a/platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/chassis.py
@@ -123,10 +123,6 @@ class Chassis(ChassisBase):
 
         for port_num in range(self.PORT_START, (self.PORT_END + 1)):
             # sfp get uses zero-indexing, but port numbers start from 1
-            #presence = self.get_sfp(port_num-1).get_presence()
-            #if presence:
-            #    self._global_port_pres_dict[port_num] = '1'
-            #else:
             self._global_port_pres_dict[port_num] = '0'
 
         self.LOCATOR_LED_ON = self.STATUS_LED_COLOR_BLUE_BLINK

--- a/platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/component.py
@@ -78,7 +78,7 @@ class Component(ComponentBase):
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]
-        self.version = self.CHASSIS_COMPONENTS[self.index][2]()
+        self.version = None
 
     def get_name(self):
         """
@@ -102,6 +102,8 @@ class Component(ComponentBase):
         Returns:
             A string containing the firmware version of the component
         """
+        if self.version == None:
+            self.version = self.CHASSIS_COMPONENTS[self.index][2]()
         return self.version
 
     def get_presence(self):

--- a/platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/chassis.py
@@ -125,10 +125,6 @@ class Chassis(ChassisBase):
 
         for port_num in range(self.PORT_START, (self.PORT_END + 1)):
             # sfp get uses zero-indexing, but port numbers start from 1
-            #presence = self.get_sfp(port_num-1).get_presence()
-            #if presence:
-            #    self._global_port_pres_dict[port_num] = '1'
-            #else:
             self._global_port_pres_dict[port_num] = '0'
 
         self.LOCATOR_LED_ON = self.STATUS_LED_COLOR_BLUE_BLINK

--- a/platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/chassis.py
@@ -125,11 +125,11 @@ class Chassis(ChassisBase):
 
         for port_num in range(self.PORT_START, (self.PORT_END + 1)):
             # sfp get uses zero-indexing, but port numbers start from 1
-            presence = self.get_sfp(port_num-1).get_presence()
-            if presence:
-                self._global_port_pres_dict[port_num] = '1'
-            else:
-                self._global_port_pres_dict[port_num] = '0'
+            #presence = self.get_sfp(port_num-1).get_presence()
+            #if presence:
+            #    self._global_port_pres_dict[port_num] = '1'
+            #else:
+            self._global_port_pres_dict[port_num] = '0'
 
         self.LOCATOR_LED_ON = self.STATUS_LED_COLOR_BLUE_BLINK
         self.LOCATOR_LED_OFF = self.STATUS_LED_COLOR_OFF

--- a/platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/component.py
@@ -77,7 +77,7 @@ class Component(ComponentBase):
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]
-        self.version = self.CHASSIS_COMPONENTS[self.index][2]()
+        self.version = None
 
     def get_name(self):
         """
@@ -101,6 +101,8 @@ class Component(ComponentBase):
         Returns:
             A string containing the firmware version of the component
         """
+        if self.version == None:
+            self.version = self.CHASSIS_COMPONENTS[self.index][2]()
         return self.version
 
     def install_firmware(self, image_path):

--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/chassis.py
@@ -92,8 +92,6 @@ class Chassis(ChassisBase):
 
         for port_num in range(self.PORT_START, self.PORTS_IN_BLOCK):
             # sfp get uses zero-indexing, but port numbers start from 1
-            #presence = self.get_sfp(port_num).get_presence()
-            #self._global_port_pres_dict[port_num] = '1' if presence else '0'
             self._global_port_pres_dict[port_num] = '0'
 
     def __del__(self):

--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/chassis.py
@@ -92,8 +92,9 @@ class Chassis(ChassisBase):
 
         for port_num in range(self.PORT_START, self.PORTS_IN_BLOCK):
             # sfp get uses zero-indexing, but port numbers start from 1
-            presence = self.get_sfp(port_num).get_presence()
-            self._global_port_pres_dict[port_num] = '1' if presence else '0'
+            #presence = self.get_sfp(port_num).get_presence()
+            #self._global_port_pres_dict[port_num] = '1' if presence else '0'
+            self._global_port_pres_dict[port_num] = '0'
 
     def __del__(self):
         if self.oir_fd != -1:

--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/component.py
@@ -86,7 +86,7 @@ class Component(ComponentBase):
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]
-        self.version = self.CHASSIS_COMPONENTS[self.index][2]()
+        self.version = None
 
     def get_name(self):
         """
@@ -110,6 +110,8 @@ class Component(ComponentBase):
         Returns:
             A string containing the firmware version of the component
         """
+        if self.version == None:
+            self.version = self.CHASSIS_COMPONENTS[self.index][2]()
         return self.version
 
     def install_firmware(self, image_path):

--- a/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/chassis.py
@@ -151,8 +151,9 @@ class Chassis(ChassisBase):
         self._component_list = [Component(i) for i in range(MAX_S5248F_COMPONENT)]
         for port_num in range(self.PORT_START, self.PORTS_IN_BLOCK):
             # sfp get uses zero-indexing, but port numbers start from 1
-            presence = self.get_sfp(port_num-1).get_presence()
-            self._global_port_pres_dict[port_num] = '1' if presence else '0'
+            #presence = self.get_sfp(port_num-1).get_presence()
+            #self._global_port_pres_dict[port_num] = '1' if presence else '0'
+            self._global_port_pres_dict[port_num] = '0'
 
         #self.LOCATOR_LED_ON = self.STATUS_LED_COLOR_BLUE_BLINK
         #self.LOCATOR_LED_OFF = self.STATUS_LED_COLOR_OFF

--- a/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/chassis.py
@@ -151,8 +151,6 @@ class Chassis(ChassisBase):
         self._component_list = [Component(i) for i in range(MAX_S5248F_COMPONENT)]
         for port_num in range(self.PORT_START, self.PORTS_IN_BLOCK):
             # sfp get uses zero-indexing, but port numbers start from 1
-            #presence = self.get_sfp(port_num-1).get_presence()
-            #self._global_port_pres_dict[port_num] = '1' if presence else '0'
             self._global_port_pres_dict[port_num] = '0'
 
         #self.LOCATOR_LED_ON = self.STATUS_LED_COLOR_BLUE_BLINK

--- a/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/component.py
@@ -86,7 +86,7 @@ class Component(ComponentBase):
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]
-        self.version = self.CHASSIS_COMPONENTS[self.index][2]()
+        self.version = None
 
     def get_name(self):
         """
@@ -110,6 +110,8 @@ class Component(ComponentBase):
         Returns:
             A string containing the firmware version of the component
         """
+        if self.version == None:
+            self.version = self.CHASSIS_COMPONENTS[self.index][2]()
         return self.version
 
     def install_firmware(self, image_path):

--- a/platform/broadcom/sonic-platform-modules-dell/s5296f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5296f/sonic_platform/chassis.py
@@ -128,8 +128,6 @@ class Chassis(ChassisBase):
         self._watchdog = Watchdog()
         for port_num in range(self.PORT_START, self.PORTS_IN_BLOCK):
             # sfp get uses zero-indexing, but port numbers start from 1
-            #presence = self.get_sfp(port_num).get_presence()
-            #self._global_port_pres_dict[port_num] = '1' if presence else '0'
             self._global_port_pres_dict[port_num] = '0'
 
     def __del__(self):

--- a/platform/broadcom/sonic-platform-modules-dell/s5296f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5296f/sonic_platform/chassis.py
@@ -126,6 +126,11 @@ class Chassis(ChassisBase):
         self._num_fans = MAX_S5296F_FANTRAY * MAX_S5296F_FAN
 
         self._watchdog = Watchdog()
+        for port_num in range(self.PORT_START, self.PORTS_IN_BLOCK):
+            # sfp get uses zero-indexing, but port numbers start from 1
+            #presence = self.get_sfp(port_num).get_presence()
+            #self._global_port_pres_dict[port_num] = '1' if presence else '0'
+            self._global_port_pres_dict[port_num] = '0'
 
     def __del__(self):
         if self.oir_fd != -1:

--- a/platform/broadcom/sonic-platform-modules-dell/s5296f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5296f/sonic_platform/component.py
@@ -111,7 +111,7 @@ class Component(ComponentBase):
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]
-        self.version = self.CHASSIS_COMPONENTS[self.index][2]()
+        self.version = None
 
     def get_name(self):
         """
@@ -135,6 +135,8 @@ class Component(ComponentBase):
         Returns:
             A string containing the firmware version of the component
         """
+        if self.version == None:
+            self.version = self.CHASSIS_COMPONENTS[self.index][2]()
         return self.version
 
     def get_presence(self):

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
@@ -56,6 +56,8 @@ class Chassis(ChassisBase):
     _is_fan_control_enabled = False
     _fan_control_initialised = False
 
+    _global_port_pres_dict = {}
+
     def __init__(self):
         ChassisBase.__init__(self)
         self.status_led_reg = "system_led"
@@ -106,6 +108,9 @@ class Chassis(ChassisBase):
         for i in range(MAX_S6000_COMPONENT):
             component = Component(i)
             self._component_list.append(component)
+
+        for port_num in range(self.PORT_START, (self.PORT_END + 1)):
+            self._global_port_pres_dict[port_num] = '0'
 
     def _get_cpld_register(self, reg_name):
         rv = 'ERR'

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
@@ -65,6 +65,8 @@ class Chassis(ChassisBase):
         'amber': 0x02, 'blinking amber': 0x08
     }
 
+    _global_port_pres_dict = {}
+
     def __init__(self):
 
         ChassisBase.__init__(self)
@@ -102,6 +104,13 @@ class Chassis(ChassisBase):
         for i in range(MAX_S6100_COMPONENT):
             component = Component(i)
             self._component_list.append(component)
+
+        for i in self._sfp_list:
+            presence = i.get_presence()
+            if presence:
+                self._global_port_pres_dict[i.index] = '1'
+            else:
+                self._global_port_pres_dict[i.index] = '0'
 
         bios_ver = self.get_component(0).get_firmware_version()
         bios_minor_ver = bios_ver.split("-")[-1]

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/eeprom.py
@@ -11,6 +11,7 @@
 
 try:
     from sonic_eeprom import eeprom_tlvinfo
+    import os
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -26,6 +27,10 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
             self.eeprom_path = "/sys/class/i2c-adapter/i2c-2/2-0050/eeprom"
         super(Eeprom, self).__init__(self.eeprom_path, 0, '', True)
         self.eeprom_tlv_dict = dict()
+
+        if os.geteuid() != 0:
+            self.eeprom_data = "N/A"
+            return
 
         try:
             if self.is_module:

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/chassis.py
@@ -83,11 +83,11 @@ class Chassis(ChassisBase):
             self._thermal_list.append(thermal)
 
         for port_num in range(self.PORT_START, (self.PORT_END + 1)):
-            presence = self.get_sfp(port_num).get_presence()
-            if presence:
-                self._global_port_pres_dict[port_num] = '1'
-            else:
-                self._global_port_pres_dict[port_num] = '0'
+            #presence = self.get_sfp(port_num).get_presence()
+            #if presence:
+            #    self._global_port_pres_dict[port_num] = '1'
+            #else:
+            self._global_port_pres_dict[port_num] = '0'
 
     def __del__(self):
         if self.oir_fd != -1:

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/chassis.py
@@ -84,9 +84,6 @@ class Chassis(ChassisBase):
 
         for port_num in range(self.PORT_START, (self.PORT_END + 1)):
             #presence = self.get_sfp(port_num).get_presence()
-            #if presence:
-            #    self._global_port_pres_dict[port_num] = '1'
-            #else:
             self._global_port_pres_dict[port_num] = '0'
 
     def __del__(self):

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/chassis.py
@@ -147,8 +147,6 @@ class Chassis(ChassisBase):
         self._component_list = [Component(i) for i in range(MAX_Z9332F_COMPONENT)]
         for port_num in range(self.PORT_START, self.PORTS_IN_BLOCK):
             # sfp get uses zero-indexing, but port numbers start from 1
-            # presence = self.get_sfp(port_num).get_presence()
-            # self._global_port_pres_dict[port_num] = '1' if presence else '0'
             self._global_port_pres_dict[port_num] = '0'
 
         self._watchdog = Watchdog()

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/chassis.py
@@ -147,8 +147,9 @@ class Chassis(ChassisBase):
         self._component_list = [Component(i) for i in range(MAX_Z9332F_COMPONENT)]
         for port_num in range(self.PORT_START, self.PORTS_IN_BLOCK):
             # sfp get uses zero-indexing, but port numbers start from 1
-            presence = self.get_sfp(port_num).get_presence()
-            self._global_port_pres_dict[port_num] = '1' if presence else '0'
+            # presence = self.get_sfp(port_num).get_presence()
+            # self._global_port_pres_dict[port_num] = '1' if presence else '0'
+            self._global_port_pres_dict[port_num] = '0'
 
         self._watchdog = Watchdog()
     def __del__(self):

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/component.py
@@ -153,7 +153,7 @@ class Component(ComponentBase):
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]
-        self.version = self.CHASSIS_COMPONENTS[self.index][2]()
+        self.version = None
 
     @staticmethod
     def _get_available_firmware_version(image_path):
@@ -242,6 +242,8 @@ class Component(ComponentBase):
         Returns:
             A string containing the firmware version of the component
         """
+        if self.version == None:
+            self.version = self.CHASSIS_COMPONENTS[self.index][2]()
         return self.version
 
     def get_presence(self):

--- a/platform/broadcom/sonic-platform-modules-dell/z9432f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9432f/sonic_platform/chassis.py
@@ -130,8 +130,9 @@ class Chassis(ChassisBase):
         self._thermal_list = [Thermal(i) for i in range(MAX_Z9432F_THERMAL)]
         self._component_list = [Component(i) for i in range(MAX_Z9432F_COMPONENT)]
         for port_num in range(PORT_START, PORTS_IN_BLOCK):
-            presence = self.get_sfp(port_num).get_presence()
-            self._global_port_pres_dict[port_num] = '1' if presence else '0'
+            #presence = self.get_sfp(port_num).get_presence()
+            #self._global_port_pres_dict[port_num] = '1' if presence else '0'
+            self._global_port_pres_dict[port_num] = '0'
 
         self._watchdog = Watchdog()
         #self.LOCATOR_LED_ON = self.STATUS_LED_COLOR_BLUE_BLINK

--- a/platform/broadcom/sonic-platform-modules-dell/z9432f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9432f/sonic_platform/chassis.py
@@ -130,8 +130,6 @@ class Chassis(ChassisBase):
         self._thermal_list = [Thermal(i) for i in range(MAX_Z9432F_THERMAL)]
         self._component_list = [Component(i) for i in range(MAX_Z9432F_COMPONENT)]
         for port_num in range(PORT_START, PORTS_IN_BLOCK):
-            #presence = self.get_sfp(port_num).get_presence()
-            #self._global_port_pres_dict[port_num] = '1' if presence else '0'
             self._global_port_pres_dict[port_num] = '0'
 
         self._watchdog = Watchdog()

--- a/platform/broadcom/sonic-platform-modules-dell/z9432f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9432f/sonic_platform/component.py
@@ -127,7 +127,7 @@ class Component(ComponentBase):
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]
-        self.version = self.CHASSIS_COMPONENTS[self.index][2]()
+        self.version = None
 
     @staticmethod
     def _get_available_firmware_version(image_path):
@@ -208,6 +208,8 @@ class Component(ComponentBase):
         Returns:
             A string containing the firmware version of the component
         """
+        if self.version == None:
+            self.version = self.CHASSIS_COMPONENTS[self.index][2]()
         return self.version
 
     def get_presence(self):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- When a non-root user tries to run 'show interface status' command, the command got break as 2.0 API throws permission denied error.

#### How I did it
- Using default definitions for sfp presence and fw version.

#### How to verify it
- By running the command 'show interface status'

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
On branch s6100-int-status                                                                                                                      
Changes to be committed:                                                                                                                          
(use "git restore --staged <file>..." to unstage)                                                                                                     
	modified:   s5212f/sonic_platform/chassis.py                                                                                                    
	modified:   s5212f/sonic_platform/component.py                                                                                                  
	modified:   s5224f/sonic_platform/chassis.py                                                                                                    
	modified:   s5224f/sonic_platform/component.py                                                                                                  
	modified:   s5232f/sonic_platform/chassis.py                                                                                                    
	modified:   s5232f/sonic_platform/component.py                                                                                                  
	modified:   s5248f/sonic_platform/chassis.py                                                                                                    
	modified:   s5248f/sonic_platform/component.py                                                                                                  
	modified:   s5296f/sonic_platform/chassis.py                                                                                                    
	modified:   s5296f/sonic_platform/component.py                                                                                                  
	modified:   s6000/sonic_platform/chassis.py                                                                                                     
	modified:   s6100/sonic_platform/chassis.py                                                                                                     
	modified:   s6100/sonic_platform/eeprom.py                                                                                                      
	modified:   z9264f/sonic_platform/chassis.py                                                                                                    
	modified:   z9332f/sonic_platform/chassis.py                                                                                                    
	modified:   z9332f/sonic_platform/component.py                                                                                                  
	modified:   z9432f/sonic_platform/chassis.py                                                                                                    
	modified:   z9432f/sonic_platform/component.py 

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

