### PR TITLE
Client Auth is not working in telemetry (dial-in mode)

### DIFF
--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -60,6 +60,8 @@ TELEMETRY_ARGS+=" --port $PORT"
 CLIENT_AUTH=$(echo $GNMI | jq -r '.client_auth')
 if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then
     TELEMETRY_ARGS+=" --allow_no_client_auth"
+else
+    TELEMETRY_ARGS+=" --client_auth $CLIENT_AUTH"
 fi
 
 LOG_LEVEL=$(echo $GNMI | jq -r '.log_level')


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Client Auth option is not working in telemetry (dial-in mode). Client Authentication value read from redis db is not passed to telemetry script in docker startup.

#### How I did it
Included client_auth option in telemetry arguments 

#### How to verify it
Verification of gnmi_get by passing certificate to the server - PASS


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211

#### Description for the changelog
When an valid client_auth is present in config db (json file), same is passed as an argument to dial-in server startup script

