### PR TITLE
[libteam]: Send LACP BPDU to notify peer upon removal of port from portchannel

### DIFF
--- a/src/libteam/patch/0013-teamd-lacp-set-port-to-disabled-state-during-removal.patch
+++ b/src/libteam/patch/0013-teamd-lacp-set-port-to-disabled-state-during-removal.patch
@@ -1,0 +1,112 @@
+From 87cf89406d7638d0c041cb816923632745bb0c74 Mon Sep 17 00:00:00 2001
+From: Jiri Pirko <jiri@nvidia.com>
+Date: Wed, 7 Dec 2022 10:44:35 +0100
+Subject: [PATCH] teamd: lacp: set port to disabled state during removal
+
+Currently, the disabled state is set only after port is removed from
+team master in kernel. Team driver puts the port netdevice down right
+away. In some cases, there is nice to send LACPDU to the partner with
+flags set accordingly for the disabled port.
+
+Introduce "port_removing" op and call it right before kernel
+is asked to remove the port. Implement the op in LACP runner
+to disable the port which leads to proper LACPDU send.
+
+Signed-off-by: Jiri Pirko <jiri@nvidia.com>
+---
+ teamd/teamd.h             |  4 ++++
+ teamd/teamd_events.c      | 12 ++++++++++++
+ teamd/teamd_per_port.c    |  1 +
+ teamd/teamd_runner_lacp.c | 12 ++++++++++++
+ 4 files changed, 29 insertions(+)
+
+diff --git a/teamd/teamd.h b/teamd/teamd.h
+index 701a6a4..d1d0f7f 100644
+--- a/teamd/teamd.h
++++ b/teamd/teamd.h
+@@ -183,6 +183,8 @@ struct teamd_event_watch_ops {
+ 	int (*admin_state_changed)(struct teamd_context *ctx, void *priv);
+ 	int (*port_added)(struct teamd_context *ctx,
+ 			  struct teamd_port *tdport, void *priv);
++	void (*port_removing)(struct teamd_context *ctx,
++			      struct teamd_port *tdport, void *priv);
+ 	void (*port_removed)(struct teamd_context *ctx,
+ 			     struct teamd_port *tdport, void *priv);
+ 	int (*port_changed)(struct teamd_context *ctx,
+@@ -209,6 +211,8 @@ void teamd_refresh_ports(struct teamd_context *ctx);
+ void teamd_ports_flush_data(struct teamd_context *ctx);
+ int teamd_event_port_added(struct teamd_context *ctx,
+ 			   struct teamd_port *tdport);
++void teamd_event_port_removing(struct teamd_context *ctx,
++			       struct teamd_port *tdport);
+ void teamd_event_port_removed(struct teamd_context *ctx,
+ 			      struct teamd_port *tdport);
+ int teamd_event_port_changed(struct teamd_context *ctx,
+diff --git a/teamd/teamd_events.c b/teamd/teamd_events.c
+index bd4dcc1..ff39990 100644
+--- a/teamd/teamd_events.c
++++ b/teamd/teamd_events.c
+@@ -76,6 +76,18 @@ int teamd_event_port_added(struct teamd_context *ctx,
+ 	return 0;
+ }
+ 
++void teamd_event_port_removing(struct teamd_context *ctx,
++			       struct teamd_port *tdport)
++{
++	struct event_watch_item *watch;
++
++	list_for_each_node_entry(watch, &ctx->event_watch_list, list) {
++		if (!watch->ops->port_removing)
++			continue;
++		watch->ops->port_removing(ctx, tdport, watch->priv);
++	}
++}
++
+ void teamd_event_port_removed(struct teamd_context *ctx,
+ 			      struct teamd_port *tdport)
+ {
+diff --git a/teamd/teamd_per_port.c b/teamd/teamd_per_port.c
+index cefd6c2..68fc553 100644
+--- a/teamd/teamd_per_port.c
++++ b/teamd/teamd_per_port.c
+@@ -358,6 +358,7 @@ static int teamd_port_remove(struct teamd_context *ctx,
+ 
+ 	teamd_log_dbg(ctx, "%s: Removing port (found ifindex \"%d\").",
+ 		      tdport->ifname, tdport->ifindex);
++	teamd_event_port_removing(ctx, tdport);
+ 	err = team_port_remove(ctx->th, tdport->ifindex);
+ 	if (err)
+ 		teamd_log_err("%s: Failed to remove port.", tdport->ifname);
+diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
+index 82b8b86..89f462a 100644
+--- a/teamd/teamd_runner_lacp.c
++++ b/teamd/teamd_runner_lacp.c
+@@ -1779,6 +1779,17 @@ static int lacp_event_watch_port_added(struct teamd_context *ctx,
+ 	return teamd_balancer_port_added(lacp->tb, tdport);
+ }
+ 
++static void lacp_event_watch_port_removing(struct teamd_context *ctx,
++					   struct teamd_port *tdport, void *priv)
++{
++	struct lacp *lacp = priv;
++	struct lacp_port *lacp_port = lacp_port_get(lacp, tdport);
++
++	/* Ensure that no incoming LACPDU is going to be processed. */
++	teamd_loop_callback_disable(ctx, LACP_SOCKET_CB_NAME, lacp_port);
++	lacp_port_set_state(lacp_port, PORT_STATE_DISABLED);
++}
++
+ static void lacp_event_watch_port_removed(struct teamd_context *ctx,
+ 					  struct teamd_port *tdport, void *priv)
+ {
+@@ -1845,6 +1856,7 @@ static const struct teamd_event_watch_ops lacp_event_watch_ops = {
+ 	.hwaddr_changed = lacp_event_watch_hwaddr_changed,
+ 	.port_hwaddr_changed = lacp_event_watch_port_hwaddr_changed,
+ 	.port_added = lacp_event_watch_port_added,
++	.port_removing = lacp_event_watch_port_removing,
+ 	.port_removed = lacp_event_watch_port_removed,
+ 	.port_changed = lacp_event_watch_port_changed,
+ 	.admin_state_changed = lacp_event_watch_admin_state_changed,
+-- 
+2.14.1
+

--- a/src/libteam/patch/0014-teamd-lacp-make-sure-that-lacp_port_agg_update-works.patch
+++ b/src/libteam/patch/0014-teamd-lacp-make-sure-that-lacp_port_agg_update-works.patch
@@ -1,0 +1,65 @@
+From 4366fa242612cbb25509c64af66f1674c54a9bdf Mon Sep 17 00:00:00 2001
+From: Jiri Pirko <jiri@nvidia.com>
+Date: Wed, 7 Dec 2022 13:26:44 +0100
+Subject: [PATCH] teamd: lacp: make sure that lacp_port_agg_update() works with
+ correct unselectable state
+
+In case of checking unselectable port state, lacp_port_agg_update()
+is checking the new one during port state change. This is wrong as it
+should check the old one. Move the state setting into
+lacp_port_agg_update() and rename the function accordingly.
+
+Signed-off-by: Jiri Pirko <jiri@nvidia.com>
+---
+ teamd/teamd_runner_lacp.c | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
+index 89f462a..4f422ec 100644
+--- a/teamd/teamd_runner_lacp.c
++++ b/teamd/teamd_runner_lacp.c
+@@ -1050,7 +1050,8 @@ static bool lacp_port_mergeable(struct lacp_port *lacp_port)
+ 	       lacp_get_agg_lead(lacp_port) != lacp_port;
+ }
+ 
+-static int lacp_port_agg_update(struct lacp_port *lacp_port)
++static int lacp_port_set_state_agg_update(struct lacp_port *lacp_port,
++					  enum lacp_port_state new_state)
+ {
+ 	if (lacp_port_selected(lacp_port) &&
+ 	    (lacp_port_unselectable_state(lacp_port) ||
+@@ -1059,6 +1060,8 @@ static int lacp_port_agg_update(struct lacp_port *lacp_port)
+ 	     lacp_port_mergeable(lacp_port)))
+ 		lacp_port_agg_unselect(lacp_port);
+ 
++	lacp_port->state = new_state;
++
+ 	if (!lacp_port_selected(lacp_port) &&
+ 	    (lacp_port_selectable_state(lacp_port) &&
+ 	     lacp_port_loopback_free(lacp_port)))
+@@ -1067,6 +1070,11 @@ static int lacp_port_agg_update(struct lacp_port *lacp_port)
+ 	return lacp_selected_agg_update(lacp_port->lacp, NULL);
+ }
+ 
++static int lacp_port_agg_update(struct lacp_port *lacp_port)
++{
++	return lacp_port_set_state_agg_update(lacp_port, lacp_port->state);
++}
++
+ static const char slow_addr[ETH_ALEN] = { 0x01, 0x80, 0xC2, 0x00, 0x00, 0x02 };
+ 
+ static int __slow_addr_add_del(struct lacp_port *lacp_port, bool add)
+@@ -1318,9 +1326,8 @@ static int lacp_port_set_state(struct lacp_port *lacp_port,
+ 		       lacp_port->tdport->ifname,
+ 		       lacp_port_state_name[lacp_port->state],
+ 		       lacp_port_state_name[new_state]);
+-	lacp_port->state = new_state;
+ 
+-	err = lacp_port_agg_update(lacp_port);
++	err = lacp_port_set_state_agg_update(lacp_port, new_state);
+ 	if (err)
+ 		return err;
+ 
+-- 
+2.14.1
+

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -10,3 +10,6 @@
 0010-When-read-of-timerfd-returned-0-don-t-consider-this-.patch
 0011-Remove-extensive-debug-output.patch
 0012-Increase-min_ports-upper-limit-to-1024.patch
+0013-teamd-lacp-set-port-to-disabled-state-during-removal.patch
+0014-teamd-lacp-make-sure-that-lacp_port_agg_update-works.patch
+


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When aggregator port was being removed from portchannel, traffic loss of 60 seconds observed.
See issue https://github.com/sonic-net/sonic-buildimage/issues/12969

#### How I did it
Upon removal of port from portchannel, send LACP BPDU to notify peer switch.
Peer switch gets LACP and remove port from portchannel as well.

#### How to verify it
Send ping between 2 LAG router ports. While traffic is running, remove port traffic is flowing from, from portchannel. Verify ping is not stopping.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

