### PR TITLE
[build] fix CI warnings issued by "git describe"

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -51,8 +51,8 @@ docker_try_rmi() {
 }
 
 sonic_get_version() {
-    local describe=$(git describe --tags)
-    local latest_tag=$(git describe --tags --abbrev=0)
+    local describe=$(git describe --tags 2>/dev/null)
+    local latest_tag=$(git describe --tags --abbrev=0 2>/dev/null)
     local branch_name=$(git rev-parse --abbrev-ref HEAD)
     if [ -n "$(git status --untracked-files=no -s --ignore-submodules)" ]; then
         local dirty="-dirty-$BUILD_TIMESTAMP"


### PR DESCRIPTION
./functions.sh script contains twice the command "git describe --tags". Azure pipelines currently retrieves the repository content by using a "git clone" or "git fetch" command with the option "--depth". When the depth is not enough sized to reach a tag in the "git log" history,  "git describe --tags" generates on stderr the warning: "fatal: No names found, cannot describe anything."

https://stackoverflow.com/questions/4916492/git-describe-fails-with-fatal-no-names-found-cannot-describe-anything

During the build process, the functions.sh script is a lot consumed and this pointless warning appears in CI thousand lines w/o any added value.
This situation can be easily avoided by redirecting related commands stderr output to /dev/null.

Issue #13106

#### Which release branch to backport (provide reason below if selected)

all

#### Description for the changelog

[build] fix CI warnings issued by "git describe"

#### A picture of a cute animal (not mandatory but encouraged)
  //
 ('>
 /rr
*\))_

