### PR TITLE
[Dual-ToR] add default value for ACL rule for mellanox platform (Standby ToR)

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -133,5 +133,16 @@
             "digits_class": "true",
             "special_class": "true"
         }
+    },
+    "SYSTEM_DEFAULTS" : {
+{%- if include_mux == "y" %}
+        "mux_tunnel_egress_acl": {
+{%- if sonic_asic_platform == "mellanox" %}
+            "status": "enabled"
+{% else %}
+            "status": "disabled"
+{% endif %}
+        }
+{% endif %}
     }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2109,6 +2109,10 @@
         "SYSTEM_DEFAULTS": {
             "tunnel_qos_remap": {
                 "status": "enabled"
+            },
+            "mux_tunnel_egress_acl":
+            {
+                "status": "enabled"
             }
          },
         "LOSSLESS_TRAFFIC_PATTERN": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/system_defaults.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/system_defaults.json
@@ -6,6 +6,10 @@
                     {
                         "name": "tunnel_qos_remap",
                         "status": "enabled"
+                    },
+                    {
+                        "name": "mux_tunnel_egress_acl",
+                        "status": "enabled"
                     }
                 ]
             }
@@ -17,6 +21,10 @@
                 "SYSTEM_DEFAULTS_LIST": [
                     {
                         "name": "tunnel_qos_remap",
+                        "status": "invalid_status"
+                    },
+                    {
+                        "name": "mux_tunnel_egress_acl",
                         "status": "invalid_status"
                     }
                 ]


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Need to add the possibility to choose between dropping packets (using ACL) on ingress or egress in Dual ToR scenario

#### How I did it
Add new attribute "mux_tunnel_ingress_acl" to SYSTEM_DEFAULTS table

#### How to verify it
check that new attribute exists in redis:
admin@sonic:~$ redis-cli -n 4
127.0.0.1:6379[4]> HGETALL SYSTEM_DEFAULTS|mux_tunnel_ingress_acl
1."state"
2."false"

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

