### PR TITLE
[202205][DellEMC] Fixing 'show interface status' break in DellEMC platforms porting changes

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/chassis.py
@@ -106,10 +106,7 @@ class Chassis(ChassisBase):
         for port_num in range(self.PORT_START, (self.PORT_END + 1)):
             # sfp get uses zero-indexing, but port numbers start from 1
             presence = self.get_sfp(port_num).get_presence()
-            if presence:
-                self._global_port_pres_dict[port_num] = '1'
-            else:
-                self._global_port_pres_dict[port_num] = '0'
+            self._global_port_pres_dict[port_num] = '0'
 
         self._watchdog = Watchdog()
 

--- a/platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/component.py
@@ -76,7 +76,7 @@ class Component(ComponentBase):
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]
-        self.version = self.CHASSIS_COMPONENTS[self.index][2]()
+        self.version = None
 
     def get_name(self):
         """
@@ -100,6 +100,8 @@ class Component(ComponentBase):
         Returns:
             A string containing the firmware version of the component
         """
+        if self.version == None:
+            self.version = self.CHASSIS_COMPONENTS[self.index][2]()
         return self.version
 
     def install_firmware(self, image_path):

--- a/platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/chassis.py
@@ -110,10 +110,7 @@ class Chassis(ChassisBase):
         for port_num in range(self.PORT_START, (self.PORT_END + 1)):
             # sfp get uses zero-indexing, but port numbers start from 1
             presence = self.get_sfp(port_num-1).get_presence()
-            if presence:
-                self._global_port_pres_dict[port_num] = '1'
-            else:
-                self._global_port_pres_dict[port_num] = '0'
+            self._global_port_pres_dict[port_num] = '0'
 
 # check for this event change for sfp / do we need to handle timeout/sleep
 

--- a/platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/component.py
@@ -76,7 +76,7 @@ class Component(ComponentBase):
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]
-        self.version = self.CHASSIS_COMPONENTS[self.index][2]()
+        self.version = None
 
     def get_name(self):
         """
@@ -100,6 +100,8 @@ class Component(ComponentBase):
         Returns:
             A string containing the firmware version of the component
         """
+        if self.version == None:
+            self.version = self.CHASSIS_COMPONENTS[self.index][2]()
         return self.version
 
     def install_firmware(self, image_path):

--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/chassis.py
@@ -92,8 +92,7 @@ class Chassis(ChassisBase):
 
         for port_num in range(self.PORT_START, self.PORTS_IN_BLOCK):
             # sfp get uses zero-indexing, but port numbers start from 1
-            presence = self.get_sfp(port_num).get_presence()
-            self._global_port_pres_dict[port_num] = '1' if presence else '0'
+            self._global_port_pres_dict[port_num] = '0'
 
     def __del__(self):
         if self.oir_fd != -1:

--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/component.py
@@ -86,7 +86,7 @@ class Component(ComponentBase):
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]
-        self.version = self.CHASSIS_COMPONENTS[self.index][2]()
+        self.version = None
 
     def get_name(self):
         """
@@ -110,6 +110,8 @@ class Component(ComponentBase):
         Returns:
             A string containing the firmware version of the component
         """
+        if self.version == None:
+            self.version = self.CHASSIS_COMPONENTS[self.index][2]()
         return self.version
 
     def install_firmware(self, image_path):

--- a/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/chassis.py
@@ -151,8 +151,7 @@ class Chassis(ChassisBase):
         self._component_list = [Component(i) for i in range(MAX_S5248F_COMPONENT)]
         for port_num in range(self.PORT_START, self.PORTS_IN_BLOCK):
             # sfp get uses zero-indexing, but port numbers start from 1
-            presence = self.get_sfp(port_num-1).get_presence()
-            self._global_port_pres_dict[port_num] = '1' if presence else '0'
+            self._global_port_pres_dict[port_num] = '0'
 
         #self.LOCATOR_LED_ON = self.STATUS_LED_COLOR_BLUE_BLINK
         #self.LOCATOR_LED_OFF = self.STATUS_LED_COLOR_OFF

--- a/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/component.py
@@ -86,7 +86,7 @@ class Component(ComponentBase):
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]
-        self.version = self.CHASSIS_COMPONENTS[self.index][2]()
+        self.version = None
 
     def get_name(self):
         """
@@ -110,6 +110,8 @@ class Component(ComponentBase):
         Returns:
             A string containing the firmware version of the component
         """
+        if self.version == None:
+            self.version = self.CHASSIS_COMPONENTS[self.index][2]()
         return self.version
 
     def install_firmware(self, image_path):

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
@@ -56,6 +56,9 @@ class Chassis(ChassisBase):
     _is_fan_control_enabled = False
     _fan_control_initialised = False
 
