### PR TITLE
[platform] Add empty get_transceiver_status() and get_transceiver_pm(…

### DIFF
--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/sonic_platform/sfp.py
@@ -851,6 +851,12 @@ class Sfp(SfpBase):
         else:
             return None
 
+    def get_transceiver_status(self):
+        return {}
+
+    def get_transceiver_pm(self):
+        return {}
+
     def get_reset_status(self):
         """
         Retrieves the reset status of SFP

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/sonic_platform/sfp.py
@@ -851,6 +851,12 @@ class Sfp(SfpBase):
         else:
             return None
 
+    def get_transceiver_status(self):
+        return {}
+
+    def get_transceiver_pm(self):
+        return {}
+
     def get_reset_status(self):
         """
         Retrieves the reset status of SFP

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/sonic_platform/sfp.py
@@ -881,6 +881,12 @@ class Sfp(SfpBase):
         else:
             return None
 
+    def get_transceiver_status(self):
+        return {}
+
+    def get_transceiver_pm(self):
+        return {}
+
     def get_reset_status(self):
         """
         Retrieves the reset status of SFP

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/sonic_platform/sfp.py
@@ -881,6 +881,12 @@ class Sfp(SfpBase):
         else:
             return None
 
+    def get_transceiver_status(self):
+        return {}
+
+    def get_transceiver_pm(self):
+        return {}
+
     def get_reset_status(self):
         """
         Retrieves the reset status of SFP

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/sonic_platform/sfp.py
@@ -881,6 +881,12 @@ class Sfp(SfpBase):
         else:
             return None
 
+    def get_transceiver_status(self):
+        return {}
+
+    def get_transceiver_pm(self):
+        return {}
+
     def get_reset_status(self):
         """
         Retrieves the reset status of SFP

--- a/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/sonic_platform/sfp.py
@@ -1087,7 +1087,6 @@ class Sfp(SfpBase):
 
         return transceiver_dom_info_dict
 
-
     def get_transceiver_threshold_info(self):
         """
         Retrieves transceiver threshold info of this SFP
@@ -1263,6 +1262,12 @@ class Sfp(SfpBase):
             transceiver_dom_threshold_info_dict['rxpowerlowwarning'] = dom_module_threshold_data['data']['RXPowerLowWarning']['value']
 
         return transceiver_dom_threshold_info_dict
+
+    def get_transceiver_status(self):
+        return {}
+
+    def get_transceiver_pm(self):
+        return {}
 
     def get_reset_status(self):
         """


### PR DESCRIPTION
…) in sfp.py for Quanta platforms

Signed-off-by: roberthong-qct <10606901@qcttw.com>

#### Why I did it
xcvrd calls these 2 APIs but they are not implemented in Quanta's sfp.py

#### How I did it
Add the APIs that return an empty dictionary since CMIS type is not supported

#### How to verify it
xcvrd and related commands such as "show interfaces transceiver presence" will work normally.


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ x] 202211

#### Description for the changelog
Add the APIs to adapt to the changes in xcvrd

