### PR TITLE
[Mellanox] Remove TODO comments which are no longer needed

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -93,7 +93,7 @@ class Module(ModuleBase):
     def is_replaceable(self):
         return True
 
-    def get_oper_status(self): # TODO: read from DB?
+    def get_oper_status(self):
         if utils.read_int_from_file('/run/hw-management/system/lc{}_active'.format(self.slot_id)) == 1:
             return ModuleBase.MODULE_STATUS_ONLINE
         elif utils.read_int_from_file('/run/hw-management/system/lc{}_present'.format(self.slot_id)) == 1:
@@ -105,7 +105,7 @@ class Module(ModuleBase):
 
     def _check_state(self):
         """Check Module status change:
-            1. If status sysfs file value has been changed TODO: read from DB?
+            1. If status sysfs file value has been changed
             2. If sequence NO has been changed which means line card has been removed and inserted again.
         """
         seq_no = self._get_seq_no()
@@ -140,7 +140,7 @@ class Module(ModuleBase):
         self._check_state()
         if self.current_state == Module.STATE_ACTIVATED and not self._thermal_list:
             from .thermal import initialize_linecard_thermals
-            self._thermal_list = initialize_linecard_thermals(self.get_name(), self.slot_id) # TODO: add presence_cb?
+            self._thermal_list = initialize_linecard_thermals(self.get_name(), self.slot_id)
 
     def get_num_thermals(self):
         """
@@ -192,7 +192,7 @@ class Module(ModuleBase):
             if index < sfp_count:
                 if not self._sfp_list:
                     self._sfp_list = [None] * sfp_count
-                
+
                 if not self._sfp_list[index]:
                     self._sfp_list[index] = self._create_sfp_object(index)
                     self.sfp_initialized_count += 1
@@ -220,7 +220,7 @@ class Module(ModuleBase):
         """
         if self.sfp_count == 0:
             self.sfp_count = DeviceDataManager.get_linecard_sfp_count(self.slot_id)
-        return self.sfp_count 
+        return self.sfp_count
 
     def get_all_sfps(self):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -84,8 +84,8 @@ class FixedPsu(PsuBase):
         Retrieves current PSU voltage output
 
         Returns:
-            A float number, the output voltage in volts, 
-            e.g. 12.1 
+            A float number, the output voltage in volts,
+            e.g. 12.1
         """
         return None
 
@@ -143,7 +143,7 @@ class FixedPsu(PsuBase):
         Gets the power available status
 
         Returns:
-            True if power is present and power on. 
+            True if power is present and power on.
             False and "absence of PSU" if power is not present.
             False and "absence of power" if power is present but not power on.
         """
@@ -176,7 +176,7 @@ class FixedPsu(PsuBase):
 
         Returns:
             A float number of current temperature in Celsius up to nearest thousandth
-            of one degree Celsius, e.g. 30.125 
+            of one degree Celsius, e.g. 30.125
         """
         return None
 
@@ -195,8 +195,8 @@ class FixedPsu(PsuBase):
         Retrieves current PSU voltage input
 
         Returns:
-            A float number, the input voltage in volts, 
-            e.g. 12.1 
+            A float number, the input voltage in volts,
+            e.g. 12.1
         """
         return None
 
@@ -264,7 +264,7 @@ class Psu(FixedPsu):
                 psu_voltage_out = os.path.join(PSU_PATH, "power/psu{}_volt".format(self.index))
                 if os.path.exists(psu_voltage_out):
                     self._psu_voltage = psu_voltage_out
-        
+
         return self._psu_voltage
 
     @property
@@ -336,12 +336,10 @@ class Psu(FixedPsu):
         Retrieves current PSU voltage output
 
         Returns:
-            A float number, the output voltage in volts, 
-            e.g. 12.1 
+            A float number, the output voltage in volts,
+            e.g. 12.1
         """
         if self.get_powergood_status() and self.psu_voltage:
-            # TODO: should we put log_func=None here? If not do this, when a PSU is back to power, some PSU related
-            # sysfs may not ready, read_int_from_file would encounter exception and log an error.
             voltage = utils.read_int_from_file(self.psu_voltage, log_func=logger.log_info)
             return float(voltage) / 1000
         return None
@@ -405,7 +403,7 @@ class Psu(FixedPsu):
 
         Returns:
             A float number of current temperature in Celsius up to nearest thousandth
-            of one degree Celsius, e.g. 30.125 
+            of one degree Celsius, e.g. 30.125
         """
         if self.get_powergood_status():
             temp = utils.read_int_from_file(self.psu_temp, log_func=logger.log_info)
@@ -492,8 +490,8 @@ class Psu(FixedPsu):
         Retrieves current PSU voltage input
 
         Returns:
-            A float number, the input voltage in volts, 
-            e.g. 12.1 
+            A float number, the input voltage in volts,
+            e.g. 12.1
         """
         if self.get_powergood_status():
             voltage = utils.read_int_from_file(self.psu_voltage_in, log_func=logger.log_info)
@@ -563,13 +561,13 @@ class Psu(FixedPsu):
 
 
 class InvalidPsuVolWA:
-    """This class is created as a workaround for a known hardware issue that the PSU voltage threshold could be a 
+    """This class is created as a workaround for a known hardware issue that the PSU voltage threshold could be a
        invalid value 127998. Once we read a voltage threshold value equal to 127998, we should do following:
            1. Check the PSU vendor, it should be Delta
            2. Generate a temp sensor configuration file which contains a few set commands. Those set commands are the WA provided by low level team.
            3. Call "sensors -s -c <tmp_conf_file>"
            4. Wait for it to take effect
-        
+
         This issue is found on 3700, 3700c, 3800, 4600c
     """
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Remove TODO comments which are no longer needed

#### How I did it

Remove TODO comments which are no longer needed

#### How to verify it

Only comment change

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

