### PR TITLE
Modified SONiC VS image file name

### DIFF
--- a/platform/vs/sonic-gns3a.sh
+++ b/platform/vs/sonic-gns3a.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # This script creates a .gns3a SONiC appliance file
-IMGFILE="sonic-vs.image"
+IMGFILE="sonic-vs.img"
 RELEASE="latest"
 
 usage() {
-    echo "`basename $0` [ -r <ReleaseNumber> ] -b <SONiC VS image: sonic-vs.image>"
-    echo "e.g.: `basename $0` -r 1.1 -b <store_path>/sonic-vs.image"
+    echo "`basename $0` [ -r <ReleaseNumber> ] -b <SONiC VS image: sonic-vs.img>"
+    echo "e.g.: `basename $0` -r 1.1 -b <store_path>/sonic-vs.img"
     exit 0
 }
 


### PR DESCRIPTION


#### Why I did it

SONiC-VS image file name is incorrect.

#### How I did it

Modified sonic.gns3.sh file by changing name of VS image from "image" to "img"

#### How to verify it

It can be verified from

[https://sonic-build.azurewebsites.net/ui/sonic/pipelines/142/builds?branchName=master](url)

When we extract VS image it has  ".img"

![Image](https://user-images.githubusercontent.com/61490193/208869533-5960afd1-f94c-4cc5-951c-e8d9a14855e5.jpg)


#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211



