### PR TITLE
[Yang-models] Modify mirror yang model src_port to match CONFIG_DB

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1933,11 +1933,7 @@
                 "direction": "RX",
                 "type": "SPAN",
                 "dst_port": "Ethernet2",
-                "src_port": [
-                    "Ethernet3",
-                    "Ethernet4"
-                ]
-
+                "src_port": "Ethernet3,Ethernet4"
             }
         },
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
@@ -72,10 +72,6 @@
     "MIRROR_ERSPAN_ENTRY_VALID_SRC_PORTCHANNEL": {
         "desc": "Configuring ERSPAN entry with valid source portchannel"
     },
-    "MIRROR_ERSPAN_ENTRY_INVALID_SRC_PORT": {
-        "desc": "Configuring ERSPAN entry with invalid source port",
-        "eStrKey" : "InvalidValue"
-    },
     "MIRROR_SPAN_ENTRY_WITH_VALID_VALUES": {
         "desc": "Configuring SPAN entry with valid source and destination ports"
     },
@@ -89,10 +85,6 @@
     },
     "MIRROR_SPAN_ENTRY_VALID_DST_PORT_CPU": {
         "desc": "Configuring SPAN entry with valid destination port CPU"
-    },
-    "MIRROR_SPAN_ENTRY_INVALID_SRC_PORT": {
-        "desc": "Configuring SPAN entry with invalid destination ports",
-        "eStrKey" : "InvalidValue"
     },
     "MIRROR_SPAN_ENTRY_INVALID_DIRECTION": {
         "desc": "Configuring SPAN entry with invalid direction",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
@@ -316,9 +316,7 @@
                         "gre_type": "0x1234",
                         "dscp": "10",
                         "ttl": "63",
-                        "src_port": [
-                            "Ethernet0"
-                        ]
+                        "src_port": "Ethernet0"
                     }
                 ]
             }
@@ -346,29 +344,7 @@
                         "gre_type": "0x1234",
                         "dscp": "10",
                         "ttl": "63",
-                        "src_port": [
-                            "PortChannel5"
-                        ]
-                    }
-                ]
-            }
-        }
-    },
-    "MIRROR_ERSPAN_ENTRY_INVALID_SRC_PORT": {
-        "sonic-mirror-session:sonic-mirror-session": {
-            "MIRROR_SESSION": {
-                "MIRROR_SESSION_LIST": [
-                    {
-                        "name": "erspan",
-                        "type": "ERSPAN",
-                        "dst_ip": "11.1.1.1",
-                        "src_ip": "10.1.1.1",
-                        "gre_type": "0x1234",
-                        "dscp": "10",
-                        "ttl": "63",
-                        "src_port": [
-                            "Ethernet0"
-                        ]
+                        "src_port": "PortChannel5"
                     }
                 ]
             }
@@ -415,10 +391,7 @@
                         "name": "span",
                         "type": "SPAN",
                         "dst_port": "Ethernet0",
-                        "src_port": [
-                            "Ethernet4",
-                            "Ethernet8"
-                        ],
+                        "src_port": "Ethernet4,Ethernet8",
                         "direction": "RX"
                     }
                 ]
@@ -474,37 +447,6 @@
                         "name": "span",
                         "type": "SPAN",
                         "dst_port": "CPU"
-                    }
-                ]
-            }
-        }
-    },
-    "MIRROR_SPAN_ENTRY_INVALID_SRC_PORT": {
-        "sonic-port:sonic-port": {
-            "sonic-port:PORT": {
-                "PORT_LIST": [
-                    {
-                        "admin_status": "up",
-                        "alias": "eth0",
-                        "description": "Ethernet0",
-                        "lanes": "1",
-                        "mtu": 9000,
-                        "name": "Ethernet0",
-                        "speed": 25000
-                    }
-                ]
-            }
-        },
-        "sonic-mirror-session:sonic-mirror-session": {
-            "MIRROR_SESSION": {
-                "MIRROR_SESSION_LIST": [
-                    {
-                        "name": "span",
-                        "type": "SPAN",
-                        "dst_port": "Ethernet0",
-                        "src_port": [
-                            "Ethernet4"
-                        ]
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -156,7 +156,7 @@ module sonic-mirror-session {
 
                 leaf src_port {
                     type string {
-                        length 1..256;
+                        length 1..2048;
                     }
                     description
                         "Source port configuration for mirroring. Can be configured for both SPAN/ERSPAN.

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -154,14 +154,9 @@ module sonic-mirror-session {
                         "Destination port configuration for port mirroring(SPAN).";
                 }
 
-                leaf-list src_port {
-                    type union {
-                        type leafref {
-                            path "/port:sonic-port/port:PORT/port:PORT_LIST/port:name";
-                        }
-                        type leafref {
-                            path "/lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name";
-                        }
+                leaf src_port {
+                    type string {
+                        length 1..256;
                     }
                     description
                         "Source port configuration for mirroring. Can be configured for both SPAN/ERSPAN.


### PR DESCRIPTION
Fixes Mirror Yang model src_port to match CONFIG_DB

#### Why I did it
Fixes issue https://github.com/sonic-net/sonic-buildimage/issues/12397#issuecomment-1343109874

#### How I did it

#### How to verify it

