### PR TITLE
[device/arista] Disabled polled_irq_mode for DNX SKUs

### DIFF
--- a/device/arista/x86_64-arista_7280cr3_32d4/Arista-7280CR3-C32D4/jr2-a7280cr3-32d4-32x100G+4x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32d4/Arista-7280CR3-C32D4/jr2-a7280cr3-32d4-32x100G+4x400G.config.bcm
@@ -270,7 +270,7 @@ tdma_timeout_usec.BCM8869X=1000000
 tslam_timeout_usec.BCM8869X=1000000
 
 appl_enable_intr_init.BCM8869X=1
-polled_irq_mode.BCM8869X=1
+polled_irq_mode.BCM8869X=0
 polled_irq_delay.BCM8869X=1000
 
 bcm_stat_interval.BCM8869X=1000

--- a/device/arista/x86_64-arista_7280cr3_32d4/Arista-7280CR3-C40/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32d4/Arista-7280CR3-C40/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -273,7 +273,7 @@ tdma_timeout_usec.BCM8869X=1000000
 tslam_timeout_usec.BCM8869X=1000000
 
 appl_enable_intr_init.BCM8869X=1
-polled_irq_mode.BCM8869X=1
+polled_irq_mode.BCM8869X=0
 polled_irq_delay.BCM8869X=1000
 
 bcm_stat_interval.BCM8869X=1000

--- a/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C28S8/jr2-a7280cr3-32p4-28x100G-8x10G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C28S8/jr2-a7280cr3-32p4-28x100G-8x10G.config.bcm
@@ -269,7 +269,7 @@ tdma_timeout_usec.BCM8869X=1000000
 tslam_timeout_usec.BCM8869X=1000000
 
 appl_enable_intr_init.BCM8869X=1
-polled_irq_mode.BCM8869X=1
+polled_irq_mode.BCM8869X=0
 polled_irq_delay.BCM8869X=1000
 
 bcm_stat_interval.BCM8869X=1000

--- a/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C32P4/jr2-a7280cr3-32p4-32x100G+4x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C32P4/jr2-a7280cr3-32p4-32x100G+4x400G.config.bcm
@@ -270,7 +270,7 @@ tdma_timeout_usec.BCM8869X=1000000
 tslam_timeout_usec.BCM8869X=1000000
 
 appl_enable_intr_init.BCM8869X=1
-polled_irq_mode.BCM8869X=1
+polled_irq_mode.BCM8869X=0
 polled_irq_delay.BCM8869X=1000
 
 bcm_stat_interval.BCM8869X=1000

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -763,7 +763,7 @@ tdma_timeout_usec.BCM8869X=1000000
 tslam_timeout_usec.BCM8869X=1000000
 
 appl_enable_intr_init.BCM8869X=1
-polled_irq_mode.BCM8869X=1
+polled_irq_mode.BCM8869X=0
 polled_irq_delay.BCM8869X=1000
 
 bcm_stat_interval.BCM8869X=1000

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -634,7 +634,7 @@ tslam_timeout_usec=1000000
 
 ### Interrupts
 appl_enable_intr_init=1
-polled_irq_mode=1
+polled_irq_mode=0
 # reduce CPU load, configure delay 100ms
 polled_irq_delay=1000
 

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -634,7 +634,7 @@ tslam_timeout_usec=1000000
 
 ### Interrupts
 appl_enable_intr_init=1
-polled_irq_mode=1
+polled_irq_mode=0
 # reduce CPU load, configure delay 100ms
 polled_irq_delay=1000
 

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -652,7 +652,7 @@ tslam_timeout_usec=1000000
 
 ### Interrupts
 appl_enable_intr_init=1
-polled_irq_mode=1
+polled_irq_mode=0
 # reduce CPU load, configure delay 100ms
 polled_irq_delay=1000
 

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -652,7 +652,7 @@ tslam_timeout_usec=1000000
 
 ### Interrupts
 appl_enable_intr_init=1
-polled_irq_mode=1
+polled_irq_mode=0
 # reduce CPU load, configure delay 100ms
 polled_irq_delay=1000
 

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -634,7 +634,7 @@ tslam_timeout_usec=1000000
 
 ### Interrupts
 appl_enable_intr_init=1
-polled_irq_mode=1
+polled_irq_mode=0
 # reduce CPU load, configure delay 100ms
 polled_irq_delay=1000
 

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -634,7 +634,7 @@ tslam_timeout_usec=1000000
 
 ### Interrupts
 appl_enable_intr_init=1
-polled_irq_mode=1
+polled_irq_mode=0
 # reduce CPU load, configure delay 100ms
 polled_irq_delay=1000
 


### PR DESCRIPTION
Disabled polled_irq_mode for all Arista DNX devices as this mode leads to excessive use of the CPU via an unneeded interrupt polling thread.

#### Why I did it
To resolve https://github.com/aristanetworks/sonic/issues/59

#### How I did it
Disabled DNX SDK SOC property corresponding to an unnecessary thread used for polling interrupts.

#### How to verify it
After loading the image, the CPU utilization is no longer excessive.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ X] 202205
- [ ] 202211

