### PR TITLE
[build] use pip install of later setup.py to install test dependencies

### DIFF
--- a/scripts/get_py_depend.py
+++ b/scripts/get_py_depend.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+
+import setuptools
+from distutils import core
+import os
+import json
+
+def setup(**kwargs):
+        ret=[]
+        a=kwargs.get('setup_requires')
+        b=kwargs.get('tests_require')
+        c=kwargs.get('install_requires')
+        if a:
+            ret+=a
+        if b:
+            ret+=b
+        if c:
+            ret+=c
+        for i,x in enumerate(ret):
+            print("'"+x+"'")
+
+
+if __name__ == "__main__":
+  setuptools.setup=setup
+  core.setup=setup
+  content = open('setup.py').read()
+  exec(content)

--- a/scripts/get_py_depend.py
+++ b/scripts/get_py_depend.py
@@ -2,8 +2,6 @@
 
 import setuptools
 from distutils import core
-import os
-import json
 
 def setup(**kwargs):
         ret=[]

--- a/scripts/get_py_depend.py
+++ b/scripts/get_py_depend.py
@@ -4,18 +4,10 @@ import setuptools
 from distutils import core
 
 def setup(**kwargs):
-        ret=[]
-        a=kwargs.get('setup_requires')
-        b=kwargs.get('tests_require')
-        c=kwargs.get('install_requires')
-        if a:
-            ret+=a
-        if b:
-            ret+=b
-        if c:
-            ret+=c
-        for i,x in enumerate(ret):
-            print("'"+x+"'")
+  ret=kwargs.get('tests_require')
+  if ret:
+    for i,x in enumerate(ret):
+      print("'"+x+"'")
 
 
 if __name__ == "__main__":

--- a/scripts/install_depends.py
+++ b/scripts/install_depends.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+import os
+import sys
 import setuptools
 from distutils import core
 
@@ -7,7 +9,7 @@ def setup(**kwargs):
   ret=kwargs.get('tests_require')
   if ret:
     for i,x in enumerate(ret):
-      print("'"+x+"'")
+      os.system("pip" + str(sys.version_info.major) + " install " + '"' + x + '"')
 
 
 if __name__ == "__main__":

