### PR TITLE
Set 'origin' and 'AS Path' for T1 SLB routes

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_rm.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_rm.py
@@ -75,11 +75,11 @@ class RouteMapMgr(Manager):
     def __update_rm(self, rm, data):
         cmds = []
         cmds.append("route-map %s permit 100" % ("%s_RM" % rm))
-        cmds.append(" set community %s" % data["community_id"])
-        cmds.append(" set origin incomplete")
         bgp_asn = \
             self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)['localhost']['bgp_asn']
         cmds.append(" set as-path prepend %s %s" % (bgp_asn, bgp_asn))
+        cmds.append(" set community %s" % data["community_id"])
+        cmds.append(" set origin incomplete")
 
         log_debug("BGPRouteMapMgr:: update route-map %s community %s origin incomplete as-path prepend %s %s" % \
                   ("%s_RM" % rm, data["community_id"], bgp_asn, bgp_asn))

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_rm.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_rm.py
@@ -74,14 +74,15 @@ class RouteMapMgr(Manager):
 
     def __update_rm(self, rm, data):
         cmds = []
-        cmds.append("route-map %s permit 100" % ("%s_RM" % rm))
-        bgp_asn = \
-            self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)['localhost']['bgp_asn']
-        cmds.append(" set as-path prepend %s %s" % (bgp_asn, bgp_asn))
-        cmds.append(" set community %s" % data["community_id"])
-        cmds.append(" set origin incomplete")
-
-        log_debug("BGPRouteMapMgr:: update route-map %s community %s origin incomplete as-path prepend %s %s" % \
-                  ("%s_RM" % rm, data["community_id"], bgp_asn, bgp_asn))
-        self.cfg_mgr.push_list(cmds)
+        if rm is "FROM_SDN_SLB_ROUTES":
+            cmds.append("route-map %s permit 100" % ("%s_RM" % rm))
+            bgp_asn = \
+                self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)['localhost']['bgp_asn']
+            cmds.append(" set as-path prepend %s %s" % (bgp_asn, bgp_asn))
+            cmds.append(" set community %s" % data["community_id"])
+            cmds.append(" set origin incomplete")
+            log_debug("BGPRouteMapMgr:: update route-map %s community %s origin incomplete as-path prepend %s %s" % \
+                      ("%s_RM" % rm, data["community_id"], bgp_asn, bgp_asn))
+        if cmds:
+            self.cfg_mgr.push_list(cmds)
         log_debug("BGPRouteMapMgr::Done")

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_rm.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_rm.py
@@ -3,7 +3,7 @@ from swsscommon import swsscommon
 from .log import log_err, log_debug
 
 ROUTE_MAPS = ["FROM_SDN_SLB_ROUTES"]
-FIXED_DEPLOYMENT_ID = '2'
+FROM_SDN_SLB_DEPLOYMENT_ID = '2'
 
 class RouteMapMgr(Manager):
     """This class add route-map when BGP_PROFILE_TABLE in APPL_DB is updated"""
@@ -76,9 +76,9 @@ class RouteMapMgr(Manager):
         if not 'deployment_id_asn_map' in self.constants:
             log_err("BGPRouteMapMgr:: 'deployment_id_asn_map' key is not found in constants")
             return None
-        if FIXED_DEPLOYMENT_ID in self.constants['deployment_id_asn_map']:
-            return self.constants['deployment_id_asn_map'][FIXED_DEPLOYMENT_ID]
-        log_err("BGPRouteMapMgr:: deployment id %s is not found in constants" % (FIXED_DEPLOYMENT_ID))
+        if FROM_SDN_SLB_DEPLOYMENT_ID in self.constants['deployment_id_asn_map']:
+            return self.constants['deployment_id_asn_map'][FROM_SDN_SLB_DEPLOYMENT_ID]
+        log_err("BGPRouteMapMgr:: deployment id %s is not found in constants" % (FROM_SDN_SLB_DEPLOYMENT_ID))
         return None
 
     def __update_rm(self, rm, data):

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_rm.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_rm.py
@@ -74,7 +74,7 @@ class RouteMapMgr(Manager):
 
     def __update_rm(self, rm, data):
         cmds = []
-        if rm is "FROM_SDN_SLB_ROUTES":
+        if rm == "FROM_SDN_SLB_ROUTES":
             cmds.append("route-map %s permit 100" % ("%s_RM" % rm))
             bgp_asn = \
                 self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)['localhost']['bgp_asn']

--- a/src/sonic-bgpcfgd/tests/test_rm.py
+++ b/src/sonic-bgpcfgd/tests/test_rm.py
@@ -38,6 +38,7 @@ def set_del_test(mgr, op, args, expected_ret, expected_cmds):
 
 def test_set_del():
     mgr = constructor()
+    mgr.directory.put("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost", {"bgp_asn": "65100"})
     set_del_test(
         mgr,
         "SET",
@@ -47,7 +48,9 @@ def test_set_del():
         True,
         [
             ["route-map FROM_SDN_SLB_ROUTES_RM permit 100",
-             " set community 1234:1234"]
+             " set as-path prepend 65100 65100",
+             " set community 1234:1234",
+             " set origin incomplete"]
         ]
     )
 

--- a/src/sonic-bgpcfgd/tests/test_rm.py
+++ b/src/sonic-bgpcfgd/tests/test_rm.py
@@ -3,13 +3,23 @@ from bgpcfgd.directory import Directory
 from bgpcfgd.managers_rm import RouteMapMgr
 from swsscommon import swsscommon
 
+
+test_rm_constants = {
+    "deployment_id_asn_map": {
+        "1": 12345,
+        "2": 12346,
+        "3": 12347,
+        "4": 12348,
+    }
+}
+
 def constructor():
     cfg_mgr = MagicMock()
 
     common_objs = {
         'directory': Directory(),
         'cfg_mgr':   cfg_mgr,
-        'constants': {},
+        'constants': test_rm_constants,
     }
 
     mgr = RouteMapMgr(common_objs, "APPL_DB", "BGP_PROFILE_TABLE")
@@ -38,7 +48,6 @@ def set_del_test(mgr, op, args, expected_ret, expected_cmds):
 
 def test_set_del():
     mgr = constructor()
-    mgr.directory.put("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost", {"bgp_asn": "65100"})
     set_del_test(
         mgr,
         "SET",
@@ -48,7 +57,7 @@ def test_set_del():
         True,
         [
             ["route-map FROM_SDN_SLB_ROUTES_RM permit 100",
-             " set as-path prepend 65100 65100",
+             " set as-path prepend 12346 12346",
              " set community 1234:1234",
              " set origin incomplete"]
         ]


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add support for Set 'origin' and 'AS Path' for T1 SLB routes.

When SLB programs routes to T1 (overlay routes), T1 must advertise such routes to match with the existing SLB 'origin' and AS path length. Following changes to be done during T1 advertisement:

'origin' set to 'incomplete' (value 2)
AS path to be appended as "x" + "x" (two prepend) to match the current AS path at T1 layer

#### How I did it
Add origin and as-path prepend for routemap FROM_SDN_SLB_ROUTES.

#### How to verify it
Follow test steps in HLD.
![image](https://user-images.githubusercontent.com/111116206/216543656-2231c4c0-c577-4c35-a6d1-c85a00e74a03.png)
![image](https://user-images.githubusercontent.com/111116206/217301880-332b4189-5b05-42a5-9b1d-bcc24830e833.png)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

