### PR TITLE
[Edgecore][device/accton] Fix subprocess.call issue in is_host().

### DIFF
--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/helper.py
@@ -1,8 +1,8 @@
 import os
 import struct
-import subprocess
 from mmap import *
 from sonic_py_common import device_info
+from sonic_py_common.general import getstatusoutput_noshell
 
 HOST_CHK_CMD = ["docker"]
 EMPTY_STRING = ""
@@ -14,7 +14,11 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.call(HOST_CHK_CMD) == 0
+        try:
+            status, output = getstatusoutput_noshell(HOST_CHK_CMD)
+            return status == 0
+        except Exception:
+            return False
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/helper.py
@@ -1,8 +1,8 @@
 import os
 import struct
-import subprocess
 from mmap import *
 from sonic_py_common import device_info
+from sonic_py_common.general import getstatusoutput_noshell
 
 HOST_CHK_CMD = ["docker"]
 EMPTY_STRING = ""
@@ -14,7 +14,11 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.call(HOST_CHK_CMD) == 0
+        try:
+            status, output = getstatusoutput_noshell(HOST_CHK_CMD)
+            return status == 0
+        except Exception:
+            return False
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/helper.py
@@ -1,8 +1,8 @@
 import os
 import struct
-import subprocess
 from mmap import *
 from sonic_py_common import device_info
+from sonic_py_common.general import getstatusoutput_noshell
 
 HOST_CHK_CMD = ["docker"]
 EMPTY_STRING = ""
@@ -14,7 +14,11 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.call(HOST_CHK_CMD) == 0
+        try:
+            status, output = getstatusoutput_noshell(HOST_CHK_CMD)
+            return status == 0
+        except Exception:
+            return False
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/helper.py
@@ -1,8 +1,8 @@
 import os
 import struct
-import subprocess
 from mmap import *
 from sonic_py_common import device_info
+from sonic_py_common.general import getstatusoutput_noshell
 
 HOST_CHK_CMD = ["docker"]
 EMPTY_STRING = ""
@@ -14,7 +14,11 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.call(HOST_CHK_CMD) == 0
+        try:
+            status, output = getstatusoutput_noshell(HOST_CHK_CMD)
+            return status == 0
+        except Exception:
+            return False
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/helper.py
@@ -1,8 +1,8 @@
 import os
 import struct
-import subprocess
 from mmap import *
 from sonic_py_common import device_info
+from sonic_py_common.general import getstatusoutput_noshell
 
 HOST_CHK_CMD = ["docker"]
 EMPTY_STRING = ""
@@ -14,7 +14,11 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.call(HOST_CHK_CMD) == 0
+        try:
+            status, output = getstatusoutput_noshell(HOST_CHK_CMD)
+            return status == 0
+        except Exception:
+            return False
 
     def pci_get_value(self, resource, offset):
         status = True

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/helper.py
@@ -1,8 +1,8 @@
 import os
 import struct
-import subprocess
 from mmap import *
 from sonic_py_common import device_info
+from sonic_py_common.general import getstatusoutput_noshell
 
 HOST_CHK_CMD = ["docker"]
 EMPTY_STRING = ""
