### PR TITLE
[dualtor][active-active] changing the default value of config knob for killing `radv` to be `True`

### DIFF
--- a/files/scripts/service_mgmt.sh
+++ b/files/scripts/service_mgmt.sh
@@ -40,7 +40,7 @@ function check_redundant_type()
         ACTIVE_ACTIVE="false"
     fi
     CONFIG_KNOB=`$SONIC_DB_CLI CONFIG_DB hget "MUX_LINKMGR|SERVICE_MGMT" kill_radv`
-    if [[ x"$CONFIG_KNOB" != x"True" ]]; then
+    if [[ x"$CONFIG_KNOB" == x"False" ]]; then
         ACTIVE_ACTIVE='false'
     fi 
     debug "DEVICE_SUBTYPE: ${DEVICE_SUBTYPE}, CONFIG_KNOB: ${CONFIG_KNOB}"


### PR DESCRIPTION
Changing the default config knob value to be `True` for killing `radv`, due to the reasons below: 

* Killing RADV is to prevent sending the "cease to be advertising interface" protocol packet.
* [RFC 4861](https://www.rfc-editor.org/rfc/rfc4861) says this ceasing packet as "should" instead of "must", considering that it's fatal to not do this. 
* In active-active scenario, host side might have difficulty distinguish if the "cease to be advertising interface" is for the last interface leaving.

>   [6.2.5](https://www.rfc-editor.org/rfc/rfc4861#section-6.2.5).  Ceasing To Be an Advertising Interface
> 
>   - shutting down the system.
> 
>    In such cases, the router SHOULD transmit one or more (but not more
>    than MAX_FINAL_RTR_ADVERTISEMENTS) final multicast Router
>    Advertisements on the interface with a Router Lifetime field of zero.
>    In the case of a router becoming a host, the system SHOULD also
>    depart from the all-routers IP multicast group on all interfaces on
>    which the router supports IP multicast (whether or not they had been
>    advertising interfaces).  In addition, the host MUST ensure that
>    subsequent Neighbor Advertisement messages sent from the interface
>    have the Router flag set to zero. 

sign-off: Jing Zhang zhangjing@microsoft.com 
