### PR TITLE
[YANG MODEL] Fix breakout validation failed

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-interface.yang
@@ -67,6 +67,14 @@ module sonic-interface {
                                         default "0";
 				}
 
+				leaf ipv6_use_link_local_only {
+					description "Enable/disable IPv6 link-local";
+					type enumeration {
+						enum enable;
+						enum disable;
+					}
+				}
+
 				leaf mpls {
 					description "Enable/disable MPLS routing for the interface";
 					type enumeration {

--- a/src/sonic-yang-models/yang-models/sonic-mgmt_interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mgmt_interface.yang
@@ -41,12 +41,12 @@ module sonic-mgmt_interface {
                 }
 
                 leaf ip_prefix {
-                    must "(contains(current(), ':') and contains(../gwaddr, ':')) or (contains(current(), '.') and contains(../gwaddr, '.'))";
+                    must "(contains(current(), ':')) or (contains(current(), '.'))";
                     type stypes:sonic-ip-prefix;
                 }
 
                 leaf gwaddr {
-                    must "(contains(current(), ':') and contains(../ip_prefix, ':')) or (contains(current(), '.') and contains(../ip_prefix, '.'))"; 
+                    must "(contains(current(), ':') and contains(../ip_prefix, ':')) or (contains(current(), '.') and contains(../ip_prefix, '.'))";
                     type inet:ip-address;
                 }
 
@@ -57,11 +57,11 @@ module sonic-mgmt_interface {
                     }
 
                     description
-                        "This configuration allows addtional routes to be added to default VRF table 
+                        "This configuration allows addtional routes to be added to default VRF table
                          or mgmt VRF table, based on if Management VRF is configured.
                          Details can be found in interfaces.j2.";
                 }
- 
+
             } /* end of list MGMT_INTERFACE_IPADDR_LIST */
 
         } /* end of container MGMT_INTERFACE */

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -106,6 +106,14 @@ module sonic-vlan {
                     description "Packet action when a packet ingress and gets routed on the same IP interface";
                     type stypes:loopback_action;
                 }
+
+				leaf ipv6_use_link_local_only {
+					description "Enable/disable IPv6 link-local";
+					type enumeration {
+						enum enable;
+						enum disable;
+					}
+				}
 			}
 			/* end of VLAN_INTERFACE_LIST */
 
@@ -163,7 +171,7 @@ module sonic-vlan {
 			list VLAN_LIST {
 
 				key "name";
-        
+
 				leaf name {
 					type string {
 						pattern 'Vlan([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The interface fails to breakout when:
- IPv6 auto link-local address generation is enabled in interfaces or vlan.
```
admin@sonic:~$ cat /etc/sonic/config_dg.json
...omitted...
    "Ethernet46": {
        "ipv6_use_link_local_only": "enable"
    },
    "Ethernet47": {
        "ipv6_use_link_local_only": "enable"
    }
...omitted...

admin@sonic:~$ sudo config interface breakout Ethernet48 4x25G -y
Running Breakout Mode : 1x100G[40G]
Target Breakout Mode : 4x25G
...omitted...
sonic_yang(6):Note: Below table(s) have no YANG models: REST_SERVER, SNMP, SNMP_COMMUNITY, SNMP_TRAP_CONFIG, VXLAN_EVPN_NVO, VXLAN_TUNNEL, VXLAN_TUNNEL_MAP, XCVRD_LOG
sonic_yang(3):All Keys are not parsed in INTERFACE
dict_keys(['Ethernet46', 'Ethernet47'])
sonic_yang(3):exceptionList:["'ipv6_use_link_local_only'", "'ipv6_use_link_local_only'", 'Value not found for name ip-prefix in Ethernet46', 'Value not found for name ip-prefix in Ethernet47']
sonic_yang(3):Data Loading Failed:All Keys are not parsed in INTERFACE
dict_keys(['Ethernet46', 'Ethernet47'])
Data Loading Failed
All Keys are not parsed in INTERFACE
dict_keys(['Ethernet46', 'Ethernet47'])
ConfigMgmt Class creation failed
Failed to break out Port. Error: Failed to load the config. Error: ConfigMgmtDPB Class creation failed
...omitted...
```
- There is no default gateway in the static management IP.
```
admin@sonic:~$ cat /etc/sonic/config_dg.json
...omitted...
    "MGMT_INTERFACE": {
        "eth0|192.168.200.71/24": {}
    },
...omitted...

admin@sonic:~$ sudo config interface breakout Ethernet48 4x25G -y
Running Breakout Mode : 1x100G[40G]
Target Breakout Mode : 4x25G
...omitted...
sonic_yang(6):Note: Below table(s) have no YANG models: REST_SERVER, SNMP, SNMP_COMMUNITY, SNMP_TRAP_CONFIG, XCVRD_LOG
libyang[0]: Must condition "(contains(current(), ':') and contains(../gwaddr, ':')) or (contains(current(), '.') and contains(../gwaddr, '.'))" not satisfied. (path: /sonic-mgmt_interface:sonic-mgmt_interface/MGMT_INTERFACE/MGMT_INTERFACE_LIST[name='eth0'][ip_prefix='192.168.200.71/24']/ip_prefix)
sonic_yang(3):Data Loading Failed:Must condition "(contains(current(), ':') and contains(../gwaddr, ':')) or (contains(current(), '.') and contains(../gwaddr, '.'))" not satisfied.
Data Loading Failed
Must condition "(contains(current(), ':') and contains(../gwaddr, ':')) or (contains(current(), '.') and contains(../gwaddr, '.'))" not satisfied.
ConfigMgmt Class creation failed
Failed to break out Port. Error: Failed to load the config. Error: ConfigMgmtDPB Class creation failed
...omitted...
```
#### How I did it
Add 'ipv6_use_link_local_only' field to vlan and interface yang files.
Remove the restriction about no default gateway from mgmt-interface yang file.

#### How to verify it
Add 'ipv6_use_link_local_only' field and remove 'gwaddr' constraint, and apply breakout setting on interface, breakout process got successfully completed.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

