### PR TITLE
[202012][PATCH]: Update FRR patch 0009 to avoid inappropriate error messages

### DIFF
--- a/src/sonic-frr/patch/0009-ignore-route-from-default-table.patch
+++ b/src/sonic-frr/patch/0009-ignore-route-from-default-table.patch
@@ -1,15 +1,42 @@
-From 96dadc6719dafdd7d58e715f59e0d1a8edc3d58f Mon Sep 17 00:00:00 2001
-From: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>
-Date: Wed, 7 Sep 2022 23:59:03 +0000
-Subject: [PATCH] ignore route from default table
+commit 8b78a43ba243df281f2096a84893ad87cb2a79ff
+Author: Stephen Xu <stexu@linkedin.com>
+Date:   Wed Nov 16 16:07:37 2022 -0500
 
-Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>
----
- zebra/zebra_fpm_netlink.c | 8 ++++++++
- 1 file changed, 8 insertions(+)
+    [PATCH] ignore route from default table
 
+    Signed-off-by: Stephen Xu <stexu@linkedin.com>
+
+diff --git a/zebra/zebra_fpm.c b/zebra/zebra_fpm.c
+index 43958fdfd..de7e246d4 100644
+--- a/zebra/zebra_fpm.c
++++ b/zebra/zebra_fpm.c
+@@ -25,6 +25,7 @@
+ 
+ #include "log.h"
+ #include "libfrr.h"
++#include "rib.h"
+ #include "stream.h"
+ #include "thread.h"
+ #include "network.h"
+@@ -1016,8 +1017,15 @@ static int zfpm_build_route_updates(void)
+ 				else
+ 					zfpm_g->stats.route_dels++;
+ 			} else {
+-				zlog_err("%s: Encoding Prefix: %pRN No valid nexthops",
+-					 __func__, dest->rnode);
++				struct rib_table_info *table_info =
++				    rib_table_info(rib_dest_table(dest));
++				if (table_info && table_info->table_id == RT_TABLE_DEFAULT) {
++					zfpm_debug("%s: Skip encoding default table prefix: %pRN",
++						   __func__, dest->rnode);
++				} else {
++					zlog_err("%s: Encoding Prefix: %pRN No valid nexthops",
++						 __func__, dest->rnode);
++				}
+ 			}
+ 		}
+ 
 diff --git a/zebra/zebra_fpm_netlink.c b/zebra/zebra_fpm_netlink.c
-index 60ea7f97e..c6a2edf03 100644
 --- a/zebra/zebra_fpm_netlink.c
 +++ b/zebra/zebra_fpm_netlink.c
 @@ -284,6 +284,14 @@ static int netlink_route_info_fill(struct netlink_route_info *ri, int cmd,


### PR DESCRIPTION
…(#12912)

Why I did it
As described in detail in #12753, the current FRR patch 0009-ignore-route-from-default-table.patch is causing unwanted FRR/zebra error logs. This change gets rid of the error messages for routes from kernel default table while these routes are ignored in prefix encoding.

How I did it
This fix updates the original 0009 patch by checking if the routes are from table default before printing the error logs. The original patch checks the same condition and ignores the routes from table default in prefix encoding.

How to verify it
Follow the steps to repro as described in #12753.
Also verify the test case ipfwd/test_nhop_count.py no longer fails due to the error messages.

Signed-off-by: Stephen Xu <stexu@linkedin.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Resolve cherry-pick conflict for https://github.com/sonic-net/sonic-buildimage/pull/12912

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

