### PR TITLE
[Build] mount cgroup2 in chroot to fix build on ubuntu 22.04

### DIFF
--- a/files/docker/docker
+++ b/files/docker/docker
@@ -63,7 +63,8 @@ cgroupfs_mount() {
 	# see also https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
 	if grep -v '^#' /etc/fstab | grep -q cgroup \
 		|| [ ! -e /proc/cgroups ] \
-		|| [ ! -d /sys/fs/cgroup ]; then
+		|| [ ! -d /sys/fs/cgroup ] \
+		|| [ "$(stat -fc '%T' /sys/fs/cgroup)" = "cgroup2fs" ]; then
 		return
 	fi
 	if ! mountpoint -q /sys/fs/cgroup; then

--- a/files/docker/docker
+++ b/files/docker/docker
@@ -67,6 +67,13 @@ cgroupfs_mount() {
 		return
 	fi
 	if ! mountpoint -q /sys/fs/cgroup; then
+		# cgroup2
+		# https://github.com/systemd/systemd/blob/5c6c587ce24096d36826418b5390599d1e5ad55c/src/shared/cgroup-setup.c#L35-L74
+		if awk '!/^#/ && $4 == 1 && $2 != 0 { count++ } END { exit count != 0 }' /proc/cgroups; then
+			mount -t cgroup2 cgroup2 /sys/fs/cgroup
+			return
+		fi
+		# cgroup1
 		mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
 	fi
 	(


### PR DESCRIPTION
#### Why I did it

Ubuntu 22.04 uses cgroup2 by default, but docker.sh doesn't  mount it.
As a result we get an error when trying to run `docker info` in chroot env:

ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?

#### How I did it

mount cgroup2 in chroot if all enabled kernel cgroup controllers are currently not in use by cgroup1

#### How to verify it

With this fix the build finished successfully on ubuntu 22.04