### PR TITLE
[BFN] Update psu.py to process sigterm signal

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/psu.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/psu.py
@@ -45,8 +45,6 @@ class Psu(PsuBase):
         self.__thermals = None
         self.__info = None
         self.__ts = 0
-        self.__temperature = None
-        self.__temperature_high_threshold = None
         # STUB IMPLEMENTATION
         self.color = ""
 
@@ -298,9 +296,7 @@ class Psu(PsuBase):
         """
         # Operation may take a few seconds to process, so if state is
         # "termination signal", plugin doesn't perform this operation
-        if not Psu.sigterm:
-            self.__temperature = self.get_thermal(0).get_temperature()
-        return self.__temperature
+        return self.get_thermal(0).get_temperature()
 
     @cancel_on_sigterm
     def get_temperature_high_threshold(self):
@@ -312,9 +308,7 @@ class Psu(PsuBase):
         """
         # Operation may take a few seconds to process, so if state is
         # "termination signal", plugin doesn't perform this operation
-        if not Psu.sigterm:
-            self.__temperature_high_threshold = self.get_thermal(0).get_high_threshold()
-        return self.__temperature_high_threshold
+        return self.get_thermal(0).get_high_threshold()
 
     @property
     def _thermal_list(self):

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/psu.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/psu.py
@@ -28,6 +28,13 @@ class Psu(PsuBase):
     __sensors_info = None
     __timestamp = 0
 
+    # When psud gets termination signal it starts processing last cycle.
+    # This cycle must be as fast as possible to be able to stop correctly,
+    # otherwise it will be killed, so the whole plugin must encounter
+    # this signal to process operations based on state, where the
+    # state is "termination signal got" and "no termination signal"
+
+    # State is "no termination signal"
     sigterm = False
     sigterm_default_handler = None
     cls_inited = False
@@ -56,11 +63,14 @@ class Psu(PsuBase):
         if cls.sigterm_default_handler:
             cls.sigterm_default_handler(sig, frame)
         syslog.syslog(syslog.LOG_INFO, "Canceling PSU platform API calls...")
+        # Changing state to "termination signal"
         cls.sigterm = True
 
     @classmethod
     def __sensors_get(cls, cached=True):
         cls.__lock.acquire()
+        # Operation may take a few seconds to process, so if state is
+        # "termination signal", plugin doesn't perform this operation
         if time.time() > cls.__timestamp + 15 and not Psu.sigterm:
             # Update cache once per 15 seconds
             try:
@@ -85,6 +95,8 @@ class Psu(PsuBase):
         def psu_info_get(client):
             return client.pltfm_mgr.pltfm_mgr_pwr_supply_info_get(self.__index)
 
+        # Operation may take a few seconds to process, so if state is
+        # "termination signal", plugin doesn't perform this operation
         # Update cache once per 2 seconds
         if self.__ts + 2 < time.time() and not Psu.sigterm:
             self.__info = None
@@ -284,6 +296,8 @@ class Psu(PsuBase):
             A float number of current temperature in Celsius up to nearest thousandth
             of one degree Celsius, e.g. 30.125
         """
+        # Operation may take a few seconds to process, so if state is
+        # "termination signal", plugin doesn't perform this operation
         if not Psu.sigterm:
             self.__temperature = self.get_thermal(0).get_temperature()
         return self.__temperature
@@ -296,6 +310,8 @@ class Psu(PsuBase):
             A float number, the high threshold temperature of PSU in Celsius
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
+        # Operation may take a few seconds to process, so if state is
+        # "termination signal", plugin doesn't perform this operation
         if not Psu.sigterm:
             self.__temperature_high_threshold = self.get_thermal(0).get_high_threshold()
         return self.__temperature_high_threshold


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Sometime, SIGTERM processing by psud takes more then default 10sec (please see stopwaitsecs in http://supervisord.org/configuration.html).

Due to this, the following two testcases may fail:

```
test_pmon_psud_stop_and_start_status
test_pmon_psud_term_and_start_status
```
#### How I did it
Update PSU plugin to process sigterm signal so that psud runs faster to end last cycle in time
#### How to verify it
Run SONiC CTs:
test_pmon_psud_stop_and_start_status
test_pmon_psud_term_and_start_status
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

