### PR TITLE
[chassis][pmon][psud] Fix the supervisorctl stop psud issue on chassis

### DIFF
--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -140,6 +140,9 @@ autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=10
+{% if IS_MODULAR_CHASSIS == 1 %}
+stopwaitsecs=90
+{% endif %}
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% endif %}


### PR DESCRIPTION
#### Why I did it
OC test case: test_pmon_psud_stop_and_start_status fails on the chassis supervisor when the chassis has more than 2 power supplies. This is an intermittent issue. The "SIGTERM' has a default wait time of 10 secs before triggering "SIGKILL", but the process takes about 80 secs to complete when all 12 PSU is present. Resulting in improper completion of shutdown.  Extend the supervisord stop wait time to allow the completion of the shutdown to fixes #13585

#### How I did it
Modify the template docker-pom.supervisord.conf.j2 such that it waits for maximum of 90 seconds for chassis to complete the child threads and finish the psud process completely and execute the __del__ function to remove entries from STATE_DB. 

#### How to verify it
After running the below command the STATE_DB should be empty.
```
admin@supervisor:~$ docker exec pmon supervisorctl stop psud
psud: stopped
admin@supervisor:~$ sonic-db-cli STATE_DB KEYS "PSU_INFO|*"
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

