### PR TITLE
SNMP Default Contact addition to configDB

### DIFF
--- a/dockers/docker-snmp/snmp_yml_to_configdb.py
+++ b/dockers/docker-snmp/snmp_yml_to_configdb.py
@@ -54,3 +54,9 @@ if yaml_snmp_info.get('snmp_location'):
 else:
     logger.log_info('snmp_location does not exist in snmp.yml file')
     sys.exit(1)
+if yaml_snmp_info.get('snmp_contact'):
+    if 'CONTACT' not in snmp_general_keys:
+        contact_info = yaml_snmp_info['snmp_contact'].split()
+        contact_name = contact_info[0]
+        contact_email = contact_info[1]
+        db.set_entry('SNMP', 'CONTACT', {contact_name : contact_email})

--- a/files/image_config/snmp/snmp.yml
+++ b/files/image_config/snmp/snmp.yml
@@ -1,2 +1,3 @@
 snmp_rocommunity: public
 snmp_location: public
+snmp_contact: SONiC-team <sonicproject@googlegroups.com>


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
SNMP Default contact value is added as `sysContact     Azure Cloud Switch vteam <linuxnetdev@microsoft.com>` in snmpd.conf during container bringup , but not updated in configDB . This creates a discrepancy between `snmpget` and `show runningconfiguration snmp` output. Hence added common default SNMP contact value.

#### How I did it
Added the default SNMP Contact value in snmp.yml and parsed it via snmp_yml_to_configdb.py to add it to configDB

#### How to verify it
Check `show runningconfiguration snmp` , `snmpget `and `/etc/snmp/snmpd.conf` in snmp container for default values
```
admin@sonic:~$ show runningconfiguration snmp
Location
----------
public


SNMP_CONTACT    SNMP_CONTACT_EMAIL
--------------  -------------------------------
SONiC-team      <sonicproject@googlegroups.com>


Community String    Community Type
------------------  ----------------
public              RO


User    Permission Type    Type    Auth Type    Auth Password    Encryption Type    Encryption Password
------  -----------------  ------  -----------  ---------------  -----------------  ---------------------
admin@sonic:~$
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
SNMP Default Contact addition to configDB via snmp.yml


#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