+    _global_port_pres_dict = {}
+
+
     def __init__(self):
         ChassisBase.__init__(self)
         self.status_led_reg = "system_led"
@@ -106,6 +109,9 @@ class Chassis(ChassisBase):
         for i in range(MAX_S6000_COMPONENT):
             component = Component(i)
             self._component_list.append(component)
+
+        for port_num in range(self.PORT_START, (self.PORT_END + 1)):
+            self._global_port_pres_dict[port_num] = '0'
 
     def _get_cpld_register(self, reg_name):
         rv = 'ERR'

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
@@ -65,6 +65,9 @@ class Chassis(ChassisBase):
         'amber': 0x02, 'blinking amber': 0x08
     }
 
+    _global_port_pres_dict = {}
+
+
     def __init__(self):
 
         ChassisBase.__init__(self)
@@ -102,6 +105,13 @@ class Chassis(ChassisBase):
         for i in range(MAX_S6100_COMPONENT):
             component = Component(i)
             self._component_list.append(component)
+
+        for i in self._sfp_list:
+            presence = i.get_presence()
+            if presence:
+                self._global_port_pres_dict[i.index] = '1'
+            else:
+                self._global_port_pres_dict[i.index] = '0'
 
         bios_ver = self.get_component(0).get_firmware_version()
         bios_minor_ver = bios_ver.split("-")[-1]

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/eeprom.py
@@ -11,6 +11,7 @@
 
 try:
     from sonic_eeprom import eeprom_tlvinfo
+    import os
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -26,6 +27,10 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
             self.eeprom_path = "/sys/class/i2c-adapter/i2c-2/2-0050/eeprom"
         super(Eeprom, self).__init__(self.eeprom_path, 0, '', True)
         self.eeprom_tlv_dict = dict()
+
+        if os.geteuid() != 0:
+            self.eeprom_data = "N/A"
+            return
 
         try:
             if self.is_module:

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/chassis.py
@@ -84,10 +84,7 @@ class Chassis(ChassisBase):
 
         for port_num in range(self.PORT_START, (self.PORT_END + 1)):
             presence = self.get_sfp(port_num).get_presence()
-            if presence:
-                self._global_port_pres_dict[port_num] = '1'
-            else:
-                self._global_port_pres_dict[port_num] = '0'
+            self._global_port_pres_dict[port_num] = '0'
 
     def __del__(self):
         if self.oir_fd != -1:

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/chassis.py
@@ -147,8 +147,7 @@ class Chassis(ChassisBase):
         self._component_list = [Component(i) for i in range(MAX_Z9332F_COMPONENT)]
         for port_num in range(self.PORT_START, self.PORTS_IN_BLOCK):
             # sfp get uses zero-indexing, but port numbers start from 1
-            presence = self.get_sfp(port_num).get_presence()
-            self._global_port_pres_dict[port_num] = '1' if presence else '0'
+            self._global_port_pres_dict[port_num] = '0'
 
         self._watchdog = Watchdog()
     def __del__(self):

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/component.py
@@ -153,7 +153,7 @@ class Component(ComponentBase):
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]
-        self.version = self.CHASSIS_COMPONENTS[self.index][2]()
+        self.version = None
 
     @staticmethod
     def _get_available_firmware_version(image_path):
@@ -242,6 +242,8 @@ class Component(ComponentBase):
         Returns:
             A string containing the firmware version of the component
         """
+        if self.version == None:
+            self.version = self.CHASSIS_COMPONENTS[self.index][2]()
         return self.version
 
     def get_presence(self):


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- When a non-root user tries to run 'show interface status' command, the command got break as 2.0 API throws permission denied error.
- Porting changes from #13021  to 202205 branch as cherry-pick failed.

#### How I did it
- Using default definitions for sfp presence and fw version.

#### How to verify it
- By running the command 'show interface status'.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
On branch 202205-s6100-int                                                                                                                      
Changes to be committed:                                                                                                                          
(use "git restore --staged <file>..." to unstage)                                                                                                     
        modified:   platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/chassis.py                                                      
        modified:   platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/component.py                                                    
        modified:   platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/chassis.py                                                      
        modified:   platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/component.py                                                    
        modified:   platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/chassis.py                                                      
        modified:   platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/component.py                                                    
        modified:   platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/chassis.py
        modified:   platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/component.py
        modified:   platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
        modified:   platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
        modified:   platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/eeprom.py
        modified:   platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/chassis.py
        modified:   platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/chassis.py
        modified:   platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/component.py
```
#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

