### PR TITLE
[Arista] Rely on automatic flash size detection for Raven

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -483,7 +483,6 @@ write_platform_specific_cmdline() {
     if [ "$platform" = "raven" ]; then
         # Assuming sid=Cloverdale
         aboot_machine=arista_7050_qx32
-        flash_size=2000
         cmdline_add modprobe.blacklist=radeon,sp5100_tco
         cmdline_add acpi=off
     fi


### PR DESCRIPTION
Many of these switches have had flash upgraded beyond 2G however, in boot0 both were assigned 2GB for legacy reasons.

Remove the hardcoding of the flash size and let boot0 autodetect the available space.

Signed-off-by: Graham Hayes <gr@ham.ie>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

