### PR TITLE
Fix ctrmgrd occasionally restart service problem

### DIFF
--- a/src/sonic-ctrmgrd/ctrmgr/ctrmgrd.py
+++ b/src/sonic-ctrmgrd/ctrmgr/ctrmgrd.py
@@ -519,7 +519,10 @@ class FeatureTransitionHandler:
         service_restart = False
 
         if set_owner == "local":
-            if ct_owner != "local":
+            # none is a default value for current_owner when docker stop.
+            # It is not necessary to restart the feature again when the system
+            #  config a new value for it. The container script will handle it.
+            if (ct_owner != "local") and (ct_owner != "none"):
                 service_restart = True
         else:
             if (ct_owner != "none") and (remote_state == "pending"):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

After I enable the Kubernetes on the SONiC, the database container keeps restarting.
And I will keep seeing the following message.
```
Jan 11 03:07:33.820227 sonic DEBUG ctrmgrd.py: run: Received message : '('database', 'SET', (('state', 'enabled'),))'
Jan 11 03:07:33.820655 sonic DEBUG ctrmgrd.py: on_state_update: database init=True old_remote_state= remote_state=none
Jan 11 03:07:33.842777 sonic DEBUG ctrmgrd.py: is_systemd_active: system status for database: 0
Jan 11 03:07:33.842894 sonic DEBUG ctrmgrd.py: handle_update: feat=database set=local ct=none state=none restart=True label_add=False
Jan 11 03:07:33.842975 sonic DEBUG ctrmgrd.py: mod_db_entry: mod_db_entry: db=STATE_DB tbl=KUBE_LABELS key=SET data={'database_enabled': 'false'}
Jan 11 03:07:33.843618 sonic DEBUG ctrmgrd.py: restart_systemd_service: Restart service database to owner:local
```

#### How I did it

Due to the current_owner "none" is the default state for the container, I intend to make the ctrmgrd skip changing the state of the container. This operation should be handled by the "container" script instead of the "ctrmgrd.py".

In the set_owner="kube" condition, it also ignores the case when the current_owner equal to "none".

#### How to verify it

After the change, the containers will not be restarted by the ctrmgrd.py unintentionally.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

* Originally, the container script will set the current_owner to none when it try to stop that feature. Later, when the container script want to start the feature, it will set local/kube as the owner and then start it. However, the ctrmgrd.py will do the same thing for the feature. It will try to restart the feature when the owner changed from none to local. The function of ctrmgrd is duplicate of the container script.

* Prevent the ctrmgrd.py from restarting the feature when the owner is changed from none to local.

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

