### PR TITLE
Chassis : PFCWD : Update BRCM SDK counter polling timer from 1sec -> 100 ms 

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/jr2cp-nokia-18x100g-4x25g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/jr2cp-nokia-18x100g-4x25g-config.bcm
@@ -1264,7 +1264,7 @@ phy_tx_polarity_flip_phy143.BCM8885X=0
 polled_irq_delay.BCM8885X=5
 polled_irq_mode.BCM8885X=0
 port_fec_fabric.BCM8885X=7
-bcm_stat_interval.BCM8885X=1000000
+bcm_stat_interval.BCM8885X=100000
 
 
 port_init_cl72_256=0

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/jr2cp-nokia-18x100g-4x25g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/jr2cp-nokia-18x100g-4x25g-config.bcm
@@ -1264,7 +1264,7 @@ phy_tx_polarity_flip_phy143.BCM8885X=0
 polled_irq_delay.BCM8885X=5
 polled_irq_mode.BCM8885X=0
 port_fec_fabric.BCM8885X=7
-bcm_stat_interval.BCM8885X=1000000
+bcm_stat_interval.BCM8885X=100000
 
 
 port_init_cl72_1=0

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
@@ -1265,7 +1265,7 @@ phy_tx_polarity_flip_phy143.BCM8885X=0
 polled_irq_delay.BCM8885X=5
 polled_irq_mode.BCM8885X=0
 port_fec_fabric.BCM8885X=7
-bcm_stat_interval.BCM8885X=1000000
+bcm_stat_interval.BCM8885X=100000
 
 
 port_init_cl72_1=0

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
@@ -1265,7 +1265,7 @@ phy_tx_polarity_flip_phy143.BCM8885X=0
 polled_irq_delay.BCM8885X=5
 polled_irq_mode.BCM8885X=0
 port_fec_fabric.BCM8885X=7
-bcm_stat_interval.BCM8885X=1000000
+bcm_stat_interval.BCM8885X=100000
 
 
 port_init_cl72_1=0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is to fix PFCWD functionality on SONIC chassis. PFCWD detection/recovery wasn't happening always during continuous PFC frames reception. SONIC PFCWD detection logic wasn't triggering since updated counters weren't available during configured detection/restoration time (400 ms).

#### How I did it
Updated SDK counter polling to 100 ms to make updated counter available for SONIC PFCWD logic to consume and trigger recovery logic.

#### How to verify it
Verified this on chassis system.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Chassis : PFCWD : Update BRCM SDK counter polling timer from 1sec -> 100 ms 

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

