### PR TITLE
Create Vxlan and Vnet default configs

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1188,6 +1188,28 @@ def parse_spine_chassis_fe(results, vni, lo_intfs, phyport_intfs, pc_intfs, pc_m
             # Enslave the port channel interface to a Vnet
             pc_intfs[pc_intf] = {'vnet_name': chassis_vnet}        
 
+def parse_default_vxlan_decap(results, vni, lo_intfs):
+    vnet ='Vnet-default'
+    vxlan_tunnel = 'Tunnel-default'
+
+    # Vxlan tunnel information
+    lo_addr = '0.0.0.0'
+    for lo in lo_intfs:
+        lo_network = ipaddress.ip_network(UNICODE_TYPE(lo[1]), False)
+        if lo_network.version == 4:
+            lo_addr = str(lo_network.network_address)
+            break
+    results['VXLAN_TUNNEL'] = {vxlan_tunnel: {
+        'src_ip': lo_addr
+    }}
+
+    # Vnet information
+    results['VNET'] = {vnet: {
+        'vxlan_tunnel': vxlan_tunnel,
+        'scope': "default",
+        'vni': vni
+    }}
+
 ###############################################################################
 #
 # Post-processing functions
@@ -1526,9 +1548,10 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         for key in voq_inband_intfs:
            results['VOQ_INBAND_INTERFACE'][key] = voq_inband_intfs[key]
 
-
     if resource_type is not None:
         results['DEVICE_METADATA']['localhost']['resource_type'] = resource_type
+        if 'Appliance' in resource_type:
+            parse_default_vxlan_decap(results, vni_default, lo_intfs)
 
     if downstream_subrole is not None:
         results['DEVICE_METADATA']['localhost']['downstream_subrole'] = downstream_subrole

--- a/src/sonic-config-engine/tests/t0-sample-deployment-id.xml
+++ b/src/sonic-config-engine/tests/t0-sample-deployment-id.xml
@@ -731,6 +731,11 @@
             <a:Reference i:nil="true"/>
             <a:Value>2.2.2.2</a:Value>
           </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>ResourceType</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>HaAppliance</a:Value>
+          </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
     </Devices>

--- a/src/sonic-config-engine/tests/t0-sample-graph.xml
+++ b/src/sonic-config-engine/tests/t0-sample-graph.xml
@@ -877,11 +877,6 @@
             <a:Reference i:nil="true"/>
             <a:Value>2.2.2.2</a:Value>
           </a:DeviceProperty>
-          <a:DeviceProperty>
-            <a:Name>ResourceType</a:Name>
-	    <a:Reference i:nil="true"/>
-	    <a:Value>HaAppliance</a:Value>
-          </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
     </Devices>

--- a/src/sonic-config-engine/tests/t0-sample-graph.xml
+++ b/src/sonic-config-engine/tests/t0-sample-graph.xml
@@ -877,6 +877,11 @@
             <a:Reference i:nil="true"/>
             <a:Value>2.2.2.2</a:Value>
           </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>ResourceType</a:Name>
+	    <a:Reference i:nil="true"/>
+	    <a:Value>HaAppliance</a:Value>
+          </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
     </Devices>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 import os
+
 import tests.common_utils as utils
 
 from unittest import TestCase
@@ -13,9 +14,8 @@ BACKEND_LEAF_ROUTER = 'BackEndLeafRouter'
 class TestCfgGen(TestCase):
 
     def setUp(self):
-        self.yang = utils.YangWrapper()
         self.test_dir = os.path.dirname(os.path.realpath(__file__))
-        self.script_file = [utils.PYTHON_INTERPRETTER, os.path.join(self.test_dir, '..', 'sonic-cfggen')]
+        self.script_file = utils.PYTHON_INTERPRETTER + ' ' + os.path.join(self.test_dir, '..', 'sonic-cfggen')
         self.sample_graph = os.path.join(self.test_dir, 'sample_graph.xml')
         self.sample_graph_t0 = os.path.join(self.test_dir, 't0-sample-graph.xml')
         self.sample_graph_simple = os.path.join(self.test_dir, 'simple-sample-graph.xml')
@@ -23,8 +23,6 @@ class TestCfgGen(TestCase):
         self.sample_graph_metadata = os.path.join(self.test_dir, 'simple-sample-graph-metadata.xml')
         self.sample_graph_pc_test = os.path.join(self.test_dir, 'pc-test-graph.xml')
         self.sample_graph_bgp_speaker = os.path.join(self.test_dir, 't0-sample-bgp-speaker.xml')
-        self.sample_graph_deployment_id = os.path.join(self.test_dir, 't0-sample-deployment-id.xml')
-        self.sample_graph_voq = os.path.join(self.test_dir, 'sample-voq-graph.xml')
         self.sample_device_desc = os.path.join(self.test_dir, 'device.xml')
         self.port_config = os.path.join(self.test_dir, 't0-sample-port-config.ini')
         self.port_config_autoneg = os.path.join(self.test_dir, 't0-sample-autoneg-port-config.ini')
@@ -34,11 +32,6 @@ class TestCfgGen(TestCase):
         self.ecmp_graph = os.path.join(self.test_dir, 'fg-ecmp-sample-minigraph.xml')
         self.sample_resource_graph = os.path.join(self.test_dir, 'sample-graph-resource-type.xml')
         self.sample_subintf_graph = os.path.join(self.test_dir, 'sample-graph-subintf.xml')
-        self.voq_port_config = os.path.join(self.test_dir, 'voq-sample-port-config.ini')
-        self.packet_chassis_graph = os.path.join(self.test_dir, 'sample-chassis-packet-lc-graph.xml')
-        self.packet_chassis_port_ini = os.path.join(self.test_dir, 'sample-chassis-packet-lc-port-config.ini')
-        self.macsec_profile = os.path.join(self.test_dir, 'macsec_profile.json')
-        self.sample_backend_graph = os.path.join(self.test_dir, 'sample-graph-storage-backend.xml')
         # To ensure that mock config_db data is used for unit-test cases
         os.environ["CFGGEN_UNIT_TESTING"] = "2"
 
@@ -50,13 +43,12 @@ class TestCfgGen(TestCase):
         except OSError:
             pass
 
-    def run_script(self, argument, check_stderr=False, verbose=False):
-        print('\n    Running sonic-cfggen ' + ' '.join(argument))
-        self.assertTrue(self.yang.validate(argument))
+    def run_script(self, argument, check_stderr=False):
+        print('\n    Running sonic-cfggen ' + argument)
         if check_stderr:
-            output = subprocess.check_output(self.script_file + argument, stderr=subprocess.STDOUT)
+            output = subprocess.check_output(self.script_file + ' ' + argument, stderr=subprocess.STDOUT, shell=True)
         else:
-            output = subprocess.check_output(self.script_file + argument)
+            output = subprocess.check_output(self.script_file + ' ' + argument, shell=True)
 
         if utils.PY3x:
             output = output.decode()
@@ -66,88 +58,79 @@ class TestCfgGen(TestCase):
             print('    Output: ' + output.strip())
         else:
             print('    Output: ({0} lines, {1} bytes)'.format(linecount + 1, len(output)))
-            if verbose == True:
-                print('    Output: ' + output.strip())
         return output
 
     def test_dummy_run(self):
-        argument = []
+        argument = ''
         output = self.run_script(argument)
         self.assertEqual(output, '')
 
     def test_device_desc(self):
-        argument = ['-v', "DEVICE_METADATA[\'localhost\'][\'hwsku\']", "-M", self.sample_device_desc]
+        argument = '-v "DEVICE_METADATA[\'localhost\'][\'hwsku\']" -M "' + self.sample_device_desc + '"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'ACS-MSN2700')
 
     def test_device_desc_mgmt_ip(self):
-        argument = ['-v', "(MGMT_INTERFACE.keys()|list)[0]", '-M', self.sample_device_desc]
+        argument = '-v "(MGMT_INTERFACE.keys()|list)[0]" -M "' + self.sample_device_desc + '"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "('eth0', '10.0.1.5/28')")
 
-    def test_minigraph_hostname(self):
-        argument = ['-v', "DEVICE_METADATA[\'localhost\'][\'hostname\']", '-m', self.sample_graph, "-p", self.port_config]
-        output = self.run_script(argument)
-        self.assertEqual(output.strip(), 'OCPSCH01040DDLF')
-
     def test_minigraph_sku(self):
-        argument = ['-v', "DEVICE_METADATA[\'localhost\'][\'hwsku\']", '-m', self.sample_graph, '-p', self.port_config]
+        argument = '-v "DEVICE_METADATA[\'localhost\'][\'hwsku\']" -m "' + self.sample_graph + '"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'Force10-Z9100')
 
     def test_minigraph_region(self):
-        argument = ['-v', "DEVICE_METADATA[\'localhost\'][\'region\']", '-m', self.sample_graph_metadata, '-p', self.port_config]
+        argument = '-v "DEVICE_METADATA[\'localhost\'][\'region\']" -m "' + self.sample_graph_metadata + '"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'usfoo')
 
     def test_minigraph_cloudtype(self):
-        argument = ['-v', "DEVICE_METADATA[\'localhost\'][\'cloudtype\']", '-m', self.sample_graph_metadata, '-p', self.port_config]
+        argument = '-v "DEVICE_METADATA[\'localhost\'][\'cloudtype\']" -m "' + self.sample_graph_metadata + '"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'Public')
 
     def test_minigraph_resourcetype(self):
-        argument = ['-v', "DEVICE_METADATA[\'localhost\'][\'resource_type\']", '-m', self.sample_graph_metadata, '-p', self.port_config]
+        argument = '-v "DEVICE_METADATA[\'localhost\'][\'resource_type\']" -m "' + self.sample_graph_metadata + '"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'resource_type_x')
 
     def test_minigraph_downstream_subrole(self):
-        argument = ['-v', "DEVICE_METADATA[\'localhost\'][\'downstream_subrole\']", '-m', self.sample_graph_metadata, '-p', self.port_config]
+        argument = '-v "DEVICE_METADATA[\'localhost\'][\'downstream_subrole\']" -m "' + self.sample_graph_metadata + '"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'downstream_subrole_y')
 
     def test_print_data(self):
-        argument = ['-m', self.sample_graph, '-p', self.port_config, '--print-data']
+        argument = '-m "' + self.sample_graph + '" --print-data'
         output = self.run_script(argument)
         self.assertTrue(len(output.strip()) > 0)
 
-    def test_jinja_expression(self, graph=None, port_config=None, expected_router_type='LeafRouter'):
+    def test_jinja_expression(self, graph=None, expected_router_type='LeafRouter'):
         if graph is None:
             graph = self.sample_graph
-        if port_config is None:
-            port_config = self.port_config
-        argument = ['-m', graph, '-p', port_config, '-v', "DEVICE_METADATA[\'localhost\'][\'type\']"]
+        argument = '-m "' + graph + '" -v "DEVICE_METADATA[\'localhost\'][\'type\']"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), expected_router_type)
 
     def test_additional_json_data(self):
-        argument = ['-a', '{"key1":"value1"}', '-v', 'key1']
+        argument = '-a \'{"key1":"value1"}\' -v key1'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'value1')
 
     def test_additional_json_data_level1_key(self):
-        argument = ['-a', '{"k1":{"k11":"v11","k12":"v12"}, "k2":{"k22":"v22"}}', '--var-json', 'k1']
+        argument = '-a \'{"k1":{"k11":"v11","k12":"v12"}, "k2":{"k22":"v22"}}\' --var-json k1'
         output = self.run_script(argument)
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict('{\n    "k11": "v11", \n    "k12": "v12"\n}'))
 
     def test_additional_json_data_level2_key(self):
-        argument = ['-a', '{"k1":{"k11":"v11","k12":"v12"},"k2":{"k22":"v22"}}', '--var-json', 'k1', '-K', 'k11']
+        argument = '-a \'{"k1":{"k11":"v11","k12":"v12"},"k2":{"k22":"v22"}}\' --var-json k1 -K k11'
         output = self.run_script(argument)
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict('{\n    "k11": "v11"\n}'))
 
     def test_var_json_data(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
         tag_mode = kwargs.get('tag_mode', 'untagged')
-        argument = ['-m', graph_file, '-p', self.port_config, '--var-json', 'VLAN_MEMBER']
+        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" --var-json VLAN_MEMBER'
         output = self.run_script(argument)
         if tag_mode == "tagged":
             self.assertEqual(
@@ -173,20 +156,20 @@ class TestCfgGen(TestCase):
             )
 
     def test_read_yaml(self):
-        argument = ['-v', 'yml_item', '-y', os.path.join(self.test_dir, 'test.yml')]
+        argument = '-v yml_item -y ' + os.path.join(self.test_dir, 'test.yml')
         output = self.run_script(argument)
         self.assertEqual(output.strip(), '[\'value1\', \'value2\']')
 
     def test_render_template(self):
-        argument = ['-y', os.path.join(self.test_dir, 'test.yml'), '-t', os.path.join(self.test_dir, 'test.j2')]
+        argument = '-y ' + os.path.join(self.test_dir, 'test.yml') + ' -t ' + os.path.join(self.test_dir, 'test.j2')
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'value1\nvalue2')
 
     def test_template_batch_mode(self):
-        argument = ['-y', os.path.join(self.test_dir, 'test.yml')]
-        argument += ['-a', '{"key1":"value"}']
-        argument += ['-t', os.path.join(self.test_dir, 'test.j2') + ',' + self.output_file]
-        argument += ['-t', os.path.join(self.test_dir, 'test2.j2') + ',' + self.output2_file]
+        argument = '-y ' + os.path.join(self.test_dir, 'test.yml')
+        argument += ' -a \'{"key1":"value"}\''
+        argument += ' -t ' + os.path.join(self.test_dir, 'test.j2') + ',' + self.output_file
+        argument += ' -t ' + os.path.join(self.test_dir, 'test2.j2') + ',' + self.output2_file
         output = self.run_script(argument)
         assert(os.path.exists(self.output_file))
         assert(os.path.exists(self.output2_file))
@@ -197,10 +180,10 @@ class TestCfgGen(TestCase):
 
     def test_template_json_batch_mode(self):
         data = {"key1_1":"value1_1", "key1_2":"value1_2", "key2_1":"value2_1", "key2_2":"value2_2"}
-        argument = ["-a", '{0}'.format(repr(data).replace('\'', '"'))]
-        argument += ['-t', os.path.join(self.test_dir, 'sample-template-1.json.j2') + ",config-db"]
-        argument += ['-t', os.path.join(self.test_dir, 'sample-template-2.json.j2') + ",config-db"]
-        argument += ['--print-data']
+        argument = " -a '{0}'".format(repr(data).replace('\'', '"'))
+        argument += ' -t ' + os.path.join(self.test_dir, 'sample-template-1.json.j2') + ",config-db"
+        argument += ' -t ' + os.path.join(self.test_dir, 'sample-template-2.json.j2') + ",config-db"
+        argument += ' --print-data'
         output = self.run_script(argument)
         output_data = json.loads(output)
         for key, value in data.items():
@@ -210,8 +193,8 @@ class TestCfgGen(TestCase):
     # it is not at all intuitive what that ordering should be. Could make it
     # more robust by adding better parsing logic.
     def test_minigraph_acl(self):
-        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', 'ACL_TABLE']
-        output = self.run_script(argument, True, True)
+        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v ACL_TABLE'
+        output = self.run_script(argument, True)
         self.assertEqual(
             utils.to_dict(output.strip().replace("Warning: Ignoring Control Plane ACL NTP_ACL without type\n", '')),
             utils.to_dict(
@@ -234,7 +217,7 @@ class TestCfgGen(TestCase):
 #         self.assertEqual(output.strip(), "{'everflow0': {'src_ip': '10.1.0.32', 'dst_ip': '2.2.2.2'}}")
 
     def test_minigraph_mgmt_ports(self):
-        argument = ['-m', self.sample_graph, '-p', self.port_config, '-v','MGMT_PORT']
+        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v MGMT_PORT'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
@@ -242,29 +225,29 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_interfaces(self):
-        argument = ['-m', self.sample_graph_simple, '-p', self.port_config, '-v', "INTERFACE.keys()|list"]
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "INTERFACE.keys()|list"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "[('Ethernet0', '10.0.0.58/31'), 'Ethernet0', ('Ethernet0', 'FC00::75/126')]")
 
     def test_minigraph_vlans(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
-        argument = ['-m', graph_file, '-p', self.port_config, '-v', 'VLAN']
+        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v VLAN'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict(
-                "{'Vlan1000': {'alias': 'ab1', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '1000'}, "
-                "'Vlan1001': {'alias': 'ab4', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '1001'},"
-                "'Vlan2001': {'alias': 'ab3', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '2001'},"
-                "'Vlan2000': {'alias': 'ab2', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '2000'},"
-                "'Vlan2020': {'alias': 'kk1', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '2020'}}"
+                "{'Vlan1000': {'alias': 'ab1', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '1000', 'members': ['Ethernet8']}, "
+                "'Vlan1001': {'alias': 'ab4', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '1001', 'members': ['Ethernet8']},"
+                "'Vlan2001': {'alias': 'ab3', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '2001', 'members': ['Ethernet12']},"
+                "'Vlan2000': {'alias': 'ab2', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '2000', 'members': ['Ethernet12']},"
+                "'Vlan2020': {'alias': 'kk1', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '2020', 'members': ['Ethernet12']}}"
             )
         )
 
     def test_minigraph_vlan_members(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
         tag_mode = kwargs.get('tag_mode', 'untagged')
-        argument = ['-m', graph_file, '-p', self.port_config, '-v', 'VLAN_MEMBER']
+        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v VLAN_MEMBER'
         output = self.run_script(argument)
         if tag_mode == "tagged":
             self.assertEqual(
@@ -291,12 +274,12 @@ class TestCfgGen(TestCase):
 
     def test_minigraph_vlan_interfaces(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
-        argument = ['-m', graph_file, '-p', self.port_config, '-v', "VLAN_INTERFACE.keys()|list"]
+        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "VLAN_INTERFACE.keys()|list"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "[('Vlan1000', '192.168.0.1/27'), 'Vlan1000']")
 
     def test_minigraph_ecmp_fg_nhg(self):
-        argument = ['-m', self.ecmp_graph, '-p', self.mlnx_port_config, '-v', 'FG_NHG']
+        argument = '-m "' + self.ecmp_graph + '" -p "' + self.mlnx_port_config + '" -v FG_NHG'
         output = self.run_script(argument)
         print(output.strip())
         self.assertEqual(utils.to_dict(output.strip()), 
@@ -306,7 +289,7 @@ class TestCfgGen(TestCase):
                         ))
 
     def test_minigraph_ecmp_members(self):
-        argument = ['-m', self.ecmp_graph, '-p', self.mlnx_port_config, '-v', "FG_NHG_MEMBER.keys()|list|sort"]
+        argument = '-m "' + self.ecmp_graph + '" -p "' + self.mlnx_port_config + '" -v "FG_NHG_MEMBER.keys()|list|sort"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "['200.200.200.1', '200.200.200.10', '200.200.200.2', '200.200.200.3', '200.200.200.4', '200.200.200.5',"
                                          " '200.200.200.6', '200.200.200.7', '200.200.200.8', '200.200.200.9', '200:200:200:200::1', '200:200:200:200::10',"
@@ -314,7 +297,7 @@ class TestCfgGen(TestCase):
                                          " '200:200:200:200::7', '200:200:200:200::8', '200:200:200:200::9']")
 
     def test_minigraph_ecmp_neighbors(self):
-        argument = ['-m', self.ecmp_graph, '-p', self.mlnx_port_config, '-v', "NEIGH.keys()|list|sort"]
+        argument = '-m "' + self.ecmp_graph + '" -p "' + self.mlnx_port_config + '" -v "NEIGH.keys()|list|sort"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "['Vlan31|200.200.200.1', 'Vlan31|200.200.200.10', 'Vlan31|200.200.200.2', 'Vlan31|200.200.200.3',"
                                          " 'Vlan31|200.200.200.4', 'Vlan31|200.200.200.5', 'Vlan31|200.200.200.6', 'Vlan31|200.200.200.7',"
@@ -324,22 +307,23 @@ class TestCfgGen(TestCase):
 
     def test_minigraph_portchannels(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
-        argument = ['-m', graph_file, '-p', self.port_config, '-v', 'PORTCHANNEL']
+        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v PORTCHANNEL'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'PortChannel1': {'admin_status': 'up', 'min_links': '1', 'members': ['Ethernet4'], 'mtu': '9100', 'tpid': '0x8100', 'lacp_key': 'auto'}}")
+            utils.to_dict("{'PortChannel01': {'admin_status': 'up', 'min_links': '1', 'members': ['Ethernet4'], 'mtu': '9100'}}")
         )
 
     def test_minigraph_portchannel_with_more_member(self):
