### PR TITLE
[Celestica DX010] fix fan drawer and watchdog platform testcase issues

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/fan_drawer.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/fan_drawer.py
@@ -106,3 +106,13 @@ class FanDrawer(FanDrawerBase):
             bool: True if it is replaceable.
         """
         return True
+
+    def get_maximum_consumed_power(self):
+        """
+        Retrives the maximum power drawn by Fan Drawer
+
+        Returns:
+            A float, with value of the maximum consumable power of the
+            component.
+        """
+        return 33.60

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/watchdog.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/watchdog.py
@@ -135,7 +135,7 @@ class Watchdog(WatchdogBase):
         ret = WDT_COMMON_ERROR
         if seconds < 0:
             return ret
-        if seconds > 16779:
+        if seconds > 16777:
             return ret
 
 


### PR DESCRIPTION
#### Why I did it
fix DX010 fan drawer and watchdog platform test case failure issues

#### How I did it
1. Add fan_drawer get_maximum_consumed_power support
2. Adjust maximum watchdog timeout value check

#### How to verify it
Run test_fan_drawer and test_watchdog test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

