### PR TITLE
[202205] sonic-host-services: Pin deepdiff to version 6.2.2

### DIFF
--- a/src/sonic-host-services/setup.py
+++ b/src/sonic-host-services/setup.py
@@ -38,7 +38,7 @@ setup(
         'pytest',
         'pyfakefs',
         'sonic-py-common',
-        'deepdiff'
+        'deepdiff==6.2.2'
     ],
     classifiers = [
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
The deepdiff python package was recently updated to 6.2.3. As part of this, a dependency was introduced on orjson. There's no armv8l python wheel available for orjson, which means it needs to be built from source. However, building it requires rust (which Buster and Bullseye don't have a new enough version of) and maturin.

As a quick fix, pin this to version 6.2.2, before the orjson dependency is introduced.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

