### PR TITLE
Fix sonic slave pipeline to set correct tag on sonic slave image. (#13177)

### DIFF
--- a/.azure-pipelines/docker-sonic-slave-template.yml
+++ b/.azure-pipelines/docker-sonic-slave-template.yml
@@ -35,7 +35,7 @@ parameters:
   - sonicbld-armhf
 
 jobs:
-- job: Build_${{ parameters.dist }}_${{ parameters.march }}${{ parameters.arch }}
+- job: sonic_slave_${{ parameters.dist }}${{ parameters.march }}
   timeoutInMinutes: 360
   variables:
   - template: /.azure-pipelines/template-variables.yml@buildimage
@@ -46,7 +46,6 @@ jobs:
   - template: /.azure-pipelines/template-clean-sonic-slave.yml@buildimage
   - checkout: self
     clean: true
-    submodules: recursive
   - task: Docker@2
     displayName: Login to ACR
     inputs:
@@ -56,6 +55,10 @@ jobs:
       set -ex
       image_tag=$(BLDENV=${{ parameters.dist }} make -f Makefile.work showtag PLATFORM=generic PLATFORM_ARCH=${{ parameters.arch }} | grep sonic-slave | tail -n 1)
       image_latest=$(echo $(echo $image_tag | awk -F: '{print$1}'):latest)
+      if echo ${{ parameters.pool }} | grep ${{ parameters.arch }};then
+        image_latest=$(echo ${image_latest} | sed 's/:/-${{ parameters.arch }}:/')
+      fi
+      image_branch=$(echo $(echo $image_latest | awk -F: '{print$1}'):$(Build.SourceBranchName))
       docker rmi $image_tag || true
 
       if [[ "$(Build.Reason)" =~ [a-zA-Z]*CI ]] && docker pull ${{ parameters.registry_url }}/${image_tag};then
@@ -69,7 +72,9 @@ jobs:
 
       docker tag ${image_tag} ${REGISTRY_SERVER}/${image_tag}
       docker push ${REGISTRY_SERVER}/${image_tag}
-      if [[ "${{ parameters.arch }}" == "amd64" ]];then
+      docker tag ${image_tag} ${REGISTRY_SERVER}/${image_branch}
+      docker push ${REGISTRY_SERVER}/${image_branch}
+      if [[ "$(Build.SourceBranchName)" == "master" ]];then
         docker tag ${image_tag} ${REGISTRY_SERVER}/${image_latest}
         docker push ${REGISTRY_SERVER}/${image_latest}
       fi

--- a/.azure-pipelines/docker-sonic-slave.yml
+++ b/.azure-pipelines/docker-sonic-slave.yml
@@ -30,7 +30,6 @@ trigger:
   paths:
     include:
     - sonic-slave-*
-    - src/sonic-build-hooks
     - files/build/versions
     - Makefile
     - Makefile.work
@@ -57,7 +56,7 @@ parameters:
   default: sonicdev
 
 stages:
-- stage: Build
+- stage: Build_in_amd64
   jobs:
   - ${{ each dist in parameters.dists }}:
     - ${{ if endswith(variables['Build.DefinitionName'], dist) }}:
@@ -67,7 +66,9 @@ stages:
             pool: sonicbld
             arch: ${{ arch }}
             dist: ${{ dist }}
-- stage: Build_march
+            ${{ if ne(arch, 'amd64') }}:
+              march: _march_${{ arch }}
+- stage: Build_native_arm
   dependsOn: []
   jobs:
   - ${{ each dist in parameters.dists }}:
@@ -79,4 +80,4 @@ stages:
               pool: sonicbld-${{ arch }}
               arch: ${{ arch }}
               dist: ${{ dist }}
-              march: march_
+              march: _${{ arch }}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently sonic-slave-* tag is confusing. Set correct tag on sonic-slave-* image. Fix job name to fit the build.
#### How I did it
build amd image in amd64:
sonic-slave-bullseye:cfe29bff67c
sonic-slave-bullseye:latest
sonic-slave-bullseye:master

build armhf image in amd64:
sonic-slave-bullseye-march-armhf:33614806dc3
sonic-slave-bullseye-march-armhf:latest
sonic-slave-bullseye-march-armhf:master

build arm64 image in amd64:
sonic-slave-bullseye-march-arm64:f3b1b16c801
sonic-slave-bullseye-march-arm64:latest
sonic-slave-bullseye-march-arm64:master

build arm64 image in arm64:
sonic-slave-bullseye:75cb326c9a7
sonic-slave-bullseye-arm64:latest
sonic-slave-bullseye:master

build armhf image in armhf:
sonic-slave-bullseye:64d178951fc
sonic-slave-bullseye-armhf:latest
sonic-slave-bullseye:master
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

