### PR TITLE
Fix rsyslog_plugin UT with timestamp formatter

### DIFF
--- a/src/sonic-eventd/rsyslog_plugin_tests/rsyslog_plugin_ut.cpp
+++ b/src/sonic-eventd/rsyslog_plugin_tests/rsyslog_plugin_ut.cpp
@@ -259,13 +259,13 @@ TEST(timestampFormatter, changeTimestampFormat) {
 
     formatter->m_storedYear = g_stored_year;
     string formattedTimestampOne = formatter->changeTimestampFormat(timestampOne);
-    string expectedTimestampOne = g_stored_year + "-07-20T10:09:40.230874Z"
+    string expectedTimestampOne = g_stored_year + "-07-20T10:09:40.230874Z";
     EXPECT_EQ(expectedTimestampOne, formattedTimestampOne);
 
     EXPECT_EQ("072010:09:40.230874", formatter->m_storedTimestamp);
 
     string formattedTimestampTwo = formatter->changeTimestampFormat(timestampTwo);
-    string expectedTimestampTwo = g_stored_year + "-01-01T00:00:00.000000Z"
+    string expectedTimestampTwo = g_stored_year + "-01-01T00:00:00.000000Z";
     EXPECT_EQ(expectedTimestampTwo, formattedTimestampTwo);
 
     formatter->m_storedTimestamp = "010100:00:00.000000";

--- a/src/sonic-eventd/rsyslog_plugin_tests/rsyslog_plugin_ut.cpp
+++ b/src/sonic-eventd/rsyslog_plugin_tests/rsyslog_plugin_ut.cpp
@@ -19,6 +19,8 @@ using namespace std;
 using namespace swss;
 using json = nlohmann::json;
 
+const string g_stored_year = "2023";
+
 vector<EventParam> createEventParams(vector<string> params, vector<string> luaCodes) {
     vector<EventParam> eventParams;
     for(long unsigned int i = 0; i < params.size(); i++) {
@@ -85,13 +87,14 @@ TEST(syslog_parser, matching_regex_timestamp) {
     event_params_t expectedDict;
     expectedDict["message"] = "test_message";
     expectedDict["other_data"] = "test_data";
-    expectedDict["timestamp"] = "2022-07-21T02:10:00.000000Z";
+    expectedDict["timestamp"] = g_stored_year + "-07-21T02:10:00.000000Z";
 
     unique_ptr<SyslogParser> parser(new SyslogParser());
     parser->m_regexList = regexList;
     lua_State* luaState = luaL_newstate();
     luaL_openlibs(luaState);
 
+    parser->m_timestampFormatter->m_storedYear = g_stored_year;
     bool success = parser->parseMessage("Jul 21 02:10:00.000000 message test_message other_data test_data", tag, paramDict, luaState);
     EXPECT_EQ(true, success);
     EXPECT_EQ("test_tag", tag);
@@ -186,13 +189,14 @@ TEST(syslog_parser, lua_code_valid_2) {
     expectedDict["ip"] = "10.10.24.216";
     expectedDict["major-code"] = "6";
     expectedDict["minor-code"] = "2";
-    expectedDict["timestamp"] = "2022-12-03T12:36:24.503424Z";
+    expectedDict["timestamp"] = g_stored_year + "-12-03T12:36:24.503424Z";
 
     unique_ptr<SyslogParser> parser(new SyslogParser());
     parser->m_regexList = regexList;
     lua_State* luaState = luaL_newstate();
     luaL_openlibs(luaState);
 
+    parser->m_timestampFormatter->m_storedYear = g_stored_year;
     bool success = parser->parseMessage("Dec  3 12:36:24.503424 NOTIFICATION: received from neighbor 10.10.24.216 active 6/2 (Administrative Shutdown) 0 bytes", tag, paramDict, luaState);
     EXPECT_EQ(true, success);
     EXPECT_EQ("test_tag", tag);
@@ -253,13 +257,16 @@ TEST(timestampFormatter, changeTimestampFormat) {
     vector<string> timestampTwo = { "Jan", "1", "00:00:00.000000" };
     vector<string> timestampThree = { "Dec", "31", "23:59:59.000000" }; 
 
+    formatter->m_storedYear = g_stored_year;
     string formattedTimestampOne = formatter->changeTimestampFormat(timestampOne);
-    EXPECT_EQ("2022-07-20T10:09:40.230874Z", formattedTimestampOne);
+    string expectedTimestampOne = g_stored_year + "-07-20T10:09:40.230874Z"
+    EXPECT_EQ(expectedTimestampOne, formattedTimestampOne);
 
     EXPECT_EQ("072010:09:40.230874", formatter->m_storedTimestamp);
 
     string formattedTimestampTwo = formatter->changeTimestampFormat(timestampTwo);
-    EXPECT_EQ("2022-01-01T00:00:00.000000Z", formattedTimestampTwo);
+    string expectedTimestampTwo = g_stored_year + "-01-01T00:00:00.000000Z"
+    EXPECT_EQ(expectedTimestampTwo, formattedTimestampTwo);
 
     formatter->m_storedTimestamp = "010100:00:00.000000";
     formatter->m_storedYear = "2025";

--- a/src/sonic-eventd/rsyslog_plugin_tests/rsyslog_plugin_ut.cpp
+++ b/src/sonic-eventd/rsyslog_plugin_tests/rsyslog_plugin_ut.cpp
@@ -87,6 +87,7 @@ TEST(syslog_parser, matching_regex_timestamp) {
     event_params_t expectedDict;
     expectedDict["message"] = "test_message";
     expectedDict["other_data"] = "test_data";
+    // Adding stored year to messages as syslog don't container year
     expectedDict["timestamp"] = g_stored_year + "-07-21T02:10:00.000000Z";
 
     unique_ptr<SyslogParser> parser(new SyslogParser());

--- a/src/sonic-eventd/rsyslog_plugin_tests/rsyslog_plugin_ut.cpp
+++ b/src/sonic-eventd/rsyslog_plugin_tests/rsyslog_plugin_ut.cpp
@@ -87,7 +87,7 @@ TEST(syslog_parser, matching_regex_timestamp) {
     event_params_t expectedDict;
     expectedDict["message"] = "test_message";
     expectedDict["other_data"] = "test_data";
-    // Adding stored year to messages as syslog don't container year
+    // Adding stored year to messages as syslog don't contain year
     expectedDict["timestamp"] = g_stored_year + "-07-21T02:10:00.000000Z";
 
     unique_ptr<SyslogParser> parser(new SyslogParser());

--- a/src/sonic-eventd/rsyslog_plugin_tests/rsyslog_plugin_ut.cpp
+++ b/src/sonic-eventd/rsyslog_plugin_tests/rsyslog_plugin_ut.cpp
@@ -19,7 +19,7 @@ using namespace std;
 using namespace swss;
 using json = nlohmann::json;
 
-const string g_stored_year = "2023";
+const string g_stored_year = "2024";
 
 vector<EventParam> createEventParams(vector<string> params, vector<string> luaCodes) {
     vector<EventParam> eventParams;
@@ -95,6 +95,7 @@ TEST(syslog_parser, matching_regex_timestamp) {
     lua_State* luaState = luaL_newstate();
     luaL_openlibs(luaState);
 
+    parser->m_timestampFormatter->m_storedTimestamp = "010100:00:00.000000";
     parser->m_timestampFormatter->m_storedYear = g_stored_year;
     bool success = parser->parseMessage("Jul 21 02:10:00.000000 message test_message other_data test_data", tag, paramDict, luaState);
     EXPECT_EQ(true, success);
@@ -197,6 +198,7 @@ TEST(syslog_parser, lua_code_valid_2) {
     lua_State* luaState = luaL_newstate();
     luaL_openlibs(luaState);
 
+    parser->m_timestampFormatter->m_storedTimestamp = "010100:00:00.000000";
     parser->m_timestampFormatter->m_storedYear = g_stored_year;
     bool success = parser->parseMessage("Dec  3 12:36:24.503424 NOTIFICATION: received from neighbor 10.10.24.216 active 6/2 (Administrative Shutdown) 0 bytes", tag, paramDict, luaState);
     EXPECT_EQ(true, success);
@@ -258,12 +260,18 @@ TEST(timestampFormatter, changeTimestampFormat) {
     vector<string> timestampTwo = { "Jan", "1", "00:00:00.000000" };
     vector<string> timestampThree = { "Dec", "31", "23:59:59.000000" }; 
 
+    formatter->m_storedTimestamp = "010100:00:00.000000";
     formatter->m_storedYear = g_stored_year;
+
     string formattedTimestampOne = formatter->changeTimestampFormat(timestampOne);
     string expectedTimestampOne = g_stored_year + "-07-20T10:09:40.230874Z";
+
     EXPECT_EQ(expectedTimestampOne, formattedTimestampOne);
 
     EXPECT_EQ("072010:09:40.230874", formatter->m_storedTimestamp);
+
+    formatter->m_storedTimestamp = "010100:00:00.000000";
+    formatter->m_storedYear = g_stored_year;
 
     string formattedTimestampTwo = formatter->changeTimestampFormat(timestampTwo);
     string expectedTimestampTwo = g_stored_year + "-01-01T00:00:00.000000Z";


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Timestamp formatter inside UT was failing due to new year change

#### How I did it

Use a const stored year that will used as expected value

#### How to verify it

Run UT

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

