### PR TITLE
[BRCM-DNX(J2/J2c/J2c+)]:Reserve Non-ECMP Fec Resource for Non-ECMP Route Nexthops/NBR Entries

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/sai.profile
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/sai.profile
@@ -1,1 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/jr2-a7280cr3-32d4-40x100G.config.bcm
+SAI_SWITCH_NON_ECMP_MAX_SIZE=3072

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/sai.profile
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/sai.profile
@@ -1,2 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/j2p-a7800r3a-36d-36x400G.config.bcm
-
+SAI_SWITCH_NON_ECMP_MAX_SIZE=3072

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/sai.profile
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/sai.profile
@@ -1,2 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/j2p-a7800r3a-36d-36x400G.config.bcm
-
+SAI_SWITCH_NON_ECMP_MAX_SIZE=3072

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/sai.profile
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/sai.profile
@@ -1,2 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/j2p-a7800r3a-36d-36x400G.config.bcm
-
+SAI_SWITCH_NON_ECMP_MAX_SIZE=3072

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/sai.profile
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/sai.profile
@@ -1,1 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/jr2cp-nokia-18x100g-4x25g-config.bcm
+SAI_SWITCH_NON_ECMP_MAX_SIZE=3072

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/sai.profile
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/sai.profile
@@ -1,1 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/jr2cp-nokia-18x100g-4x25g-config.bcm
+SAI_SWITCH_NON_ECMP_MAX_SIZE=3072

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/sai.profile
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/sai.profile
@@ -1,1 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/jr2cp-nokia-18x400g-config.bcm
+SAI_SWITCH_NON_ECMP_MAX_SIZE=3072

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/sai.profile
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/sai.profile
@@ -1,1 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/jr2cp-nokia-18x400g-config.bcm
+SAI_SWITCH_NON_ECMP_MAX_SIZE=3072


### PR DESCRIPTION
fixes #12608 by reserving NON_ECMP Fec entries for single path Nexthops/V4/v6NBR Entries.


#### Why I did it
On DNX (J2/J2c/J2c+) platforms, Single Path Nexthops and ECMp Nexthop resources(FECs) are shared. BRCM SAI do not have partition of this resource, and hence more single path Nexthop entries, causes ECMP programming to fail in scaled setup.

#### How I did it
Broadcom provided SAI changes to reserve resources for single path nexthop entries(More details in CSP: https://brcmsemiconductor-csm.wolkenservicedesk.com/wolken-support/allcases/request-details?requestId=CS00012251649). 
Along with SAI changes, they provided configurable Macro/flag to reserve NON_ECMP entries. 
This PR is to add that flag in various sai.profile files wherever applicable. 

PS: We are reserving 3072 single path Nexthop entries on each Linecard. Calculation is as follows.
Max Slots per chassis: 8
Max No of Ports(each LC): 64
MyIP/Subnet Entries per port: 4(v4/v6)
Nbr Entries Per port: 2(v4/v6)

Total Non_ECMP Count: 8x64x(4+2) = 3072


#### How to verify it
Without this change, the ECMP group count will be shown as Max_count in 'crm show resources all' command, and with this change the ECMP group count will be decreased by 24(3072/128).

#### Which release branch to backport (provide reason below if selected)
Since the change is applicable to BRCM DNX pltforms, it needs to go in 202205 branch which is being used for T2-Chassis.
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x ] 202205
- [ ] 202211

#######UT########
The change has been verified on DNX(J2/j2c/J2c+) platforms..
