### PR TITLE
[Mellanox] Add ASIC simulation version tag to fw.mk 

### DIFF
--- a/platform/mellanox/fw.mk
+++ b/platform/mellanox/fw.mk
@@ -21,6 +21,8 @@ MLNX_FW_BASE_PATH = $(MLNX_SDK_BASE_PATH)
 # Place an URL here to FW if you want to download FW instead
 MLNX_FW_BASE_URL =
 
+SIMX_VERSION = 5.1-0006
+
 ifneq ($(MLNX_FW_BASE_URL), )
 FW_FROM_URL = y
 else

--- a/platform/mellanox/fw.mk
+++ b/platform/mellanox/fw.mk
@@ -21,7 +21,7 @@ MLNX_FW_BASE_PATH = $(MLNX_SDK_BASE_PATH)
 # Place an URL here to FW if you want to download FW instead
 MLNX_FW_BASE_URL =
 
-SIMX_VERSION = 5.1-0006
+SIMX_VERSION = 5.1-1065
 
 ifneq ($(MLNX_FW_BASE_URL), )
 FW_FROM_URL = y


### PR DESCRIPTION
Signed-off-by: dprital <drorp@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Add SIMX version tag to fw.mk file

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

