### PR TITLE
[Mellanox] Skip the leftover hardware reboot cause in case of last boot is warm/fast reboot

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -30,6 +30,7 @@ try:
     from .utils import extract_RJ45_ports_index
     from . import utils
     from .device_data import DeviceDataManager
+    import re
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
@@ -740,7 +741,7 @@ class Chassis(ChassisBase):
         self.reboot_by_software = 'reset_sw_reset'
         self.reboot_cause_initialized = True
 
-    def _parse_warmfast_reboot_from_proc_cmdline():
+    def _parse_warmfast_reboot_from_proc_cmdline(self):
         if os.path.isfile(REBOOT_TYPE_KEXEC_FILE):
             with open(REBOOT_TYPE_KEXEC_FILE) as cause_file:
                 cause_file_kexec = cause_file.readline()
@@ -768,7 +769,7 @@ class Chassis(ChassisBase):
         # Skip the hardware reboot cause check if reboot cause found from cmdline
         # This is because the leftover hardware reboot cause will confuse the reboot cause determine
         if utils.is_host():
-            reboot_cause = _parse_warmfast_reboot_from_proc_cmdline()
+            reboot_cause = self._parse_warmfast_reboot_from_proc_cmdline()
             if reboot_cause:
                 return self.REBOOT_CAUSE_NON_HARDWARE, ''
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -61,6 +61,10 @@ REBOOT_CAUSE_ROOT = HWMGMT_SYSTEM_ROOT
 
 REBOOT_CAUSE_FILE_LENGTH = 1
 
+REBOOT_TYPE_KEXEC_FILE = "/proc/cmdline"
+REBOOT_TYPE_KEXEC_PATTERN_WARM = ".*SONIC_BOOT_TYPE=(warm|fastfast).*"
+REBOOT_TYPE_KEXEC_PATTERN_FAST = ".*SONIC_BOOT_TYPE=(fast|fast-reboot).*"
+
 # Global logger class instance
 logger = Logger()
 
@@ -736,6 +740,18 @@ class Chassis(ChassisBase):
         self.reboot_by_software = 'reset_sw_reset'
         self.reboot_cause_initialized = True
 
+    def _parse_warmfast_reboot_from_proc_cmdline():
+        if os.path.isfile(REBOOT_TYPE_KEXEC_FILE):
+            with open(REBOOT_TYPE_KEXEC_FILE) as cause_file:
+                cause_file_kexec = cause_file.readline()
+            m = re.search(REBOOT_TYPE_KEXEC_PATTERN_WARM, cause_file_kexec)
+            if m and m.group(1):
+                return 'warm-reboot'
+            m = re.search(REBOOT_TYPE_KEXEC_PATTERN_FAST, cause_file_kexec)
+            if m and m.group(1):
+                return 'fast-reboot'
+        return None
+
     def get_reboot_cause(self):
         """
         Retrieves the cause of the previous reboot
@@ -748,6 +764,14 @@ class Chassis(ChassisBase):
             to pass a description of the reboot cause.
         """
         #read reboot causes files in the following order
+
+        # Skip the hardware reboot cause check if reboot cause found from cmdline
+        # This is because the leftover hardware reboot cause will confuse the reboot cause determine
+        if utils.is_host():
+            reboot_cause = _parse_warmfast_reboot_from_proc_cmdline()
+            if reboot_cause:
+                return self.REBOOT_CAUSE_NON_HARDWARE, ''
+
         if not self.reboot_cause_initialized:
             self.initialize_reboot_cause()
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -766,8 +766,8 @@ class Chassis(ChassisBase):
         """
         #read reboot causes files in the following order
 
-        # Skip the hardware reboot cause check if reboot cause found from cmdline
-        # This is because the leftover hardware reboot cause will confuse the reboot cause determine
+        # To avoid the leftover hardware reboot cause confusing the reboot cause determine service
+        # Skip the hardware reboot cause check if warm/fast reboot cause found from cmdline
         if utils.is_host():
             reboot_cause = self._parse_warmfast_reboot_from_proc_cmdline()
             if reboot_cause:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In case of warm/fast reboot, the hardware reboot cause will NOT be cleared because CPLD will not be touched in this flow. To not confuse the reboot cause determine logic, the leftover hardware reboot cause shall be skipped by the platform API, platform API will return the 'REBOOT_CAUSE_NON_HARDWARE'  instead of the "hardware" reboot cause.

#### How I did it
Check the proc cmdline to see whether the last reboot is a warm or fast reboot, if yes skip checking the leftover hardware reboot cause.

#### How to verify it
a. Manual test:
1. Perform a power loss
2. Perform a warm/fast reboot
3. check the reboot cause should be "warm-reboot" or "fast-reboot" instead of "power loss" 

b. Run reboot cause related regression test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. 
#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)