-        argument = ['-m', self.sample_graph_pc_test, '-p', self.port_config, '-v', 'PORTCHANNEL']
+        argument = '-m "' + self.sample_graph_pc_test + '" -p "' + self.port_config + '" -v PORTCHANNEL'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'PortChannel01': {'admin_status': 'up', 'min_links': '3', 'members': ['Ethernet112', 'Ethernet116', 'Ethernet120', 'Ethernet124'], 'mtu': '9100', 'tpid': '0x8100', 'lacp_key': 'auto'}}"))
+            utils.to_dict("{'PortChannel01': {'admin_status': 'up', 'min_links': '3', 'members': ['Ethernet112', 'Ethernet116', 'Ethernet120', 'Ethernet124'], 'mtu': '9100'}}")
+        )
 
     def test_minigraph_portchannel_members(self):
-        argument = ['-m', self.sample_graph_pc_test, '-p', self.port_config, '-v', "PORTCHANNEL_MEMBER.keys()|list"]
+        argument = '-m "' + self.sample_graph_pc_test + '" -p "' + self.port_config + '" -v "PORTCHANNEL_MEMBER.keys()|list"'
         output = self.run_script(argument)
         self.assertEqual(
             utils.liststr_to_dict(output.strip()),
@@ -347,15 +331,15 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_portchannel_interfaces(self):
-        argument = ['-m', self.sample_graph_simple, '-p', self.port_config, '-v', "PORTCHANNEL_INTERFACE.keys()|list"]
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "PORTCHANNEL_INTERFACE.keys()|list"'
         output = self.run_script(argument)
         self.assertEqual(
             utils.liststr_to_dict(output.strip()),
-            utils.liststr_to_dict("['PortChannel1', ('PortChannel1', '10.0.0.56/31'), ('PortChannel1', 'FC00::71/126')]")
+            utils.liststr_to_dict("['PortChannel01', ('PortChannel01', '10.0.0.56/31'), ('PortChannel01', 'FC00::71/126')]")
         )
 
     def test_minigraph_neighbors(self):
-        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', "DEVICE_NEIGHBOR[\'Ethernet124\']"]
+        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "DEVICE_NEIGHBOR[\'Ethernet124\']"'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
@@ -366,7 +350,7 @@ class TestCfgGen(TestCase):
     # it is not at all intuitive what that ordering should be. Could make it
     # more robust by adding better parsing logic.
     def test_minigraph_extra_neighbors(self):
-        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', 'DEVICE_NEIGHBOR']
+        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v DEVICE_NEIGHBOR'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
@@ -380,115 +364,131 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_port_description(self):
-        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', "PORT[\'Ethernet124\']"]
+        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "PORT[\'Ethernet124\']"'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}")
+            utils.to_dict("{'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}")
         )
 
     def test_minigraph_port_fec_disabled(self):
         # Test for FECDisabled
-        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', "PORT[\'Ethernet4\']"]
+        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "PORT[\'Ethernet4\']"'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'lanes': '25,26,27,28', 'description': 'Servers0:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '100000', 'autoneg': 'on', 'fec': 'none'}")
+            utils.to_dict("{'lanes': '25,26,27,28', 'description': 'Servers0:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '100000', 'autoneg': '1', 'fec': 'none'}")
         )
 
     def test_minigraph_port_autonegotiation(self):
         # Test with a port_config.ini file which doesn't have an 'autoneg' column
