### PR TITLE
[armhf][Nokia-7215] Implement PMON SFP API get_error_description for Nokia-7215 platform 

### DIFF
--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp.py
@@ -969,3 +969,20 @@ class Sfp(SfpBase):
             integer: The 1-based relative physical position in parent device
         """
         return self.index
+    
+    def get_error_description(self):
+        """
+        Retrives the error descriptions of the SFP module
+
+        Returns:
+            String that represents the current error descriptions of vendor specific errors
+            In case there are multiple errors, they should be joined by '|',
+            like: "Bad EEPROM|Unsupported cable"
+        """
+        
+        if not self.get_presence():
+            error_description = self.SFP_STATUS_UNPLUGGED
+        else:
+            error_description = self.SFP_STATUS_OK
+
+        return error_description


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Command "sudo sfputil show error-status -hw" shows "OK (Not implemented)" in the output.  
#### How I did it
Add a new SFP API get_error_description  support in Nokia sonic-platform  sfp.py module.
#### How to verify it
Run the new image and execute command "sudo sfputil show error-status -hw"

```
admin@sonic:~$ sudo sfputil show error-status -p Ethernet49 -hw
Port        Error Status
----------  --------------
Ethernet49  Unplugged
admin@sonic:~$ sudo sfputil show error-status -p Ethernet50 -hw
Port        Error Status
----------  --------------
Ethernet50  OK
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Implement PMON SFP API get_error_description for Nokia-7215 platform 
#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

