### PR TITLE
Set default SYNCD_SHM_SIZE for Broadcom XGS devices

### DIFF
--- a/device/arista/x86_64-arista_7050dx4_32s/platform_env.conf
+++ b/device/arista/x86_64-arista_7050dx4_32s/platform_env.conf
@@ -1,2 +1,2 @@
-SYNCD_SHM_SIZE=256m
+SYNCD_SHM_SIZE=512m
 is_ltsw_chip=1

--- a/device/arista/x86_64-arista_7050px4_32s/platform_env.conf
+++ b/device/arista/x86_64-arista_7050px4_32s/platform_env.conf
@@ -1,2 +1,2 @@
-SYNCD_SHM_SIZE=256m
+SYNCD_SHM_SIZE=512m
 is_ltsw_chip=1

--- a/device/arista/x86_64-arista_7060dx5_64s/platform_env.conf
+++ b/device/arista/x86_64-arista_7060dx5_64s/platform_env.conf
@@ -1,2 +1,2 @@
-SYNCD_SHM_SIZE=128m
+SYNCD_SHM_SIZE=512m
 is_ltsw_chip=1

--- a/device/arista/x86_64-arista_7060px5_64s/platform_env.conf
+++ b/device/arista/x86_64-arista_7060px5_64s/platform_env.conf
@@ -1,2 +1,2 @@
-SYNCD_SHM_SIZE=128m
+SYNCD_SHM_SIZE=512m
 is_ltsw_chip=1

--- a/device/broadcom/x86_64-broadcom_common/syncd_shm.ini
+++ b/device/broadcom/x86_64-broadcom_common/syncd_shm.ini
@@ -1,4 +1,4 @@
-# This file contains the default memory size for each platform
+# This file contains the default memory size for each ASICs in broadcom platform
 # Format: ASIC_NAME=Memory_size
 td2=256m
 td3=256m

--- a/device/broadcom/x86_64-broadcom_common/syncd_shm.ini
+++ b/device/broadcom/x86_64-broadcom_common/syncd_shm.ini
@@ -1,9 +1,14 @@
 # This file contains the default memory size for each ASICs in broadcom platform
-# Format: ASIC_NAME=Memory_size
-td2=256m
-td3=256m
-td4=512m
-th=256m
-th2=256m
-th3=300m
-th4=256m
+# Format: ASIC_ID=Memory_size
+#b77->td3
+b77=256m
+#b85->td2
+b85=256m
+#b87->td3
+b87=512m
+#b96->th
+b96=256m
+#b97->th2
+b97=256m
+#b98->th3
+b98=300m

