### PR TITLE
[PTF] Patch PTF library to use correct VXLAN module

### DIFF
--- a/src/ptf.patch/0001-Use-VXLAN-module-defined-in-packet.py.patch
+++ b/src/ptf.patch/0001-Use-VXLAN-module-defined-in-packet.py.patch
@@ -1,0 +1,26 @@
+From 5f0df673c8e2d6a8795346127d176d753217bd24 Mon Sep 17 00:00:00 2001
+From: Lawrence Lee <lawlee@microsoft.com>
+Date: Fri, 23 Dec 2022 19:32:17 +0000
+Subject: [PATCH] Use VXLAN module defined in packet.py
+
+Signed-off-by: Lawrence Lee <lawlee@microsoft.com>
+---
+ src/ptf/testutils.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ptf/testutils.py b/src/ptf/testutils.py
+index 6394ad3..5aa46b0 100755
+--- a/src/ptf/testutils.py
++++ b/src/ptf/testutils.py
+@@ -674,7 +674,7 @@ def simple_vxlan_packet(pktlen=300,
+                 scapy.IP(src=ip_src, dst=ip_dst, tos=ip_tos, ttl=ip_ttl, id=ip_id, flags=ip_flags, ihl=ip_ihl, options=ip_options)/ \
+                 udp_hdr
+ 
+-    pkt = pkt / VXLAN(vni = vxlan_vni, reserved1 = vxlan_reserved1, reserved2 = vxlan_reserved2)
++    pkt = pkt / scapy.VXLAN(vni = vxlan_vni, reserved1 = vxlan_reserved1, reserved2 = vxlan_reserved2)
+ 
+     if inner_frame:
+         pkt = pkt / inner_frame
+-- 
+2.25.1
+

--- a/src/ptf.patch/series
+++ b/src/ptf.patch/series
@@ -1,0 +1,1 @@
+0001-Use-VXLAN-module-defined-in-packet.py.patch


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The current PTF library contains a typo - when building a VxLAN packet, it uses the VxLAN module directly from the scapy library which will cause test failures.

#### How I did it
Patch `simple_vxlan_packet` to use the `VxLAN` module wrapped/defined in `packet.py` from the PTF library.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