--- a/slave.mk
+++ b/slave.mk
@@ -865,7 +865,7 @@ $(addprefix $(PYTHON_WHEELS_PATH)/, $(SONIC_PYTHON_WHEELS)) : $(PYTHON_WHEELS_PA
 ifneq ($(CROSS_BUILD_ENVIRON),y)
 		# Use pip instead of later setup.py to install dependencies into user home, but uninstall self
 		pip$($*_PYTHON_VERSION) install . && pip$($*_PYTHON_VERSION) uninstall --yes `python$($*_PYTHON_VERSION) setup.py --name`
-		if [ ! "$($*_TEST)" = "n" ]; then python$($*_PYTHON_VERSION) $(BUILD_WORKDIR)/scripts/get_py_depend.py | xargs -i pip$($*_PYTHON_VERSION) install {}; python$($*_PYTHON_VERSION) setup.py test $(LOG); fi
+		if [ ! "$($*_TEST)" = "n" ]; then python$($*_PYTHON_VERSION) $(BUILD_WORKDIR)/scripts/get_py_depend.py | xargs -i pip$($*_PYTHON_VERSION) install {}; python$($*_PYTHON_VERSION) setup.py test; fi $(LOG)
 		python$($*_PYTHON_VERSION) setup.py bdist_wheel $(LOG)
 else
 		{

--- a/slave.mk
+++ b/slave.mk
@@ -862,10 +862,10 @@ $(addprefix $(PYTHON_WHEELS_PATH)/, $(SONIC_PYTHON_WHEELS)) : $(PYTHON_WHEELS_PA
 		pushd $($*_SRC_PATH) $(LOG_SIMPLE)
 		# apply series of patches if exist
 		if [ -f ../$(notdir $($*_SRC_PATH)).patch/series ]; then QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; fi
-		# Use pip instead of later setup.py to install dependencies into user home
-		{ python$($*_PYTHON_VERSION) $(BUILD_WORKDIR)/scripts/get_py_depend.py | xargs -i pip$($*_PYTHON_VERSION) install {}; } $(LOG)
 ifneq ($(CROSS_BUILD_ENVIRON),y)
-		if [ ! "$($*_TEST)" = "n" ]; then python$($*_PYTHON_VERSION) setup.py test $(LOG); fi
+		# Use pip instead of later setup.py to install dependencies into user home, but uninstall self
+		pip$($*_PYTHON_VERSION) install . && pip$($*_PYTHON_VERSION) uninstall --yes `python$($*_PYTHON_VERSION) setup.py --name`
+		if [ ! "$($*_TEST)" = "n" ]; then python$($*_PYTHON_VERSION) $(BUILD_WORKDIR)/scripts/get_py_depend.py | xargs -i pip$($*_PYTHON_VERSION) install {}; python$($*_PYTHON_VERSION) setup.py test $(LOG); fi
 		python$($*_PYTHON_VERSION) setup.py bdist_wheel $(LOG)
 else
 		{

--- a/slave.mk
+++ b/slave.mk
@@ -862,9 +862,9 @@ $(addprefix $(PYTHON_WHEELS_PATH)/, $(SONIC_PYTHON_WHEELS)) : $(PYTHON_WHEELS_PA
 		pushd $($*_SRC_PATH) $(LOG_SIMPLE)
 		# apply series of patches if exist
 		if [ -f ../$(notdir $($*_SRC_PATH)).patch/series ]; then QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; fi
+		# Use pip instead of later setup.py to install dependencies into user home
+		python$($*_PYTHON_VERSION) $(BUILD_WORKDIR)/scripts/get_py_depend.py | xargs -i pip$($*_PYTHON_VERSION) install {} $(LOG)
 ifneq ($(CROSS_BUILD_ENVIRON),y)
-		# Use pip instead of later setup.py to install dependencies into user home, but uninstall self
-		pip$($*_PYTHON_VERSION) install . && pip$($*_PYTHON_VERSION) uninstall --yes `python$($*_PYTHON_VERSION) setup.py --name`
 		if [ ! "$($*_TEST)" = "n" ]; then python$($*_PYTHON_VERSION) setup.py test $(LOG); fi
 		python$($*_PYTHON_VERSION) setup.py bdist_wheel $(LOG)
 else

--- a/slave.mk
+++ b/slave.mk
@@ -865,7 +865,7 @@ $(addprefix $(PYTHON_WHEELS_PATH)/, $(SONIC_PYTHON_WHEELS)) : $(PYTHON_WHEELS_PA
 ifneq ($(CROSS_BUILD_ENVIRON),y)
 		# Use pip instead of later setup.py to install dependencies into user home, but uninstall self
 		pip$($*_PYTHON_VERSION) install . && pip$($*_PYTHON_VERSION) uninstall --yes `python$($*_PYTHON_VERSION) setup.py --name`
-		if [ ! "$($*_TEST)" = "n" ]; then python$($*_PYTHON_VERSION) $(BUILD_WORKDIR)/scripts/get_py_depend.py | xargs -i pip$($*_PYTHON_VERSION) install {}; python$($*_PYTHON_VERSION) setup.py test; fi $(LOG)
+		if [ ! "$($*_TEST)" = "n" ]; then python$($*_PYTHON_VERSION) $(BUILD_WORKDIR)/scripts/install_depends.py && python$($*_PYTHON_VERSION) setup.py test; fi $(LOG)
 		python$($*_PYTHON_VERSION) setup.py bdist_wheel $(LOG)
 else
 		{

--- a/slave.mk
+++ b/slave.mk
@@ -863,7 +863,7 @@ $(addprefix $(PYTHON_WHEELS_PATH)/, $(SONIC_PYTHON_WHEELS)) : $(PYTHON_WHEELS_PA
 		# apply series of patches if exist
 		if [ -f ../$(notdir $($*_SRC_PATH)).patch/series ]; then QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; fi
 		# Use pip instead of later setup.py to install dependencies into user home
-		python$($*_PYTHON_VERSION) $(BUILD_WORKDIR)/scripts/get_py_depend.py | xargs -i pip$($*_PYTHON_VERSION) install {} $(LOG)
+		python$($*_PYTHON_VERSION) $(BUILD_WORKDIR)/scripts/get_py_depend.py | xargs -i pip$($*_PYTHON_VERSION) install {}
 ifneq ($(CROSS_BUILD_ENVIRON),y)
 		if [ ! "$($*_TEST)" = "n" ]; then python$($*_PYTHON_VERSION) setup.py test $(LOG); fi
 		python$($*_PYTHON_VERSION) setup.py bdist_wheel $(LOG)

--- a/slave.mk
+++ b/slave.mk
@@ -863,7 +863,7 @@ $(addprefix $(PYTHON_WHEELS_PATH)/, $(SONIC_PYTHON_WHEELS)) : $(PYTHON_WHEELS_PA
 		# apply series of patches if exist
 		if [ -f ../$(notdir $($*_SRC_PATH)).patch/series ]; then QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; fi
 		# Use pip instead of later setup.py to install dependencies into user home
-		python$($*_PYTHON_VERSION) $(BUILD_WORKDIR)/scripts/get_py_depend.py | xargs -i pip$($*_PYTHON_VERSION) install {}
+		{ python$($*_PYTHON_VERSION) $(BUILD_WORKDIR)/scripts/get_py_depend.py | xargs -i pip$($*_PYTHON_VERSION) install {}; } $(LOG)
 ifneq ($(CROSS_BUILD_ENVIRON),y)
 		if [ ! "$($*_TEST)" = "n" ]; then python$($*_PYTHON_VERSION) setup.py test $(LOG); fi
 		python$($*_PYTHON_VERSION) setup.py bdist_wheel $(LOG)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Using 'python setup.py test' to install dependencies doesn't meet secure requirement.
#### How I did it
Use 'pip install' instead of setup.py to install dependencies.
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