--- a/device/common/profiles/syncd_shm.ini
+++ b/device/common/profiles/syncd_shm.ini
@@ -1,0 +1,9 @@
+# This file contains the default memory size for each platform
+# Format: ASIC_NAME=Memory_size
+td2=256m
+td3=256m
+td4=512m
+th=256m
+th2=256m
+th3=300m
+th4=256m

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -315,6 +315,35 @@ start() {
         source $PLATFORM_ENV_CONF
     fi
 
+    {%- if sonic_asic_platform == "broadcom" %}
+    {%- if docker_container_name == "syncd" %}
+    # Set the SYNCD_SHM_SIZE if this variable not defined
+    SYNCD_SHM_INI=/usr/share/sonic/device/profiles/syncd_shm.ini
+    BRCM_PLATFORM_COMMON_DIR=/usr/share/sonic/device/x86_64-broadcom_common
+
+    readline=$(grep '0x14e4' /proc/linux-kernel-bde)
+    bcm_chip_id=${readline#*0x14e4:0x}
+    bcm_chip_id=${chip_id::3}
+    if [ -f $BRCM_PLATFORM_COMMON_DIR/x86_64-broadcom_${bcm_chip_id}/broadcom-sonic*.config.bcm ]; then
+        COMMON_CONFIG_BCM=$(find $BRCM_PLATFORM_COMMON_DIR/x86_64-broadcom_${bcm_chip_id} -name 'broadcom-sonic*.config.bcm')
+        CHIP_NAME=${COMMON_CONFIG_BCM#*broadcom-sonic-}
+        CHIP_NAME=`echo $CHIP_NAME | awk -F. '{print $1}'`
+        echo "Get Broadcom Chip Name: [$CHIP_NAME] for bcm_chip_id: [${bcm_chip_id}] "
+    fi
+
+    if [ -z "$SYNCD_SHM_SIZE" ]; then
+        if [ -z "$CHIP_NAME" ]; then
+            echo "Cannot get Broadcom Chip Name. Skip set SYNCD_SHM_SIZE."
+        elif [ -f "$SYNCD_SHM_INI" ] && [ "$(grep -m1 "^${CHIP_NAME}=" $SYNCD_SHM_INI)" ]; then
+                SYNCD_SHM_SIZE=`grep -m1 "^${CHIP_NAME}=" $SYNCD_SHM_INI | awk -F= '{print $2}'`
+        else
+            echo "Cannot get SYNCD_SHM_SIZE for chip: [${CHIP_NAME}] in $SYNCD_SHM_INI. Skip set SYNCD_SHM_SIZE."
+        fi
+
+    fi
+    {%- endif %}
+    {%- endif %}
+
     {%- if docker_container_name == "gbsyncd" %}
     GBSYNCD_CONF=/usr/share/sonic/device/$PLATFORM/gbsyncd.ini
     GBSYNCD_PLATFORM=gbsyncd-vs

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -323,21 +323,15 @@ start() {
 
     readline=$(grep '0x14e4' /proc/linux-kernel-bde)
     bcm_chip_id=${readline#*0x14e4:0x}
-    bcm_chip_id=${chip_id::3}
-    if [ -f $BRCM_PLATFORM_COMMON_DIR/x86_64-broadcom_${bcm_chip_id}/broadcom-sonic*.config.bcm ]; then
-        COMMON_CONFIG_BCM=$(find $BRCM_PLATFORM_COMMON_DIR/x86_64-broadcom_${bcm_chip_id} -name 'broadcom-sonic*.config.bcm')
-        CHIP_NAME=${COMMON_CONFIG_BCM#*broadcom-sonic-}
-        CHIP_NAME=`echo $CHIP_NAME | awk -F. '{print $1}'`
-        echo "Get Broadcom Chip Name: [$CHIP_NAME] for bcm_chip_id: [${bcm_chip_id}] "
-    fi
+    bcm_chip_id=${bcm_chip_id::3}
 
     if [ -z "$SYNCD_SHM_SIZE" ]; then
-        if [ -z "$CHIP_NAME" ]; then
-            echo "Cannot get Broadcom Chip Name. Skip set SYNCD_SHM_SIZE."
-        elif [ -f "$SYNCD_SHM_INI" ] && [ "$(grep -m1 "^${CHIP_NAME}=" $SYNCD_SHM_INI)" ]; then
-                SYNCD_SHM_SIZE=`grep -m1 "^${CHIP_NAME}=" $SYNCD_SHM_INI | awk -F= '{print $2}'`
+        if [ -z "$bcm_chip_id" ]; then
+            echo "Cannot get Broadcom Chip Id. Skip set SYNCD_SHM_SIZE."
+        elif [ -f "$SYNCD_SHM_INI" ] && [ "$(grep -m1 "^${bcm_chip_id}=" $SYNCD_SHM_INI)" ]; then
+                SYNCD_SHM_SIZE=`grep -m1 "^${bcm_chip_id}=" $SYNCD_SHM_INI | awk -F= '{print $2}'`
         else
-            echo "Cannot get SYNCD_SHM_SIZE for chip: [${CHIP_NAME}] in $SYNCD_SHM_INI. Skip set SYNCD_SHM_SIZE."
+            echo "Cannot get SYNCD_SHM_SIZE for chip: [${bcm_chip_id}] in $SYNCD_SHM_INI. Skip set SYNCD_SHM_SIZE."
         fi
 
     fi

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -317,9 +317,9 @@ start() {
 
     {%- if sonic_asic_platform == "broadcom" %}
     {%- if docker_container_name == "syncd" %}
-    # Set the SYNCD_SHM_SIZE if this variable not defined
-    SYNCD_SHM_INI=/usr/share/sonic/device/profiles/syncd_shm.ini
+    # Set the SYNCD_SHM_SIZE if this variable not defined    
     BRCM_PLATFORM_COMMON_DIR=/usr/share/sonic/device/x86_64-broadcom_common
+    SYNCD_SHM_INI=$BRCM_PLATFORM_COMMON_DIR/syncd_shm.ini
 
     readline=$(grep '0x14e4' /proc/linux-kernel-bde)
     bcm_chip_id=${readline#*0x14e4:0x}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

After upgrade to brcmsai 8.1, the sdk running environment (container) recommended with mininum memory size as below
- TH4/TD4(ltsw) uses 512MB
- TH3 used 300MB
- Helix4/TD2/TD3/TH/TH 256 MB

Base on this requirement, adjust the default syncd share memory size and set the memory size for special ACISs in platform_env.conf file for different types of Broadcom ASICs.

#### How I did it

Add the platform_env.conf file if none of it for broadcom platform (base on platform_asic file)
Add the 'SYNCD_SHM_SIZE' and set the value
- for ltsw(TD4/TH4) devices set to 512M at least (update the platform_env.conf)
- for Td2/TH2/TH devices set to 256M
- for TH3 set to 300M

#### How to verify it
verify the image with code fix
Check with UT
Check on lab devices
- On a problematic device which cannot start successfully
Run with the command
```
$ cat /proc/linux-kernel-bde
Broadcom Device Enumerator (linux-kernel-bde)
Module parameters:
        maxpayload=128
        usemsi=0
        dmasize=32M
        himem=(null)
        himemaddr=(null)
DMA Memory (kernel): 33554432 bytes, 0 used, 33554432 free, local mmap
No devices found
$ docker rm -f syncd
syncd
$ sudo /usr/bin/syncd.sh start
Cannot get Broadcom Chip Id. Skip set SYNCD_SHM_SIZE.
Creating new syncd container with HWSKU Force10-S6000
a4862129a7fea04f00ed71a88715eac65a41cdae51c3158f9cdd7de3ccc3dd31
$ docker inspect syncd | grep -i shm
            "ShmSize": 67108864,
                "Tag": "fix_8.1_shm_issue.67873427-9f7ca60a0e",
```
- On Normal device
```
$ docker inspect syncd | grep -i shm
            "ShmSize": 268435456,
                "Tag": "fix_8.1_shm_issue.67873427-9f7ca60a0e"
```
change the config syncd_shm.ini to b85=128m
```
$ docker rm -f syncd
syncd
$ sudo /usr/bin/syncd.sh start
Creating new syncd container with HWSKU Force10-S6000
3209ffc1e5a7224b99640eb9a286c4c7aa66a2e6a322be32fb7fe2113bb9524c
$  docker inspect syncd | grep -i shm
            "ShmSize": 134217728,
                "Tag": "fix_8.1_shm_issue.67873427-9f7ca60a0e",
```
change the config under 
/usr/share/sonic/device/x86_64-dell_s6000_s1220-r0/Force10-S6000/platform_env.conf
and run command
```
$ cat /usr/share/sonic/device/x86_64-dell_s6000_s1220-r0/platform_env.conf
SYNCD_SHM_SIZE=300m

$ sudo /usr/bin/syncd.sh start
Creating new syncd container with HWSKU Force10-S6000
897f6fcde1f669ad2caab7da4326079abd7e811bf73f018c6dacc24cf24bfda5
$  docker inspect syncd | grep -i shm
            "ShmSize": 314572800,
                "Tag": "fix_8.1_shm_issue.67873427-9f7ca60a0e",
```


Signed-off-by: richardyu-ms <richard.yu@microsoft.com>

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

