### PR TITLE
Add support for platform syncd pre shutdown plugin

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -105,6 +105,11 @@ function stopplatform1() {
     fi
 
     if [[ x$sonic_asic_platform != x"mellanox" ]] || [[ x$TYPE != x"cold" ]]; then
+        # Invoke platform specific pre shutdown routine.
+        PLATFORM=`$SONIC_DB_CLI CONFIG_DB hget 'DEVICE_METADATA|localhost' platform`
+        PLATFORM_PRE_SHUTDOWN="/usr/share/sonic/device/$PLATFORM/plugins/syncd_pre_shutdown.sh"
+        [ -f $PLATFORM_PRE_SHUTDOWN ] && $PLATFORM_PRE_SHUTDOWN start $DEV
+
         debug "${TYPE} shutdown syncd process ..."
         /usr/bin/docker exec -i syncd$DEV /usr/bin/syncd_request_shutdown --${TYPE}
 

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -105,8 +105,11 @@ function stopplatform1() {
     fi
 
     if [[ x$sonic_asic_platform != x"mellanox" ]] || [[ x$TYPE != x"cold" ]]; then
-        # Invoke syncd pre shutdown routine
-        /usr/bin/docker exec -i syncd$DEV /usr/bin/syncd_request_pre_shutdown --${TYPE} > /dev/null
+        # Invoke platform specific pre shutdown routine.
+        PLATFORM=`$SONIC_DB_CLI CONFIG_DB hget 'DEVICE_METADATA|localhost' platform`
+        PLATFORM_PRE_SHUTDOWN="/usr/share/sonic/device/$PLATFORM/plugins/syncd_request_pre_shutdown"
+        [ -f $PLATFORM_PRE_SHUTDOWN ] && \
+            /usr/bin/docker exec -i syncd$DEV /usr/share/sonic/platform/plugins/syncd_request_pre_shutdown --${TYPE}
 
         debug "${TYPE} shutdown syncd process ..."
         /usr/bin/docker exec -i syncd$DEV /usr/bin/syncd_request_shutdown --${TYPE}

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -105,10 +105,8 @@ function stopplatform1() {
     fi
 
     if [[ x$sonic_asic_platform != x"mellanox" ]] || [[ x$TYPE != x"cold" ]]; then
-        # Invoke platform specific pre shutdown routine.
-        PLATFORM=`$SONIC_DB_CLI CONFIG_DB hget 'DEVICE_METADATA|localhost' platform`
-        PLATFORM_PRE_SHUTDOWN="/usr/share/sonic/device/$PLATFORM/plugins/syncd_pre_shutdown.sh"
-        [ -f $PLATFORM_PRE_SHUTDOWN ] && $PLATFORM_PRE_SHUTDOWN start $DEV
+        # Invoke syncd pre shutdown routine
+        /usr/bin/docker exec -i syncd$DEV /usr/bin/syncd_request_pre_shutdown --${TYPE} > /dev/null
 
         debug "${TYPE} shutdown syncd process ..."
         /usr/bin/docker exec -i syncd$DEV /usr/bin/syncd_request_shutdown --${TYPE}


### PR DESCRIPTION
Signed-off-by: anamehra <anamehra@cisco.com>
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Vendor platform may require running platform specific pre-shutdown routine before shutting down the syncd process which runs the SAI and vendor sdk instance.

#### How I did it
Added a platform script hook which will be executed if the plugin script is provided by the platform in device/<platform>/plugins/

#### How to verify it
Add platform plugin script and run systemctl stop syncd<>

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

