### PR TITLE
[dualtor][active-active]Killing radv instead of stopping on `active-active` dualtor if config knob is on

### DIFF
--- a/files/scripts/service_mgmt.sh
+++ b/files/scripts/service_mgmt.sh
@@ -39,7 +39,11 @@ function check_redundant_type()
     else
         ACTIVE_ACTIVE="false"
     fi
-    debug "Active-active cable type dualtor: ${ACTIVE_ACTIVE}"
+    CONFIG_KNOB=`$SONIC_DB_CLI CONFIG_DB hget "FEATURE|mux" kill_radv`
+    if [[ x"$CONFIG_KNOB" == x"False" ]]; then
+        ACTIVE_ACTIVE='false'
+    fi 
+    debug "DEVICE_SUBTYPE: ${DEVICE_SUBTYPE}, CONFIG_KNOB: ${CONFIG_KNOB}"
 }
 
 start() {
@@ -66,10 +70,10 @@ stop() {
     # For WARM/FAST boot do not perform service stop
     if [[ x"$WARM_BOOT" != x"true" ]] && [[ x"$FAST_BOOT" != x"true" ]]; then
         if [[ x"$SERVICE" == x"radv" ]] && [[ x"$ACTIVE_ACTIVE" == x"true" ]]; then
-	    debug "Killing Docker ${SERVICE}${DEV}..."
+            debug "Killing Docker ${SERVICE}${DEV} for active-active dualtor device..."
             /usr/bin/${SERVICE}.sh kill $DEV
-	else
-	    /usr/bin/${SERVICE}.sh stop $DEV
+        else
+            /usr/bin/${SERVICE}.sh stop $DEV
             debug "Stopped ${SERVICE}$DEV service..."
         fi
     else

--- a/files/scripts/service_mgmt.sh
+++ b/files/scripts/service_mgmt.sh
@@ -26,6 +26,22 @@ function check_fast_boot ()
     fi
 }
 
+function check_redundant_type()
+{
+    DEVICE_SUBTYPE=`$SONIC_DB_CLI CONFIG_DB hget "DEVICE_METADATA|localhost" subtype`
+    if [[ x"$DEVICE_SUBTYPE" == x"DualToR" ]]; then
+        MUX_CONFIG=`show muxcable config`
+        if [[ $MUX_CONFIG =~ .*active-active.* ]]; then 
+            ACTIVE_ACTIVE="true"
+        else
+            ACTIVE_ACTIVE="false"
+        fi
+    else
+        ACTIVE_ACTIVE="false"
+    fi
+    debug "Active-active cable type dualtor: ${ACTIVE_ACTIVE}"
+}
+
 start() {
     debug "Starting ${SERVICE}$DEV service..."
 
@@ -43,13 +59,19 @@ stop() {
 
     check_warm_boot
     check_fast_boot
+    check_redundant_type
     debug "Warm boot flag: ${SERVICE}$DEV ${WARM_BOOT}."
     debug "Fast boot flag: ${SERVICE}$DEV ${FAST_BOOT}."
 
     # For WARM/FAST boot do not perform service stop
     if [[ x"$WARM_BOOT" != x"true" ]] && [[ x"$FAST_BOOT" != x"true" ]]; then
-        /usr/bin/${SERVICE}.sh stop $DEV
-        debug "Stopped ${SERVICE}$DEV service..."
+        if [[ x"$SERVICE" == x"radv" ]] && [[ x"$ACTIVE_ACTIVE" == x"true" ]]; then
+	    debug "Killing Docker ${SERVICE}${DEV}..."
+            /usr/bin/${SERVICE}.sh kill $DEV
+	else
+	    /usr/bin/${SERVICE}.sh stop $DEV
+            debug "Stopped ${SERVICE}$DEV service..."
+        fi
     else
         debug "Killing Docker ${SERVICE}${DEV}..."
         /usr/bin/${SERVICE}.sh kill $DEV

--- a/files/scripts/service_mgmt.sh
+++ b/files/scripts/service_mgmt.sh
@@ -39,8 +39,8 @@ function check_redundant_type()
     else
         ACTIVE_ACTIVE="false"
     fi
-    CONFIG_KNOB=`$SONIC_DB_CLI CONFIG_DB hget "FEATURE|mux" kill_radv`
-    if [[ x"$CONFIG_KNOB" == x"False" ]]; then
+    CONFIG_KNOB=`$SONIC_DB_CLI CONFIG_DB hget "MUX_LINKMGR|SERVICE_MGMT" kill_radv`
+    if [[ x"$CONFIG_KNOB" != x"True" ]]; then
         ACTIVE_ACTIVE='false'
     fi 
     debug "DEVICE_SUBTYPE: ${DEVICE_SUBTYPE}, CONFIG_KNOB: ${CONFIG_KNOB}"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

`radv` sends a good-bye packet when the service is stopped, which causes a IPv6 route update on SoC side. And this update leads to an interface bouncing and causes traffic disruption even though the ToR device might already be isolated. 

This PR is to mitigate the traffic disruption issue during planned maintenance, by killing radv instead of stopping. So the cease packet won't be sent. 

sign-off: Jing Zhang zhangjing@microsoft.com

#### Why I did it

#### How I did it

#### How to verify it
Verified on dev clusters: 
* Traffic disruption was no longer reproducible.
* `radv` took the killing path
* if knob was off, `radv` would take the stopping path 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

