### PR TITLE
Revert "[Arista] Disable pcie checking on x86_64-arista_7050cx3_32s (#12900)

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/config.bcm.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/config.bcm.j2
@@ -529,4 +529,3 @@ serdes_preemphasis_127=0x14410a
 serdes_driver_current_130=0xe
 serdes_preemphasis_130=0x102804
 phy_an_lt_msft=1
-disable_pcie_firmware_check=1

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/config.bcm.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/config.bcm.j2
@@ -572,4 +572,3 @@ serdes_preemphasis_125=0x85804
 serdes_preemphasis_127=0x85804
 serdes_preemphasis_129=0x85804
 phy_an_lt_msft=1
-disable_pcie_firmware_check=1

--- a/device/arista/x86_64-arista_7050cx3_32s/td3-a7050cx3-32s-flex.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/td3-a7050cx3-32s-flex.config.bcm
@@ -467,4 +467,3 @@ serdes_core_tx_polarity_flip_physical{129}=0x0
 stable_size=0x5500000
 tdma_timeout_usec=15000000
 tslam_timeout_usec=15000000
-disable_pcie_firmware_check=1


### PR DESCRIPTION
…"

revert PR https://github.com/sonic-net/sonic-buildimage/pull/12900

This reverts commit dd87a791b4973c170314ae861514250f26eb31d1.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

