### PR TITLE
[Bug][202012] Fix SONiC installation failure caused by pip/pip3 not found

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -292,7 +292,7 @@ if [ -f $FIRST_BOOT_FILE ]; then
             mv /etc/apt/sources.list /etc/apt/sources.list.rc-local
             echo "deb [trusted=yes] file:///host/image-$SONIC_VERSION/platform/common /" > /etc/apt/sources.list.d/sonic_debian_extension.list
             LANG=C DEBIAN_FRONTEND=noninteractive apt-get update
-            LANG=C DEBIAN_FRONTEND=noninteractive apt-get -y install /host/image-$SONIC_VERSION/platform/$platform/*.deb
+            LANG=C DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Path=$PATH:/usr/local/bin -y install /host/image-$SONIC_VERSION/platform/$platform/*.deb
             # Cleanup
             rm -f /etc/apt/sources.list.d/sonic_debian_extension.list
             rm -f /var/lib/apt/lists/_host_image-${SONIC_VERSION}_platform_common_Packages.lz4


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
[Bug] Fix SONiC installation failure caused by pip/pip3 not found
```
[   13.214043] rc.local[523]: Reading package lists...
[   13.282396] rc.local[427]: + LANG=C DEBIAN_FRONTEND=noninteractive apt-get -y install /host/image-20201231.84/platform/x86_64-cel_e1031-r0/platform-modules-haliburton_0.9_amd64.deb
[   13.491331] rc.local[538]: Reading package lists...
[   13.562286] rc.local[538]: Building dependency tree...
[   13.634080] rc.local[538]: Reading state information...
[   13.706067] rc.local[538]: The following NEW packages will be installed:
[   13.794253] rc.local[538]:   platform-modules-haliburton
[   13.866269] rc.local[538]: 0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
[   13.970064] rc.local[538]: Need to get 0 B/313 kB of archives.
[   14.046052] rc.local[538]: After this operation, 1831 kB of additional disk space will be used.
[   14.154261] rc.local[538]: Get:1 file:/host/image-20201231.84/platform/common  platform-modules-haliburton 0.9 [313 kB]
[   14.296631] rc.local[558]: debconf: delaying package configuration, since apt-utils is not installed
[   14.420187] rc.local[538]: Selecting previously unselected package platform-modules-haliburton.
(Reading database ... 31363 files and directories currently installed.)
[   15.206593] rc.local[538]: Preparing to unpack .../platform-modules-haliburton_0.9_amd64.deb ...
[   15.318549] rc.local[538]: Unpacking platform-modules-haliburton (0.9) ...
[   15.406080] rc.local[538]: Setting up platform-modules-haliburton (0.9) ...
[   18.459690] rc.local[538]: /usr/local/bin/platform_api_mgnt.sh: line 13: pip: command not found
[   18.570199] rc.local[538]: /usr/local/bin/platform_api_mgnt.sh: line 18: pip3: command not found
[   19.289708] rc.local[538]: Synchronizing state of platform-modules-haliburton.service with SysV service script with /lib/systemd/systemd-sysv-install.
[   19.463222] rc.local[538]: Executing: /lib/systemd/systemd-sysv-install enable platform-modules-haliburton

```
The main issue is the pip/pip3 command cannot be found when the package is being installed by apt-get.
When using the dpkg install, the searching path is PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
When using the apt-get install, the searching path is PATH=/usr/sbin:/usr/bin:/sbin:/bin
But the pip/pip3 default path is at /usr/local/bin, so dpkg works, but apt-get not work.


#### How I did it
Export the path /usr/local/bin for pip/pip3.
Make the deb packages can be installed by apt-get.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

