### PR TITLE
Generate the unique machine-id from mac address

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -217,6 +217,9 @@ sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-bottom/varlog
 #sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-bottom/mgmt-intf-dhcp
 sudo cp files/initramfs-tools/union-fsck $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/union-fsck
 sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/union-fsck
+# Generate the machine-id from the MAC addr during initramfs setup
+sudo cp files/initramfs-tools/machineid $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-bottom/machineid
+sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-bottom/machineid
 pushd $FILESYSTEM_ROOT/usr/share/initramfs-tools/scripts/init-bottom && sudo patch -p1 < $OLDPWD/files/initramfs-tools/udev.patch; popd
 if [[ $CONFIGURED_ARCH == armhf || $CONFIGURED_ARCH == arm64 ]]; then
     sudo cp files/initramfs-tools/uboot-utils $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/uboot-utils
@@ -457,6 +460,9 @@ sudo rm -f $FILESYSTEM_ROOT/etc/ssh/ssh_host_*_key*
 sudo cp files/sshd/host-ssh-keygen.sh $FILESYSTEM_ROOT/usr/local/bin/
 sudo mkdir $FILESYSTEM_ROOT/etc/systemd/system/ssh.service.d
 sudo cp files/sshd/override.conf $FILESYSTEM_ROOT/etc/systemd/system/ssh.service.d/override.conf
+# The /run/machine-id will be created during initramfs preparing
+sudo ln -sf /run/machine-id $FILESYSTEM_ROOT/etc/machine-id
+sudo ln -sf /run/machine-id $FILESYSTEM_ROOT/var/lib/dbus/machine-id
 # Config sshd
 # 1. Set 'UseDNS' to 'no'
 # 2. Configure sshd to close all SSH connetions after 15 minutes of inactivity

--- a/files/initramfs-tools/machineid
+++ b/files/initramfs-tools/machineid
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+
+PREREQS=""
+
+prereqs() { echo "$PREREQS"; }
+
+case "$1" in
+    prereqs)
+    prereqs
+    exit 0
+    ;;
+esac
+
+# reconstruct the MAC address to 16bytes and output to /run/machine-id
+sed 's/:/0000/g' /sys/class/net/eth0/address > /run/machine-id


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

1. The machine-id is generated during the building process and will be copied to each installed device. So each device will have the same id.
2. The machine-id will be different for each different image on the same device.

#### How I did it

1. Generate the machine-id from the eth0 MAC address during initializing the ram-file system
2. Use symbolic files target to the /run/machine-id to replace original /etc/machine-id and /var/lib/dbus/machine-id
3. Due to the existence of the symbolic files, the SONiC boot up process will be consistent after this commit. If the Linux system detect /etc/machine-id missing, it will trigger its first boot mechanism.

#### How to verify it

After the change, the behavior will be:
1. The machine-id will be different for each device with the same version image.
2. The machine-id will be the same for each different image on the same device.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211

This change can fit to any release which using build_debian.sh to build the SONiC image.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Originally, the machine-id is generated randomly during the building process. And will be copied to each device during installing.
* After this, the machine-id will be generated according to mac address which is unique for each device. And will be consistent even installing new image.

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

