### PR TITLE
Set owner after restoring counters folder during warmboot

### DIFF
--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -112,6 +112,7 @@ function restore_counters_folder()
     cache_counters_folder="/host/counters"
     if [[ -d $cache_counters_folder ]]; then
         mv $cache_counters_folder /tmp/cache
+        chown -R admin:admin /tmp/cache
     fi
 }
 


### PR DESCRIPTION
Signed-off-by: Oleksandr Kolomeiets <oleksandrx.kolomeiets@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
After warm reboot, `show environment` prints the following error:
`failed to import plugin show.plugins.macsec: [Errno 13] Permission denied: '/tmp/cache/macsec'`

#### How I did it
Set owner back to admin after restoring counters folder.

#### How to verify it
`sudo warm-reboot`, then ensure `show environement` does not print errors.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
Set owner after restoring counters folder during warmboot.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

