### PR TITLE
[202205]Update SAI version to 7.1.32.4 in DMZ

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
-LIBSAIBCM_XGS_VERSION = 7.1.31.4
-LIBSAIBCM_DNX_VERSION = 7.1.31.4
-LIBSAIBCM_BRANCH_NAME = REL_7.0_202205
-LIBSAIBCM_XGS_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/bcmsai/$(LIBSAIBCM_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)"
-LIBSAIBCM_DNX_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/bcmsai/$(LIBSAIBCM_BRANCH_NAME)/$(LIBSAIBCM_DNX_VERSION)"
+LIBSAIBCM_XGS_VERSION = 7.1.32.4
+LIBSAIBCM_DNX_VERSION = 7.1.32.4
+LIBSAIBCM_BRANCH_NAME = SAI_7.1.0_GA
+LIBSAIBCM_XGS_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/sai-broadcom/$(LIBSAIBCM_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)"
+LIBSAIBCM_DNX_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/sai-broadcom/$(LIBSAIBCM_BRANCH_NAME)/$(LIBSAIBCM_DNX_VERSION)"
 
 BRCM_XGS_SAI = libsaibcm_$(LIBSAIBCM_XGS_VERSION)_amd64.deb
 $(BRCM_XGS_SAI)_URL = "$(LIBSAIBCM_XGS_URL_PREFIX)/$(BRCM_XGS_SAI)"

--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
 LIBSAIBCM_XGS_VERSION = 7.1.32.4
 LIBSAIBCM_DNX_VERSION = 7.1.32.4
 LIBSAIBCM_BRANCH_NAME = SAI_7.1.0_GA
-LIBSAIBCM_XGS_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/sai-broadcom/$(LIBSAIBCM_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)"
-LIBSAIBCM_DNX_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/sai-broadcom/$(LIBSAIBCM_BRANCH_NAME)/$(LIBSAIBCM_DNX_VERSION)"
+LIBSAIBCM_XGS_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/sai-broadcom/$(LIBSAIBCM_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)/xgs"
+LIBSAIBCM_DNX_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/sai-broadcom/$(LIBSAIBCM_BRANCH_NAME)/$(LIBSAIBCM_DNX_VERSION)/dnx"
 
 BRCM_XGS_SAI = libsaibcm_$(LIBSAIBCM_XGS_VERSION)_amd64.deb
 $(BRCM_XGS_SAI)_URL = "$(LIBSAIBCM_XGS_URL_PREFIX)/$(BRCM_XGS_SAI)"


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Update to 7.1.32.4 with the DMZ repo releases
Fix issues
JIRA# SONIC-69367
Issue Summary: DSCP to TC mapping incorrect for LAG ports. Root Cause: QOS Profile was not assigned during LAG LIF creation. Fix Description: Called API to set the DSCP map on AC LIF of LAG.

JIRA# SONIC-70001
Issue Summary: Crash with stats polling queries SAI_PORT_STAT_IF_IN_DISCARDS for fabric ports. Root Cause: SAI_PORT_STAT_IF_IN_DISCARDS is not applicable for fabric ports, caused crash. Fix Description: Return error when SAI_PORT_STAT_IF_IN_DISCARDS is queried on fabric ports.


#### How I did it
Backport fix
Updated SAI code with the fixes above.

#### How to verify it
Run the SONiC and SAI test with the SAI pipeline.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

