### PR TITLE
Fix sonic-slave-* build errors about sudo command not found

### DIFF
--- a/scripts/run_with_retry
+++ b/scripts/run_with_retry
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 run_with_retry(){
+    # set default value and change invalid param input to 0
     (( SONIC_BUILD_RETRY_COUNT > 0 )) || SONIC_BUILD_RETRY_COUNT=0
+    (( SONIC_BUILD_RETRY_INTERVAL > 0 )) || SONIC_BUILD_RETRY_INTERVAL=0
     [[ "$*" == "" ]] && { echo "run_with_retry: input command can't be empty." 1>&2;exit 1; }
     for ((i=0; i<=$SONIC_BUILD_RETRY_COUNT; i++))
     do

--- a/scripts/run_with_retry
+++ b/scripts/run_with_retry
@@ -3,7 +3,7 @@
 run_with_retry(){
     # set default value and change invalid param input to 0
     (( SONIC_BUILD_RETRY_COUNT > 0 )) || SONIC_BUILD_RETRY_COUNT=0
-    (( SONIC_BUILD_RETRY_INTERVAL > 0 )) || SONIC_BUILD_RETRY_INTERVAL=0
+    (( SONIC_BUILD_RETRY_INTERVAL > 0 )) || SONIC_BUILD_RETRY_INTERVAL=600
     [[ "$*" == "" ]] && { echo "run_with_retry: input command can't be empty." 1>&2;exit 1; }
     for ((i=0; i<=$SONIC_BUILD_RETRY_COUNT; i++))
     do

--- a/scripts/run_with_retry
+++ b/scripts/run_with_retry
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 run_with_retry(){
-    [ "$SONIC_BUILD_RETRY_COUNT" -gt 0 ] || SONIC_BUILD_RETRY_COUNT=0
+    (( SONIC_BUILD_RETRY_COUNT > 0 )) || SONIC_BUILD_RETRY_COUNT=0
     [[ "$*" == "" ]] && { echo "run_with_retry: input command can't be empty." 1>&2;exit 1; }
     for ((i=0; i<=$SONIC_BUILD_RETRY_COUNT; i++))
     do

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -15,25 +15,26 @@ REPR_MIRROR_URL_PATTERN='http:\/\/packages.trafficmanager.net\/'
 DPKG_INSTALLTION_LOCK_FILE=/tmp/.dpkg_installation.lock
 
 . $BUILDINFO_PATH/config/buildinfo.config
-if [ -e /vcache ]; then
-	PKG_CACHE_PATH=/vcache/${IMAGENAME}
-else
-	PKG_CACHE_PATH=/sonic/target/vcache/${IMAGENAME}
-fi
-PKG_CACHE_FILE_NAME=${PKG_CACHE_PATH}/cache.tgz
-sudo chown $USER $(dirname $PKG_CACHE_PATH)
-mkdir -p ${PKG_CACHE_PATH}
-
-. ${BUILDINFO_PATH}/scripts/utils.sh
-
-
-URL_PREFIX=$(echo "${PACKAGE_URL_PREFIX}" | sed -E "s#(//[^/]*/).*#\1#")
 
 if [ "$(whoami)" != "root" ] && [ -n "$(which sudo)" ];then
     SUDO=sudo
 else
     SUDO=''
 fi
+
+if [ -e /vcache ]; then
+	PKG_CACHE_PATH=/vcache/${IMAGENAME}
+else
+	PKG_CACHE_PATH=/sonic/target/vcache/${IMAGENAME}
+fi
+PKG_CACHE_FILE_NAME=${PKG_CACHE_PATH}/cache.tgz
+$SUDO chown $USER $(dirname $PKG_CACHE_PATH)
+mkdir -p ${PKG_CACHE_PATH}
+
+. ${BUILDINFO_PATH}/scripts/utils.sh
+
+
+URL_PREFIX=$(echo "${PACKAGE_URL_PREFIX}" | sed -E "s#(//[^/]*/).*#\1#")
 
 log_err()
 {

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -28,8 +28,8 @@ else
 	PKG_CACHE_PATH=/sonic/target/vcache/${IMAGENAME}
 fi
 PKG_CACHE_FILE_NAME=${PKG_CACHE_PATH}/cache.tgz
-$SUDO chown $USER $(dirname $PKG_CACHE_PATH)
-mkdir -p ${PKG_CACHE_PATH}
+$SUDO mkdir -p ${PKG_CACHE_PATH}
+$SUDO chown $USER $PKG_CACHE_PATH
 
 . ${BUILDINFO_PATH}/scripts/utils.sh
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
issue https://github.com/sonic-net/sonic-buildimage/issues/13395
1. Fix a bug about sudo failure.
```
/usr/local/share/buildinfo/scripts/buildinfo_base.sh: line 24: sudo: command not found
```
2. Fix an issue about warning message.
```
./scripts/run_with_retry: line 4: [: : integer expression expected
```
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