-        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', "PORT"]
+        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "PORT"'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict(
-                "{'Ethernet0': {'alias': 'fortyGigE0/0', 'pfc_asym': 'off', 'lanes': '29,30,31,32', 'description': 'fortyGigE0/0', 'mtu': '9100', 'tpid': '0x8100', 'speed': '40000'}, "
-                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'Servers0:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'autoneg': 'on', 'speed': '100000', 'fec': 'none'}, "
-                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'fortyGigE0/8', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'autoneg': 'off', 'fec': 'none', 'speed': '40000'}, "
-                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'fortyGigE0/12', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet16': {'lanes': '41,42,43,44', 'description': 'fortyGigE0/16', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/16', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet20': {'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/20', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet24': {'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/24', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet28': {'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/28', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet32': {'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/32', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet36': {'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/36', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet40': {'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/40', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet44': {'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/44', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet48': {'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/48', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet52': {'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/52', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet56': {'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/56', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet60': {'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/60', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet64': {'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/64', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet68': {'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/68', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet72': {'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/72', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet76': {'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/76', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet80': {'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/80', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet84': {'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/84', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet88': {'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/88', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet92': {'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/92', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet96': {'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/96', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet100': {'lanes': '125,126,127,128', 'description': 'Servers100:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/100', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100', 'tpid': '0x8100', 'speed': '40000'}, "
-                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100', 'tpid': '0x8100', 'speed': '40000'}, "
-                "'Ethernet112': {'lanes': '89,90,91,92', 'description': 'ARISTA01T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/112', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet116': {'lanes': '93,94,95,96', 'description': 'ARISTA02T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/116', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet120': {'lanes': '97,98,99,100', 'description': 'ARISTA03T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/120', 'admin_status': 'up', 'speed': '40000'}, "
-                "'Ethernet124': {'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}}"
+                "{'Ethernet0': {'alias': 'fortyGigE0/0', 'pfc_asym': 'off', 'lanes': '29,30,31,32', 'description': 'fortyGigE0/0', 'mtu': '9100'}, "
+                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'Servers0:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'autoneg': '1', 'speed': '100000', 'fec': 'none'}, "
+                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'fortyGigE0/8', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'autoneg': '0', 'fec': 'none'}, "
+                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'fortyGigE0/12', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/12', 'admin_status': 'up'}, "
+                "'Ethernet16': {'lanes': '41,42,43,44', 'description': 'fortyGigE0/16', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/16', 'admin_status': 'up'}, "
+                "'Ethernet20': {'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/20', 'admin_status': 'up'}, "
+                "'Ethernet24': {'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/24', 'admin_status': 'up'}, "
+                "'Ethernet28': {'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/28', 'admin_status': 'up'}, "
+                "'Ethernet32': {'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/32', 'admin_status': 'up'}, "
+                "'Ethernet36': {'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/36', 'admin_status': 'up'}, "
+                "'Ethernet40': {'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/40', 'admin_status': 'up'}, "
+                "'Ethernet44': {'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/44', 'admin_status': 'up'}, "
+                "'Ethernet48': {'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/48', 'admin_status': 'up'}, "
+                "'Ethernet52': {'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/52', 'admin_status': 'up'}, "
+                "'Ethernet56': {'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/56', 'admin_status': 'up'}, "
+                "'Ethernet60': {'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/60', 'admin_status': 'up'}, "
+                "'Ethernet64': {'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/64', 'admin_status': 'up'}, "
+                "'Ethernet68': {'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/68', 'admin_status': 'up'}, "
+                "'Ethernet72': {'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/72', 'admin_status': 'up'}, "
+                "'Ethernet76': {'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/76', 'admin_status': 'up'}, "
+                "'Ethernet80': {'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/80', 'admin_status': 'up'}, "
+                "'Ethernet84': {'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/84', 'admin_status': 'up'}, "
+                "'Ethernet88': {'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/88', 'admin_status': 'up'}, "
+                "'Ethernet92': {'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/92', 'admin_status': 'up'}, "
+                "'Ethernet96': {'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/96', 'admin_status': 'up'}, "
+                "'Ethernet100': {'lanes': '125,126,127,128', 'description': 'Servers100:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/100', 'admin_status': 'up'}, "
+                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100'}, "
+                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100'}, "
+                "'Ethernet112': {'lanes': '89,90,91,92', 'description': 'ARISTA01T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/112', 'admin_status': 'up'}, "
+                "'Ethernet116': {'lanes': '93,94,95,96', 'description': 'ARISTA02T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/116', 'admin_status': 'up'}, "
+                "'Ethernet120': {'lanes': '97,98,99,100', 'description': 'ARISTA03T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/120', 'admin_status': 'up'}, "
+                "'Ethernet124': {'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}}"
             )
         )
 
         # Test with a port_config.ini file which has an 'autoneg' column
-        argument = ['-m', self.sample_graph_t0, '-p', self.port_config_autoneg, '-v', "PORT"]
+        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config_autoneg + '" -v "PORT"'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict(
-                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'fortyGigE0/0', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/0', 'pfc_asym': 'off', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'Servers0:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'autoneg': 'on', 'speed': '100000', 'fec': 'none'}, "
-                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'fortyGigE0/8', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'autoneg': 'off', 'fec': 'none', 'speed': '40000'}, "
-                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'fortyGigE0/12', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet16': {'lanes': '41,42,43,44', 'description': 'fortyGigE0/16', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/16', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet20': {'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/20', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet24': {'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/24', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet28': {'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/28', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet32': {'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/32', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet36': {'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/36', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet40': {'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/40', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet44': {'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/44', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet48': {'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/48', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet52': {'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/52', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet56': {'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/56', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet60': {'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/60', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet64': {'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/64', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet68': {'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/68', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet72': {'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/72', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet76': {'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/76', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet80': {'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/80', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet84': {'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/84', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet88': {'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/88', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet92': {'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/92', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet96': {'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/96', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet100': {'lanes': '125,126,127,128', 'description': 'Servers100:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/100', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet104': {'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet108': {'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'autoneg': 'off', 'speed': '40000'}, "
-                "'Ethernet112': {'lanes': '89,90,91,92', 'description': 'ARISTA01T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/112', 'admin_status': 'up', 'autoneg': 'on', 'speed': '40000'}, "
-                "'Ethernet116': {'lanes': '93,94,95,96', 'description': 'ARISTA02T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/116', 'admin_status': 'up', 'autoneg': 'on', 'speed': '40000'}, "
-                "'Ethernet120': {'lanes': '97,98,99,100', 'description': 'ARISTA03T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/120', 'admin_status': 'up', 'autoneg': 'on', 'speed': '40000'}, "
-                "'Ethernet124': {'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'autoneg': 'on', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1', 'speed': '100000'}}"
+                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'fortyGigE0/0', 'mtu': '9100', 'alias': 'fortyGigE0/0', 'pfc_asym': 'off', 'autoneg': '0'}, "
+                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'Servers0:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'autoneg': '1', 'speed': '100000', 'fec': 'none'}, "
+                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'fortyGigE0/8', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'autoneg': '0', 'fec': 'none'}, "
+                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'fortyGigE0/12', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet16': {'lanes': '41,42,43,44', 'description': 'fortyGigE0/16', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/16', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet20': {'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/20', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet24': {'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/24', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet28': {'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/28', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet32': {'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/32', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet36': {'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/36', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet40': {'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/40', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet44': {'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/44', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet48': {'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/48', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet52': {'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/52', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet56': {'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/56', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet60': {'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/60', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet64': {'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/64', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet68': {'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/68', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet72': {'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/72', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet76': {'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/76', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet80': {'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/80', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet84': {'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/84', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet88': {'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/88', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet92': {'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/92', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet96': {'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/96', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet100': {'lanes': '125,126,127,128', 'description': 'Servers100:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/100', 'admin_status': 'up', 'autoneg': '0'}, "
+                "'Ethernet104': {'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100', 'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'autoneg': '0'}, "
+                "'Ethernet108': {'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100', 'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'autoneg': '0'}, "
+                "'Ethernet112': {'lanes': '89,90,91,92', 'description': 'ARISTA01T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/112', 'admin_status': 'up', 'autoneg': '1'}, "
+                "'Ethernet116': {'lanes': '93,94,95,96', 'description': 'ARISTA02T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/116', 'admin_status': 'up', 'autoneg': '1'}, "
+                "'Ethernet120': {'lanes': '97,98,99,100', 'description': 'ARISTA03T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/120', 'admin_status': 'up', 'autoneg': '1'}, "
+                "'Ethernet124': {'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'autoneg': '1', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}}"
             )
         )
 
     def test_minigraph_port_rs(self):
-        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', "PORT[\'Ethernet124\']"]
+        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "PORT[\'Ethernet124\']"'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}")
+            utils.to_dict("{'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}")
+        )
+
+    def test_minigraph_default_vxlan(self):
+        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "VXLAN_TUNNEL"'
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            utils.to_dict("{'src': '10.1.0.32'}")
+        )
+
+    def test_minigraph_default_vnet(self):
+        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "VNET"'
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            utils.to_dict("{'vxlan_tunnel': 'Tunnel-default', 'scope': 'default', 'vni': 8000}")
         )
 
     def test_minigraph_bgp(self):
-        argument = ['-m', self.sample_graph_bgp_speaker, '-p', self.port_config, '-v', "BGP_NEIGHBOR[\'10.0.0.59\']"]
+        argument = '-m "' + self.sample_graph_bgp_speaker + '" -p "' + self.port_config + '" -v "BGP_NEIGHBOR[\'10.0.0.59\']"'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
@@ -496,7 +496,7 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_peers_with_range(self):
-        argument = ["-m", self.sample_graph_bgp_speaker, "-p", self.port_config, "-v", "BGP_PEER_RANGE.values()|list"]
+        argument = "-m " + self.sample_graph_bgp_speaker + " -p " + self.port_config + " -v \"BGP_PEER_RANGE.values()|list\""
         output = self.run_script(argument)
         self.assertEqual(
             utils.liststr_to_dict(output.strip()),
@@ -504,155 +504,150 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_deployment_id(self):
-        argument = ['-m', self.sample_graph_bgp_speaker, '-p', self.port_config, '-v', "DEVICE_METADATA[\'localhost\'][\'deployment_id\']"]
+        argument = '-m "' + self.sample_graph_bgp_speaker + '" -p "' + self.port_config + '" -v "DEVICE_METADATA[\'localhost\'][\'deployment_id\']"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "1")
 
-    def test_minigraph_deployment_id_null(self):
-        argument = ['-m', self.sample_graph_deployment_id, '-p', self.port_config, '-v', "DEVICE_METADATA[\'localhost\']"]
-        output = self.run_script(argument)
-        self.assertNotIn('deployment_id', output.strip())
-
     def test_minigraph_ethernet_interfaces(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
-        argument = ['-m', graph_file, '-p', self.port_config, '-v', "PORT[\'Ethernet8\']"]
+        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "PORT[\'Ethernet8\']"'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '1000', 'tpid': '0x8100'}")
+            utils.to_dict("{'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '1000'}")
         )
-        argument = ['-m', graph_file, '-p', self.port_config, '-v', "PORT[\'Ethernet12\']"]
+        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "PORT[\'Ethernet12\']"'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'lanes': '33,34,35,36', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '100000', 'description': 'Interface description'}")
+            utils.to_dict("{'lanes': '33,34,35,36', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '100000', 'description': 'Interface description'}")
         )
 
     def test_minigraph_neighbor_interfaces(self):
-        argument = ['-m', self.sample_graph_simple_case, '-p', self.port_config, '-v', "PORT"]
+        argument = '-m "' + self.sample_graph_simple_case + '" -p "' + self.port_config + '" -v "PORT"'
         output = self.run_script(argument)
 
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict(
-                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'switch-01t1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/0', 'admin_status': 'up', 'speed': '10000', 'autoneg': 'on'}, "
-                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'server1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '25000', 'autoneg': 'on', 'mux_cable': 'true'}, "
-                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '40000', 'autoneg': 'on', 'mux_cable': 'true'}, "
-                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '10000', 'autoneg': 'on'}, "
-                "'Ethernet16': {'alias': 'fortyGigE0/16', 'pfc_asym': 'off', 'lanes': '41,42,43,44', 'description': 'fortyGigE0/16', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet20': {'alias': 'fortyGigE0/20', 'pfc_asym': 'off', 'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet24': {'alias': 'fortyGigE0/24', 'pfc_asym': 'off', 'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet28': {'alias': 'fortyGigE0/28', 'pfc_asym': 'off', 'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet32': {'alias': 'fortyGigE0/32', 'pfc_asym': 'off', 'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet36': {'alias': 'fortyGigE0/36', 'pfc_asym': 'off', 'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet40': {'alias': 'fortyGigE0/40', 'pfc_asym': 'off', 'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet44': {'alias': 'fortyGigE0/44', 'pfc_asym': 'off', 'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet48': {'alias': 'fortyGigE0/48', 'pfc_asym': 'off', 'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet52': {'alias': 'fortyGigE0/52', 'pfc_asym': 'off', 'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet56': {'alias': 'fortyGigE0/56', 'pfc_asym': 'off', 'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet60': {'alias': 'fortyGigE0/60', 'pfc_asym': 'off', 'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet64': {'alias': 'fortyGigE0/64', 'pfc_asym': 'off', 'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet68': {'alias': 'fortyGigE0/68', 'pfc_asym': 'off', 'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet72': {'alias': 'fortyGigE0/72', 'pfc_asym': 'off', 'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet76': {'alias': 'fortyGigE0/76', 'pfc_asym': 'off', 'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet80': {'alias': 'fortyGigE0/80', 'pfc_asym': 'off', 'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet84': {'alias': 'fortyGigE0/84', 'pfc_asym': 'off', 'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet88': {'alias': 'fortyGigE0/88', 'pfc_asym': 'off', 'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet92': {'alias': 'fortyGigE0/92', 'pfc_asym': 'off', 'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet96': {'alias': 'fortyGigE0/96', 'pfc_asym': 'off', 'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet100': {'alias': 'fortyGigE0/100', 'pfc_asym': 'off', 'lanes': '125,126,127,128', 'description': 'fortyGigE0/100', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet112': {'alias': 'fortyGigE0/112', 'pfc_asym': 'off', 'lanes': '89,90,91,92', 'description': 'fortyGigE0/112', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet116': {'alias': 'fortyGigE0/116', 'pfc_asym': 'off', 'lanes': '93,94,95,96', 'description': 'fortyGigE0/116', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet120': {'alias': 'fortyGigE0/120', 'pfc_asym': 'off', 'lanes': '97,98,99,100', 'description': 'fortyGigE0/120', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet124': {'alias': 'fortyGigE0/124', 'pfc_asym': 'off', 'lanes': '101,102,103,104', 'description': 'fortyGigE0/124', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}}"
+                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'switch-01t1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/0', 'admin_status': 'up', 'speed': '10000', 'autoneg': '1'}, "
+                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'server1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '25000', 'autoneg': '1', 'mux_cable': 'true'}, "
+                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '40000', 'autoneg': '1', 'mux_cable': 'true'}, "
+                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '10000', 'autoneg': '1'}, "
+                "'Ethernet16': {'alias': 'fortyGigE0/16', 'pfc_asym': 'off', 'lanes': '41,42,43,44', 'description': 'fortyGigE0/16', 'mtu': '9100'}, "
+                "'Ethernet20': {'alias': 'fortyGigE0/20', 'pfc_asym': 'off', 'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'mtu': '9100'}, "
+                "'Ethernet24': {'alias': 'fortyGigE0/24', 'pfc_asym': 'off', 'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'mtu': '9100'}, "
+                "'Ethernet28': {'alias': 'fortyGigE0/28', 'pfc_asym': 'off', 'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'mtu': '9100'}, "
+                "'Ethernet32': {'alias': 'fortyGigE0/32', 'pfc_asym': 'off', 'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'mtu': '9100'}, "
+                "'Ethernet36': {'alias': 'fortyGigE0/36', 'pfc_asym': 'off', 'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'mtu': '9100'}, "
+                "'Ethernet40': {'alias': 'fortyGigE0/40', 'pfc_asym': 'off', 'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'mtu': '9100'}, "
+                "'Ethernet44': {'alias': 'fortyGigE0/44', 'pfc_asym': 'off', 'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'mtu': '9100'}, "
+                "'Ethernet48': {'alias': 'fortyGigE0/48', 'pfc_asym': 'off', 'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'mtu': '9100'}, "
+                "'Ethernet52': {'alias': 'fortyGigE0/52', 'pfc_asym': 'off', 'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'mtu': '9100'}, "
+                "'Ethernet56': {'alias': 'fortyGigE0/56', 'pfc_asym': 'off', 'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'mtu': '9100'}, "
+                "'Ethernet60': {'alias': 'fortyGigE0/60', 'pfc_asym': 'off', 'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'mtu': '9100'}, "
+                "'Ethernet64': {'alias': 'fortyGigE0/64', 'pfc_asym': 'off', 'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'mtu': '9100'}, "
+                "'Ethernet68': {'alias': 'fortyGigE0/68', 'pfc_asym': 'off', 'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'mtu': '9100'}, "
+                "'Ethernet72': {'alias': 'fortyGigE0/72', 'pfc_asym': 'off', 'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'mtu': '9100'}, "
+                "'Ethernet76': {'alias': 'fortyGigE0/76', 'pfc_asym': 'off', 'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'mtu': '9100'}, "
+                "'Ethernet80': {'alias': 'fortyGigE0/80', 'pfc_asym': 'off', 'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'mtu': '9100'}, "
+                "'Ethernet84': {'alias': 'fortyGigE0/84', 'pfc_asym': 'off', 'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'mtu': '9100'}, "
+                "'Ethernet88': {'alias': 'fortyGigE0/88', 'pfc_asym': 'off', 'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'mtu': '9100'}, "
+                "'Ethernet92': {'alias': 'fortyGigE0/92', 'pfc_asym': 'off', 'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'mtu': '9100'}, "
+                "'Ethernet96': {'alias': 'fortyGigE0/96', 'pfc_asym': 'off', 'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'mtu': '9100'}, "
+                "'Ethernet100': {'alias': 'fortyGigE0/100', 'pfc_asym': 'off', 'lanes': '125,126,127,128', 'description': 'fortyGigE0/100', 'mtu': '9100'}, "
+                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100'}, "
+                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100'}, "
+                "'Ethernet112': {'alias': 'fortyGigE0/112', 'pfc_asym': 'off', 'lanes': '89,90,91,92', 'description': 'fortyGigE0/112', 'mtu': '9100'}, "
+                "'Ethernet116': {'alias': 'fortyGigE0/116', 'pfc_asym': 'off', 'lanes': '93,94,95,96', 'description': 'fortyGigE0/116', 'mtu': '9100'}, "
+                "'Ethernet120': {'alias': 'fortyGigE0/120', 'pfc_asym': 'off', 'lanes': '97,98,99,100', 'description': 'fortyGigE0/120', 'mtu': '9100'}, "
+                "'Ethernet124': {'alias': 'fortyGigE0/124', 'pfc_asym': 'off', 'lanes': '101,102,103,104', 'description': 'fortyGigE0/124', 'mtu': '9100'}}"
             )
         )
 
     def test_minigraph_neighbor_interfaces_config_db(self):
         # test to check if PORT table is retrieved from config_db
-        argument = ['-m', self.sample_graph_simple_case, '-p', self.port_config, '-v', "PORT"]
+        argument = '-m "' + self.sample_graph_simple_case + '" -v "PORT"'
         output = self.run_script(argument)
 
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict(
-                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'switch-01t1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/0', 'admin_status': 'up', 'speed': '10000', 'autoneg': 'on'}, "
-                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'server1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '25000', 'autoneg': 'on', 'mux_cable': 'true'}, "
-                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '40000', 'autoneg': 'on', 'mux_cable': 'true'}, "
-                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '10000', 'autoneg': 'on'}, "
-                "'Ethernet16': {'alias': 'fortyGigE0/16', 'pfc_asym': 'off', 'lanes': '41,42,43,44', 'description': 'fortyGigE0/16', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet20': {'alias': 'fortyGigE0/20', 'pfc_asym': 'off', 'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet24': {'alias': 'fortyGigE0/24', 'pfc_asym': 'off', 'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet28': {'alias': 'fortyGigE0/28', 'pfc_asym': 'off', 'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet32': {'alias': 'fortyGigE0/32', 'pfc_asym': 'off', 'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet36': {'alias': 'fortyGigE0/36', 'pfc_asym': 'off', 'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet40': {'alias': 'fortyGigE0/40', 'pfc_asym': 'off', 'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet44': {'alias': 'fortyGigE0/44', 'pfc_asym': 'off', 'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet48': {'alias': 'fortyGigE0/48', 'pfc_asym': 'off', 'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet52': {'alias': 'fortyGigE0/52', 'pfc_asym': 'off', 'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet56': {'alias': 'fortyGigE0/56', 'pfc_asym': 'off', 'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet60': {'alias': 'fortyGigE0/60', 'pfc_asym': 'off', 'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet64': {'alias': 'fortyGigE0/64', 'pfc_asym': 'off', 'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet68': {'alias': 'fortyGigE0/68', 'pfc_asym': 'off', 'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet72': {'alias': 'fortyGigE0/72', 'pfc_asym': 'off', 'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet76': {'alias': 'fortyGigE0/76', 'pfc_asym': 'off', 'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet80': {'alias': 'fortyGigE0/80', 'pfc_asym': 'off', 'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet84': {'alias': 'fortyGigE0/84', 'pfc_asym': 'off', 'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet88': {'alias': 'fortyGigE0/88', 'pfc_asym': 'off', 'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet92': {'alias': 'fortyGigE0/92', 'pfc_asym': 'off', 'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet96': {'alias': 'fortyGigE0/96', 'pfc_asym': 'off', 'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet100': {'alias': 'fortyGigE0/100', 'pfc_asym': 'off', 'lanes': '125,126,127,128', 'description': 'fortyGigE0/100', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet112': {'alias': 'fortyGigE0/112', 'pfc_asym': 'off', 'lanes': '89,90,91,92', 'description': 'fortyGigE0/112', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet116': {'alias': 'fortyGigE0/116', 'pfc_asym': 'off', 'lanes': '93,94,95,96', 'description': 'fortyGigE0/116', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet120': {'alias': 'fortyGigE0/120', 'pfc_asym': 'off', 'lanes': '97,98,99,100', 'description': 'fortyGigE0/120', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet124': {'alias': 'fortyGigE0/124', 'pfc_asym': 'off', 'lanes': '101,102,103,104', 'description': 'fortyGigE0/124', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}}"
+                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'config_db:switch-01t1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/0', 'admin_status': 'up', 'speed': '10000', 'autoneg': '1'}, "
+                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'config_db:server1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '25000', 'autoneg': '1', 'mux_cable': 'true'}, "
+                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '40000', 'autoneg': '1', 'mux_cable': 'true'}, "
+                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '10000', 'autoneg': '1'}, "
+                "'Ethernet16': {'alias': 'fortyGigE0/16', 'pfc_asym': 'off', 'lanes': '41,42,43,44', 'description': 'config_db:fortyGigE0/16', 'mtu': '9100'}, "
+                "'Ethernet20': {'alias': 'fortyGigE0/20', 'pfc_asym': 'off', 'lanes': '45,46,47,48', 'description': 'config_db:fortyGigE0/20', 'mtu': '9100'}, "
+                "'Ethernet24': {'alias': 'fortyGigE0/24', 'pfc_asym': 'off', 'lanes': '5,6,7,8', 'description': 'config_db:fortyGigE0/24', 'mtu': '9100'}, "
+                "'Ethernet28': {'alias': 'fortyGigE0/28', 'pfc_asym': 'off', 'lanes': '1,2,3,4', 'description': 'config_db:fortyGigE0/28', 'mtu': '9100'}, "
+                "'Ethernet32': {'alias': 'fortyGigE0/32', 'pfc_asym': 'off', 'lanes': '9,10,11,12', 'description': 'config_db:fortyGigE0/32', 'mtu': '9100'}, "
+                "'Ethernet36': {'alias': 'fortyGigE0/36', 'pfc_asym': 'off', 'lanes': '13,14,15,16', 'description': 'config_db:fortyGigE0/36', 'mtu': '9100'}, "
+                "'Ethernet40': {'alias': 'fortyGigE0/40', 'pfc_asym': 'off', 'lanes': '21,22,23,24', 'description': 'config_db:fortyGigE0/40', 'mtu': '9100'}, "
+                "'Ethernet44': {'alias': 'fortyGigE0/44', 'pfc_asym': 'off', 'lanes': '17,18,19,20', 'description': 'config_db:fortyGigE0/44', 'mtu': '9100'}, "
+                "'Ethernet48': {'alias': 'fortyGigE0/48', 'pfc_asym': 'off', 'lanes': '49,50,51,52', 'description': 'config_db:fortyGigE0/48', 'mtu': '9100'}, "
+                "'Ethernet52': {'alias': 'fortyGigE0/52', 'pfc_asym': 'off', 'lanes': '53,54,55,56', 'description': 'config_db:fortyGigE0/52', 'mtu': '9100'}, "
+                "'Ethernet56': {'alias': 'fortyGigE0/56', 'pfc_asym': 'off', 'lanes': '61,62,63,64', 'description': 'config_db:fortyGigE0/56', 'mtu': '9100'}, "
+                "'Ethernet60': {'alias': 'fortyGigE0/60', 'pfc_asym': 'off', 'lanes': '57,58,59,60', 'description': 'config_db:fortyGigE0/60', 'mtu': '9100'}, "
+                "'Ethernet64': {'alias': 'fortyGigE0/64', 'pfc_asym': 'off', 'lanes': '65,66,67,68', 'description': 'config_db:fortyGigE0/64', 'mtu': '9100'}, "
+                "'Ethernet68': {'alias': 'fortyGigE0/68', 'pfc_asym': 'off', 'lanes': '69,70,71,72', 'description': 'config_db:fortyGigE0/68', 'mtu': '9100'}, "
+                "'Ethernet72': {'alias': 'fortyGigE0/72', 'pfc_asym': 'off', 'lanes': '77,78,79,80', 'description': 'config_db:fortyGigE0/72', 'mtu': '9100'}, "
+                "'Ethernet76': {'alias': 'fortyGigE0/76', 'pfc_asym': 'off', 'lanes': '73,74,75,76', 'description': 'config_db:fortyGigE0/76', 'mtu': '9100'}, "
+                "'Ethernet80': {'alias': 'fortyGigE0/80', 'pfc_asym': 'off', 'lanes': '105,106,107,108', 'description': 'config_db:fortyGigE0/80', 'mtu': '9100'}, "
+                "'Ethernet84': {'alias': 'fortyGigE0/84', 'pfc_asym': 'off', 'lanes': '109,110,111,112', 'description': 'config_db:fortyGigE0/84', 'mtu': '9100'}, "
+                "'Ethernet88': {'alias': 'fortyGigE0/88', 'pfc_asym': 'off', 'lanes': '117,118,119,120', 'description': 'config_db:fortyGigE0/88', 'mtu': '9100'}, "
+                "'Ethernet92': {'alias': 'fortyGigE0/92', 'pfc_asym': 'off', 'lanes': '113,114,115,116', 'description': 'config_db:fortyGigE0/92', 'mtu': '9100'}, "
+                "'Ethernet96': {'alias': 'fortyGigE0/96', 'pfc_asym': 'off', 'lanes': '121,122,123,124', 'description': 'config_db:fortyGigE0/96', 'mtu': '9100'}, "
+                "'Ethernet100': {'alias': 'fortyGigE0/100', 'pfc_asym': 'off', 'lanes': '125,126,127,128', 'description': 'config_db:fortyGigE0/100', 'mtu': '9100'}, "
+                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'config_db:fortyGigE0/104', 'mtu': '9100'}, "
+                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'config_db:fortyGigE0/108', 'mtu': '9100'}, "
+                "'Ethernet112': {'alias': 'fortyGigE0/112', 'pfc_asym': 'off', 'lanes': '89,90,91,92', 'description': 'config_db:fortyGigE0/112', 'mtu': '9100'}, "
+                "'Ethernet116': {'alias': 'fortyGigE0/116', 'pfc_asym': 'off', 'lanes': '93,94,95,96', 'description': 'config_db:fortyGigE0/116', 'mtu': '9100'}, "
+                "'Ethernet120': {'alias': 'fortyGigE0/120', 'pfc_asym': 'off', 'lanes': '97,98,99,100', 'description': 'config_db:fortyGigE0/120', 'mtu': '9100'}, "
+                "'Ethernet124': {'alias': 'fortyGigE0/124', 'pfc_asym': 'off', 'lanes': '101,102,103,104', 'description': 'config_db:fortyGigE0/124', 'mtu': '9100'}}"
             )
         )
 
     def test_minigraph_extra_ethernet_interfaces(self, **kwargs):
-        graph_file = kwargs.get('graph_file', self.sample_graph_simple) 
-        argument = ['-m', graph_file, '-p', self.port_config, '-v', "PORT"]
+        graph_file = kwargs.get('graph_file', self.sample_graph_simple)
+        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "PORT"'
         output = self.run_script(argument)
 
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict(
-                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'fortyGigE0/0', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/0', 'admin_status': 'up', 'speed': '10000'}, "
-                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'fortyGigE0/4', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '25000'}, "
-                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '1000'}, "
-                "'Ethernet12': {'lanes': '33,34,35,36', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '100000', 'description': 'Interface description'}, "
-                "'Ethernet16': {'lanes': '41,42,43,44', 'pfc_asym': 'off', 'description': 'fortyGigE0/16', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/16', 'speed': '1000'}, "
-                "'Ethernet20': {'alias': 'fortyGigE0/20', 'pfc_asym': 'off', 'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet24': {'alias': 'fortyGigE0/24', 'pfc_asym': 'off', 'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet28': {'alias': 'fortyGigE0/28', 'pfc_asym': 'off', 'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet32': {'alias': 'fortyGigE0/32', 'pfc_asym': 'off', 'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet36': {'alias': 'fortyGigE0/36', 'pfc_asym': 'off', 'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet40': {'alias': 'fortyGigE0/40', 'pfc_asym': 'off', 'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet44': {'alias': 'fortyGigE0/44', 'pfc_asym': 'off', 'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet48': {'alias': 'fortyGigE0/48', 'pfc_asym': 'off', 'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet52': {'alias': 'fortyGigE0/52', 'pfc_asym': 'off', 'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet56': {'alias': 'fortyGigE0/56', 'pfc_asym': 'off', 'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet60': {'alias': 'fortyGigE0/60', 'pfc_asym': 'off', 'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet64': {'alias': 'fortyGigE0/64', 'pfc_asym': 'off', 'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet68': {'alias': 'fortyGigE0/68', 'pfc_asym': 'off', 'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet72': {'alias': 'fortyGigE0/72', 'pfc_asym': 'off', 'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet76': {'alias': 'fortyGigE0/76', 'pfc_asym': 'off', 'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet80': {'alias': 'fortyGigE0/80', 'pfc_asym': 'off', 'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet84': {'alias': 'fortyGigE0/84', 'pfc_asym': 'off', 'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet88': {'alias': 'fortyGigE0/88', 'pfc_asym': 'off', 'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet92': {'alias': 'fortyGigE0/92', 'pfc_asym': 'off', 'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet96': {'alias': 'fortyGigE0/96', 'pfc_asym': 'off', 'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet100': {'alias': 'fortyGigE0/100', 'pfc_asym': 'off', 'lanes': '125,126,127,128', 'description': 'fortyGigE0/100', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet112': {'alias': 'fortyGigE0/112', 'pfc_asym': 'off', 'lanes': '89,90,91,92', 'description': 'fortyGigE0/112', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet116': {'alias': 'fortyGigE0/116', 'pfc_asym': 'off', 'lanes': '93,94,95,96', 'description': 'fortyGigE0/116', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet120': {'alias': 'fortyGigE0/120', 'pfc_asym': 'off', 'lanes': '97,98,99,100', 'description': 'fortyGigE0/120', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
-                "'Ethernet124': {'alias': 'fortyGigE0/124', 'pfc_asym': 'off', 'lanes': '101,102,103,104', 'description': 'fortyGigE0/124', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}}"
+                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'fortyGigE0/0', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/0', 'admin_status': 'up', 'speed': '10000'}, "
+                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'fortyGigE0/4', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '25000'}, "
+                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '1000'}, "
+                "'Ethernet12': {'lanes': '33,34,35,36', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '100000', 'description': 'Interface description'}, "
+                "'Ethernet16': {'lanes': '41,42,43,44', 'pfc_asym': 'off', 'description': 'fortyGigE0/16', 'mtu': '9100', 'alias': 'fortyGigE0/16', 'speed': '1000'}, "
+                "'Ethernet20': {'alias': 'fortyGigE0/20', 'pfc_asym': 'off', 'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'mtu': '9100'}, "
+                "'Ethernet24': {'alias': 'fortyGigE0/24', 'pfc_asym': 'off', 'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'mtu': '9100'}, "
+                "'Ethernet28': {'alias': 'fortyGigE0/28', 'pfc_asym': 'off', 'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'mtu': '9100'}, "
+                "'Ethernet32': {'alias': 'fortyGigE0/32', 'pfc_asym': 'off', 'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'mtu': '9100'}, "
+                "'Ethernet36': {'alias': 'fortyGigE0/36', 'pfc_asym': 'off', 'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'mtu': '9100'}, "
+                "'Ethernet40': {'alias': 'fortyGigE0/40', 'pfc_asym': 'off', 'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'mtu': '9100'}, "
+                "'Ethernet44': {'alias': 'fortyGigE0/44', 'pfc_asym': 'off', 'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'mtu': '9100'}, "
+                "'Ethernet48': {'alias': 'fortyGigE0/48', 'pfc_asym': 'off', 'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'mtu': '9100'}, "
+                "'Ethernet52': {'alias': 'fortyGigE0/52', 'pfc_asym': 'off', 'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'mtu': '9100'}, "
+                "'Ethernet56': {'alias': 'fortyGigE0/56', 'pfc_asym': 'off', 'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'mtu': '9100'}, "
+                "'Ethernet60': {'alias': 'fortyGigE0/60', 'pfc_asym': 'off', 'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'mtu': '9100'}, "
+                "'Ethernet64': {'alias': 'fortyGigE0/64', 'pfc_asym': 'off', 'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'mtu': '9100'}, "
+                "'Ethernet68': {'alias': 'fortyGigE0/68', 'pfc_asym': 'off', 'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'mtu': '9100'}, "
+                "'Ethernet72': {'alias': 'fortyGigE0/72', 'pfc_asym': 'off', 'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'mtu': '9100'}, "
+                "'Ethernet76': {'alias': 'fortyGigE0/76', 'pfc_asym': 'off', 'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'mtu': '9100'}, "
+                "'Ethernet80': {'alias': 'fortyGigE0/80', 'pfc_asym': 'off', 'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'mtu': '9100'}, "
+                "'Ethernet84': {'alias': 'fortyGigE0/84', 'pfc_asym': 'off', 'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'mtu': '9100'}, "
+                "'Ethernet88': {'alias': 'fortyGigE0/88', 'pfc_asym': 'off', 'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'mtu': '9100'}, "
+                "'Ethernet92': {'alias': 'fortyGigE0/92', 'pfc_asym': 'off', 'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'mtu': '9100'}, "
+                "'Ethernet96': {'alias': 'fortyGigE0/96', 'pfc_asym': 'off', 'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'mtu': '9100'}, "
+                "'Ethernet100': {'alias': 'fortyGigE0/100', 'pfc_asym': 'off', 'lanes': '125,126,127,128', 'description': 'fortyGigE0/100', 'mtu': '9100'}, "
+                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100'}, "
+                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100'}, "
+                "'Ethernet112': {'alias': 'fortyGigE0/112', 'pfc_asym': 'off', 'lanes': '89,90,91,92', 'description': 'fortyGigE0/112', 'mtu': '9100'}, "
+                "'Ethernet116': {'alias': 'fortyGigE0/116', 'pfc_asym': 'off', 'lanes': '93,94,95,96', 'description': 'fortyGigE0/116', 'mtu': '9100'}, "
+                "'Ethernet120': {'alias': 'fortyGigE0/120', 'pfc_asym': 'off', 'lanes': '97,98,99,100', 'description': 'fortyGigE0/120', 'mtu': '9100'}, "
+                "'Ethernet124': {'alias': 'fortyGigE0/124', 'pfc_asym': 'off', 'lanes': '101,102,103,104', 'description': 'fortyGigE0/124', 'mtu': '9100'}}"
             )
         )
 
@@ -663,7 +658,7 @@ class TestCfgGen(TestCase):
 #         self.assertEqual(output.strip(), "{'everflow0': {'src_ip': '10.1.0.32', 'dst_ip': '10.0.100.1'}}")
 
     def test_metadata_tacacs(self):
-        argument = ['-m', self.sample_graph_metadata, '-p', self.port_config, '-v', "TACPLUS_SERVER"]
+        argument = '-m "' + self.sample_graph_metadata + '" -p "' + self.port_config + '" -v "TACPLUS_SERVER"'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
@@ -671,48 +666,38 @@ class TestCfgGen(TestCase):
         )
 
     def test_metadata_ntp(self):
-        argument = ['-m', self.sample_graph_metadata, '-p', self.port_config, '-v', "NTP_SERVER"]
+        argument = '-m "' + self.sample_graph_metadata + '" -p "' + self.port_config + '" -v "NTP_SERVER"'
         output = self.run_script(argument)
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict("{'10.0.10.1': {}, '10.0.10.2': {}}"))
 
     def test_minigraph_vnet(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
-        argument = ['-m', graph_file, '-p', self.port_config, '-v', "VNET"]
+        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "VNET"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "")
 
     def test_minigraph_vxlan(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
-        argument = ['-m', graph_file, '-p', self.port_config, '-v', "VXLAN_TUNNEL"]
+        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "VXLAN_TUNNEL"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "")
 
     def test_minigraph_bgp_mon(self):
