### PR TITLE
[Chassis][multiasic] Fix the sonic-db-cli core files issue on multiasic platform after the c++ implementation of sonic-db-cli

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -155,11 +155,13 @@ function waitForAllInstanceDatabaseConfigJsonFilesReady()
                     fi
 		done
             done
-	fi
+        fi
+        # Delay a second to allow all instance database_config.json files to be completely generated and fully accessible.
+        # This delay is needed to make sure that the database_config.json files are correctly rendered from j2 template 
+        # files ( renderning takes some time )
+        sleep 1 
     fi
 }
-# delay a second to allow the file to be fully accessible
-sleep 1
 {%- endif %}
 
 function postStartAction()
@@ -225,6 +227,10 @@ function postStartAction()
         # then we catch python exception of file not valid
         # that comes to syslog which is unwanted so wait till database
         # config is ready and then ping
+	# sonic-db-cli try to initialize the global database. If in multiasic platform, inital global
+        # database will try to access to all other instance database-config.json. If other instance
+        # database-config.json files are not ready yet, it will generate the sonic-db-cli core files.
+	waitForAllInstanceDatabaseConfigJsonFilesReady
         until [[ ($(docker exec -i database$DEV pgrep -x -c supervisord) -gt 0) && ($($SONIC_DB_CLI PING | grep -c PONG) -gt 0) &&
                  ($(docker exec -i database$DEV sonic-db-cli PING | grep -c PONG) -gt 0) ]]; do
           sleep 1;
@@ -234,11 +240,7 @@ function postStartAction()
             mv $WARM_DIR/dump.rdb $WARM_DIR/dump.rdb.old
         else
             # If there is a config_db.json dump file, load it.
-            if [ -r /etc/sonic/config_db$DEV.json ]; then
-
-		# For multi-asic, all /var/run/redis$DEV/sonic-db/database_config.json need to ready
-                # for loading config with --write-to-db
-		waitForAllInstanceDatabaseConfigJsonFilesReady
+            if [ -r /etc/sonic/config_db$DEV.json ]; then		
 
                 if [ -r /etc/sonic/init_cfg.json ]; then
                     $SONIC_CFGGEN -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db$DEV.json --write-to-db


### PR DESCRIPTION

#### Why I did it
Fixe #12047.  After the c++ implementation of the sonic-db-cli,  sonic-db-cli PING command tries to initialize the global database for all instances database starting.  If all instance database-config.json are not ready yet. it will crash and generate core file.  PR https://github.com/sonic-net/sonic-swss-common/pull/701 only fix the crash and the process abortion.  With this PR, many core files are still generated: 
The following error are logged in the syslog
```
Dec 28 16:44:34.811893 ixre-cpm-chassis8 ERR sonic-db-cli: :- parseDatabaseConfig: Sonic database config file doesn't exist at /var/run/redis/sonic-db/../../redis0/sonic-db/database_config.json
Dec 28 16:44:34.812099 ixre-cpm-chassis8 ERR sonic-db-cli: :- initializeGlobalConfig: Sonic database config file syntax error >> Sonic database config file doesn't exist at /var/run/redis/sonic-db/../../redis0/sonic-db/database_config.json
Dec 28 16:44:34.812162 ixre-cpm-chassis8 INFO database.sh[5764]: terminate called after throwing an instance of 'std::runtime_error'
Dec 28 16:44:34.812215 ixre-cpm-chassis8 INFO database.sh[5764]:   what():  Sonic database config file syntax error >> Sonic database config file doesn't exist at /var/run/redis/sonic-db/../../redis0/sonic-db/database_config.json
```
The following core files are generated
```
admin@supervisor:~$ ls /var/core -al
total 376
drwxr-xr-x 1 root root 4096 Nov 22 22:00 .
drwxr-xr-x 1 root root 4096 Nov 22 20:50 ..
-rw-r--r-- 1 root root 88525 Nov 22 21:42 sonic-db-cli.1669153338.6192.core.gz
-rw-r--r-- 1 root root 93392 Nov 22 21:42 sonic-db-cli.1669153339.6757.core.gz
-rw-r--r-- 1 root root 93413 Nov 22 21:42 sonic-db-cli.1669153339.6886.core.gz
-rw-r--r-- 1 root root 93284 Nov 22 21:42 sonic-db-cli.1669153339.7072.core.gz
```
#### How I did it
In the database.sh, call function  waitForAllInstanceDatabaseConfigJsonFilesReady  to make sure all instance database-config.json are present before the command sonic-db-cli PING.  This will avoid the database-config,json doesn't exist and cause errors and generate the core file.  

#### How to verify it
With this change, after the image install and boot up, check and verify the syslog, the following lines should not be in the syslog and this related core file should not be seen.
'''
Dec 28 16:44:34.811893 ixre-cpm-chassis8 ERR sonic-db-cli: :- parseDatabaseConfig: Sonic database config file doesn't exist at /var/run/redis/sonic-db/../../redis0/sonic-db/database_config.json
Dec 28 16:44:34.812099 ixre-cpm-chassis8 ERR sonic-db-cli: :- initializeGlobalConfig: Sonic database config file syntax error >> Sonic database config file doesn't exist at /var/run/redis/sonic-db/../../redis0/sonic-db/database_config.json
Dec 28 16:44:34.812162 ixre-cpm-chassis8 INFO database.sh[5764]: terminate called after throwing an instance of 'std::runtime_error'
Dec 28 16:44:34.812215 ixre-cpm-chassis8 INFO database.sh[5764]:   what():  Sonic database config file syntax error >> Sonic database config file doesn't exist at /var/run/redis/sonic-db/../../redis0/sonic-db/database_config.json
'''

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

