### PR TITLE
[Build][202106] Fix libyang build broken issue

### DIFF
--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -379,10 +379,10 @@ RUN apt-get -y build-dep openssh
        RUN cp /bin/true /usr/bin/aspell
 
        # Upgrade cmake to support dbus-python build in armhf, but the latest version of cmake conflicts with libyang
-       RUN apt-get install -t buster-backports -y cmake
+       RUN apt-get install -t buster-backports -y cmake -f
        RUN pip3 install --upgrade pip
        RUN pip3 install dbus-python
-       RUN apt-get remove -y cmake cmake-data && apt-get install -y cmake
+       RUN apt-get install cmake=3.13.4-1 cmake-data=3.13.4-1 -f
 {%- endif %}
 
 ## Config dpkg

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -354,9 +354,6 @@ RUN apt-get update && apt-get install -y \
         libsystemd-dev \
         pkg-config
 
-# Upgrade cmake to support dbus-python build in armhf
-RUN apt-get install -t buster-backports -y cmake
-
 RUN apt-get -y build-dep openssh
 
 # Build fix for ARMHF buster libsairedis
@@ -380,6 +377,12 @@ RUN apt-get -y build-dep openssh
 
        # workaround because of https://bugs.launchpad.net/qemu/+bug/1805913, just disable aspell
        RUN cp /bin/true /usr/bin/aspell
+
+       # Upgrade cmake to support dbus-python build in armhf, but the latest version of cmake conflicts with libyang
+       RUN apt-get install -t buster-backports -y cmake
+       RUN pip3 install --upgrade pip
+       RUN pip3 install dbus-python
+       RUN apt-get remove -y cmake cmake-data && apt-get install -y cmake
 {%- endif %}
 
 ## Config dpkg


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The libyang cannot be built with the latest version of cmake.
Example: https://dev.azure.com/mssonic/build/_build/results?buildId=181862&view=logs&j=993d6e22-aeec-5c03-fa19-35ecba587dd9&t=d0538dec-1681-5ff8-bd45-c0de13be9706
```
[ 96%] Building CXX object swig/python2/CMakeFiles/_yang2.dir/yangPYTHON_wrap.cxx.o
/sonic/src/libyang/libyang-1.0.73/build/swig/python2/yangPYTHON_wrap.cxx:3292:33: error: expected initializer before '.' token
 #  define SWIG_init    init_yang.so
                                 ^
/sonic/src/libyang/libyang-1.0.73/build/swig/python2/yangPYTHON_wrap.cxx:102537:1: note: in expansion of macro 'SWIG_init'
 SWIG_init(void) {
 ^~~~~~~~~
/sonic/src/libyang/libyang-1.0.73/build/swig/python2/yangPYTHON_wrap.cxx:101971:24: warning: 'swig_const_table' defined but not used [-Wunused-variable]
 static swig_const_info swig_const_table[] = {

```

#### How I did it
Reinstall the cmake after the  dbus-python installed.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

