### PR TITLE
[Dual-ToR] add 'additional_mac' attr to swss vars 

### DIFF
--- a/files/build_templates/swss_vars.j2
+++ b/files/build_templates/swss_vars.j2
@@ -6,5 +6,6 @@
     "asic_id": "{{ DEVICE_METADATA.localhost.asic_id }}",
     "mac": "{{ DEVICE_METADATA.localhost.mac }}",
     "resource_type": "{{ DEVICE_METADATA.localhost.resource_type }}",
-    "synchronous_mode": {% if DEVICE_METADATA.localhost.synchronous_mode == "disable" %}"disable"{% else %}"enable"{% endif %}
+    "synchronous_mode": {% if DEVICE_METADATA.localhost.synchronous_mode == "disable" %}"disable"{% else %}"enable"{% endif %},
+    "additional_mac": {% if DEVICE_METADATA.localhost.type == "ToRRouter" and DEVICE_METADATA.localhost.subtype == "DualToR" %}"enable"{% else %}"disable"{% endif %}
 }


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Need to add additional MAC to VLAN interface on SPC-1. It is impossible on SPC-1, so we just add this additional MAC to FDB table, so forwarding will work.

#### How I did it
Send attr 'additional_mac=enabled' to syncd in order to update sai.profile with **SAI_ADDITIONAL_MAC_ENABLED**

#### How to verify it
apply Dual-ToR configuration on SPC-1
`ansible-playbook -i inventory --limit sonic-switch-1 deploy_minigraph.yml -e dut_minigraph=sonic-switch-1.dualtor.xml -b -v`
No crashes expected

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

