### PR TITLE
[buildsystem]: Fix error 'chown: missing operand after'

### DIFF
--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -28,8 +28,7 @@ else
 	PKG_CACHE_PATH=/sonic/target/vcache/${IMAGENAME}
 fi
 PKG_CACHE_FILE_NAME=${PKG_CACHE_PATH}/cache.tgz
-$SUDO mkdir -p ${PKG_CACHE_PATH}
-$SUDO chown $USER $PKG_CACHE_PATH
+mkdir -p ${PKG_CACHE_PATH}
 
 . ${BUILDINFO_PATH}/scripts/utils.sh
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/13395

This fix resolves ownership configuration for `vcache`:
```
Step 24/40 : RUN pip3 install j2cli
 ---> Running in fcc39df62a98
chown: missing operand after '/sonic/target/vcache/docker-base-bullseye'
Try 'chown --help' for more information.
```

Originally the issue was introduced here: https://github.com/sonic-net/sonic-buildimage/pull/13287

#### Why I did it
* To fix ownership configuration

#### How I did it
* Removed redundant stuff

#### How to verify it
* N/A

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
* N/A

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
* N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```