### PR TITLE
[dhcpv6_relay] Fix DHCPv6 Relay config CLI to update DHCP_RELAY table

### DIFF
--- a/dockers/docker-dhcp-relay/cli-plugin-tests/conftest.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/conftest.py
@@ -10,6 +10,11 @@ def mock_cfgdb():
             'Vlan1000': {
                 'dhcp_servers': ['192.0.0.1']
             }
+        },
+        'DHCP_RELAY': {
+            'Vlan1000': {
+                'dhcpv6_servers': ['fc02:2000::100']
+            }
         }
     }
 

--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_dhcp_relay.py
@@ -154,7 +154,7 @@ class TestConfigVlanDhcpRelay(object):
             assert result.exit_code == 0
             assert result.output == config_vlan_add_dhcpv6_relay_output
             assert mock_run_command.call_count == 3
-            db.cfgdb.set_entry.assert_called_once_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1'], 'dhcpv6_servers': ['fc02:2000::1']})
+            db.cfgdb.set_entry.assert_called_once_with('DHCP_RELAY', 'Vlan1000', {'dhcpv6_servers': ['fc02:2000::100','fc02:2000::1']})
 
         db.cfgdb.set_entry.reset_mock()
 
@@ -167,7 +167,7 @@ class TestConfigVlanDhcpRelay(object):
             assert result.exit_code == 0
             assert result.output == config_vlan_del_dhcpv6_relay_output
             assert mock_run_command.call_count == 3
-            db.cfgdb.set_entry.assert_called_once_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1']})
+            db.cfgdb.set_entry.assert_called_once_with('DHCP_RELAY', 'Vlan1000', {'dhcpv6_servers': ['fc02:2000::100']})
 
     def test_config_vlan_add_del_multiple_dhcpv6_relay_dest(self, mock_cfgdb):
         runner = CliRunner()
@@ -183,7 +183,7 @@ class TestConfigVlanDhcpRelay(object):
             assert result.exit_code == 0
             assert result.output == config_vlan_add_multiple_dhcpv6_relay_output
             assert mock_run_command.call_count == 3
-            db.cfgdb.set_entry.assert_called_once_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1'], 'dhcpv6_servers': ['fc02:2000::1', 'fc02:2000::2', 'fc02:2000::3']})
+            db.cfgdb.set_entry.assert_called_once_with('DHCP_RELAY', 'Vlan1000', {'dhcpv6_servers': ['fc02:2000::100', 'fc02:2000::1', 'fc02:2000::2', 'fc02:2000::3']})
 
         db.cfgdb.set_entry.reset_mock()
 
@@ -196,7 +196,7 @@ class TestConfigVlanDhcpRelay(object):
             assert result.exit_code == 0
             assert result.output == config_vlan_del_multiple_dhcpv6_relay_output
             assert mock_run_command.call_count == 3
-            db.cfgdb.set_entry.assert_called_once_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1']})
+            db.cfgdb.set_entry.assert_called_once_with('DHCP_RELAY', 'Vlan1000', {'dhcpv6_servers': ['fc02:2000::100']})
 
     def test_config_vlan_remove_nonexist_dhcp_relay_dest(self, mock_cfgdb):
         runner = CliRunner()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Recently, DHCPv6 Relay DB table is changed from VLAN to DHCP_RELAY. The dhcp6relay process is spawned with the data fetched from this new table . The show CLIs were updated , but config CLIs were not updated to write to new table and still updated old VLAN table. Hence the DHCPv6 Relay was not working with CLI configurations.

#### How I did it
The config CLI script is modified to update new table DHCP_RELAY. The UT scripts are modified to test new table. 

#### How to verify it
Configure DHCPv6 Relay address for vlan using CLI and check if the config is updated in DHCP_RELAY table and verify if DHCPv6 Relay process is started for that vlan.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixed configuration CLI for DHCPv6 Relay to update data in DHCP_RELAY table.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

