### PR TITLE
Issue # 2636 : Midstone-100x & Silverstonex: Increasing the netlink buffer size to p…

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -297,6 +297,12 @@ start() {
     PLATFORM=${PLATFORM:-`$SONIC_CFGGEN -H -v DEVICE_METADATA.localhost.platform`}
 
 
+    SUPPORTS_INCREASED_NETLINK_BUFFER="false"
+    if [ "$PLATFORM" = "x86_64-cel_midstone-100x-r0" ] || \
+           [ "$PLATFORM" = "x86_64-cel_silverstone-x-r0" ]; then
+        SUPPORTS_INCREASED_NETLINK_BUFFER="true"
+    fi
+
     # Parse the device specific asic conf file, if it exists
     ASIC_CONF=/usr/share/sonic/device/$PLATFORM/asic.conf
     if [ -f "$ASIC_CONF" ]; then
@@ -519,6 +525,8 @@ start() {
 {%- endif %}
 {%- if docker_container_name == "swss" %}
         -e ASIC_VENDOR={{ sonic_asic_platform }} \
+        -e platform=$PLATFORM  \
+        -e supports_increased_netlink_buffer=$SUPPORTS_INCREASED_NETLINK_BUFFER \
 {%- endif -%}
 {%- if docker_container_name in ["swss", "syncd"] and enable_asan == "y" %}
         -v /var/log/asan/:/var/log/asan \


### PR DESCRIPTION
…revent message drops in swss layer

<!--

Fixes https://github.com/sonic-net/sonic-swss/issues/2636

-->

#### Why I did it

We need a way increase ntelink buffer size to prevent message drops in swss. This is needs to be done for certain platforms alone.

#### How I did it

Exported new 'env' var to swss docker - "supports_increased_netlink_buffer"

This is currently set only for Midstone & silverstone platforms, in swss code we check this and increase the netlink buffer size. 

#### How to verify it

1) Check the env in swss container. 
2) Run test case mentioned in https://github.com/sonic-net/sonic-swss/issues/2636 and see that no netlink message drop happens. 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