-        argument = ['-m', self.sample_graph_simple, '-p', self.port_config, '-v', "BGP_MONITORS"]
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "BGP_MONITORS"'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'10.20.30.40': {'rrclient': 0, 'name': 'BGPMonitor', 'local_addr': '10.1.0.32', 'nhopself': 0, 'holdtime': '10', 'asn': '1', 'keepalive': '3'}}")
+            utils.to_dict("{'10.20.30.40': {'rrclient': 0, 'name': 'BGPMonitor', 'local_addr': '10.1.0.32', 'nhopself': 0, 'holdtime': '10', 'asn': '0', 'keepalive': '3'}}")
         )
 
-    def test_minigraph_bgp_voq_chassis_peer(self):
-        argument = ['-m', self.sample_graph_simple, '-p', self.port_config, '-v', "BGP_VOQ_CHASSIS_NEIGHBOR[\'10.2.0.21\']"]
-        output = self.run_script(argument)
-        self.assertEqual(
-            utils.to_dict(output.strip()),
-            utils.to_dict("{'rrclient': 0, 'name': 'CHASSIS_PEER', 'local_addr': '10.2.0.20', 'nhopself': 0, 'holdtime': '180', 'asn': '65100', 'keepalive': '60', 'admin_status': 'up'}")
-        )
-
-        # make sure VoQChassisInternal value of false is honored
-        argument = ['-m', self.sample_graph_simple, '-p', self.port_config, '-v', "BGP_VOQ_CHASSIS_NEIGHBOR[\'10.0.0.57\']"]
-        output = self.run_script(argument)
-        self.assertEqual(output.strip(), "")
+    def test_minigraph_sub_port_interfaces(self, check_stderr=True):
+        self.verify_sub_intf(check_stderr=check_stderr)
 
     def test_minigraph_sub_port_intf_resource_type_non_backend_tor(self, check_stderr=True):
         self.verify_sub_intf_non_backend_tor(graph_file=self.sample_resource_graph, check_stderr=check_stderr)
 
-    def test_minigraph_sub_port_intf_hwsku(self, check_stderr=True):
-        self.verify_sub_intf(graph_file=self.sample_backend_graph, check_stderr=check_stderr)
+    def test_minigraph_sub_port_intf_resource_type(self, check_stderr=True):
+        self.verify_sub_intf(graph_file=self.sample_resource_graph, check_stderr=check_stderr)
 
     def test_minigraph_sub_port_intf_sub(self, check_stderr=True):
         self.verify_sub_intf(graph_file=self.sample_subintf_graph, check_stderr=check_stderr)
@@ -720,53 +705,27 @@ class TestCfgGen(TestCase):
     def test_minigraph_no_vlan_member(self, check_stderr=True):
         self.verify_no_vlan_member()
 
-    def test_minigraph_backend_acl_leaf(self, check_stderr=True):
-        try:
-            print('\n    Change device type to %s' % (BACKEND_LEAF_ROUTER))
-            if check_stderr:
-                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (TOR_ROUTER, BACKEND_LEAF_ROUTER), self.sample_backend_graph], stderr=subprocess.STDOUT)
-            else:
-                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (TOR_ROUTER, BACKEND_LEAF_ROUTER), self.sample_backend_graph])
-
-            self.test_jinja_expression(self.sample_backend_graph, self.port_config, BACKEND_LEAF_ROUTER)
-
-            # ACL_TABLE should contain EVERFLOW related entries
-            argument = ['-m', self.sample_backend_graph, '-p', self.port_config, '-v', "ACL_TABLE"]
-            output = self.run_script(argument)
-            sample_output = utils.to_dict(output.strip()).keys()
-            assert 'DATAACL' not in sample_output, sample_output
-            assert 'EVERFLOW' in sample_output, sample_output
-
-        finally:
-            print('\n    Change device type back to %s' % (TOR_ROUTER))
-            if check_stderr:
-                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (BACKEND_LEAF_ROUTER, TOR_ROUTER), self.sample_backend_graph], stderr=subprocess.STDOUT)
-            else:
-                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (BACKEND_LEAF_ROUTER, TOR_ROUTER), self.sample_backend_graph])
-
-            self.test_jinja_expression(self.sample_backend_graph, self.port_config, TOR_ROUTER)
-
     def test_minigraph_sub_port_no_vlan_member(self, check_stderr=True):
         try:
             print('\n    Change device type to %s' % (BACKEND_LEAF_ROUTER))
             if check_stderr:
-                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (LEAF_ROUTER, BACKEND_LEAF_ROUTER), self.sample_graph], stderr=subprocess.STDOUT)
+                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (LEAF_ROUTER, BACKEND_LEAF_ROUTER, self.sample_graph), stderr=subprocess.STDOUT, shell=True)
             else:
-                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (LEAF_ROUTER, BACKEND_LEAF_ROUTER), self.sample_graph])
+                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (LEAF_ROUTER, BACKEND_LEAF_ROUTER, self.sample_graph), shell=True)
 
-            self.test_jinja_expression(self.sample_graph, self.port_config, BACKEND_LEAF_ROUTER)
+            self.test_jinja_expression(self.sample_graph, BACKEND_LEAF_ROUTER)
             self.verify_no_vlan_member()
         finally:
             print('\n    Change device type back to %s' % (LEAF_ROUTER))
             if check_stderr:
-                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (BACKEND_LEAF_ROUTER, LEAF_ROUTER), self.sample_graph], stderr=subprocess.STDOUT)
+                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (BACKEND_LEAF_ROUTER, LEAF_ROUTER, self.sample_graph), stderr=subprocess.STDOUT, shell=True)
             else:
-                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (BACKEND_LEAF_ROUTER, LEAF_ROUTER), self.sample_graph])
+                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (BACKEND_LEAF_ROUTER, LEAF_ROUTER, self.sample_graph), shell=True)
 
-            self.test_jinja_expression(self.sample_graph, self.port_config, LEAF_ROUTER)
+            self.test_jinja_expression(self.sample_graph, LEAF_ROUTER)
 
     def verify_no_vlan_member(self):
-        argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "VLAN_MEMBER"]
+        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "VLAN_MEMBER"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "{}")
 
@@ -784,37 +743,21 @@ class TestCfgGen(TestCase):
         try:
             print('\n    Change device type to %s' % (BACKEND_TOR_ROUTER))
             if check_stderr:
-                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (TOR_ROUTER, BACKEND_TOR_ROUTER), graph_file], stderr=subprocess.STDOUT)
+                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (TOR_ROUTER, BACKEND_TOR_ROUTER, graph_file), stderr=subprocess.STDOUT, shell=True)
             else:
-                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (TOR_ROUTER, BACKEND_TOR_ROUTER), graph_file])
+                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (TOR_ROUTER, BACKEND_TOR_ROUTER, graph_file), shell=True)
 
-            self.test_jinja_expression(graph_file, self.port_config, BACKEND_TOR_ROUTER)
-
+            self.test_jinja_expression(graph_file, BACKEND_TOR_ROUTER)
 
             # INTERFACE table does not exist
-            argument = ['-m', graph_file, '-p', self.port_config, '-v',  "INTERFACE"]
+            argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "INTERFACE"'
             output = self.run_script(argument)
             self.assertEqual(output.strip(), "")
 
             # PORTCHANNEL_INTERFACE table does not exist
-            argument = ['-m', graph_file, '-p', self.port_config, '-v', "PORTCHANNEL_INTERFACE"]
+            argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "PORTCHANNEL_INTERFACE"'
             output = self.run_script(argument)
             self.assertEqual(output.strip(), "")
-
-            # SLB and BGP Monitor table does not exist
-            argument = ['-m', graph_file, '-p', self.port_config, '-v', "BGP_PEER_RANGE"]
-            output = self.run_script(argument)
-            self.assertEqual(output.strip(), "{}")
-            argument = ['-m', graph_file, '-p', self.port_config, '-v', "BGP_MONITORS"]
-            output = self.run_script(argument)
-            self.assertEqual(output.strip(), "{}")
-
-            # ACL_TABLE should not contain EVERFLOW related entries
-            argument = ['-m', graph_file, '-p', self.port_config, '-v', "ACL_TABLE"]
-            output = self.run_script(argument)
-            sample_output = utils.to_dict(output.strip()).keys()
-            assert 'DATAACL' in sample_output, sample_output
-            assert 'EVERFLOW' not in sample_output, sample_output
 
             # All the other tables stay unchanged
             self.test_minigraph_vlans(graph_file=graph_file)
@@ -826,7 +769,7 @@ class TestCfgGen(TestCase):
             self.test_minigraph_vxlan(graph_file=graph_file)
 
             # VLAN_SUB_INTERFACE
-            argument = ['-m', graph_file, '-p', self.port_config, '-v', 'VLAN_SUB_INTERFACE']
+            argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v VLAN_SUB_INTERFACE'
             output = self.run_script(argument)
             print(output.strip())
             # not a usecase to parse SubInterfaces under PortChannel
@@ -843,11 +786,11 @@ class TestCfgGen(TestCase):
                 self.assertEqual(
                     utils.to_dict(output.strip()),
                     utils.to_dict(
-                        "{('PortChannel1.10', '10.0.0.56/31'): {}, "
+                        "{('PortChannel01.10', '10.0.0.56/31'): {}, "
                         "'Ethernet0.10': {'admin_status': 'up'}, "
                         "('Ethernet0.10', '10.0.0.58/31'): {}, "
-                        "('PortChannel1.10', 'FC00::71/126'): {}, "
-                        "'PortChannel1.10': {'admin_status': 'up'}, "
+                        "('PortChannel01.10', 'FC00::71/126'): {}, "
+                        "'PortChannel01.10': {'admin_status': 'up'}, "
                         "('Ethernet0.10', 'FC00::75/126'): {}}"
                     )
                 )
@@ -859,108 +802,24 @@ class TestCfgGen(TestCase):
         finally:
             print('\n    Change device type back to %s' % (TOR_ROUTER))
             if check_stderr:
-                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (BACKEND_TOR_ROUTER, TOR_ROUTER), graph_file], stderr=subprocess.STDOUT)
+                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (BACKEND_TOR_ROUTER, TOR_ROUTER, graph_file), stderr=subprocess.STDOUT, shell=True)
             else:
-                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (BACKEND_TOR_ROUTER, TOR_ROUTER), graph_file])
+                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (BACKEND_TOR_ROUTER, TOR_ROUTER, graph_file), shell=True)
 
-            self.test_jinja_expression(graph_file, self.port_config, TOR_ROUTER)
+            self.test_jinja_expression(graph_file, TOR_ROUTER)
 
     def test_show_run_acl(self):
-        argument = ['-a', '{"key1":"value"}', '--var-json', 'ACL_RULE']
+        argument = '-a \'{"key1":"value"}\' --var-json ACL_RULE'
         output = self.run_script(argument)
         self.assertEqual(output, '')
 
     def test_show_run_interfaces(self):
-        argument = ['-a', '{"key1":"value"}', '--var-json', 'INTERFACE']
+        argument = '-a \'{"key1":"value"}\' --var-json INTERFACE'
         output = self.run_script(argument)
         self.assertEqual(output, '')
 
-    def test_minigraph_voq_metadata(self):
-        argument = ["-j", self.macsec_profile, "-m", self.sample_graph_voq, "-p", self.voq_port_config, "--var-json", "DEVICE_METADATA"]
-        output = json.loads(self.run_script(argument))
-        self.assertEqual(output['localhost']['asic_name'], 'Asic0')
-        self.assertEqual(output['localhost']['switch_id'], '0')
-        self.assertEqual(output['localhost']['switch_type'], 'voq')
-        self.assertEqual(output['localhost']['max_cores'], '16')
-
-    def test_minigraph_voq_system_ports(self):
-        argument = ["-j", self.macsec_profile, "-m", self.sample_graph_voq, "-p", self.voq_port_config, "--var-json", "SYSTEM_PORT"]
-        self.assertDictEqual(
-            json.loads(self.run_script(argument)),
-            {
-                "linecard-1|Asic0|Cpu0": { "core_port_index": "0", "num_voq": "8", "switch_id": "0", "speed": "1000", "core_index": "0", "system_port_id": "1" },
-                "linecard-1|Asic0|Ethernet1/1": { "core_port_index": "1", "num_voq": "8", "switch_id": "0", "speed": "40000", "core_index": "0", "system_port_id": "2" },
-                "linecard-1|Asic0|Ethernet1/2": { "core_port_index": "2", "num_voq": "8", "switch_id": "0", "speed": "40000", "core_index": "0", "system_port_id": "3" },
-                "linecard-1|Asic0|Ethernet1/3": { "core_port_index": "3", "num_voq": "8", "switch_id": "0", "speed": "40000", "core_index": "1", "system_port_id": "4" },
-                "linecard-1|Asic0|Ethernet1/4": { "core_port_index": "4", "num_voq": "8", "switch_id": "0", "speed": "40000", "core_index": "1", "system_port_id": "5" },
-                "linecard-2|Asic0|Cpu0": { "core_port_index": "0", "num_voq": "8", "switch_id": "2", "speed": "1000", "core_index": "0", "system_port_id": "256" },
-                "linecard-2|Asic0|Ethernet1/5": { "core_port_index": "1", "num_voq": "8", "switch_id": "2", "speed": "40000", "core_index": "0", "system_port_id": "257" },
-                "linecard-2|Asic0|Ethernet1/6": { "core_port_index": "2", "num_voq": "8", "switch_id": "2", "speed": "40000", "core_index": "1", "system_port_id": "258" },
-                "linecard-2|Asic1|Cpu0": { "core_port_index": "0", "num_voq": "8", "switch_id": "4", "speed": "1000", "core_index": "0", "system_port_id": "259" },
-                "linecard-2|Asic1|Ethernet1/7": { "core_port_index": "1", "num_voq": "8", "switch_id": "4", "speed": "40000", "core_index": "0", "system_port_id": "260" },
-                "linecard-2|Asic1|Ethernet1/8": { "core_port_index": "2", "num_voq": "8", "switch_id": "4", "speed": "40000", "core_index": "1", "system_port_id": "261" }
-            }
-        )
-
-    def test_minigraph_voq_port_macsec_enabled(self):
-        argument = ['-j', self.macsec_profile, '-m', self.sample_graph_voq, '-p', self.voq_port_config, '-v', "PORT[\'Ethernet0\']"]
-        output = self.run_script(argument)
-        self.assertEqual(
-            utils.to_dict(output.strip()),
-            utils.to_dict("{'lanes': '6,7', 'fec': 'rs', 'alias': 'Ethernet1/1', 'index': '1', 'role': 'Ext', 'speed': '100000', 'macsec': 'macsec-profile', 'description': 'Ethernet1/1', 'mtu': '9100', 'tpid': '0x8100', 'pfc_asym': 'off'}")
-        )
-
-    def test_minigraph_voq_inband_interface_port(self):
-        argument = ["-j", self.macsec_profile, "-m", self.sample_graph_voq, "-p", self.voq_port_config, "--var-json", "VOQ_INBAND_INTERFACE"]
-        output = self.run_script(argument)
-        output_dict = utils.to_dict(output.strip())
-        self.assertDictEqual(
-            output_dict['Ethernet-IB0'],
-            {'inband_type': 'port'}
-        )
-        self.assertDictEqual(
-            output_dict['Ethernet-IB0|2.2.2.2/32'],
-            {}
-        )
-
-    def test_minigraph_voq_inband_port(self):
-        argument = ["-j", self.macsec_profile, "-m", self.sample_graph_voq, "-p", self.voq_port_config, "--var-json", "PORT"]
-        output = self.run_script(argument)
-        output_dict = utils.to_dict(output.strip())
-        self.assertDictEqual(
-            output_dict['Ethernet-IB0'], {
-                "lanes": "222",
-                "alias": "Recirc0/1",
-                "index": "52",
-                "role": "Inb",
-                "speed": "400000",
-                "description": "Recirc0/1",
-                "mtu": "9100",
-                "tpid": "0x8100",
-                "pfc_asym": "off",
-                "admin_status": "up"
-            })
-
-    def test_minigraph_voq_recirc_ports(self):
-        argument = ["-j", self.macsec_profile, "-m", self.sample_graph_voq, "-p", self.voq_port_config, "--var-json", "PORT"]
-        output = self.run_script(argument)
-        output_dict = utils.to_dict(output.strip())
-        self.assertDictEqual(
-            output_dict['Ethernet-Rec0'], {
-                "lanes": "221",
-                "alias": "Recirc0/0",
-                "index": "51",
-                "role": "Rec",
-                "speed": "400000",
-                "description": "Recirc0/0",
-                "mtu": "9100",
-                "tpid": "0x8100",
-                "pfc_asym": "off",
-                "admin_status": "up"
-            })
-
     def test_minigraph_dhcp(self):
-        argument = ['-m', self.sample_graph_simple_case, '-p', self.port_config, '-v', 'DHCP_RELAY']
+        argument = '-m "' + self.sample_graph_simple_case + '" -p "' + self.port_config + '" -v DHCP_RELAY'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
@@ -969,48 +828,3 @@ class TestCfgGen(TestCase):
                 "'Vlan2000': {'dhcpv6_servers': ['fc02:2000::3', 'fc02:2000::4']}}"
             )
         )
-       
-    def test_minigraph_bgp_packet_chassis_peer(self):
-        argument = ['-m', self.packet_chassis_graph, '-p', self.packet_chassis_port_ini, '-n', "asic1", '-v', "BGP_INTERNAL_NEIGHBOR[\'8.0.0.1\']"]
-        output = self.run_script(argument)
-        self.assertEqual(
-            utils.to_dict(output.strip()),
-            utils.to_dict("{'rrclient': 0, 'name': 'str2-8808-lc0-ASIC1', 'local_addr': '8.0.0.3', 'nhopself': 0, 'admin_status': 'up', 'holdtime': '0', 'asn': '65100', 'keepalive': '0'}")
-        )
-
-    def test_minigraph_bgp_packet_chassis_static_route(self):
-        argument = ['-m', self.packet_chassis_graph, '-p', self.packet_chassis_port_ini, '-v', "STATIC_ROUTE"]
-        output = self.run_script(argument)
-        self.assertEqual(
-            utils.to_dict(output.strip()),
-            utils.to_dict("{'8.0.0.1/32': {'nexthop': '192.168.1.2,192.168.2.2', 'ifname': 'PortChannel40,PortChannel50', 'advertise':'false'}}")
-        )
-
-        argument = ['-m', self.packet_chassis_graph, '-p', self.packet_chassis_port_ini, '-n', "asic1", '-v', "STATIC_ROUTE"]
-        output = self.run_script(argument)
-        self.assertEqual(
-            utils.to_dict(output.strip()),
-            utils.to_dict("{'8.0.0.1/32': {'nexthop': '192.168.1.2,192.168.2.2', 'ifname': 'PortChannel40,PortChannel50', 'advertise':'false'}}")
-        )
-
-    def test_minigraph_bgp_packet_chassis_vlan_subintf(self):
-        argument = ['-m', self.packet_chassis_graph, '-p', self.packet_chassis_port_ini, '-n', "asic1", '-v', "VLAN_SUB_INTERFACE"]
-        output = self.run_script(argument)
-        self.assertEqual(
-            utils.to_dict(output.strip()),
-            utils.to_dict("{('PortChannel32.2', '192.168.1.4/24'): {}, 'PortChannel32.2': {'admin_status': 'up'}, ('PortChannel33.2', '192.168.2.4/24'): {}, 'PortChannel33.2': {'admin_status': 'up'}}")
-        )
-
-    def test_minigraph_voq_400g_zr_port_config(self):
-        argument = ["-j", self.macsec_profile, "-m", self.sample_graph_voq, "-p", self.voq_port_config, "-v" "PORT[\'Ethernet4\']"]
-        output = self.run_script(argument)
-        output_dict = utils.to_dict(output.strip())
-        self.assertEqual(output_dict['tx_power'], '-10')
-        self.assertEqual(output_dict['laser_freq'], 195875)
-
-    def test_minigraph_packet_chassis_400g_zr_port_config(self):
-        argument = ["-m", self.packet_chassis_graph, "-p", self.packet_chassis_port_ini, "-n", "asic1", "-v", "PORT[\'Ethernet13\']"]
-        output = self.run_script(argument)
-        output_dict = utils.to_dict(output.strip())
-        self.assertEqual(output_dict['tx_power'], '7.5')
-        self.assertEqual(output_dict['laser_freq'], 131000)

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -488,7 +488,7 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_default_vxlan(self):
-        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "VXLAN_TUNNEL"'
+        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', "VXLAN_TUNNEL"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
@@ -496,7 +496,7 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_default_vnet(self):
-        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "VNET"'
+        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', "VNET"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -488,19 +488,19 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_default_vxlan(self):
-        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', "VXLAN_TUNNEL"]
+        argument = ['-m', self.sample_graph_deployment_id, '-p', self.port_config, '-v', "VXLAN_TUNNEL"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'src': '10.1.0.32'}")
+            utils.to_dict("'Tunnel-default': {'src_ip': '10.1.0.32'}")
         )
 
     def test_minigraph_default_vnet(self):
