### PR TITLE
[DX010 platform] fix dx010 platform testcase issues

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/platform.json
+++ b/device/celestica/x86_64-cel_seastone-r0/platform.json
@@ -1,6 +1,6 @@
 {
     "chassis": {
-        "name": "Celestica-DX010-C32",
+        "name": "DX010",
         "status_led": {
             "controllable": true,
             "colors": ["green", "off"]
@@ -17,6 +17,9 @@
             },
             {
                 "name": "CPLD4"
+            },
+            {
+                "name": "CPLD5"
             },
             {
                 "name": "BIOS"
@@ -123,10 +126,22 @@
                 },
                 "fans": [
                     {
-                        "name": "FAN-1F"
+                        "name": "FAN-1F",
+                        "status_led": {
+                            "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-1R"
+                        "name": "FAN-1R",
+                        "status_led": {
+                            "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
@@ -138,10 +153,22 @@
                 },
                 "fans": [
                     {
-                        "name": "FAN-2F"
+                        "name": "FAN-2F",
+                        "status_led": {
+                            "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-2R"
+                        "name": "FAN-2R",
+                        "status_led": {
+                            "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
@@ -153,10 +180,22 @@
                 },
                 "fans": [
                     {
-                        "name": "FAN-3F"
+                        "name": "FAN-3F",
+                        "status_led": {
+                            "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-3R"
+                        "name": "FAN-3R",
+                        "status_led": {
+                            "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
@@ -168,10 +207,22 @@
                 },
                 "fans": [
                     {
-                        "name": "FAN-4F"
+                        "name": "FAN-4F",
+                        "status_led": {
+                            "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-4R"
+                        "name": "FAN-4R",
+                        "status_led": {
+                            "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
@@ -183,10 +234,22 @@
                 },
                 "fans": [
                     {
-                        "name": "FAN-5F"
+                        "name": "FAN-5F",
+                        "status_led": {
+                            "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-5R"
+                        "name": "FAN-5R",
+                        "status_led": {
+                            "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
+                        }
                     }
                 ]
             }

--- a/device/celestica/x86_64-cel_seastone-r0/platform_components.json
+++ b/device/celestica/x86_64-cel_seastone-r0/platform_components.json
@@ -1,6 +1,6 @@
 {
     "chassis": {
-        "Seastone-DX010": {
+        "DX010": {
             "component": {
                 "CPLD1": {},
                 "CPLD2": {},

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/chassis.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/chassis.py
@@ -269,7 +269,7 @@ class Chassis(ChassisBase):
             Returns:
             string: The name of the device
         """
-        return self._api_helper.hwsku
+        return self._eeprom.get_product_name()
 
     def get_presence(self):
         """

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/eeprom.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/eeprom.py
@@ -131,6 +131,9 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
     def get_eeprom(self):
         return self._valid_tlv(self._eeprom)
 
+    def get_product_name(self):
+        return self._eeprom.get('0x21', NULL)
+
     def get_pn(self):
         return self._eeprom.get('0x22', NULL)
 

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/sfp.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/sfp.py
@@ -2202,3 +2202,16 @@ class Sfp(SfpBase):
             A boolean value, True if replaceable
         """
         return True
+
+    def get_error_description(self):
+        """
+        Retrives the error descriptions of the SFP module
+        Returns:
+            String that represents the current error descriptions of vendor specific errors
+            In case there are multiple errors, they should be joined by '|',
+            like: "Bad EEPROM|Unsupported cable"
+        """
+        if not self.get_presence():
+            return self.SFP_STATUS_UNPLUGGED
+
+        return self.SFP_STATUS_OK


### PR DESCRIPTION
#### Why I did it
1. fix chassis test_set_fans_led case
2. fix chassis get_name case mismatch issue
3. fix fan_drawer test_set_fans_speed
4. fix component test_components test case

#### How I did it
Add corresponding configuration into chassis json file

#### How to verify it
Run platform tests cases to verify these failure cases

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

