### PR TITLE
[sonic-frr] Improve the command to generate dependent files for frr s…

### DIFF
--- a/rules/frr.dep
+++ b/rules/frr.dep
@@ -1,24 +1,25 @@
 
 SPATH       := $($(FRR)_SRC_PATH)
-DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/frr.mk rules/frr.dep   
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/frr.mk rules/frr.dep
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files |grep -Ev '^frr$$$$'))
 
 # Account for source files under the frr submodule directory as well.
-# Remove all the symbolic link files
+# The directories under frr submodule directory need to be filtered out because
+# the checksum cannot be generated against directories
 FRR_SPATH   := $(SPATH)/frr
-SMDEP_FILES := $(addprefix $(FRR_SPATH)/,$(shell cd $(FRR_SPATH) && git ls-files \
-			| grep -Ev -e 'debian/changelog$$$$' \
-			-e '^tests/topotests/bgp_instance_del_test/ce[0-9]$$$$' \
-			-e '^tests/topotests/bgp_instance_del_test/r[0-9]$$$$' \
-			-e '^tests/topotests/bgp_instance_del_test/scripts$$$$' \
-			-e '^tests/topotests/bgp_instance_del_test/customize.py$$$$' \
-			-e '^tests/topotests/bgp_rfapi_basic_sanity_config2/customize.py$$$$' \
-			-e '^tests/topotests/bgp_rfapi_basic_sanity_config2/scripts$$$$' \
-			-e '^tests/topotests/bgp_rfapi_basic_sanity_config2/test_bgp_rfapi_basic_sanity_config2.py$$$$' \
+# Use find to search the type 'file' with git ls-files under FRR_SPATH
+# to enumerate those managed by git
+SMDEP_FILES := $(addprefix $(FRR_SPATH)/,$(shell cd $(FRR_SPATH) &&  \
+			find . -type f -exec git ls-files '''{}''' ';' \
+			))
+# Use find to search the type 'symbolic to file' with git ls-files under FRR_SPATH
+# to enumerate those managed by git
+SMDEP_FILES += $(addprefix $(FRR_SPATH)/,$(shell cd $(FRR_SPATH) && \
+			find . -xtype f -exec test -h '''{}''' ';' -exec git ls-files '''{}''' ';' \
 			))
 
-$(FRR)_CACHE_MODE  := GIT_CONTENT_SHA 
+$(FRR)_CACHE_MODE  := GIT_CONTENT_SHA
 $(FRR)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
 $(FRR)_DEP_FILES   := $(DEP_FILES)
 $(FRR)_SMDEP_FILES := $(SMDEP_FILES)


### PR DESCRIPTION
…ubmodule in frr.dep
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
  In frr.dep, it lists the dependent files for the submodules through
  'git ls-files' and filter the symbolic links through 'grep' with
  explicitly patterns. The patterns might need to be adjusted upon
  each frr version upgrade.

#### How I did it
  The dependent files can be found by using 'find' to list all of the
  'file' under the 'frr' submodule directory and pass the file to
  'git ls-files' to know whether the file is included in the git
  control.

#### How to verify it
Compare the file 'frr_8.2.2-sonic-0_amd64.deb.smdep' before and after the change and make sure the file contains the correct list, which should include all of the files and symbolic links to file under the 'frr' submodule directory.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Improve the command to generate dependent files for frr submodule in frr.dep

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)