### PR TITLE
[Dash] Fix a typo in yang model

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-dash.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dash.yang
@@ -385,7 +385,7 @@ module sonic-dash {
                 }
 
                 leaf vnet {
-                    when "((current()/../action_type = 'vnet') or (current()/../action_type = 'vnet-direct'))";
+                    when "((current()/../action_type = 'vnet') or (current()/../action_type = 'vnet_direct'))";
                     type leafref {
                         path /dash:sonic-dash/dash:DASH_VNET/dash:DASH_VNET_LIST/dash:name;
                     }
@@ -399,8 +399,8 @@ module sonic-dash {
                 }
 
                 leaf overlay_ip {
-                    when "((current()/../action_type = 'vnet') or (current()/../action_type = 'vnet-direct'))";
-                    description "Overlay IP to use for mapping lookup, if routing_type is vnet-direct";
+                    when "((current()/../action_type = 'vnet') or (current()/../action_type = 'vnet_direct'))";
+                    description "Overlay IP to use for mapping lookup, if routing_type is vnet_direct";
                     type inet:ip-address;
                 }
 


### PR DESCRIPTION
#### Why I did it
Fix a typo in yang 

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