-        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', "VNET"]
+        argument = ['-m', self.sample_graph_deployment_id, '-p', self.port_config, '-v', "VNET']"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'vxlan_tunnel': 'Tunnel-default', 'scope': 'default', 'vni': 8000}")
+            utils.to_dict("'Vnet-default': {'vxlan_tunnel': 'Tunnel-default', 'scope': 'default', 'vni': 8000}")
         )
 
     def test_minigraph_bgp(self):

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -1,7 +1,6 @@
 import json
 import subprocess
 import os
-
 import tests.common_utils as utils
 
 from unittest import TestCase
@@ -14,8 +13,9 @@ BACKEND_LEAF_ROUTER = 'BackEndLeafRouter'
 class TestCfgGen(TestCase):
 
     def setUp(self):
+        self.yang = utils.YangWrapper()
         self.test_dir = os.path.dirname(os.path.realpath(__file__))
-        self.script_file = utils.PYTHON_INTERPRETTER + ' ' + os.path.join(self.test_dir, '..', 'sonic-cfggen')
+        self.script_file = [utils.PYTHON_INTERPRETTER, os.path.join(self.test_dir, '..', 'sonic-cfggen')]
         self.sample_graph = os.path.join(self.test_dir, 'sample_graph.xml')
         self.sample_graph_t0 = os.path.join(self.test_dir, 't0-sample-graph.xml')
         self.sample_graph_simple = os.path.join(self.test_dir, 'simple-sample-graph.xml')
@@ -23,6 +23,8 @@ class TestCfgGen(TestCase):
         self.sample_graph_metadata = os.path.join(self.test_dir, 'simple-sample-graph-metadata.xml')
         self.sample_graph_pc_test = os.path.join(self.test_dir, 'pc-test-graph.xml')
         self.sample_graph_bgp_speaker = os.path.join(self.test_dir, 't0-sample-bgp-speaker.xml')
+        self.sample_graph_deployment_id = os.path.join(self.test_dir, 't0-sample-deployment-id.xml')
+        self.sample_graph_voq = os.path.join(self.test_dir, 'sample-voq-graph.xml')
         self.sample_device_desc = os.path.join(self.test_dir, 'device.xml')
         self.port_config = os.path.join(self.test_dir, 't0-sample-port-config.ini')
         self.port_config_autoneg = os.path.join(self.test_dir, 't0-sample-autoneg-port-config.ini')
@@ -32,6 +34,11 @@ class TestCfgGen(TestCase):
         self.ecmp_graph = os.path.join(self.test_dir, 'fg-ecmp-sample-minigraph.xml')
         self.sample_resource_graph = os.path.join(self.test_dir, 'sample-graph-resource-type.xml')
         self.sample_subintf_graph = os.path.join(self.test_dir, 'sample-graph-subintf.xml')
+        self.voq_port_config = os.path.join(self.test_dir, 'voq-sample-port-config.ini')
+        self.packet_chassis_graph = os.path.join(self.test_dir, 'sample-chassis-packet-lc-graph.xml')
+        self.packet_chassis_port_ini = os.path.join(self.test_dir, 'sample-chassis-packet-lc-port-config.ini')
+        self.macsec_profile = os.path.join(self.test_dir, 'macsec_profile.json')
+        self.sample_backend_graph = os.path.join(self.test_dir, 'sample-graph-storage-backend.xml')
         # To ensure that mock config_db data is used for unit-test cases
         os.environ["CFGGEN_UNIT_TESTING"] = "2"
 
@@ -43,12 +50,13 @@ class TestCfgGen(TestCase):
         except OSError:
             pass
 
-    def run_script(self, argument, check_stderr=False):
-        print('\n    Running sonic-cfggen ' + argument)
+    def run_script(self, argument, check_stderr=False, verbose=False):
+        print('\n    Running sonic-cfggen ' + ' '.join(argument))
+        self.assertTrue(self.yang.validate(argument))
         if check_stderr:
-            output = subprocess.check_output(self.script_file + ' ' + argument, stderr=subprocess.STDOUT, shell=True)
+            output = subprocess.check_output(self.script_file + argument, stderr=subprocess.STDOUT)
         else:
-            output = subprocess.check_output(self.script_file + ' ' + argument, shell=True)
+            output = subprocess.check_output(self.script_file + argument)
 
         if utils.PY3x:
             output = output.decode()
@@ -58,79 +66,88 @@ class TestCfgGen(TestCase):
             print('    Output: ' + output.strip())
         else:
             print('    Output: ({0} lines, {1} bytes)'.format(linecount + 1, len(output)))
+            if verbose == True:
+                print('    Output: ' + output.strip())
         return output
 
     def test_dummy_run(self):
-        argument = ''
+        argument = []
         output = self.run_script(argument)
         self.assertEqual(output, '')
 
     def test_device_desc(self):
-        argument = '-v "DEVICE_METADATA[\'localhost\'][\'hwsku\']" -M "' + self.sample_device_desc + '"'
+        argument = ['-v', "DEVICE_METADATA[\'localhost\'][\'hwsku\']", "-M", self.sample_device_desc]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'ACS-MSN2700')
 
     def test_device_desc_mgmt_ip(self):
-        argument = '-v "(MGMT_INTERFACE.keys()|list)[0]" -M "' + self.sample_device_desc + '"'
+        argument = ['-v', "(MGMT_INTERFACE.keys()|list)[0]", '-M', self.sample_device_desc]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "('eth0', '10.0.1.5/28')")
 
+    def test_minigraph_hostname(self):
+        argument = ['-v', "DEVICE_METADATA[\'localhost\'][\'hostname\']", '-m', self.sample_graph, "-p", self.port_config]
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), 'OCPSCH01040DDLF')
+
     def test_minigraph_sku(self):
-        argument = '-v "DEVICE_METADATA[\'localhost\'][\'hwsku\']" -m "' + self.sample_graph + '"'
+        argument = ['-v', "DEVICE_METADATA[\'localhost\'][\'hwsku\']", '-m', self.sample_graph, '-p', self.port_config]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'Force10-Z9100')
 
     def test_minigraph_region(self):
-        argument = '-v "DEVICE_METADATA[\'localhost\'][\'region\']" -m "' + self.sample_graph_metadata + '"'
+        argument = ['-v', "DEVICE_METADATA[\'localhost\'][\'region\']", '-m', self.sample_graph_metadata, '-p', self.port_config]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'usfoo')
 
     def test_minigraph_cloudtype(self):
-        argument = '-v "DEVICE_METADATA[\'localhost\'][\'cloudtype\']" -m "' + self.sample_graph_metadata + '"'
+        argument = ['-v', "DEVICE_METADATA[\'localhost\'][\'cloudtype\']", '-m', self.sample_graph_metadata, '-p', self.port_config]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'Public')
 
     def test_minigraph_resourcetype(self):
-        argument = '-v "DEVICE_METADATA[\'localhost\'][\'resource_type\']" -m "' + self.sample_graph_metadata + '"'
+        argument = ['-v', "DEVICE_METADATA[\'localhost\'][\'resource_type\']", '-m', self.sample_graph_metadata, '-p', self.port_config]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'resource_type_x')
 
     def test_minigraph_downstream_subrole(self):
-        argument = '-v "DEVICE_METADATA[\'localhost\'][\'downstream_subrole\']" -m "' + self.sample_graph_metadata + '"'
+        argument = ['-v', "DEVICE_METADATA[\'localhost\'][\'downstream_subrole\']", '-m', self.sample_graph_metadata, '-p', self.port_config]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'downstream_subrole_y')
 
     def test_print_data(self):
-        argument = '-m "' + self.sample_graph + '" --print-data'
+        argument = ['-m', self.sample_graph, '-p', self.port_config, '--print-data']
         output = self.run_script(argument)
         self.assertTrue(len(output.strip()) > 0)
 
-    def test_jinja_expression(self, graph=None, expected_router_type='LeafRouter'):
+    def test_jinja_expression(self, graph=None, port_config=None, expected_router_type='LeafRouter'):
         if graph is None:
             graph = self.sample_graph
-        argument = '-m "' + graph + '" -v "DEVICE_METADATA[\'localhost\'][\'type\']"'
+        if port_config is None:
+            port_config = self.port_config
+        argument = ['-m', graph, '-p', port_config, '-v', "DEVICE_METADATA[\'localhost\'][\'type\']"]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), expected_router_type)
 
     def test_additional_json_data(self):
-        argument = '-a \'{"key1":"value1"}\' -v key1'
+        argument = ['-a', '{"key1":"value1"}', '-v', 'key1']
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'value1')
 
     def test_additional_json_data_level1_key(self):
-        argument = '-a \'{"k1":{"k11":"v11","k12":"v12"}, "k2":{"k22":"v22"}}\' --var-json k1'
+        argument = ['-a', '{"k1":{"k11":"v11","k12":"v12"}, "k2":{"k22":"v22"}}', '--var-json', 'k1']
         output = self.run_script(argument)
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict('{\n    "k11": "v11", \n    "k12": "v12"\n}'))
 
     def test_additional_json_data_level2_key(self):
-        argument = '-a \'{"k1":{"k11":"v11","k12":"v12"},"k2":{"k22":"v22"}}\' --var-json k1 -K k11'
+        argument = ['-a', '{"k1":{"k11":"v11","k12":"v12"},"k2":{"k22":"v22"}}', '--var-json', 'k1', '-K', 'k11']
         output = self.run_script(argument)
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict('{\n    "k11": "v11"\n}'))
 
     def test_var_json_data(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
         tag_mode = kwargs.get('tag_mode', 'untagged')
-        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" --var-json VLAN_MEMBER'
+        argument = ['-m', graph_file, '-p', self.port_config, '--var-json', 'VLAN_MEMBER']
         output = self.run_script(argument)
         if tag_mode == "tagged":
             self.assertEqual(
@@ -156,20 +173,20 @@ class TestCfgGen(TestCase):
             )
 
     def test_read_yaml(self):
-        argument = '-v yml_item -y ' + os.path.join(self.test_dir, 'test.yml')
+        argument = ['-v', 'yml_item', '-y', os.path.join(self.test_dir, 'test.yml')]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), '[\'value1\', \'value2\']')
 
     def test_render_template(self):
-        argument = '-y ' + os.path.join(self.test_dir, 'test.yml') + ' -t ' + os.path.join(self.test_dir, 'test.j2')
+        argument = ['-y', os.path.join(self.test_dir, 'test.yml'), '-t', os.path.join(self.test_dir, 'test.j2')]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'value1\nvalue2')
 
     def test_template_batch_mode(self):
-        argument = '-y ' + os.path.join(self.test_dir, 'test.yml')
-        argument += ' -a \'{"key1":"value"}\''
-        argument += ' -t ' + os.path.join(self.test_dir, 'test.j2') + ',' + self.output_file
-        argument += ' -t ' + os.path.join(self.test_dir, 'test2.j2') + ',' + self.output2_file
+        argument = ['-y', os.path.join(self.test_dir, 'test.yml')]
+        argument += ['-a', '{"key1":"value"}']
+        argument += ['-t', os.path.join(self.test_dir, 'test.j2') + ',' + self.output_file]
+        argument += ['-t', os.path.join(self.test_dir, 'test2.j2') + ',' + self.output2_file]
         output = self.run_script(argument)
         assert(os.path.exists(self.output_file))
         assert(os.path.exists(self.output2_file))
@@ -180,10 +197,10 @@ class TestCfgGen(TestCase):
 
     def test_template_json_batch_mode(self):
         data = {"key1_1":"value1_1", "key1_2":"value1_2", "key2_1":"value2_1", "key2_2":"value2_2"}
-        argument = " -a '{0}'".format(repr(data).replace('\'', '"'))
-        argument += ' -t ' + os.path.join(self.test_dir, 'sample-template-1.json.j2') + ",config-db"
-        argument += ' -t ' + os.path.join(self.test_dir, 'sample-template-2.json.j2') + ",config-db"
-        argument += ' --print-data'
+        argument = ["-a", '{0}'.format(repr(data).replace('\'', '"'))]
+        argument += ['-t', os.path.join(self.test_dir, 'sample-template-1.json.j2') + ",config-db"]
+        argument += ['-t', os.path.join(self.test_dir, 'sample-template-2.json.j2') + ",config-db"]
+        argument += ['--print-data']
         output = self.run_script(argument)
         output_data = json.loads(output)
         for key, value in data.items():
@@ -193,8 +210,8 @@ class TestCfgGen(TestCase):
     # it is not at all intuitive what that ordering should be. Could make it
     # more robust by adding better parsing logic.
     def test_minigraph_acl(self):
-        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v ACL_TABLE'
-        output = self.run_script(argument, True)
+        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', 'ACL_TABLE']
+        output = self.run_script(argument, True, True)
         self.assertEqual(
             utils.to_dict(output.strip().replace("Warning: Ignoring Control Plane ACL NTP_ACL without type\n", '')),
             utils.to_dict(
@@ -217,7 +234,7 @@ class TestCfgGen(TestCase):
 #         self.assertEqual(output.strip(), "{'everflow0': {'src_ip': '10.1.0.32', 'dst_ip': '2.2.2.2'}}")
 
     def test_minigraph_mgmt_ports(self):
-        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v MGMT_PORT'
+        argument = ['-m', self.sample_graph, '-p', self.port_config, '-v','MGMT_PORT']
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
@@ -225,29 +242,29 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_interfaces(self):
-        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "INTERFACE.keys()|list"'
+        argument = ['-m', self.sample_graph_simple, '-p', self.port_config, '-v', "INTERFACE.keys()|list"]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "[('Ethernet0', '10.0.0.58/31'), 'Ethernet0', ('Ethernet0', 'FC00::75/126')]")
 
     def test_minigraph_vlans(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
-        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v VLAN'
+        argument = ['-m', graph_file, '-p', self.port_config, '-v', 'VLAN']
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict(
-                "{'Vlan1000': {'alias': 'ab1', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '1000', 'members': ['Ethernet8']}, "
-                "'Vlan1001': {'alias': 'ab4', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '1001', 'members': ['Ethernet8']},"
-                "'Vlan2001': {'alias': 'ab3', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '2001', 'members': ['Ethernet12']},"
-                "'Vlan2000': {'alias': 'ab2', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '2000', 'members': ['Ethernet12']},"
-                "'Vlan2020': {'alias': 'kk1', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '2020', 'members': ['Ethernet12']}}"
+                "{'Vlan1000': {'alias': 'ab1', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '1000'}, "
+                "'Vlan1001': {'alias': 'ab4', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '1001'},"
+                "'Vlan2001': {'alias': 'ab3', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '2001'},"
+                "'Vlan2000': {'alias': 'ab2', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '2000'},"
+                "'Vlan2020': {'alias': 'kk1', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '2020'}}"
             )
         )
 
     def test_minigraph_vlan_members(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
         tag_mode = kwargs.get('tag_mode', 'untagged')
-        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v VLAN_MEMBER'
+        argument = ['-m', graph_file, '-p', self.port_config, '-v', 'VLAN_MEMBER']
         output = self.run_script(argument)
         if tag_mode == "tagged":
             self.assertEqual(
@@ -274,12 +291,12 @@ class TestCfgGen(TestCase):
 
     def test_minigraph_vlan_interfaces(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
-        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "VLAN_INTERFACE.keys()|list"'
+        argument = ['-m', graph_file, '-p', self.port_config, '-v', "VLAN_INTERFACE.keys()|list"]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "[('Vlan1000', '192.168.0.1/27'), 'Vlan1000']")
 
     def test_minigraph_ecmp_fg_nhg(self):
-        argument = '-m "' + self.ecmp_graph + '" -p "' + self.mlnx_port_config + '" -v FG_NHG'
+        argument = ['-m', self.ecmp_graph, '-p', self.mlnx_port_config, '-v', 'FG_NHG']
         output = self.run_script(argument)
         print(output.strip())
         self.assertEqual(utils.to_dict(output.strip()), 
@@ -289,7 +306,7 @@ class TestCfgGen(TestCase):
                         ))
 
     def test_minigraph_ecmp_members(self):
-        argument = '-m "' + self.ecmp_graph + '" -p "' + self.mlnx_port_config + '" -v "FG_NHG_MEMBER.keys()|list|sort"'
+        argument = ['-m', self.ecmp_graph, '-p', self.mlnx_port_config, '-v', "FG_NHG_MEMBER.keys()|list|sort"]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "['200.200.200.1', '200.200.200.10', '200.200.200.2', '200.200.200.3', '200.200.200.4', '200.200.200.5',"
                                          " '200.200.200.6', '200.200.200.7', '200.200.200.8', '200.200.200.9', '200:200:200:200::1', '200:200:200:200::10',"
@@ -297,7 +314,7 @@ class TestCfgGen(TestCase):
                                          " '200:200:200:200::7', '200:200:200:200::8', '200:200:200:200::9']")
 
     def test_minigraph_ecmp_neighbors(self):
-        argument = '-m "' + self.ecmp_graph + '" -p "' + self.mlnx_port_config + '" -v "NEIGH.keys()|list|sort"'
+        argument = ['-m', self.ecmp_graph, '-p', self.mlnx_port_config, '-v', "NEIGH.keys()|list|sort"]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "['Vlan31|200.200.200.1', 'Vlan31|200.200.200.10', 'Vlan31|200.200.200.2', 'Vlan31|200.200.200.3',"
                                          " 'Vlan31|200.200.200.4', 'Vlan31|200.200.200.5', 'Vlan31|200.200.200.6', 'Vlan31|200.200.200.7',"
@@ -307,23 +324,22 @@ class TestCfgGen(TestCase):
 
     def test_minigraph_portchannels(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
-        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v PORTCHANNEL'
+        argument = ['-m', graph_file, '-p', self.port_config, '-v', 'PORTCHANNEL']
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'PortChannel01': {'admin_status': 'up', 'min_links': '1', 'members': ['Ethernet4'], 'mtu': '9100'}}")
+            utils.to_dict("{'PortChannel1': {'admin_status': 'up', 'min_links': '1', 'members': ['Ethernet4'], 'mtu': '9100', 'tpid': '0x8100', 'lacp_key': 'auto'}}")
         )
 
     def test_minigraph_portchannel_with_more_member(self):
-        argument = '-m "' + self.sample_graph_pc_test + '" -p "' + self.port_config + '" -v PORTCHANNEL'
+        argument = ['-m', self.sample_graph_pc_test, '-p', self.port_config, '-v', 'PORTCHANNEL']
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'PortChannel01': {'admin_status': 'up', 'min_links': '3', 'members': ['Ethernet112', 'Ethernet116', 'Ethernet120', 'Ethernet124'], 'mtu': '9100'}}")
-        )
+            utils.to_dict("{'PortChannel01': {'admin_status': 'up', 'min_links': '3', 'members': ['Ethernet112', 'Ethernet116', 'Ethernet120', 'Ethernet124'], 'mtu': '9100', 'tpid': '0x8100', 'lacp_key': 'auto'}}"))
 
     def test_minigraph_portchannel_members(self):
