### PR TITLE
[Seastone] Enhancement fix for PR12200 syseeprom issue

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
@@ -147,11 +147,11 @@ start)
         sleep 0.1
         done
 
-    # Set pca9548 idle_state
-    echo -2 > /sys/bus/i2c/devices/i2c-${devnum}/0-0071/idle_state
-    echo -2 > /sys/bus/i2c/devices/i2c-${devnum}/0-0073/idle_state
-    echo -2 > /sys/bus/i2c/devices/i2c-${devnum}/0-0077/idle_state
-    sleep 0.1
+	# Set pca9548 idle_state
+	echo -2 > /sys/bus/i2c/devices/i2c-${devnum}/${devnum}-0071/idle_state
+	echo -2 > /sys/bus/i2c/devices/i2c-${devnum}/${devnum}-0073/idle_state
+	echo -2 > /sys/bus/i2c/devices/i2c-${devnum}/${devnum}-0077/idle_state
+	sleep 0.1
 
 	bus_en=8
 	cfg_r=`i2cget -y -f 8 0x60 0xD1`


### PR DESCRIPTION
#### Why I did it
[Seastone] Enhancement fix for PR12200 syseeprom issue.

#### How I did it
Enhance the fix through replace the hardcoded devnum to bash variable

#### How to verify it
```
show platform syseeprom or decode-syseeprom
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

