### PR TITLE
Fix sonic slave pipeline to set correct tag on sonic slave image. (#13177)

### DIFF
--- a/.azure-pipelines/docker-sonic-slave.yml
+++ b/.azure-pipelines/docker-sonic-slave.yml
@@ -3,26 +3,36 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 # Build and push sonic-slave-[buster|jessie|stretch] images for amd64/armhf/arm64
+resources:
+  repositories:
+  - repository: buildimage
+    type: github
+    name: sonic-net/sonic-buildimage
+    ref: master
+    endpoint: sonic-net
 
 schedules:
-- cron: "0 8 * * *"
+- cron: "0 0 * * 0"
+  displayName: Weekly build
   branches:
     include:
     - master
-    - 202012
+    - 202???
   always: true
 
-trigger: none
-pr:
+pr: none
+trigger:
+  batch: true
   branches:
     include:
     - master
+    - 202???
   paths:
     include:
-    - sonic-slave-jessie
-    - sonic-slave-stretch
-    - sonic-slave-buster
-    - src/sonic-build-hooks
+    - sonic-slave-*
+    - files/build/versions
+    - Makefile
+    - Makefile.work
 
 parameters:
 - name: 'arches'
@@ -34,6 +44,7 @@ parameters:
 - name: 'dists'
   type: object
   default:
+  - bullseye
   - buster
   - stretch
   - jessie
@@ -44,70 +55,29 @@ parameters:
   type: string
   default: sonicdev
 
-variables:
-- ${{ if eq(variables['Build.SourceBranchName'], '202012') }}:
-  - name: BUILD_OPTIONS
-    value: 'SONIC_VERSION_CONTROL_COMPONENTS=deb,py2,py3,web,git,docker'
-
 stages:
-- stage: Build
+- stage: Build_in_amd64
   jobs:
   - ${{ each dist in parameters.dists }}:
     - ${{ if endswith(variables['Build.DefinitionName'], dist) }}:
       - ${{ each arch in parameters.arches }}:
-        - job: Build_${{ dist }}_${{ arch }}
-          timeoutInMinutes: 360
-          pool: sonicbld
-          steps:
-          - template: cleanup.yml
-          - checkout: self
-            clean: true
-            submodules: recursive
-          - bash: |
-              set -ex
-
-              containers=$(docker container ls | grep "sonic-slave" | awk '{ print $1 }')
-              if [ ! -z "$containers" ]; then
-                docker container kill $containers || true
-                sleep 5
-              fi
-              images=$(docker images 'sonic-slave-*' -a -q)
-              if [ ! -z "$images" ]; then
-                docker rmi -f $images
-              fi
-
-              SLAVE_DIR=sonic-slave-${{ dist }}
-              if [ x${{ arch }} == x"amd64" ]; then
-                SLAVE_BASE_IMAGE=${SLAVE_DIR}
-              else
-                SLAVE_BASE_IMAGE=${SLAVE_DIR}-march-${{ arch }}
-              fi
-
-              tmpfile=$(mktemp)
-
-              echo ${{ arch }} > .arch
-
-              DOCKER_DATA_ROOT_FOR_MULTIARCH=/data/march/docker BLDENV=${{ dist }} $(BUILD_OPTIONS) make -f Makefile.work sonic-slave-build | tee $tmpfile
-              SLAVE_BASE_TAG=$(grep "^Checking sonic-slave-base image:" $tmpfile | awk -F ':' '{print $3}')
-              SLAVE_TAG=$(grep "^Checking sonic-slave image:" $tmpfile | awk -F ':' '{print $3}')
-
-              mkdir -p target
-
-              docker tag $SLAVE_BASE_IMAGE:$SLAVE_BASE_TAG $REGISTRY_SERVER/$SLAVE_BASE_IMAGE:latest
-              docker tag $SLAVE_BASE_IMAGE:$SLAVE_BASE_TAG $REGISTRY_SERVER/$SLAVE_BASE_IMAGE:$SLAVE_BASE_TAG
-              set +x
-              echo "##vso[task.setvariable variable=VARIABLE_SLAVE_BASE_IMAGE]$SLAVE_BASE_IMAGE"
-              echo "##vso[task.setvariable variable=VARIABLE_SLAVE_BASE_TAG]$SLAVE_BASE_TAG"
-            env:
-              REGISTRY_SERVER: ${{ parameters.registry_url }}
-            displayName: Build sonic-slave-${{ dist }}-${{ arch }}
-
-          - task: Docker@2
-            displayName: Upload image
-            inputs:
-              containerRegistry: ${{ parameters.registry_conn }}
-              repository: $(VARIABLE_SLAVE_BASE_IMAGE)
-              command: push
-              tags: |
-                $(VARIABLE_SLAVE_BASE_TAG)
-                latest
+        - template: .azure-pipelines/docker-sonic-slave-template.yml@buildimage
+          parameters:
+            pool: sonicbld
+            arch: ${{ arch }}
+            dist: ${{ dist }}
+            ${{ if ne(arch, 'amd64') }}:
+              march: _march_${{ arch }}
+- stage: Build_native_arm
+  dependsOn: []
+  jobs:
+  - ${{ each dist in parameters.dists }}:
+    - ${{ if endswith(variables['Build.DefinitionName'], dist) }}:
+      - ${{ each arch in parameters.arches }}:
+        - ${{ if ne(arch, 'amd64') }}:
+          - template: .azure-pipelines/docker-sonic-slave-template.yml@buildimage
+            parameters:
+              pool: sonicbld-${{ arch }}
+              arch: ${{ arch }}
+              dist: ${{ dist }}
+              march: _${{ arch }}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
    Currently sonic-slave-* tag is confusing. Set correct tag on sonic-slave-* image.
    Fix job name to fit the build.
#### How I did it
    build amd image in amd64:
    sonic-slave-bullseye:cfe29bff67c
    sonic-slave-bullseye:latest
    sonic-slave-bullseye:master

    build armhf image in amd64:
    sonic-slave-bullseye-march-armhf:33614806dc3
    sonic-slave-bullseye-march-armhf:latest
    sonic-slave-bullseye-march-armhf:master

    build arm64 image in amd64:
    sonic-slave-bullseye-march-arm64:f3b1b16c801
    sonic-slave-bullseye-march-arm64:latest
    sonic-slave-bullseye-march-arm64:master

    build arm64 image in arm64:
    sonic-slave-bullseye:75cb326c9a7
    sonic-slave-bullseye-arm64:latest
    sonic-slave-bullseye:master

    build armhf image in armhf:
    sonic-slave-bullseye:64d178951fc
    sonic-slave-bullseye-armhf:latest
    sonic-slave-bullseye:master
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