-        argument = '-m "' + self.sample_graph_pc_test + '" -p "' + self.port_config + '" -v "PORTCHANNEL_MEMBER.keys()|list"'
+        argument = ['-m', self.sample_graph_pc_test, '-p', self.port_config, '-v', "PORTCHANNEL_MEMBER.keys()|list"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.liststr_to_dict(output.strip()),
@@ -331,15 +347,15 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_portchannel_interfaces(self):
-        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "PORTCHANNEL_INTERFACE.keys()|list"'
+        argument = ['-m', self.sample_graph_simple, '-p', self.port_config, '-v', "PORTCHANNEL_INTERFACE.keys()|list"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.liststr_to_dict(output.strip()),
-            utils.liststr_to_dict("['PortChannel01', ('PortChannel01', '10.0.0.56/31'), ('PortChannel01', 'FC00::71/126')]")
+            utils.liststr_to_dict("['PortChannel1', ('PortChannel1', '10.0.0.56/31'), ('PortChannel1', 'FC00::71/126')]")
         )
 
     def test_minigraph_neighbors(self):
-        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "DEVICE_NEIGHBOR[\'Ethernet124\']"'
+        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', "DEVICE_NEIGHBOR[\'Ethernet124\']"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
@@ -350,7 +366,7 @@ class TestCfgGen(TestCase):
     # it is not at all intuitive what that ordering should be. Could make it
     # more robust by adding better parsing logic.
     def test_minigraph_extra_neighbors(self):
-        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v DEVICE_NEIGHBOR'
+        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', 'DEVICE_NEIGHBOR']
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
@@ -364,111 +380,111 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_port_description(self):
-        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "PORT[\'Ethernet124\']"'
+        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', "PORT[\'Ethernet124\']"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}")
+            utils.to_dict("{'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}")
         )
 
     def test_minigraph_port_fec_disabled(self):
         # Test for FECDisabled
-        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "PORT[\'Ethernet4\']"'
+        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', "PORT[\'Ethernet4\']"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'lanes': '25,26,27,28', 'description': 'Servers0:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '100000', 'autoneg': '1', 'fec': 'none'}")
+            utils.to_dict("{'lanes': '25,26,27,28', 'description': 'Servers0:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '100000', 'autoneg': 'on', 'fec': 'none'}")
         )
 
     def test_minigraph_port_autonegotiation(self):
         # Test with a port_config.ini file which doesn't have an 'autoneg' column
