### PR TITLE
[Build][202106] Fix libyang build broken issue

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -266,6 +266,10 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y -t
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install gir1.2-glib-2.0 libdbus-1-3 libgirepository-1.0-1
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y -t $IMAGE_DISTRO-backports install libsystemd0
 
+if [[ $CONFIGURED_ARCH == armhf ]]; then
+    sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install dbus-python==1.2.18
+fi
+
 # Install SONiC host services package
 SONIC_HOST_SERVICES_PY3_WHEEL_NAME=$(basename {{sonic_host_services_py3_wheel_path}})
 sudo cp {{sonic_host_services_py3_wheel_path}} $FILESYSTEM_ROOT/$SONIC_HOST_SERVICES_PY3_WHEEL_NAME

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -354,9 +354,6 @@ RUN apt-get update && apt-get install -y \
         libsystemd-dev \
         pkg-config
 
-# Upgrade cmake to support dbus-python build in armhf
-RUN apt-get install -t buster-backports -y cmake
-
 RUN apt-get -y build-dep openssh
 
 # Build fix for ARMHF buster libsairedis
@@ -380,6 +377,9 @@ RUN apt-get -y build-dep openssh
 
        # workaround because of https://bugs.launchpad.net/qemu/+bug/1805913, just disable aspell
        RUN cp /bin/true /usr/bin/aspell
+
+       # The cmake (>3.15) is required to install the latest version of dbus-python in armhf, but the cmake will conflict with libyang
+       RUN pip3 install dbus-python==1.2.18
 {%- endif %}
 
 ## Config dpkg


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The libyang cannot be built with the latest version of cmake.
Example: https://dev.azure.com/mssonic/build/_build/results?buildId=181862&view=logs&j=993d6e22-aeec-5c03-fa19-35ecba587dd9&t=d0538dec-1681-5ff8-bd45-c0de13be9706
```
[ 96%] Building CXX object swig/python2/CMakeFiles/_yang2.dir/yangPYTHON_wrap.cxx.o
/sonic/src/libyang/libyang-1.0.73/build/swig/python2/yangPYTHON_wrap.cxx:3292:33: error: expected initializer before '.' token
 #  define SWIG_init    init_yang.so
                                 ^
/sonic/src/libyang/libyang-1.0.73/build/swig/python2/yangPYTHON_wrap.cxx:102537:1: note: in expansion of macro 'SWIG_init'
 SWIG_init(void) {
 ^~~~~~~~~
/sonic/src/libyang/libyang-1.0.73/build/swig/python2/yangPYTHON_wrap.cxx:101971:24: warning: 'swig_const_table' defined but not used [-Wunused-variable]
 static swig_const_info swig_const_table[] = {

```
See relative issue: https://github.com/sonic-net/sonic-buildimage/issues/4315

#### How I did it
Not upgrade the cmake, change to use the dbus-python 1.2.18 which is compatible with cmake 3.13.4

#### How to verify it
See https://dev.azure.com/mssonic/build/_build/results?buildId=194756&view=results

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

