### PR TITLE
arista: Fix platform.json on Wolverine for thermal sensors and SFPs

### DIFF
--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/platform.json
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/platform.json
@@ -21,22 +21,6 @@
                 "controllable": false
             },
             {
-                "name": "Center back",
-                "controllable": false
-            },
-            {
-                "name": "Fap0 core0",
-                "controllable": false
-            },
-            {
-                "name": "Fap0 core1",
-                "controllable": false
-            },
-            {
-                "name": "PCIE",
-                "controllable": false
-            },
-            {
                 "name": "Cpu SBTSI",
                 "controllable": false
             }
@@ -149,42 +133,6 @@
             },
             {
                 "name": "osfp36"
-            },
-            {
-                "name": "osfp37"
-            },
-            {
-                "name": "osfp38"
-            },
-            {
-                "name": "osfp39"
-            },
-            {
-                "name": "osfp40"
-            },
-            {
-                "name": "osfp41"
-            },
-            {
-                "name": "osfp42"
-            },
-            {
-                "name": "osfp43"
-            },
-            {
-                "name": "osfp44"
-            },
-            {
-                "name": "osfp45"
-            },
-            {
-                "name": "osfp46"
-            },
-            {
-                "name": "osfp47"
-            },
-            {
-                "name": "osfp48"
             }
         ]
     },


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The current `platform.json` contains entries for thermals and SFPs that do not exist on Wolverine.

#### How I did it

I removed the incorrect entries.

#### How to verify it

Verify using applicable sonic-mgmt platform API tests.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [X] 202205
- [ ] 202211

This change is required for 202205 sonic-mgmt testing

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