-        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "PORT"'
+        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', "PORT"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict(
-                "{'Ethernet0': {'alias': 'fortyGigE0/0', 'pfc_asym': 'off', 'lanes': '29,30,31,32', 'description': 'fortyGigE0/0', 'mtu': '9100'}, "
-                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'Servers0:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'autoneg': '1', 'speed': '100000', 'fec': 'none'}, "
-                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'fortyGigE0/8', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'autoneg': '0', 'fec': 'none'}, "
-                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'fortyGigE0/12', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/12', 'admin_status': 'up'}, "
-                "'Ethernet16': {'lanes': '41,42,43,44', 'description': 'fortyGigE0/16', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/16', 'admin_status': 'up'}, "
-                "'Ethernet20': {'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/20', 'admin_status': 'up'}, "
-                "'Ethernet24': {'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/24', 'admin_status': 'up'}, "
-                "'Ethernet28': {'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/28', 'admin_status': 'up'}, "
-                "'Ethernet32': {'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/32', 'admin_status': 'up'}, "
-                "'Ethernet36': {'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/36', 'admin_status': 'up'}, "
-                "'Ethernet40': {'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/40', 'admin_status': 'up'}, "
-                "'Ethernet44': {'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/44', 'admin_status': 'up'}, "
-                "'Ethernet48': {'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/48', 'admin_status': 'up'}, "
-                "'Ethernet52': {'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/52', 'admin_status': 'up'}, "
-                "'Ethernet56': {'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/56', 'admin_status': 'up'}, "
-                "'Ethernet60': {'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/60', 'admin_status': 'up'}, "
-                "'Ethernet64': {'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/64', 'admin_status': 'up'}, "
-                "'Ethernet68': {'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/68', 'admin_status': 'up'}, "
-                "'Ethernet72': {'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/72', 'admin_status': 'up'}, "
-                "'Ethernet76': {'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/76', 'admin_status': 'up'}, "
-                "'Ethernet80': {'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/80', 'admin_status': 'up'}, "
-                "'Ethernet84': {'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/84', 'admin_status': 'up'}, "
-                "'Ethernet88': {'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/88', 'admin_status': 'up'}, "
-                "'Ethernet92': {'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/92', 'admin_status': 'up'}, "
-                "'Ethernet96': {'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/96', 'admin_status': 'up'}, "
-                "'Ethernet100': {'lanes': '125,126,127,128', 'description': 'Servers100:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/100', 'admin_status': 'up'}, "
-                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100'}, "
-                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100'}, "
-                "'Ethernet112': {'lanes': '89,90,91,92', 'description': 'ARISTA01T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/112', 'admin_status': 'up'}, "
-                "'Ethernet116': {'lanes': '93,94,95,96', 'description': 'ARISTA02T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/116', 'admin_status': 'up'}, "
-                "'Ethernet120': {'lanes': '97,98,99,100', 'description': 'ARISTA03T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/120', 'admin_status': 'up'}, "
-                "'Ethernet124': {'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}}"
+                "{'Ethernet0': {'alias': 'fortyGigE0/0', 'pfc_asym': 'off', 'lanes': '29,30,31,32', 'description': 'fortyGigE0/0', 'mtu': '9100', 'tpid': '0x8100', 'speed': '40000'}, "
+                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'Servers0:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'autoneg': 'on', 'speed': '100000', 'fec': 'none'}, "
+                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'fortyGigE0/8', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'autoneg': 'off', 'fec': 'none', 'speed': '40000'}, "
+                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'fortyGigE0/12', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet16': {'lanes': '41,42,43,44', 'description': 'fortyGigE0/16', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/16', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet20': {'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/20', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet24': {'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/24', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet28': {'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/28', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet32': {'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/32', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet36': {'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/36', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet40': {'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/40', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet44': {'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/44', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet48': {'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/48', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet52': {'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/52', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet56': {'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/56', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet60': {'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/60', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet64': {'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/64', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet68': {'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/68', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet72': {'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/72', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet76': {'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/76', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet80': {'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/80', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet84': {'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/84', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet88': {'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/88', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet92': {'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/92', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet96': {'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/96', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet100': {'lanes': '125,126,127,128', 'description': 'Servers100:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/100', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100', 'tpid': '0x8100', 'speed': '40000'}, "
+                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100', 'tpid': '0x8100', 'speed': '40000'}, "
+                "'Ethernet112': {'lanes': '89,90,91,92', 'description': 'ARISTA01T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/112', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet116': {'lanes': '93,94,95,96', 'description': 'ARISTA02T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/116', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet120': {'lanes': '97,98,99,100', 'description': 'ARISTA03T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/120', 'admin_status': 'up', 'speed': '40000'}, "
+                "'Ethernet124': {'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}}"
             )
         )
 
         # Test with a port_config.ini file which has an 'autoneg' column
-        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config_autoneg + '" -v "PORT"'
+        argument = ['-m', self.sample_graph_t0, '-p', self.port_config_autoneg, '-v', "PORT"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict(
-                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'fortyGigE0/0', 'mtu': '9100', 'alias': 'fortyGigE0/0', 'pfc_asym': 'off', 'autoneg': '0'}, "
-                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'Servers0:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'autoneg': '1', 'speed': '100000', 'fec': 'none'}, "
-                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'fortyGigE0/8', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'autoneg': '0', 'fec': 'none'}, "
-                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'fortyGigE0/12', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet16': {'lanes': '41,42,43,44', 'description': 'fortyGigE0/16', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/16', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet20': {'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/20', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet24': {'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/24', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet28': {'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/28', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet32': {'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/32', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet36': {'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/36', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet40': {'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/40', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet44': {'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/44', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet48': {'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/48', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet52': {'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/52', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet56': {'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/56', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet60': {'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/60', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet64': {'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/64', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet68': {'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/68', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet72': {'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/72', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet76': {'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/76', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet80': {'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/80', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet84': {'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/84', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet88': {'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/88', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet92': {'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/92', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet96': {'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/96', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet100': {'lanes': '125,126,127,128', 'description': 'Servers100:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/100', 'admin_status': 'up', 'autoneg': '0'}, "
-                "'Ethernet104': {'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100', 'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'autoneg': '0'}, "
-                "'Ethernet108': {'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100', 'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'autoneg': '0'}, "
-                "'Ethernet112': {'lanes': '89,90,91,92', 'description': 'ARISTA01T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/112', 'admin_status': 'up', 'autoneg': '1'}, "
-                "'Ethernet116': {'lanes': '93,94,95,96', 'description': 'ARISTA02T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/116', 'admin_status': 'up', 'autoneg': '1'}, "
-                "'Ethernet120': {'lanes': '97,98,99,100', 'description': 'ARISTA03T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/120', 'admin_status': 'up', 'autoneg': '1'}, "
-                "'Ethernet124': {'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'autoneg': '1', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}}"
+                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'fortyGigE0/0', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/0', 'pfc_asym': 'off', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'Servers0:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'autoneg': 'on', 'speed': '100000', 'fec': 'none'}, "
+                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'fortyGigE0/8', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'autoneg': 'off', 'fec': 'none', 'speed': '40000'}, "
+                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'fortyGigE0/12', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet16': {'lanes': '41,42,43,44', 'description': 'fortyGigE0/16', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/16', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet20': {'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/20', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet24': {'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/24', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet28': {'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/28', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet32': {'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/32', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet36': {'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/36', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet40': {'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/40', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet44': {'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/44', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet48': {'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/48', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet52': {'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/52', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet56': {'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/56', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet60': {'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/60', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet64': {'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/64', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet68': {'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/68', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet72': {'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/72', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet76': {'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/76', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet80': {'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/80', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet84': {'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/84', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet88': {'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/88', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet92': {'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/92', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet96': {'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/96', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet100': {'lanes': '125,126,127,128', 'description': 'Servers100:eth0', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/100', 'admin_status': 'up', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet104': {'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet108': {'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'autoneg': 'off', 'speed': '40000'}, "
+                "'Ethernet112': {'lanes': '89,90,91,92', 'description': 'ARISTA01T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/112', 'admin_status': 'up', 'autoneg': 'on', 'speed': '40000'}, "
+                "'Ethernet116': {'lanes': '93,94,95,96', 'description': 'ARISTA02T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/116', 'admin_status': 'up', 'autoneg': 'on', 'speed': '40000'}, "
+                "'Ethernet120': {'lanes': '97,98,99,100', 'description': 'ARISTA03T1:Ethernet1/1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/120', 'admin_status': 'up', 'autoneg': 'on', 'speed': '40000'}, "
+                "'Ethernet124': {'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'autoneg': 'on', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1', 'speed': '100000'}}"
             )
         )
 
     def test_minigraph_port_rs(self):
-        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "PORT[\'Ethernet124\']"'
+        argument = ['-m', self.sample_graph_t0, '-p', self.port_config, '-v', "PORT[\'Ethernet124\']"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}")
+            utils.to_dict("{'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}")
         )
 
     def test_minigraph_default_vxlan(self):
@@ -488,7 +504,7 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_bgp(self):
-        argument = '-m "' + self.sample_graph_bgp_speaker + '" -p "' + self.port_config + '" -v "BGP_NEIGHBOR[\'10.0.0.59\']"'
+        argument = ['-m', self.sample_graph_bgp_speaker, '-p', self.port_config, '-v', "BGP_NEIGHBOR[\'10.0.0.59\']"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
@@ -496,7 +512,7 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_peers_with_range(self):
-        argument = "-m " + self.sample_graph_bgp_speaker + " -p " + self.port_config + " -v \"BGP_PEER_RANGE.values()|list\""
+        argument = ["-m", self.sample_graph_bgp_speaker, "-p", self.port_config, "-v", "BGP_PEER_RANGE.values()|list"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.liststr_to_dict(output.strip()),
@@ -504,150 +520,155 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_deployment_id(self):
-        argument = '-m "' + self.sample_graph_bgp_speaker + '" -p "' + self.port_config + '" -v "DEVICE_METADATA[\'localhost\'][\'deployment_id\']"'
+        argument = ['-m', self.sample_graph_bgp_speaker, '-p', self.port_config, '-v', "DEVICE_METADATA[\'localhost\'][\'deployment_id\']"]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "1")
 
+    def test_minigraph_deployment_id_null(self):
+        argument = ['-m', self.sample_graph_deployment_id, '-p', self.port_config, '-v', "DEVICE_METADATA[\'localhost\']"]
+        output = self.run_script(argument)
+        self.assertNotIn('deployment_id', output.strip())
+
     def test_minigraph_ethernet_interfaces(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
-        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "PORT[\'Ethernet8\']"'
+        argument = ['-m', graph_file, '-p', self.port_config, '-v', "PORT[\'Ethernet8\']"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '1000'}")
+            utils.to_dict("{'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '1000', 'tpid': '0x8100'}")
         )
-        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "PORT[\'Ethernet12\']"'
+        argument = ['-m', graph_file, '-p', self.port_config, '-v', "PORT[\'Ethernet12\']"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'lanes': '33,34,35,36', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '100000', 'description': 'Interface description'}")
+            utils.to_dict("{'lanes': '33,34,35,36', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '100000', 'description': 'Interface description'}")
         )
 
     def test_minigraph_neighbor_interfaces(self):
-        argument = '-m "' + self.sample_graph_simple_case + '" -p "' + self.port_config + '" -v "PORT"'
+        argument = ['-m', self.sample_graph_simple_case, '-p', self.port_config, '-v', "PORT"]
         output = self.run_script(argument)
 
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict(
-                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'switch-01t1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/0', 'admin_status': 'up', 'speed': '10000', 'autoneg': '1'}, "
-                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'server1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '25000', 'autoneg': '1', 'mux_cable': 'true'}, "
-                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '40000', 'autoneg': '1', 'mux_cable': 'true'}, "
-                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '10000', 'autoneg': '1'}, "
-                "'Ethernet16': {'alias': 'fortyGigE0/16', 'pfc_asym': 'off', 'lanes': '41,42,43,44', 'description': 'fortyGigE0/16', 'mtu': '9100'}, "
-                "'Ethernet20': {'alias': 'fortyGigE0/20', 'pfc_asym': 'off', 'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'mtu': '9100'}, "
-                "'Ethernet24': {'alias': 'fortyGigE0/24', 'pfc_asym': 'off', 'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'mtu': '9100'}, "
-                "'Ethernet28': {'alias': 'fortyGigE0/28', 'pfc_asym': 'off', 'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'mtu': '9100'}, "
-                "'Ethernet32': {'alias': 'fortyGigE0/32', 'pfc_asym': 'off', 'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'mtu': '9100'}, "
-                "'Ethernet36': {'alias': 'fortyGigE0/36', 'pfc_asym': 'off', 'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'mtu': '9100'}, "
-                "'Ethernet40': {'alias': 'fortyGigE0/40', 'pfc_asym': 'off', 'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'mtu': '9100'}, "
-                "'Ethernet44': {'alias': 'fortyGigE0/44', 'pfc_asym': 'off', 'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'mtu': '9100'}, "
-                "'Ethernet48': {'alias': 'fortyGigE0/48', 'pfc_asym': 'off', 'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'mtu': '9100'}, "
-                "'Ethernet52': {'alias': 'fortyGigE0/52', 'pfc_asym': 'off', 'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'mtu': '9100'}, "
-                "'Ethernet56': {'alias': 'fortyGigE0/56', 'pfc_asym': 'off', 'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'mtu': '9100'}, "
-                "'Ethernet60': {'alias': 'fortyGigE0/60', 'pfc_asym': 'off', 'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'mtu': '9100'}, "
-                "'Ethernet64': {'alias': 'fortyGigE0/64', 'pfc_asym': 'off', 'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'mtu': '9100'}, "
-                "'Ethernet68': {'alias': 'fortyGigE0/68', 'pfc_asym': 'off', 'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'mtu': '9100'}, "
-                "'Ethernet72': {'alias': 'fortyGigE0/72', 'pfc_asym': 'off', 'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'mtu': '9100'}, "
-                "'Ethernet76': {'alias': 'fortyGigE0/76', 'pfc_asym': 'off', 'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'mtu': '9100'}, "
-                "'Ethernet80': {'alias': 'fortyGigE0/80', 'pfc_asym': 'off', 'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'mtu': '9100'}, "
-                "'Ethernet84': {'alias': 'fortyGigE0/84', 'pfc_asym': 'off', 'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'mtu': '9100'}, "
-                "'Ethernet88': {'alias': 'fortyGigE0/88', 'pfc_asym': 'off', 'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'mtu': '9100'}, "
-                "'Ethernet92': {'alias': 'fortyGigE0/92', 'pfc_asym': 'off', 'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'mtu': '9100'}, "
-                "'Ethernet96': {'alias': 'fortyGigE0/96', 'pfc_asym': 'off', 'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'mtu': '9100'}, "
-                "'Ethernet100': {'alias': 'fortyGigE0/100', 'pfc_asym': 'off', 'lanes': '125,126,127,128', 'description': 'fortyGigE0/100', 'mtu': '9100'}, "
-                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100'}, "
-                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100'}, "
-                "'Ethernet112': {'alias': 'fortyGigE0/112', 'pfc_asym': 'off', 'lanes': '89,90,91,92', 'description': 'fortyGigE0/112', 'mtu': '9100'}, "
-                "'Ethernet116': {'alias': 'fortyGigE0/116', 'pfc_asym': 'off', 'lanes': '93,94,95,96', 'description': 'fortyGigE0/116', 'mtu': '9100'}, "
-                "'Ethernet120': {'alias': 'fortyGigE0/120', 'pfc_asym': 'off', 'lanes': '97,98,99,100', 'description': 'fortyGigE0/120', 'mtu': '9100'}, "
-                "'Ethernet124': {'alias': 'fortyGigE0/124', 'pfc_asym': 'off', 'lanes': '101,102,103,104', 'description': 'fortyGigE0/124', 'mtu': '9100'}}"
+                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'switch-01t1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/0', 'admin_status': 'up', 'speed': '10000', 'autoneg': 'on'}, "
+                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'server1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '25000', 'autoneg': 'on', 'mux_cable': 'true'}, "
+                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '40000', 'autoneg': 'on', 'mux_cable': 'true'}, "
+                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '10000', 'autoneg': 'on'}, "
+                "'Ethernet16': {'alias': 'fortyGigE0/16', 'pfc_asym': 'off', 'lanes': '41,42,43,44', 'description': 'fortyGigE0/16', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet20': {'alias': 'fortyGigE0/20', 'pfc_asym': 'off', 'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet24': {'alias': 'fortyGigE0/24', 'pfc_asym': 'off', 'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet28': {'alias': 'fortyGigE0/28', 'pfc_asym': 'off', 'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet32': {'alias': 'fortyGigE0/32', 'pfc_asym': 'off', 'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet36': {'alias': 'fortyGigE0/36', 'pfc_asym': 'off', 'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet40': {'alias': 'fortyGigE0/40', 'pfc_asym': 'off', 'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet44': {'alias': 'fortyGigE0/44', 'pfc_asym': 'off', 'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet48': {'alias': 'fortyGigE0/48', 'pfc_asym': 'off', 'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet52': {'alias': 'fortyGigE0/52', 'pfc_asym': 'off', 'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet56': {'alias': 'fortyGigE0/56', 'pfc_asym': 'off', 'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet60': {'alias': 'fortyGigE0/60', 'pfc_asym': 'off', 'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet64': {'alias': 'fortyGigE0/64', 'pfc_asym': 'off', 'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet68': {'alias': 'fortyGigE0/68', 'pfc_asym': 'off', 'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet72': {'alias': 'fortyGigE0/72', 'pfc_asym': 'off', 'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet76': {'alias': 'fortyGigE0/76', 'pfc_asym': 'off', 'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet80': {'alias': 'fortyGigE0/80', 'pfc_asym': 'off', 'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet84': {'alias': 'fortyGigE0/84', 'pfc_asym': 'off', 'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet88': {'alias': 'fortyGigE0/88', 'pfc_asym': 'off', 'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet92': {'alias': 'fortyGigE0/92', 'pfc_asym': 'off', 'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet96': {'alias': 'fortyGigE0/96', 'pfc_asym': 'off', 'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet100': {'alias': 'fortyGigE0/100', 'pfc_asym': 'off', 'lanes': '125,126,127,128', 'description': 'fortyGigE0/100', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet112': {'alias': 'fortyGigE0/112', 'pfc_asym': 'off', 'lanes': '89,90,91,92', 'description': 'fortyGigE0/112', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet116': {'alias': 'fortyGigE0/116', 'pfc_asym': 'off', 'lanes': '93,94,95,96', 'description': 'fortyGigE0/116', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet120': {'alias': 'fortyGigE0/120', 'pfc_asym': 'off', 'lanes': '97,98,99,100', 'description': 'fortyGigE0/120', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet124': {'alias': 'fortyGigE0/124', 'pfc_asym': 'off', 'lanes': '101,102,103,104', 'description': 'fortyGigE0/124', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}}"
             )
         )
 
     def test_minigraph_neighbor_interfaces_config_db(self):
         # test to check if PORT table is retrieved from config_db
-        argument = '-m "' + self.sample_graph_simple_case + '" -v "PORT"'
+        argument = ['-m', self.sample_graph_simple_case, '-p', self.port_config, '-v', "PORT"]
         output = self.run_script(argument)
 
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict(
-                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'config_db:switch-01t1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/0', 'admin_status': 'up', 'speed': '10000', 'autoneg': '1'}, "
-                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'config_db:server1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '25000', 'autoneg': '1', 'mux_cable': 'true'}, "
-                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '40000', 'autoneg': '1', 'mux_cable': 'true'}, "
-                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '10000', 'autoneg': '1'}, "
-                "'Ethernet16': {'alias': 'fortyGigE0/16', 'pfc_asym': 'off', 'lanes': '41,42,43,44', 'description': 'config_db:fortyGigE0/16', 'mtu': '9100'}, "
-                "'Ethernet20': {'alias': 'fortyGigE0/20', 'pfc_asym': 'off', 'lanes': '45,46,47,48', 'description': 'config_db:fortyGigE0/20', 'mtu': '9100'}, "
-                "'Ethernet24': {'alias': 'fortyGigE0/24', 'pfc_asym': 'off', 'lanes': '5,6,7,8', 'description': 'config_db:fortyGigE0/24', 'mtu': '9100'}, "
-                "'Ethernet28': {'alias': 'fortyGigE0/28', 'pfc_asym': 'off', 'lanes': '1,2,3,4', 'description': 'config_db:fortyGigE0/28', 'mtu': '9100'}, "
-                "'Ethernet32': {'alias': 'fortyGigE0/32', 'pfc_asym': 'off', 'lanes': '9,10,11,12', 'description': 'config_db:fortyGigE0/32', 'mtu': '9100'}, "
-                "'Ethernet36': {'alias': 'fortyGigE0/36', 'pfc_asym': 'off', 'lanes': '13,14,15,16', 'description': 'config_db:fortyGigE0/36', 'mtu': '9100'}, "
-                "'Ethernet40': {'alias': 'fortyGigE0/40', 'pfc_asym': 'off', 'lanes': '21,22,23,24', 'description': 'config_db:fortyGigE0/40', 'mtu': '9100'}, "
-                "'Ethernet44': {'alias': 'fortyGigE0/44', 'pfc_asym': 'off', 'lanes': '17,18,19,20', 'description': 'config_db:fortyGigE0/44', 'mtu': '9100'}, "
-                "'Ethernet48': {'alias': 'fortyGigE0/48', 'pfc_asym': 'off', 'lanes': '49,50,51,52', 'description': 'config_db:fortyGigE0/48', 'mtu': '9100'}, "
-                "'Ethernet52': {'alias': 'fortyGigE0/52', 'pfc_asym': 'off', 'lanes': '53,54,55,56', 'description': 'config_db:fortyGigE0/52', 'mtu': '9100'}, "
-                "'Ethernet56': {'alias': 'fortyGigE0/56', 'pfc_asym': 'off', 'lanes': '61,62,63,64', 'description': 'config_db:fortyGigE0/56', 'mtu': '9100'}, "
-                "'Ethernet60': {'alias': 'fortyGigE0/60', 'pfc_asym': 'off', 'lanes': '57,58,59,60', 'description': 'config_db:fortyGigE0/60', 'mtu': '9100'}, "
-                "'Ethernet64': {'alias': 'fortyGigE0/64', 'pfc_asym': 'off', 'lanes': '65,66,67,68', 'description': 'config_db:fortyGigE0/64', 'mtu': '9100'}, "
-                "'Ethernet68': {'alias': 'fortyGigE0/68', 'pfc_asym': 'off', 'lanes': '69,70,71,72', 'description': 'config_db:fortyGigE0/68', 'mtu': '9100'}, "
-                "'Ethernet72': {'alias': 'fortyGigE0/72', 'pfc_asym': 'off', 'lanes': '77,78,79,80', 'description': 'config_db:fortyGigE0/72', 'mtu': '9100'}, "
-                "'Ethernet76': {'alias': 'fortyGigE0/76', 'pfc_asym': 'off', 'lanes': '73,74,75,76', 'description': 'config_db:fortyGigE0/76', 'mtu': '9100'}, "
-                "'Ethernet80': {'alias': 'fortyGigE0/80', 'pfc_asym': 'off', 'lanes': '105,106,107,108', 'description': 'config_db:fortyGigE0/80', 'mtu': '9100'}, "
-                "'Ethernet84': {'alias': 'fortyGigE0/84', 'pfc_asym': 'off', 'lanes': '109,110,111,112', 'description': 'config_db:fortyGigE0/84', 'mtu': '9100'}, "
-                "'Ethernet88': {'alias': 'fortyGigE0/88', 'pfc_asym': 'off', 'lanes': '117,118,119,120', 'description': 'config_db:fortyGigE0/88', 'mtu': '9100'}, "
-                "'Ethernet92': {'alias': 'fortyGigE0/92', 'pfc_asym': 'off', 'lanes': '113,114,115,116', 'description': 'config_db:fortyGigE0/92', 'mtu': '9100'}, "
-                "'Ethernet96': {'alias': 'fortyGigE0/96', 'pfc_asym': 'off', 'lanes': '121,122,123,124', 'description': 'config_db:fortyGigE0/96', 'mtu': '9100'}, "
-                "'Ethernet100': {'alias': 'fortyGigE0/100', 'pfc_asym': 'off', 'lanes': '125,126,127,128', 'description': 'config_db:fortyGigE0/100', 'mtu': '9100'}, "
-                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'config_db:fortyGigE0/104', 'mtu': '9100'}, "
-                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'config_db:fortyGigE0/108', 'mtu': '9100'}, "
-                "'Ethernet112': {'alias': 'fortyGigE0/112', 'pfc_asym': 'off', 'lanes': '89,90,91,92', 'description': 'config_db:fortyGigE0/112', 'mtu': '9100'}, "
-                "'Ethernet116': {'alias': 'fortyGigE0/116', 'pfc_asym': 'off', 'lanes': '93,94,95,96', 'description': 'config_db:fortyGigE0/116', 'mtu': '9100'}, "
-                "'Ethernet120': {'alias': 'fortyGigE0/120', 'pfc_asym': 'off', 'lanes': '97,98,99,100', 'description': 'config_db:fortyGigE0/120', 'mtu': '9100'}, "
-                "'Ethernet124': {'alias': 'fortyGigE0/124', 'pfc_asym': 'off', 'lanes': '101,102,103,104', 'description': 'config_db:fortyGigE0/124', 'mtu': '9100'}}"
+                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'switch-01t1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/0', 'admin_status': 'up', 'speed': '10000', 'autoneg': 'on'}, "
+                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'server1:port1', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '25000', 'autoneg': 'on', 'mux_cable': 'true'}, "
+                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '40000', 'autoneg': 'on', 'mux_cable': 'true'}, "
+                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '10000', 'autoneg': 'on'}, "
+                "'Ethernet16': {'alias': 'fortyGigE0/16', 'pfc_asym': 'off', 'lanes': '41,42,43,44', 'description': 'fortyGigE0/16', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet20': {'alias': 'fortyGigE0/20', 'pfc_asym': 'off', 'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet24': {'alias': 'fortyGigE0/24', 'pfc_asym': 'off', 'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet28': {'alias': 'fortyGigE0/28', 'pfc_asym': 'off', 'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet32': {'alias': 'fortyGigE0/32', 'pfc_asym': 'off', 'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet36': {'alias': 'fortyGigE0/36', 'pfc_asym': 'off', 'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet40': {'alias': 'fortyGigE0/40', 'pfc_asym': 'off', 'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet44': {'alias': 'fortyGigE0/44', 'pfc_asym': 'off', 'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet48': {'alias': 'fortyGigE0/48', 'pfc_asym': 'off', 'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet52': {'alias': 'fortyGigE0/52', 'pfc_asym': 'off', 'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet56': {'alias': 'fortyGigE0/56', 'pfc_asym': 'off', 'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet60': {'alias': 'fortyGigE0/60', 'pfc_asym': 'off', 'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet64': {'alias': 'fortyGigE0/64', 'pfc_asym': 'off', 'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet68': {'alias': 'fortyGigE0/68', 'pfc_asym': 'off', 'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet72': {'alias': 'fortyGigE0/72', 'pfc_asym': 'off', 'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet76': {'alias': 'fortyGigE0/76', 'pfc_asym': 'off', 'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet80': {'alias': 'fortyGigE0/80', 'pfc_asym': 'off', 'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet84': {'alias': 'fortyGigE0/84', 'pfc_asym': 'off', 'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet88': {'alias': 'fortyGigE0/88', 'pfc_asym': 'off', 'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet92': {'alias': 'fortyGigE0/92', 'pfc_asym': 'off', 'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet96': {'alias': 'fortyGigE0/96', 'pfc_asym': 'off', 'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet100': {'alias': 'fortyGigE0/100', 'pfc_asym': 'off', 'lanes': '125,126,127,128', 'description': 'fortyGigE0/100', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet112': {'alias': 'fortyGigE0/112', 'pfc_asym': 'off', 'lanes': '89,90,91,92', 'description': 'fortyGigE0/112', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet116': {'alias': 'fortyGigE0/116', 'pfc_asym': 'off', 'lanes': '93,94,95,96', 'description': 'fortyGigE0/116', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet120': {'alias': 'fortyGigE0/120', 'pfc_asym': 'off', 'lanes': '97,98,99,100', 'description': 'fortyGigE0/120', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet124': {'alias': 'fortyGigE0/124', 'pfc_asym': 'off', 'lanes': '101,102,103,104', 'description': 'fortyGigE0/124', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}}"
             )
         )
 
     def test_minigraph_extra_ethernet_interfaces(self, **kwargs):
-        graph_file = kwargs.get('graph_file', self.sample_graph_simple)
-        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "PORT"'
+        graph_file = kwargs.get('graph_file', self.sample_graph_simple) 
+        argument = ['-m', graph_file, '-p', self.port_config, '-v', "PORT"]
         output = self.run_script(argument)
 
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict(
-                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'fortyGigE0/0', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/0', 'admin_status': 'up', 'speed': '10000'}, "
-                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'fortyGigE0/4', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '25000'}, "
-                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '1000'}, "
-                "'Ethernet12': {'lanes': '33,34,35,36', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '100000', 'description': 'Interface description'}, "
-                "'Ethernet16': {'lanes': '41,42,43,44', 'pfc_asym': 'off', 'description': 'fortyGigE0/16', 'mtu': '9100', 'alias': 'fortyGigE0/16', 'speed': '1000'}, "
-                "'Ethernet20': {'alias': 'fortyGigE0/20', 'pfc_asym': 'off', 'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'mtu': '9100'}, "
-                "'Ethernet24': {'alias': 'fortyGigE0/24', 'pfc_asym': 'off', 'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'mtu': '9100'}, "
-                "'Ethernet28': {'alias': 'fortyGigE0/28', 'pfc_asym': 'off', 'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'mtu': '9100'}, "
-                "'Ethernet32': {'alias': 'fortyGigE0/32', 'pfc_asym': 'off', 'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'mtu': '9100'}, "
-                "'Ethernet36': {'alias': 'fortyGigE0/36', 'pfc_asym': 'off', 'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'mtu': '9100'}, "
-                "'Ethernet40': {'alias': 'fortyGigE0/40', 'pfc_asym': 'off', 'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'mtu': '9100'}, "
-                "'Ethernet44': {'alias': 'fortyGigE0/44', 'pfc_asym': 'off', 'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'mtu': '9100'}, "
-                "'Ethernet48': {'alias': 'fortyGigE0/48', 'pfc_asym': 'off', 'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'mtu': '9100'}, "
-                "'Ethernet52': {'alias': 'fortyGigE0/52', 'pfc_asym': 'off', 'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'mtu': '9100'}, "
-                "'Ethernet56': {'alias': 'fortyGigE0/56', 'pfc_asym': 'off', 'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'mtu': '9100'}, "
-                "'Ethernet60': {'alias': 'fortyGigE0/60', 'pfc_asym': 'off', 'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'mtu': '9100'}, "
-                "'Ethernet64': {'alias': 'fortyGigE0/64', 'pfc_asym': 'off', 'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'mtu': '9100'}, "
-                "'Ethernet68': {'alias': 'fortyGigE0/68', 'pfc_asym': 'off', 'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'mtu': '9100'}, "
-                "'Ethernet72': {'alias': 'fortyGigE0/72', 'pfc_asym': 'off', 'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'mtu': '9100'}, "
-                "'Ethernet76': {'alias': 'fortyGigE0/76', 'pfc_asym': 'off', 'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'mtu': '9100'}, "
-                "'Ethernet80': {'alias': 'fortyGigE0/80', 'pfc_asym': 'off', 'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'mtu': '9100'}, "
-                "'Ethernet84': {'alias': 'fortyGigE0/84', 'pfc_asym': 'off', 'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'mtu': '9100'}, "
-                "'Ethernet88': {'alias': 'fortyGigE0/88', 'pfc_asym': 'off', 'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'mtu': '9100'}, "
-                "'Ethernet92': {'alias': 'fortyGigE0/92', 'pfc_asym': 'off', 'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'mtu': '9100'}, "
-                "'Ethernet96': {'alias': 'fortyGigE0/96', 'pfc_asym': 'off', 'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'mtu': '9100'}, "
-                "'Ethernet100': {'alias': 'fortyGigE0/100', 'pfc_asym': 'off', 'lanes': '125,126,127,128', 'description': 'fortyGigE0/100', 'mtu': '9100'}, "
-                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100'}, "
-                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100'}, "
-                "'Ethernet112': {'alias': 'fortyGigE0/112', 'pfc_asym': 'off', 'lanes': '89,90,91,92', 'description': 'fortyGigE0/112', 'mtu': '9100'}, "
-                "'Ethernet116': {'alias': 'fortyGigE0/116', 'pfc_asym': 'off', 'lanes': '93,94,95,96', 'description': 'fortyGigE0/116', 'mtu': '9100'}, "
-                "'Ethernet120': {'alias': 'fortyGigE0/120', 'pfc_asym': 'off', 'lanes': '97,98,99,100', 'description': 'fortyGigE0/120', 'mtu': '9100'}, "
-                "'Ethernet124': {'alias': 'fortyGigE0/124', 'pfc_asym': 'off', 'lanes': '101,102,103,104', 'description': 'fortyGigE0/124', 'mtu': '9100'}}"
+                "{'Ethernet0': {'lanes': '29,30,31,32', 'description': 'fortyGigE0/0', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/0', 'admin_status': 'up', 'speed': '10000'}, "
+                "'Ethernet4': {'lanes': '25,26,27,28', 'description': 'fortyGigE0/4', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/4', 'admin_status': 'up', 'speed': '25000'}, "
+                "'Ethernet8': {'lanes': '37,38,39,40', 'description': 'Interface description', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/8', 'admin_status': 'up', 'speed': '1000'}, "
+                "'Ethernet12': {'lanes': '33,34,35,36', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/12', 'admin_status': 'up', 'speed': '100000', 'description': 'Interface description'}, "
+                "'Ethernet16': {'lanes': '41,42,43,44', 'pfc_asym': 'off', 'description': 'fortyGigE0/16', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/16', 'speed': '1000'}, "
+                "'Ethernet20': {'alias': 'fortyGigE0/20', 'pfc_asym': 'off', 'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet24': {'alias': 'fortyGigE0/24', 'pfc_asym': 'off', 'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet28': {'alias': 'fortyGigE0/28', 'pfc_asym': 'off', 'lanes': '1,2,3,4', 'description': 'fortyGigE0/28', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet32': {'alias': 'fortyGigE0/32', 'pfc_asym': 'off', 'lanes': '9,10,11,12', 'description': 'fortyGigE0/32', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet36': {'alias': 'fortyGigE0/36', 'pfc_asym': 'off', 'lanes': '13,14,15,16', 'description': 'fortyGigE0/36', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet40': {'alias': 'fortyGigE0/40', 'pfc_asym': 'off', 'lanes': '21,22,23,24', 'description': 'fortyGigE0/40', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet44': {'alias': 'fortyGigE0/44', 'pfc_asym': 'off', 'lanes': '17,18,19,20', 'description': 'fortyGigE0/44', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet48': {'alias': 'fortyGigE0/48', 'pfc_asym': 'off', 'lanes': '49,50,51,52', 'description': 'fortyGigE0/48', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet52': {'alias': 'fortyGigE0/52', 'pfc_asym': 'off', 'lanes': '53,54,55,56', 'description': 'fortyGigE0/52', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet56': {'alias': 'fortyGigE0/56', 'pfc_asym': 'off', 'lanes': '61,62,63,64', 'description': 'fortyGigE0/56', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet60': {'alias': 'fortyGigE0/60', 'pfc_asym': 'off', 'lanes': '57,58,59,60', 'description': 'fortyGigE0/60', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet64': {'alias': 'fortyGigE0/64', 'pfc_asym': 'off', 'lanes': '65,66,67,68', 'description': 'fortyGigE0/64', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet68': {'alias': 'fortyGigE0/68', 'pfc_asym': 'off', 'lanes': '69,70,71,72', 'description': 'fortyGigE0/68', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet72': {'alias': 'fortyGigE0/72', 'pfc_asym': 'off', 'lanes': '77,78,79,80', 'description': 'fortyGigE0/72', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet76': {'alias': 'fortyGigE0/76', 'pfc_asym': 'off', 'lanes': '73,74,75,76', 'description': 'fortyGigE0/76', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet80': {'alias': 'fortyGigE0/80', 'pfc_asym': 'off', 'lanes': '105,106,107,108', 'description': 'fortyGigE0/80', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet84': {'alias': 'fortyGigE0/84', 'pfc_asym': 'off', 'lanes': '109,110,111,112', 'description': 'fortyGigE0/84', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet88': {'alias': 'fortyGigE0/88', 'pfc_asym': 'off', 'lanes': '117,118,119,120', 'description': 'fortyGigE0/88', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet92': {'alias': 'fortyGigE0/92', 'pfc_asym': 'off', 'lanes': '113,114,115,116', 'description': 'fortyGigE0/92', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet96': {'alias': 'fortyGigE0/96', 'pfc_asym': 'off', 'lanes': '121,122,123,124', 'description': 'fortyGigE0/96', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet100': {'alias': 'fortyGigE0/100', 'pfc_asym': 'off', 'lanes': '125,126,127,128', 'description': 'fortyGigE0/100', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet104': {'alias': 'fortyGigE0/104', 'pfc_asym': 'off', 'lanes': '85,86,87,88', 'description': 'fortyGigE0/104', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet108': {'alias': 'fortyGigE0/108', 'pfc_asym': 'off', 'lanes': '81,82,83,84', 'description': 'fortyGigE0/108', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet112': {'alias': 'fortyGigE0/112', 'pfc_asym': 'off', 'lanes': '89,90,91,92', 'description': 'fortyGigE0/112', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet116': {'alias': 'fortyGigE0/116', 'pfc_asym': 'off', 'lanes': '93,94,95,96', 'description': 'fortyGigE0/116', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet120': {'alias': 'fortyGigE0/120', 'pfc_asym': 'off', 'lanes': '97,98,99,100', 'description': 'fortyGigE0/120', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}, "
+                "'Ethernet124': {'alias': 'fortyGigE0/124', 'pfc_asym': 'off', 'lanes': '101,102,103,104', 'description': 'fortyGigE0/124', 'mtu': '9100', 'tpid': '0x8100', 'fec': 'rs', 'speed': '100000'}}"
             )
         )
 
@@ -658,7 +679,7 @@ class TestCfgGen(TestCase):
 #         self.assertEqual(output.strip(), "{'everflow0': {'src_ip': '10.1.0.32', 'dst_ip': '10.0.100.1'}}")
 
     def test_metadata_tacacs(self):
-        argument = '-m "' + self.sample_graph_metadata + '" -p "' + self.port_config + '" -v "TACPLUS_SERVER"'
+        argument = ['-m', self.sample_graph_metadata, '-p', self.port_config, '-v', "TACPLUS_SERVER"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
@@ -666,38 +687,48 @@ class TestCfgGen(TestCase):
         )
 
     def test_metadata_ntp(self):
-        argument = '-m "' + self.sample_graph_metadata + '" -p "' + self.port_config + '" -v "NTP_SERVER"'
+        argument = ['-m', self.sample_graph_metadata, '-p', self.port_config, '-v', "NTP_SERVER"]
         output = self.run_script(argument)
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict("{'10.0.10.1': {}, '10.0.10.2': {}}"))
 
     def test_minigraph_vnet(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
-        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "VNET"'
+        argument = ['-m', graph_file, '-p', self.port_config, '-v', "VNET"]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "")
 
     def test_minigraph_vxlan(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
-        argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "VXLAN_TUNNEL"'
+        argument = ['-m', graph_file, '-p', self.port_config, '-v', "VXLAN_TUNNEL"]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "")
 
     def test_minigraph_bgp_mon(self):
