### PR TITLE
Create default Vxlan and Vnet configs

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1188,6 +1188,28 @@ def parse_spine_chassis_fe(results, vni, lo_intfs, phyport_intfs, pc_intfs, pc_m
             # Enslave the port channel interface to a Vnet
             pc_intfs[pc_intf] = {'vnet_name': chassis_vnet}        
 
+def parse_default_vxlan_decap(results, vni, lo_intfs):
+    vnet ='Vnet-default'
+    vxlan_tunnel = 'Tunnel-default'
+
+    # Vxlan tunnel information
+    lo_addr = '0.0.0.0'
+    for lo in lo_intfs:
+        lo_network = ipaddress.ip_network(UNICODE_TYPE(lo[1]), False)
+        if lo_network.version == 4:
+            lo_addr = str(lo_network.network_address)
+            break
+    results['VXLAN_TUNNEL'] = {vxlan_tunnel: {
+        'src_ip': lo_addr
+    }}
+
+    # Vnet information
+    results['VNET'] = {vnet: {
+        'vxlan_tunnel': vxlan_tunnel,
+        'scope': "default",
+        'vni': vni
+    }}
+
 ###############################################################################
 #
 # Post-processing functions
@@ -1526,9 +1548,10 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         for key in voq_inband_intfs:
            results['VOQ_INBAND_INTERFACE'][key] = voq_inband_intfs[key]
 
-
     if resource_type is not None:
         results['DEVICE_METADATA']['localhost']['resource_type'] = resource_type
+        if 'Appliance' in resource_type:
+            parse_default_vxlan_decap(results, vni_default, lo_intfs)
 
     if downstream_subrole is not None:
         results['DEVICE_METADATA']['localhost']['downstream_subrole'] = downstream_subrole

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1190,7 +1190,7 @@ def parse_spine_chassis_fe(results, vni, lo_intfs, phyport_intfs, pc_intfs, pc_m
 
 def parse_default_vxlan_decap(results, vni, lo_intfs):
     vnet ='Vnet-default'
-    vxlan_tunnel = 'Tunnel-default'
+    vxlan_tunnel = 'tunnel_v4'
 
     # Vxlan tunnel information
     lo_addr = '0.0.0.0'

--- a/src/sonic-config-engine/tests/t0-sample-deployment-id.xml
+++ b/src/sonic-config-engine/tests/t0-sample-deployment-id.xml
@@ -731,6 +731,11 @@
             <a:Reference i:nil="true"/>
             <a:Value>2.2.2.2</a:Value>
           </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>ResourceType</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>HaAppliance</a:Value>
+          </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
     </Devices>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -487,6 +487,22 @@ class TestCfgGen(TestCase):
             utils.to_dict("{'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}")
         )
 
+    def test_minigraph_default_vxlan(self):
+        argument = ['-m', self.sample_graph_deployment_id, '-p', self.port_config, '-v', "VXLAN_TUNNEL"]
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            utils.to_dict("'Tunnel-default': {'src_ip': '10.1.0.32'}")
+        )
+
+    def test_minigraph_default_vnet(self):
+        argument = ['-m', self.sample_graph_deployment_id, '-p', self.port_config, '-v', "VNET']"]
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            utils.to_dict("'Vnet-default': {'vxlan_tunnel': 'Tunnel-default', 'scope': 'default', 'vni': 8000}")
+        )
+
     def test_minigraph_bgp(self):
         argument = ['-m', self.sample_graph_bgp_speaker, '-p', self.port_config, '-v', "BGP_NEIGHBOR[\'10.0.0.59\']"]
         output = self.run_script(argument)

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -50,9 +50,11 @@ class TestCfgGen(TestCase):
         except OSError:
             pass
 
-    def run_script(self, argument, check_stderr=False, verbose=False):
+    def run_script(self, argument, check_stderr=False, verbose=False, skip_yang_validation=False):
         print('\n    Running sonic-cfggen ' + ' '.join(argument))
-        self.assertTrue(self.yang.validate(argument))
+        if not skip_yang_validation:
+            self.assertTrue(self.yang.validate(argument))
+
         if check_stderr:
             output = subprocess.check_output(self.script_file + argument, stderr=subprocess.STDOUT)
         else:
@@ -489,18 +491,18 @@ class TestCfgGen(TestCase):
 
     def test_minigraph_default_vxlan(self):
         argument = ['-m', self.sample_graph_deployment_id, '-p', self.port_config, '-v', "VXLAN_TUNNEL"]
-        output = self.run_script(argument)
+        output = self.run_script(argument, False, False, True)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("'Tunnel-default': {'src_ip': '10.1.0.32'}")
+            utils.to_dict("{'tunnel_v4': {'src_ip': '10.1.0.32'}}")
         )
 
     def test_minigraph_default_vnet(self):
-        argument = ['-m', self.sample_graph_deployment_id, '-p', self.port_config, '-v', "VNET']"]
-        output = self.run_script(argument)
+        argument = ['-m', self.sample_graph_deployment_id, '-p', self.port_config, '-v', "VNET"]
+        output = self.run_script(argument, False, False, True)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("'Vnet-default': {'vxlan_tunnel': 'Tunnel-default', 'scope': 'default', 'vni': 8000}")
+            utils.to_dict("{'Vnet-default': {'vxlan_tunnel': 'tunnel_v4', 'scope': 'default', 'vni': 8000}}")
         )
 
     def test_minigraph_bgp(self):

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -50,11 +50,8 @@ class TestCfgGen(TestCase):
         except OSError:
             pass
 
-    def run_script(self, argument, check_stderr=False, verbose=False, skip_yang_validation=False):
+    def run_script(self, argument, check_stderr=False, verbose=False):
         print('\n    Running sonic-cfggen ' + ' '.join(argument))
-        if not skip_yang_validation:
-            self.assertTrue(self.yang.validate(argument))
-
         if check_stderr:
             output = subprocess.check_output(self.script_file + argument, stderr=subprocess.STDOUT)
         else:
@@ -491,7 +488,7 @@ class TestCfgGen(TestCase):
 
     def test_minigraph_default_vxlan(self):
         argument = ['-m', self.sample_graph_deployment_id, '-p', self.port_config, '-v', "VXLAN_TUNNEL"]
-        output = self.run_script(argument, False, False, True)
+        output = self.run_script(argument, False, False)
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict("{'tunnel_v4': {'src_ip': '10.1.0.32'}}")
@@ -499,7 +496,7 @@ class TestCfgGen(TestCase):
 
     def test_minigraph_default_vnet(self):
         argument = ['-m', self.sample_graph_deployment_id, '-p', self.port_config, '-v', "VNET"]
-        output = self.run_script(argument, False, False, True)
+        output = self.run_script(argument, False, False)
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict("{'Vnet-default': {'vxlan_tunnel': 'tunnel_v4', 'scope': 'default', 'vni': 8000}}")


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Create Vxlan and Vnet default configs as below for certain cases:

```
"VNET": {
    "Vnet-default": {
        "scope": "default",
        "vni": "8000",
        "vxlan_tunnel": "Tunnel-default"
    }
},
"VXLAN_TUNNEL": {
    "Tunnel-default": {
        "src_ip": "10.1.0.32"
    }
},
```
MSFT ADO - 24263117

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

