### PR TITLE
[202205][Supervisor][multiasic][hostcfgd] Optimize the hostcfgs by moving the definition cmds into the loop to optimize the enable/disable service command run.

### DIFF
--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -324,7 +324,7 @@ class FeatureHandler(object):
             None.
         """
 
-        cmds = []
+
         feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature_config, True)
         for feature_name in feature_names:
             if '@' not in feature_name:
@@ -333,6 +333,7 @@ class FeatureHandler(object):
             if not unit_file_state:
                 continue
             if unit_file_state != "disabled" and not feature_config.has_per_asic_scope:
+                cmds = []
                 for suffix in reversed(feature_suffixes):
                     cmds.append("sudo systemctl stop {}.{}".format(feature_name, suffix))
                     cmds.append("sudo systemctl disable {}.{}".format(feature_name, feature_suffixes[-1]))
@@ -420,14 +421,13 @@ class FeatureHandler(object):
         return props["UnitFileState"]
 
     def enable_feature(self, feature):
-        cmds = []
         feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature)
         for feature_name in feature_names:
             # Check if it is already enabled, if yes skip the system call
             unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
             if unit_file_state == "enabled" or not unit_file_state:
                 continue
-
+            cmds = []    
             for suffix in feature_suffixes:
                 cmds.append("sudo systemctl unmask {}.{}".format(feature_name, suffix))
 
@@ -450,14 +450,13 @@ class FeatureHandler(object):
         self.set_feature_state(feature, self.FEATURE_STATE_ENABLED)
 
     def disable_feature(self, feature):
-        cmds = []
         feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature)
         for feature_name in feature_names:
             # Check if it is already disabled, if yes skip the system call
             unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
             if unit_file_state in ("disabled", "masked") or not unit_file_state:
                 continue
-
+            cmds = []
             for suffix in reversed(feature_suffixes):
                 cmds.append("sudo systemctl stop {}.{}".format(feature_name, suffix))
                 cmds.append("sudo systemctl disable {}.{}".format(feature_name, feature_suffixes[-1]))


### PR DESCRIPTION
#### Why I did it
Merge PR https://github.com/sonic-net/sonic-host-services/pull/28 from master to202205 branch
The cmds list is defined outsize of the for loop, which results that the "systemctl .." commands executed multiple times (based on number of ASICs). This causes the system takes a longer time to be stabilized.
#### How I did it
Merge PR https://github.com/sonic-net/sonic-host-services/pull/28 from master to202205 branch
#### How to verify it
Boot the image on Supervisor card, after the system is stabilized, the check the log file. For the same service command, it should not be executed more than once
```
Dec  5 17:50:44.401100 ixre-cpm-chassis7 INFO hostcfgd: Running cmd: 'sudo systemctl stop bgp@0.service'
Dec  5 17:50:45.085547 ixre-cpm-chassis7 INFO hostcfgd: Running cmd: 'sudo systemctl disable bgp@0.service'
Dec  5 17:50:45.433360 ixre-cpm-chassis7 INFO hostcfgd: Running cmd: 'sudo systemctl mask bgp@0.service'
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ x] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

