### PR TITLE
[Arista] Increase 720DT-48S varlog size to 2G

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -469,8 +469,7 @@ write_platform_specific_cmdline() {
     local platform="$(cmdline_get platform)"
     local sid="$(cmdline_get sid | sed 's/Ssd$//')"
 
-    # set varlog size to 100MB
-    local varlog_size=100
+    local varlog_size=0
 
     # sonic_mode is set to fixed by default.
     sonic_mode="fixed"
@@ -543,6 +542,7 @@ write_platform_specific_cmdline() {
     fi
     if in_array "$sid" "PikeIslandZ" "PikeIslandZ-F" "PikeIslandZ-2F" "PikeIslandZ-R" "PikeIslandZ-2R"; then
         aboot_machine=arista_720dt_48s
+        varlog_size=2048
     fi
     if [ "$sid" = "BlackhawkT4O" ]; then
         aboot_machine=arista_7050px4_32s
@@ -638,18 +638,20 @@ write_platform_specific_cmdline() {
         read_system_eeprom
     fi
 
-    if [ $flash_size -ge 28000 ]; then
-        varlog_size=4096
-    elif [ $flash_size -gt 4000 ]; then
-        varlog_size=400
-    else
-        varlog_size=256
-        cmdline_add logs_inram=on
-        if [ $flash_size -le 2000 ]; then
-            # enable docker_inram for switches with less than 2G of flash
-            varlog_size=128
-            cmdline_add docker_inram=on
-        fi
+    if [ $varlog_size -eq 0 ]; then
+       if [ $flash_size -ge 28000 ]; then
+           varlog_size=4096
+       elif [ $flash_size -gt 4000 ]; then
+           varlog_size=400
+       else
+           varlog_size=256
+           cmdline_add logs_inram=on
+           if [ $flash_size -le 2000 ]; then
+               # enable docker_inram for switches with less than 2G of flash
+               varlog_size=128
+               cmdline_add docker_inram=on
+           fi
+       fi
     fi
 
     cmdline_add "varlog_size=$varlog_size"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To address error sometimes seen when running sonic-mgmt test_stress_routes.py::test_announce_withdraw_route on 720DT-48S

#### How I did it
Update boot0 logic to set platform specific varlog size for 720DT-48S

#### How to verify it
Verified that /var/log size increased and error is no longer observed when running test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

