### PR TITLE
Add retries mechanism to watchdog init to protect from issue in which watchdog device is not ready on time

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/watchdog.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/watchdog.py
@@ -33,7 +33,7 @@ try:
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
- Global logger class instance
+# Global logger class instance
 logger = Logger()
 
 # watchdog retries workaround for device missing after first install from ONIE on 24xx/2700 switches
@@ -308,7 +308,7 @@ def get_watchdog():
                 logger.log_notice('Found watchdog device {} after {} retries with delay {}'.format(device, iteration, DELAY_BETWEEN_RETRIES))
         if found:
             break
-        logger.log_notice('watchdog device not fount, iteration {}, sleeping {}'.format(iteration, DELAY_BETWEEN_RETRIES))
+        logger.log_error('watchdog device was not found, try #{}, sleeping {}'.format(iteration, DELAY_BETWEEN_RETRIES))
         time.sleep(DELAY_BETWEEN_RETRIES)
 
     if watchdog_main_device_name is None:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
workaround get watchdog failure due to driver not ready on time

#### How I did it
add retries with delay between retries

#### How to verify it
install image from ONIE on an 2700 switch and verify watchdog issue resolved
run service watchdog-control status and verify no service failures

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

