### PR TITLE
Fix code issue when SonicV2Connector.get() return None.

### DIFF
--- a/device/alphanetworks/x86_64-alphanetworks_snh60a0_320fv2-r0/plugins/led_control.py
+++ b/device/alphanetworks/x86_64-alphanetworks_snh60a0_320fv2-r0/plugins/led_control.py
@@ -186,10 +186,14 @@ class LedControl(LedControlBase):
 
         lanes = swss.get(
             swss.APPL_DB, self.PORT_TABLE_PREFIX + port_name, 'lanes')
+        lanes_len = 0
+        # SonicV2Connector.get() will return None when key does not exist.
+        if lanes:
+            lanes_len = len(lanes.split(','))
 
         # SONiC port nums are 0-based and increment by 4
         # Arista QSFP indices are 1-based and increment by 1
-        return (((sonic_port_num/4) + 1), sonic_port_num % 4, len(lanes.split(',')))
+        return (((sonic_port_num/4) + 1), sonic_port_num % 4, lanes_len)
 
     # Concrete implementation of port_link_state_change() method
 

--- a/device/alphanetworks/x86_64-alphanetworks_snh60a0_320fv2-r0/plugins/led_control.py
+++ b/device/alphanetworks/x86_64-alphanetworks_snh60a0_320fv2-r0/plugins/led_control.py
@@ -186,10 +186,12 @@ class LedControl(LedControlBase):
 
         lanes = swss.get(
             swss.APPL_DB, self.PORT_TABLE_PREFIX + port_name, 'lanes')
-        lanes_len = 0
+
         # SonicV2Connector.get() will return None when key does not exist.
         if lanes:
             lanes_len = len(lanes.split(','))
+        else:
+            lanes_len = 0
 
         # SONiC port nums are 0-based and increment by 4
         # Arista QSFP indices are 1-based and increment by 1

--- a/device/alphanetworks/x86_64-alphanetworks_snh60b0_640f-r0/plugins/led_control.py
+++ b/device/alphanetworks/x86_64-alphanetworks_snh60b0_640f-r0/plugins/led_control.py
@@ -153,10 +153,14 @@ class LedControl(LedControlBase):
 
         lanes = swss.get(
             swss.APPL_DB, self.PORT_TABLE_PREFIX + port_name, 'lanes')
+        lanes_len = 0
+        # SonicV2Connector.get() will return None when key does not exist.
+        if lanes:
+            lanes_len = len(lanes.split(','))
 
         # SONiC port nums are 0-based and increment by 4
         # Arista QSFP indices are 1-based and increment by 1
-        return (((sonic_port_num/4) + 1), sonic_port_num % 4, len(lanes.split(',')))
+        return (((sonic_port_num/4) + 1), sonic_port_num % 4, lanes_len)
 
     # Concrete implementation of port_link_state_change() method
 

--- a/device/alphanetworks/x86_64-alphanetworks_snh60b0_640f-r0/plugins/led_control.py
+++ b/device/alphanetworks/x86_64-alphanetworks_snh60b0_640f-r0/plugins/led_control.py
@@ -153,10 +153,13 @@ class LedControl(LedControlBase):
 
         lanes = swss.get(
             swss.APPL_DB, self.PORT_TABLE_PREFIX + port_name, 'lanes')
-        lanes_len = 0
+
         # SonicV2Connector.get() will return None when key does not exist.
         if lanes:
             lanes_len = len(lanes.split(','))
+        else:
+            lanes_len = 0
+
 
         # SONiC port nums are 0-based and increment by 4
         # Arista QSFP indices are 1-based and increment by 1


### PR DESCRIPTION
Fix code issue when SonicV2Connector.get() return None.

#### Why I did it
When database key does not exist, SonicV2Connector.get() will return None.
Code will break if not check return value.

#### How I did it
Check SonicV2Connector.get() return value before use it.

#### How to verify it
Pass all E2E test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
Add new Redis database PROFILE_DB

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