-        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "BGP_MONITORS"'
+        argument = ['-m', self.sample_graph_simple, '-p', self.port_config, '-v', "BGP_MONITORS"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'10.20.30.40': {'rrclient': 0, 'name': 'BGPMonitor', 'local_addr': '10.1.0.32', 'nhopself': 0, 'holdtime': '10', 'asn': '0', 'keepalive': '3'}}")
+            utils.to_dict("{'10.20.30.40': {'rrclient': 0, 'name': 'BGPMonitor', 'local_addr': '10.1.0.32', 'nhopself': 0, 'holdtime': '10', 'asn': '1', 'keepalive': '3'}}")
         )
 
-    def test_minigraph_sub_port_interfaces(self, check_stderr=True):
-        self.verify_sub_intf(check_stderr=check_stderr)
+    def test_minigraph_bgp_voq_chassis_peer(self):
+        argument = ['-m', self.sample_graph_simple, '-p', self.port_config, '-v', "BGP_VOQ_CHASSIS_NEIGHBOR[\'10.2.0.21\']"]
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            utils.to_dict("{'rrclient': 0, 'name': 'CHASSIS_PEER', 'local_addr': '10.2.0.20', 'nhopself': 0, 'holdtime': '180', 'asn': '65100', 'keepalive': '60', 'admin_status': 'up'}")
+        )
+
+        # make sure VoQChassisInternal value of false is honored
+        argument = ['-m', self.sample_graph_simple, '-p', self.port_config, '-v', "BGP_VOQ_CHASSIS_NEIGHBOR[\'10.0.0.57\']"]
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), "")
 
     def test_minigraph_sub_port_intf_resource_type_non_backend_tor(self, check_stderr=True):
         self.verify_sub_intf_non_backend_tor(graph_file=self.sample_resource_graph, check_stderr=check_stderr)
 
-    def test_minigraph_sub_port_intf_resource_type(self, check_stderr=True):
-        self.verify_sub_intf(graph_file=self.sample_resource_graph, check_stderr=check_stderr)
+    def test_minigraph_sub_port_intf_hwsku(self, check_stderr=True):
+        self.verify_sub_intf(graph_file=self.sample_backend_graph, check_stderr=check_stderr)
 
     def test_minigraph_sub_port_intf_sub(self, check_stderr=True):
         self.verify_sub_intf(graph_file=self.sample_subintf_graph, check_stderr=check_stderr)
@@ -705,27 +736,53 @@ class TestCfgGen(TestCase):
     def test_minigraph_no_vlan_member(self, check_stderr=True):
         self.verify_no_vlan_member()
 
+    def test_minigraph_backend_acl_leaf(self, check_stderr=True):
+        try:
+            print('\n    Change device type to %s' % (BACKEND_LEAF_ROUTER))
+            if check_stderr:
+                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (TOR_ROUTER, BACKEND_LEAF_ROUTER), self.sample_backend_graph], stderr=subprocess.STDOUT)
+            else:
+                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (TOR_ROUTER, BACKEND_LEAF_ROUTER), self.sample_backend_graph])
+
+            self.test_jinja_expression(self.sample_backend_graph, self.port_config, BACKEND_LEAF_ROUTER)
+
+            # ACL_TABLE should contain EVERFLOW related entries
+            argument = ['-m', self.sample_backend_graph, '-p', self.port_config, '-v', "ACL_TABLE"]
+            output = self.run_script(argument)
+            sample_output = utils.to_dict(output.strip()).keys()
+            assert 'DATAACL' not in sample_output, sample_output
+            assert 'EVERFLOW' in sample_output, sample_output
+
+        finally:
+            print('\n    Change device type back to %s' % (TOR_ROUTER))
+            if check_stderr:
+                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (BACKEND_LEAF_ROUTER, TOR_ROUTER), self.sample_backend_graph], stderr=subprocess.STDOUT)
+            else:
+                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (BACKEND_LEAF_ROUTER, TOR_ROUTER), self.sample_backend_graph])
+
+            self.test_jinja_expression(self.sample_backend_graph, self.port_config, TOR_ROUTER)
+
     def test_minigraph_sub_port_no_vlan_member(self, check_stderr=True):
         try:
             print('\n    Change device type to %s' % (BACKEND_LEAF_ROUTER))
             if check_stderr:
-                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (LEAF_ROUTER, BACKEND_LEAF_ROUTER, self.sample_graph), stderr=subprocess.STDOUT, shell=True)
+                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (LEAF_ROUTER, BACKEND_LEAF_ROUTER), self.sample_graph], stderr=subprocess.STDOUT)
             else:
-                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (LEAF_ROUTER, BACKEND_LEAF_ROUTER, self.sample_graph), shell=True)
+                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (LEAF_ROUTER, BACKEND_LEAF_ROUTER), self.sample_graph])
 
-            self.test_jinja_expression(self.sample_graph, BACKEND_LEAF_ROUTER)
+            self.test_jinja_expression(self.sample_graph, self.port_config, BACKEND_LEAF_ROUTER)
             self.verify_no_vlan_member()
         finally:
             print('\n    Change device type back to %s' % (LEAF_ROUTER))
             if check_stderr:
-                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (BACKEND_LEAF_ROUTER, LEAF_ROUTER, self.sample_graph), stderr=subprocess.STDOUT, shell=True)
+                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (BACKEND_LEAF_ROUTER, LEAF_ROUTER), self.sample_graph], stderr=subprocess.STDOUT)
             else:
-                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (BACKEND_LEAF_ROUTER, LEAF_ROUTER, self.sample_graph), shell=True)
+                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (BACKEND_LEAF_ROUTER, LEAF_ROUTER), self.sample_graph])
 
-            self.test_jinja_expression(self.sample_graph, LEAF_ROUTER)
+            self.test_jinja_expression(self.sample_graph, self.port_config, LEAF_ROUTER)
 
     def verify_no_vlan_member(self):
-        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "VLAN_MEMBER"'
+        argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "VLAN_MEMBER"]
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "{}")
 
@@ -743,21 +800,37 @@ class TestCfgGen(TestCase):
         try:
             print('\n    Change device type to %s' % (BACKEND_TOR_ROUTER))
             if check_stderr:
-                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (TOR_ROUTER, BACKEND_TOR_ROUTER, graph_file), stderr=subprocess.STDOUT, shell=True)
+                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (TOR_ROUTER, BACKEND_TOR_ROUTER), graph_file], stderr=subprocess.STDOUT)
             else:
-                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (TOR_ROUTER, BACKEND_TOR_ROUTER, graph_file), shell=True)
+                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (TOR_ROUTER, BACKEND_TOR_ROUTER), graph_file])
 
-            self.test_jinja_expression(graph_file, BACKEND_TOR_ROUTER)
+            self.test_jinja_expression(graph_file, self.port_config, BACKEND_TOR_ROUTER)
+
 
             # INTERFACE table does not exist
-            argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "INTERFACE"'
+            argument = ['-m', graph_file, '-p', self.port_config, '-v',  "INTERFACE"]
             output = self.run_script(argument)
             self.assertEqual(output.strip(), "")
 
             # PORTCHANNEL_INTERFACE table does not exist
-            argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v "PORTCHANNEL_INTERFACE"'
+            argument = ['-m', graph_file, '-p', self.port_config, '-v', "PORTCHANNEL_INTERFACE"]
             output = self.run_script(argument)
             self.assertEqual(output.strip(), "")
+
+            # SLB and BGP Monitor table does not exist
+            argument = ['-m', graph_file, '-p', self.port_config, '-v', "BGP_PEER_RANGE"]
+            output = self.run_script(argument)
+            self.assertEqual(output.strip(), "{}")
+            argument = ['-m', graph_file, '-p', self.port_config, '-v', "BGP_MONITORS"]
+            output = self.run_script(argument)
+            self.assertEqual(output.strip(), "{}")
+
+            # ACL_TABLE should not contain EVERFLOW related entries
+            argument = ['-m', graph_file, '-p', self.port_config, '-v', "ACL_TABLE"]
+            output = self.run_script(argument)
+            sample_output = utils.to_dict(output.strip()).keys()
+            assert 'DATAACL' in sample_output, sample_output
+            assert 'EVERFLOW' not in sample_output, sample_output
 
             # All the other tables stay unchanged
             self.test_minigraph_vlans(graph_file=graph_file)
@@ -769,7 +842,7 @@ class TestCfgGen(TestCase):
             self.test_minigraph_vxlan(graph_file=graph_file)
 
             # VLAN_SUB_INTERFACE
-            argument = '-m "' + graph_file + '" -p "' + self.port_config + '" -v VLAN_SUB_INTERFACE'
+            argument = ['-m', graph_file, '-p', self.port_config, '-v', 'VLAN_SUB_INTERFACE']
             output = self.run_script(argument)
             print(output.strip())
             # not a usecase to parse SubInterfaces under PortChannel
@@ -786,11 +859,11 @@ class TestCfgGen(TestCase):
                 self.assertEqual(
                     utils.to_dict(output.strip()),
                     utils.to_dict(
-                        "{('PortChannel01.10', '10.0.0.56/31'): {}, "
+                        "{('PortChannel1.10', '10.0.0.56/31'): {}, "
                         "'Ethernet0.10': {'admin_status': 'up'}, "
                         "('Ethernet0.10', '10.0.0.58/31'): {}, "
-                        "('PortChannel01.10', 'FC00::71/126'): {}, "
-                        "'PortChannel01.10': {'admin_status': 'up'}, "
+                        "('PortChannel1.10', 'FC00::71/126'): {}, "
+                        "'PortChannel1.10': {'admin_status': 'up'}, "
                         "('Ethernet0.10', 'FC00::75/126'): {}}"
                     )
                 )
@@ -802,24 +875,108 @@ class TestCfgGen(TestCase):
         finally:
             print('\n    Change device type back to %s' % (TOR_ROUTER))
             if check_stderr:
-                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (BACKEND_TOR_ROUTER, TOR_ROUTER, graph_file), stderr=subprocess.STDOUT, shell=True)
+                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (BACKEND_TOR_ROUTER, TOR_ROUTER), graph_file], stderr=subprocess.STDOUT)
             else:
-                output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (BACKEND_TOR_ROUTER, TOR_ROUTER, graph_file), shell=True)
+                output = subprocess.check_output(["sed", "-i", 's/%s/%s/g' % (BACKEND_TOR_ROUTER, TOR_ROUTER), graph_file])
 
-            self.test_jinja_expression(graph_file, TOR_ROUTER)
+            self.test_jinja_expression(graph_file, self.port_config, TOR_ROUTER)
 
     def test_show_run_acl(self):
-        argument = '-a \'{"key1":"value"}\' --var-json ACL_RULE'
+        argument = ['-a', '{"key1":"value"}', '--var-json', 'ACL_RULE']
         output = self.run_script(argument)
         self.assertEqual(output, '')
 
     def test_show_run_interfaces(self):
-        argument = '-a \'{"key1":"value"}\' --var-json INTERFACE'
+        argument = ['-a', '{"key1":"value"}', '--var-json', 'INTERFACE']
         output = self.run_script(argument)
         self.assertEqual(output, '')
 
+    def test_minigraph_voq_metadata(self):
+        argument = ["-j", self.macsec_profile, "-m", self.sample_graph_voq, "-p", self.voq_port_config, "--var-json", "DEVICE_METADATA"]
+        output = json.loads(self.run_script(argument))
+        self.assertEqual(output['localhost']['asic_name'], 'Asic0')
+        self.assertEqual(output['localhost']['switch_id'], '0')
+        self.assertEqual(output['localhost']['switch_type'], 'voq')
+        self.assertEqual(output['localhost']['max_cores'], '16')
+
+    def test_minigraph_voq_system_ports(self):
+        argument = ["-j", self.macsec_profile, "-m", self.sample_graph_voq, "-p", self.voq_port_config, "--var-json", "SYSTEM_PORT"]
+        self.assertDictEqual(
+            json.loads(self.run_script(argument)),
+            {
+                "linecard-1|Asic0|Cpu0": { "core_port_index": "0", "num_voq": "8", "switch_id": "0", "speed": "1000", "core_index": "0", "system_port_id": "1" },
+                "linecard-1|Asic0|Ethernet1/1": { "core_port_index": "1", "num_voq": "8", "switch_id": "0", "speed": "40000", "core_index": "0", "system_port_id": "2" },
+                "linecard-1|Asic0|Ethernet1/2": { "core_port_index": "2", "num_voq": "8", "switch_id": "0", "speed": "40000", "core_index": "0", "system_port_id": "3" },
+                "linecard-1|Asic0|Ethernet1/3": { "core_port_index": "3", "num_voq": "8", "switch_id": "0", "speed": "40000", "core_index": "1", "system_port_id": "4" },
+                "linecard-1|Asic0|Ethernet1/4": { "core_port_index": "4", "num_voq": "8", "switch_id": "0", "speed": "40000", "core_index": "1", "system_port_id": "5" },
+                "linecard-2|Asic0|Cpu0": { "core_port_index": "0", "num_voq": "8", "switch_id": "2", "speed": "1000", "core_index": "0", "system_port_id": "256" },
+                "linecard-2|Asic0|Ethernet1/5": { "core_port_index": "1", "num_voq": "8", "switch_id": "2", "speed": "40000", "core_index": "0", "system_port_id": "257" },
+                "linecard-2|Asic0|Ethernet1/6": { "core_port_index": "2", "num_voq": "8", "switch_id": "2", "speed": "40000", "core_index": "1", "system_port_id": "258" },
+                "linecard-2|Asic1|Cpu0": { "core_port_index": "0", "num_voq": "8", "switch_id": "4", "speed": "1000", "core_index": "0", "system_port_id": "259" },
+                "linecard-2|Asic1|Ethernet1/7": { "core_port_index": "1", "num_voq": "8", "switch_id": "4", "speed": "40000", "core_index": "0", "system_port_id": "260" },
+                "linecard-2|Asic1|Ethernet1/8": { "core_port_index": "2", "num_voq": "8", "switch_id": "4", "speed": "40000", "core_index": "1", "system_port_id": "261" }
+            }
+        )
+
+    def test_minigraph_voq_port_macsec_enabled(self):
+        argument = ['-j', self.macsec_profile, '-m', self.sample_graph_voq, '-p', self.voq_port_config, '-v', "PORT[\'Ethernet0\']"]
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            utils.to_dict("{'lanes': '6,7', 'fec': 'rs', 'alias': 'Ethernet1/1', 'index': '1', 'role': 'Ext', 'speed': '100000', 'macsec': 'macsec-profile', 'description': 'Ethernet1/1', 'mtu': '9100', 'tpid': '0x8100', 'pfc_asym': 'off'}")
+        )
+
+    def test_minigraph_voq_inband_interface_port(self):
+        argument = ["-j", self.macsec_profile, "-m", self.sample_graph_voq, "-p", self.voq_port_config, "--var-json", "VOQ_INBAND_INTERFACE"]
+        output = self.run_script(argument)
+        output_dict = utils.to_dict(output.strip())
+        self.assertDictEqual(
+            output_dict['Ethernet-IB0'],
+            {'inband_type': 'port'}
+        )
+        self.assertDictEqual(
+            output_dict['Ethernet-IB0|2.2.2.2/32'],
+            {}
+        )
+
+    def test_minigraph_voq_inband_port(self):
+        argument = ["-j", self.macsec_profile, "-m", self.sample_graph_voq, "-p", self.voq_port_config, "--var-json", "PORT"]
+        output = self.run_script(argument)
+        output_dict = utils.to_dict(output.strip())
+        self.assertDictEqual(
+            output_dict['Ethernet-IB0'], {
+                "lanes": "222",
+                "alias": "Recirc0/1",
+                "index": "52",
+                "role": "Inb",
+                "speed": "400000",
+                "description": "Recirc0/1",
+                "mtu": "9100",
+                "tpid": "0x8100",
+                "pfc_asym": "off",
+                "admin_status": "up"
+            })
+
+    def test_minigraph_voq_recirc_ports(self):
+        argument = ["-j", self.macsec_profile, "-m", self.sample_graph_voq, "-p", self.voq_port_config, "--var-json", "PORT"]
+        output = self.run_script(argument)
+        output_dict = utils.to_dict(output.strip())
+        self.assertDictEqual(
+            output_dict['Ethernet-Rec0'], {
+                "lanes": "221",
+                "alias": "Recirc0/0",
+                "index": "51",
+                "role": "Rec",
+                "speed": "400000",
+                "description": "Recirc0/0",
+                "mtu": "9100",
+                "tpid": "0x8100",
+                "pfc_asym": "off",
+                "admin_status": "up"
+            })
+
     def test_minigraph_dhcp(self):
-        argument = '-m "' + self.sample_graph_simple_case + '" -p "' + self.port_config + '" -v DHCP_RELAY'
+        argument = ['-m', self.sample_graph_simple_case, '-p', self.port_config, '-v', 'DHCP_RELAY']
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
@@ -828,3 +985,48 @@ class TestCfgGen(TestCase):
                 "'Vlan2000': {'dhcpv6_servers': ['fc02:2000::3', 'fc02:2000::4']}}"
             )
         )
+       
+    def test_minigraph_bgp_packet_chassis_peer(self):
+        argument = ['-m', self.packet_chassis_graph, '-p', self.packet_chassis_port_ini, '-n', "asic1", '-v', "BGP_INTERNAL_NEIGHBOR[\'8.0.0.1\']"]
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            utils.to_dict("{'rrclient': 0, 'name': 'str2-8808-lc0-ASIC1', 'local_addr': '8.0.0.3', 'nhopself': 0, 'admin_status': 'up', 'holdtime': '0', 'asn': '65100', 'keepalive': '0'}")
+        )
+
+    def test_minigraph_bgp_packet_chassis_static_route(self):
+        argument = ['-m', self.packet_chassis_graph, '-p', self.packet_chassis_port_ini, '-v', "STATIC_ROUTE"]
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            utils.to_dict("{'8.0.0.1/32': {'nexthop': '192.168.1.2,192.168.2.2', 'ifname': 'PortChannel40,PortChannel50', 'advertise':'false'}}")
+        )
+
+        argument = ['-m', self.packet_chassis_graph, '-p', self.packet_chassis_port_ini, '-n', "asic1", '-v', "STATIC_ROUTE"]
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            utils.to_dict("{'8.0.0.1/32': {'nexthop': '192.168.1.2,192.168.2.2', 'ifname': 'PortChannel40,PortChannel50', 'advertise':'false'}}")
+        )
+
+    def test_minigraph_bgp_packet_chassis_vlan_subintf(self):
+        argument = ['-m', self.packet_chassis_graph, '-p', self.packet_chassis_port_ini, '-n', "asic1", '-v', "VLAN_SUB_INTERFACE"]
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            utils.to_dict("{('PortChannel32.2', '192.168.1.4/24'): {}, 'PortChannel32.2': {'admin_status': 'up'}, ('PortChannel33.2', '192.168.2.4/24'): {}, 'PortChannel33.2': {'admin_status': 'up'}}")
+        )
+
+    def test_minigraph_voq_400g_zr_port_config(self):
+        argument = ["-j", self.macsec_profile, "-m", self.sample_graph_voq, "-p", self.voq_port_config, "-v" "PORT[\'Ethernet4\']"]
+        output = self.run_script(argument)
+        output_dict = utils.to_dict(output.strip())
+        self.assertEqual(output_dict['tx_power'], '-10')
+        self.assertEqual(output_dict['laser_freq'], 195875)
+
+    def test_minigraph_packet_chassis_400g_zr_port_config(self):
+        argument = ["-m", self.packet_chassis_graph, "-p", self.packet_chassis_port_ini, "-n", "asic1", "-v", "PORT[\'Ethernet13\']"]
+        output = self.run_script(argument)
+        output_dict = utils.to_dict(output.strip())
+        self.assertEqual(output_dict['tx_power'], '7.5')
+        self.assertEqual(output_dict['laser_freq'], 131000)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Create Vxlan and Vnet default configs as below for certain cases:

    "VNET": {
        "Vnet-default": {
            "scope": "default",
            "vni": "8000",
            "vxlan_tunnel": "Tunnel-default"
        }
    },
    "VXLAN_TUNNEL": {
        "Tunnel-default": {
            "src_ip": "10.1.0.32"
        }
    },

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

