### PR TITLE
[device/arista] Reduce SDK stat polling freq in DNX devices

### DIFF
--- a/device/arista/x86_64-arista_7280cr3_32d4/Arista-7280CR3-C32D4/jr2-a7280cr3-32d4-32x100G+4x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32d4/Arista-7280CR3-C32D4/jr2-a7280cr3-32d4-32x100G+4x400G.config.bcm
@@ -273,7 +273,7 @@ appl_enable_intr_init.BCM8869X=1
 polled_irq_mode.BCM8869X=0
 polled_irq_delay.BCM8869X=1000
 
-bcm_stat_interval.BCM8869X=1000
+bcm_stat_interval.BCM8869X=1000000
 
 mem_cache_enable_ecc.BCM8869X=1
 mem_cache_enable_parity.BCM8869X=1

--- a/device/arista/x86_64-arista_7280cr3_32d4/Arista-7280CR3-C40/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32d4/Arista-7280CR3-C40/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -276,7 +276,7 @@ appl_enable_intr_init.BCM8869X=1
 polled_irq_mode.BCM8869X=0
 polled_irq_delay.BCM8869X=1000
 
-bcm_stat_interval.BCM8869X=1000
+bcm_stat_interval.BCM8869X=1000000
 
 mem_cache_enable_ecc.BCM8869X=1
 mem_cache_enable_parity.BCM8869X=1

--- a/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C28S8/jr2-a7280cr3-32p4-28x100G-8x10G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C28S8/jr2-a7280cr3-32p4-28x100G-8x10G.config.bcm
@@ -272,7 +272,7 @@ appl_enable_intr_init.BCM8869X=1
 polled_irq_mode.BCM8869X=0
 polled_irq_delay.BCM8869X=1000
 
-bcm_stat_interval.BCM8869X=1000
+bcm_stat_interval.BCM8869X=1000000
 
 mem_cache_enable_ecc.BCM8869X=1
 mem_cache_enable_parity.BCM8869X=1

--- a/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C32P4/jr2-a7280cr3-32p4-32x100G+4x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C32P4/jr2-a7280cr3-32p4-32x100G+4x400G.config.bcm
@@ -273,7 +273,7 @@ appl_enable_intr_init.BCM8869X=1
 polled_irq_mode.BCM8869X=0
 polled_irq_delay.BCM8869X=1000
 
-bcm_stat_interval.BCM8869X=1000
+bcm_stat_interval.BCM8869X=1000000
 
 mem_cache_enable_ecc.BCM8869X=1
 mem_cache_enable_parity.BCM8869X=1

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -766,7 +766,7 @@ appl_enable_intr_init.BCM8869X=1
 polled_irq_mode.BCM8869X=0
 polled_irq_delay.BCM8869X=1000
 
-bcm_stat_interval.BCM8869X=1000
+bcm_stat_interval.BCM8869X=1000000
 
 mem_cache_enable_ecc.BCM8869X=1
 mem_cache_enable_parity.BCM8869X=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -639,7 +639,7 @@ polled_irq_mode=0
 polled_irq_delay=1000
 
 # reduce the CPU load over adapter (caused by counter thread)
-bcm_stat_interval=1000
+bcm_stat_interval=1000000
 
 # shadow memory
 mem_cache_enable_ecc=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -639,7 +639,7 @@ polled_irq_mode=0
 polled_irq_delay=1000
 
 # reduce the CPU load over adapter (caused by counter thread)
-bcm_stat_interval=1000
+bcm_stat_interval=1000000
 
 # shadow memory
 mem_cache_enable_ecc=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -657,7 +657,7 @@ polled_irq_mode=0
 polled_irq_delay=1000
 
 # reduce the CPU load over adapter (caused by counter thread)
-bcm_stat_interval=1000
+bcm_stat_interval=1000000
 
 # shadow memory
 mem_cache_enable_ecc=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -657,7 +657,7 @@ polled_irq_mode=0
 polled_irq_delay=1000
 
 # reduce the CPU load over adapter (caused by counter thread)
-bcm_stat_interval=1000
+bcm_stat_interval=1000000
 
 # shadow memory
 mem_cache_enable_ecc=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -639,7 +639,7 @@ polled_irq_mode=0
 polled_irq_delay=1000
 
 # reduce the CPU load over adapter (caused by counter thread)
-bcm_stat_interval=1000
+bcm_stat_interval=1000000
 
 # shadow memory
 mem_cache_enable_ecc=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -639,7 +639,7 @@ polled_irq_mode=0
 polled_irq_delay=1000
 
 # reduce the CPU load over adapter (caused by counter thread)
-bcm_stat_interval=1000
+bcm_stat_interval=1000000
 
 # shadow memory
 mem_cache_enable_ecc=1


### PR DESCRIPTION
Earlier the SDK stat polling was erroneously set to once every msec which is far more frequent than required by SWSS. The new setting, which is consistent with other vendor SKUs, is once a second. The net result is reduced CPU MHz by syncd.

#### Why I did it
To address https://github.com/aristanetworks/sonic/issues/59

#### How I did it
Updated BCM SOC property `bcm_stat_interval` accordingly. 

#### How to verify it
Loaded the image and checked MHz usage with `top`

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
