### PR TITLE
[202205][Mellanox] change the implementation of is_host() to fix a stuck issue on simx platform

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -186,18 +186,8 @@ def is_host():
     Test whether current process is running on the host or an docker
     return True for host and False for docker
     """
-    try:
-        proc = subprocess.Popen("docker --version 2>/dev/null",
-                                stdout=subprocess.PIPE,
-                                shell=True,
-                                stderr=subprocess.STDOUT,
-                                universal_newlines=True)
-        stdout = proc.communicate()[0]
-        proc.wait()
-        result = stdout.rstrip('\n')
-        return result != ''
-    except OSError as e:
-        return False
+    docker_env_file = '/.dockerenv'
+    return os.path.exists(docker_env_file) == False
 
 
 def default_return(return_value, log_func=logger.log_debug):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -187,7 +187,7 @@ def is_host():
     return True for host and False for docker
     """
     docker_env_file = '/.dockerenv'
-    return os.path.exists(docker_env_file) == False
+    return os.path.exists(docker_env_file) is False
 
 
 def default_return(return_value, log_func=logger.log_debug):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
**This PR is to backport https://github.com/sonic-net/sonic-buildimage/pull/13100 to the 202205 branch since can not be cleanly cherry-picked.**

Following code to judge whether a process is running inside a docker could get stuck on the simx platform
```
subprocess.Popen(["docker", "--version"],
                                stdout=subprocess.PIPE,
                                stderr=subprocess.STDOUT,
                                universal_newlines=True)
```

When it gets stuck, the **config-chassisdb** service can not be successfully started, thus the system can not be booted up.

```
root@sonic:/# service config-chassisdb status
     config-chassisdb.service - Config chassis_db
     Loaded: loaded (/lib/systemd/system/config-chassisdb.service; enabled; vendor preset: enabled)
     Active: activating (start) since Thu 2022-12-15 09:23:02 UTC; 29min ago
   Main PID: 571 (config-chassisd)
      Tasks: 14 (limit: 9501)
     Memory: 132.4M
     CGroup: /system.slice/config-chassisdb.service
                        ├─571 /bin/bash /usr/bin/config-chassisdb
			├─575 /usr/bin/python3 /usr/local/bin/sonic-cfggen -H -v DEVICE_METADATA.localhost.platform
			├─602 /bin/sh -c sudo decode-syseeprom -m
			├─603 sudo decode-syseeprom -m
			├─607 /usr/bin/python3 /usr/local/bin/decode-syseeprom -m
			├─616 /bin/sh -c docker --version 2>/dev/null
			└─617 docker --version
```

#### How I did it

Use an alternative way to implement this function and issue can be avoided:

```
docker_env_file = '/.dockerenv'
return os.path.exists(docker_env_file) is False
```

#### How to verify it
run regression on real hardware and simx platform.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

