### PR TITLE
[swss/syncd] remove dependency on interfaces-config.service

### DIFF
--- a/files/build_templates/per_namespace/swss.service.j2
+++ b/files/build_templates/per_namespace/swss.service.j2
@@ -11,7 +11,6 @@ Requires=opennsl-modules.service
 {% endif %}
 Requires=updategraph.service
 After=updategraph.service
-After=interfaces-config.service
 BindsTo=sonic.target
 After=sonic.target
 Before=ntp-config.service

--- a/files/build_templates/per_namespace/syncd.service.j2
+++ b/files/build_templates/per_namespace/syncd.service.j2
@@ -16,7 +16,6 @@ After=nps-modules.service
 {% endif %}
 Requires=updategraph.service
 After=updategraph.service
-After=interfaces-config.service
 BindsTo=sonic.target
 After=sonic.target
 Before=ntp-config.service


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Remove dependency on interfaces-config.service to speed up boot, because interfaces-config.service takes a lot of time on boot.

#### How I did it

Changed service files for swss, syncd.

#### How to verify it

Boot and check swss/syncd start time comparing to interfaces-config

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

