### PR TITLE
fix an issue with starting user-defined healthcheck scripts

### DIFF
--- a/src/system-health/health_checker/user_defined_checker.py
+++ b/src/system-health/health_checker/user_defined_checker.py
@@ -1,3 +1,4 @@
+import shlex
 from .health_checker import HealthChecker
 from . import utils
 
@@ -44,7 +45,8 @@ class UserDefinedChecker(HealthChecker):
         """
         self.reset()
 
-        output = utils.run_command(self._cmd)
+        tokenized_cmd = shlex.split(self._cmd)
+        output = utils.run_command(tokenized_cmd)
         if not output:
             self.set_object_not_ok('UserDefine', str(self), 'Failed to get output of command \"{}\"'.format(self._cmd))
             return


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix https://github.com/sonic-net/sonic-buildimage/issues/12701
#### How I did it
Tokenized user-defined command before starting it by `subprocess.Popen`
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

