### PR TITLE
[202205][yang] Add collector_vrf to sflow yang model   (#12897)

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -43,6 +43,7 @@ Table of Contents
          * [Scheduler](#scheduler)  
          * [Port QoS Map](#port-qos-map)  
          * [Queue](#queue)  
+         * [Sflow](#sflow)  
          * [Tacplus Server](#tacplus-server)    
          * [TC to Priority group map](#tc-to-priority-group-map)  
          * [TC to Queue map](#tc-to-queue-map)    
@@ -57,7 +58,7 @@ Table of Contents
    * [For Developers](#for-developers)  
       * [Generating Application Config by Jinja2 Template](#generating-application-config-by-jinja2-template)
       * [Incremental Configuration by Subscribing to ConfigDB](#incremental-configuration-by-subscribing-to-configdb)
-
+ 
 
 
 # Introduction																																									
@@ -1331,6 +1332,68 @@ name as object key and member list as attribute.
 }
 ```
 
+### Sflow
+
+The below are the tables and their schema for SFLOW feature
+
+SFLOW
+
+| Field            | Description                                                                             | Mandatory   | Default   | Reference                                 |
+|------------------|-----------------------------------------------------------------------------------------|-------------|-----------|-------------------------------------------|
+| admin_state      | Global sflow admin state                                                                |             | down      |                                           |
+| polling_interval | The interval within which sFlow data is collected and sent to the configured collectors |             | 20        |                                           |
+| agent_id         | Interface name                                                                          |             |           | PORT:name,PORTCHANNEL:name,MGMT_PORT:name, VLAN:name |
+
+SFLOW_SESSION
+
+key - port
+| Field       | Description                                                                                                             | Mandatory   | Default   | Reference   |
+|-------------|-------------------------------------------------------------------------------------------------------------------------|-------------|-----------|-------------|
+| port        | Sets sflow session table attributes for either all interfaces or a specific Ethernet interface.                         |             |           | PORT:name   |
+| admin_state | Per port sflow admin state                                                                                              |             | up        |             |
+| sample_rate | Sets the packet sampling rate.  The rate is expressed as an integer N, where the intended sampling rate is 1/N packets. |             |           |             |
+
+SFLOW_COLLECTOR
+
+key - name
+| Field          | Description                                                                             | Mandatory   | Default   | Reference   |
+|----------------|-----------------------------------------------------------------------------------------|-------------|-----------|-------------|
+| name           | Name of the Sflow collector                                                             |             |           |             |
+| collector_ip   | IPv4/IPv6 address of the Sflow collector                                                | true        |           |             |
+| collector_port | Destination L4 port of the Sflow collector                                              |             | 6343      |             |
+| collector_vrf  | Specify the Collector VRF. In this revision, it is either default VRF or Management VRF.|             |           |             |
+
+### Syslog Rate Limit
+
+Host side configuration:
+
+```
+{
+"SYSLOG_CONFIG": {
+    "GLOBAL": {
+        "rate_limit_interval": "300",
+        "rate_limit_burst": "20000"
+    }
+  }
+}
+```
+
+Container side configuration:
+
+```
+{
+"SYSLOG_CONFIG_FEATURE": {
+    "bgp": {
+        "rate_limit_interval": "300",
+        "rate_limit_burst": "20000"
+    },
+    "pmon": {
+        "rate_limit_interval": "300",
+        "rate_limit_burst": "20000"
+    }
+  }
+}
+```
 
 ### Tacplus Server
 

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1186,7 +1186,8 @@
                 "collector_port": "6343"
             },
             "collector2": {
-                "collector_ip": "10.144.1.2"
+                "collector_ip": "10.144.1.2",
+                "collector_vrf": "mgmt"
             }
         },
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/sflow.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/sflow.json
@@ -14,6 +14,21 @@
         "desc": "Configure collectors above the specified limit in SFLOW_COLLECTOR table.",
         "eStr":	["Too many \"SFLOW_COLLECTOR_LIST\" elements"]
     },
+    "SFLOW_TEST_WITH_COLLECTOR_DEFAULT_VRF": {
+        "desc": "Configure a collector in SFLOW_COLLECTOR table with default VRF."
+    },
+    "SFLOW_TEST_WITH_COLLECTOR_MGMT_VRF": {
+        "desc": "Configure a collector in SFLOW_COLLECTOR table with mgmt VRF."
+    },
+    "SFLOW_TEST_WITH_COLLECTOR_NON_EXISTING_MGMT_VRF": {
+        "desc": "Configure a collector in SFLOW_COLLECTOR table with mgmt VRF when MGMT VRF is not configured",
+        "eStrKey": "Must"
+    },
+    "SFLOW_TEST_WITH_COLLECTOR_INVALID_VRF": {
+        "desc": "Configure a collector in SFLOW_COLLECTOR table with invalid vrf",
+        "eStrKey": "Pattern",
+        "eStr": ["mgmt|default"]
+    },
     "SFLOW_SESSION_TEST": {
         "desc": "Configure a sflow session in SFLOW_SESSION table."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/sflow.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/sflow.json
@@ -59,6 +59,69 @@
         }
     },
 
+    "SFLOW_TEST_WITH_COLLECTOR_DEFAULT_VRF": {
+        "sonic-sflow:sonic-sflow": {
+            "sonic-sflow:SFLOW_COLLECTOR": {
+                "SFLOW_COLLECTOR_LIST": [
+                    {
+                        "name": "collector1",
+                        "collector_ip": "2001:1:2::23",
+                        "collector_vrf": "default"
+                    }
+                ]
+            }
+        }
+    },
+
+    "SFLOW_TEST_WITH_COLLECTOR_MGMT_VRF": {
+        "sonic-sflow:sonic-sflow": {
+            "sonic-sflow:SFLOW_COLLECTOR": {
+                "SFLOW_COLLECTOR_LIST": [
+                    {
+                        "name": "collector1",
+                        "collector_ip": "10.100.12.13",
+                        "collector_vrf": "mgmt"
+                    }
+                ]
+            }
+        },
+        "sonic-mgmt_vrf:sonic-mgmt_vrf": {
+            "sonic-mgmt_vrf:MGMT_VRF_CONFIG": {
+                "sonic-mgmt_vrf:vrf_global": {
+                    "mgmtVrfEnabled": "true"
+                }
+            }
+        }
+    },
+
+    "SFLOW_TEST_WITH_COLLECTOR_NON_EXISTING_MGMT_VRF": {
+        "sonic-sflow:sonic-sflow": {
+            "sonic-sflow:SFLOW_COLLECTOR": {
+                "SFLOW_COLLECTOR_LIST": [
+                    {
+                        "name": "collector1",
+                        "collector_ip": "10.100.12.13",
+                        "collector_vrf": "mgmt"
+                    }
+                ]
+            }
+        }
+    },
+
+    "SFLOW_TEST_WITH_COLLECTOR_INVALID_VRF": {
+        "sonic-sflow:sonic-sflow": {
+            "sonic-sflow:SFLOW_COLLECTOR": {
+                "SFLOW_COLLECTOR_LIST": [
+                    {
+                        "name": "collector1",
+                        "collector_ip": "10.100.12.13",
+                        "collector_vrf": "Vrf1"
+                    }
+                ]
+            }
+        }
+    },
+
     "SFLOW_SESSION_TEST": {
 	"sonic-port:sonic-port": {
             "sonic-port:PORT": {

--- a/src/sonic-yang-models/yang-models/sonic-sflow.yang
+++ b/src/sonic-yang-models/yang-models/sonic-sflow.yang
@@ -25,6 +25,10 @@ module sonic-sflow{
     import sonic-mgmt_port {
         prefix mgmt-port;
     }
+    import sonic-mgmt_vrf {
+        prefix mvrf;
+    }
+
 
     description "SFLOW yang Module for SONiC OS";
 
@@ -43,17 +47,34 @@ module sonic-sflow{
                     type string {
                         length 1..64;
                     }
+                    description "Name of the Sflow collector";
                 }
 
                 leaf collector_ip {
                     mandatory true;
                     type inet:ip-address;
+                    description "IPv4/IPv6 address of the Sflow collector";
                 }
 
 
                 leaf collector_port {
                     type inet:port-number;
                     default 6343;
+                    description "Destination L4 port of the Sflow collector";
+                }
+
+                leaf collector_vrf {
+                    must "(current() != 'mgmt') or (/mvrf:sonic-mgmt_vrf/mvrf:MGMT_VRF_CONFIG/mvrf:vrf_global/mvrf:mgmtVrfEnabled = 'true')" {
+                        error-message "Must condition not satisfied. Try enable Management VRF.";
+                    }
+
+                    type string {
+                        pattern "mgmt|default";
+                    }
+
+                    description
+                        "Specify the Collector VRF. In this revision, it is either
+                         default VRF or Management VRF.";
                 }
 
             } /* end of list SFLOW_COLLECTOR_LIST */
@@ -78,6 +99,7 @@ module sonic-sflow{
                 leaf admin_state {
                     type stypes:admin_status;
                     default up;
+                    description "Per port sflow admin state";
                 }
 
                 leaf sample_rate {
@@ -99,6 +121,7 @@ module sonic-sflow{
                 leaf admin_state {
                     type stypes:admin_status;
                     default down;
+                    description "Global sflow admin state";
                 }
 
                 leaf polling_interval {


### PR DESCRIPTION
Porting fix https://github.com/sonic-net/sonic-buildimage/pull/12897
- Why I did it
 Fixed sflow yang model to include collector_vrf field.

- How I did it 
-Added leaf for collector_vrf under sflow_collector. Additionally aligned the configuration guide

- How to verify it 
Added UT to verify.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