@@ -14,7 +14,11 @@ class APIHelper():
         (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
 
     def is_host(self):
-        return subprocess.call(HOST_CHK_CMD) == 0
+        try:
+            status, output = getstatusoutput_noshell(HOST_CHK_CMD)
+            return status == 0
+        except Exception:
+            return False
 
     def pci_get_value(self, resource, offset):
         status = True


### PR DESCRIPTION
Signed-off-by: roger530-ho <roger530_ho@edge-core.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Why I did it

The is_host function causes the system to get some errors, as below.

1. The thermalctld got exception.

```
admin@sonic:~$ show platform temperature
Thermal Not detected
admin@sonic:~$ sudo cat /var/log/syslog | grep thermalctld
Dec 19 07:04:41.905942 sonic INFO pmon#supervisord 2022-12-19 07:04:41,905 INFO spawned: 'thermalctld' with pid 66
Dec 19 07:04:42.190356 sonic INFO pmon#supervisord: thermalctld Traceback (most recent call last):
Dec 19 07:04:42.190405 sonic INFO pmon#supervisord: thermalctld   File "/usr/local/bin/thermalctld", line 922, in <module>
Dec 19 07:04:42.190476 sonic INFO pmon#supervisord: thermalctld     sys.exit(main())
Dec 19 07:04:42.190544 sonic INFO pmon#supervisord: thermalctld   File "/usr/local/bin/thermalctld", line 907, in main
Dec 19 07:04:42.190613 sonic INFO pmon#supervisord: thermalctld     thermal_control = ThermalControlDaemon()
Dec 19 07:04:42.190680 sonic INFO pmon#supervisord: thermalctld   File "/usr/local/bin/thermalctld", line 816, in __init__
Dec 19 07:04:42.190749 sonic INFO pmon#supervisord: thermalctld     self.chassis = sonic_platform.platform.Platform().get_chassis()
Dec 19 07:04:42.190816 sonic INFO pmon#supervisord: thermalctld   File "/usr/local/lib/python3.9/dist-packages/sonic_platform/platform.py", line 21, in __init__
Dec 19 07:04:42.190884 sonic INFO pmon#supervisord: thermalctld     self._chassis = Chassis()
Dec 19 07:04:42.190949 sonic INFO pmon#supervisord: thermalctld   File "/usr/local/lib/python3.9/dist-packages/sonic_platform/chassis.py", line 47, in __init__
Dec 19 07:04:42.191014 sonic INFO pmon#supervisord: thermalctld     self.is_host = self._api_helper.is_host()
Dec 19 07:04:42.191083 sonic INFO pmon#supervisord: thermalctld   File "/usr/local/lib/python3.9/dist-packages/sonic_platform/helper.py", line 17, in is_host
Dec 19 07:04:42.191149 sonic INFO pmon#supervisord: thermalctld     return subprocess.call(HOST_CHK_CMD) == 0
Dec 19 07:04:42.191215 sonic INFO pmon#supervisord: thermalctld   File "/usr/lib/python3.9/subprocess.py", line 349, in call
Dec 19 07:04:42.191281 sonic INFO pmon#supervisord: thermalctld     with Popen(*popenargs, **kwargs) as p:
Dec 19 07:04:42.191348 sonic INFO pmon#supervisord: thermalctld   File "/usr/lib/python3.9/subprocess.py", line 951, in __init__
Dec 19 07:04:42.191416 sonic INFO pmon#supervisord: thermalctld     self._execute_child(args, executable, preexec_fn, close_fds,
Dec 19 07:04:42.191482 sonic INFO pmon#supervisord: thermalctld   File "/usr/lib/python3.9/subprocess.py", line 1823, in _execute_child
Dec 19 07:04:42.214114 sonic INFO pmon#supervisord: thermalctld     raise child_exception_type(errno_num, err_msg, err_filename)
Dec 19 07:04:42.214114 sonic INFO pmon#supervisord: thermalctld FileNotFoundError: [Errno 2] No such file or directory: 'docker'
Dec 19 07:04:42.217201 sonic INFO pmon#supervisord 2022-12-19 07:04:42,216 INFO exited: thermalctld (exit status 1; not expected)

```
2. It got an extra message(docker command) after performing 'show version'.

```
admin@sonic:~$ show version

Usage:  docker [OPTIONS] COMMAND

A self-sufficient runtime for containers

Options:
      --config string      Location of client config files (default "/home/admin/.docker")
  -c, --context string     Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default context set with "docker context use")
  -D, --debug              Enable debug mode
  -H, --host list          Daemon socket(s) to connect to
  -l, --log-level string   Set the logging level ("debug"|"info"|"warn"|"error"|"fatal") (default "info")
      --tls                Use TLS; implied by --tlsverify
      --tlscacert string   Trust certs signed only by this CA (default "/home/admin/.docker/ca.pem")
      --tlscert string     Path to TLS certificate file (default "/home/admin/.docker/cert.pem")
      --tlskey string      Path to TLS key file (default "/home/admin/.docker/key.pem")
      --tlsverify          Use TLS and verify the remote
  -v, --version            Print version information and quit

Management Commands:
  app*        Docker App (Docker Inc., v0.9.1-beta3)
  builder     Manage builds
  buildx*     Docker Buildx (Docker Inc., v0.8.1-docker)
  config      Manage Docker configs
  container   Manage containers
  context     Manage contexts
  image       Manage images
  manifest    Manage Docker image manifests and manifest lists
  network     Manage networks
  node        Manage Swarm nodes
  plugin      Manage plugins
  secret      Manage Docker secrets
  service     Manage services
  stack       Manage Docker stacks
  swarm       Manage Swarm
  system      Manage Docker
  trust       Manage trust on Docker images
  volume      Manage volumes

Commands:
  attach      Attach local standard input, output, and error streams to a running container
  build       Build an image from a Dockerfile
  commit      Create a new image from a container's changes
  cp          Copy files/folders between a container and the local filesystem
  create      Create a new container
  diff        Inspect changes to files or directories on a container's filesystem
  events      Get real time events from the server
  exec        Run a command in a running container
  export      Export a container's filesystem as a tar archive
  history     Show the history of an image
  images      List images
  import      Import the contents from a tarball to create a filesystem image
  info        Display system-wide information
  inspect     Return low-level information on Docker objects
  kill        Kill one or more running containers
  load        Load an image from a tar archive or STDIN
  login       Log in to a Docker registry
  logout      Log out from a Docker registry
  logs        Fetch the logs of a container
  pause       Pause all processes within one or more containers
  port        List port mappings or a specific mapping for the container
  ps          List containers
  pull        Pull an image or a repository from a registry
  push        Push an image or a repository to a registry
  rename      Rename a container
  restart     Restart one or more containers
  rm          Remove one or more containers
  rmi         Remove one or more images
  run         Run a command in a new container
  save        Save one or more images to a tar archive (streamed to STDOUT by default)
  search      Search the Docker Hub for images
  start       Start one or more stopped containers
  stats       Display a live stream of container(s) resource usage statistics
  stop        Stop one or more running containers
  tag         Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
  top         Display the running processes of a container
  unpause     Unpause all processes within one or more containers
  update      Update configuration of one or more containers
  version     Show the Docker version information
  wait        Block until one or more containers stop, then print their exit codes

Run 'docker COMMAND --help' for more information on a command.

To get more help with docker, check out our guides at https://docs.docker.com/go/guides/

SONiC Software Version: SONiC.master.190759-bb09ebe97
Distribution: Debian 11.6
Kernel: 5.10.0-18-2-amd64
Build commit: bb09ebe97
Build date: Sun Dec 18 19:57:13 UTC 2022
Built by: AzDevOps@vmss-soni0005W3

Platform: x86_64-accton_as5835_54x-r0
HwSKU: Accton-AS5835-54X
ASIC: broadcom
ASIC Count: 1
Serial Number: 1234567890
Model Number: FP1AO5696000A
Hardware Revision: N/A
Uptime: 07:10:13 up 7 min,  1 user,  load average: 2.37, 1.96, 1.01
Date: Mon 19 Dec 2022 07:10:13

Docker images:
REPOSITORY                    TAG                       IMAGE ID       SIZE
docker-gbsyncd-broncos        latest                    8b5c7ce67335   404MB
docker-gbsyncd-broncos        master.190759-bb09ebe97   8b5c7ce67335   404MB
docker-gbsyncd-credo          latest                    6e4b5b71a5b3   374MB
docker-gbsyncd-credo          master.190759-bb09ebe97   6e4b5b71a5b3   374MB
docker-syncd-brcm             latest                    3ce73bfaa6da   699MB
docker-syncd-brcm             master.190759-bb09ebe97   3ce73bfaa6da   699MB
docker-orchagent              latest                    77b9ae73f607   384MB
docker-orchagent              master.190759-bb09ebe97   77b9ae73f607   384MB
docker-teamd                  latest                    50667ade5f4b   373MB
docker-teamd                  master.190759-bb09ebe97   50667ade5f4b   373MB
docker-fpm-frr                latest                    34127eceb0e8   402MB
docker-fpm-frr                master.190759-bb09ebe97   34127eceb0e8   402MB
docker-macsec                 latest                    05dad2fc9761   375MB
docker-dhcp-relay             latest                    49288984e793   366MB
docker-eventd                 latest                    38a7737bd0b7   356MB
docker-eventd                 master.190759-bb09ebe97   38a7737bd0b7   356MB
docker-sonic-p4rt             latest                    99ab69f59719   927MB
docker-sonic-p4rt             master.190759-bb09ebe97   99ab69f59719   927MB
docker-snmp                   latest                    26fea3ab55d2   396MB
docker-snmp                   master.190759-bb09ebe97   26fea3ab55d2   396MB
docker-platform-monitor       latest                    a91a9cf8010f   477MB
docker-platform-monitor       master.190759-bb09ebe97   a91a9cf8010f   477MB
docker-database               latest                    db297c33054c   356MB
docker-database               master.190759-bb09ebe97   db297c33054c   356MB
docker-sonic-telemetry        latest                    003a51b0ee6d   655MB
docker-sonic-telemetry        master.190759-bb09ebe97   003a51b0ee6d   655MB
docker-router-advertiser      latest                    5c548d205d7d   356MB
docker-router-advertiser      master.190759-bb09ebe97   5c548d205d7d   356MB
docker-mux                    latest                    7617fc8fafaf   405MB
docker-mux                    master.190759-bb09ebe97   7617fc8fafaf   405MB
docker-lldp                   latest                    0de3f2462e9e   399MB
docker-lldp                   master.190759-bb09ebe97   0de3f2462e9e   399MB
docker-nat                    latest                    d9ea3231ddc9   350MB
docker-nat                    master.190759-bb09ebe97   d9ea3231ddc9   350MB
docker-sflow                  latest                    751d2fc41032   348MB
docker-sflow                  master.190759-bb09ebe97   751d2fc41032   348MB
docker-sonic-mgmt-framework   latest                    c642db0b3d15   476MB
docker-sonic-mgmt-framework   master.190759-bb09ebe97   c642db0b3d15   476MB
```
How I did it

Use getstatusoutput_noshell to replace subprocess.call. 

How to verify it

Perform 'show platform temperature' or 'show version' will get the correct message.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [] 201911
- [] 202006
- [] 202012
- [] 202106
- [] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

