### PR TITLE
[Arista]: Update the brcm configs for 7050dx4_32s and 7050px4_32s

### DIFF
--- a/device/arista/x86_64-arista_7050dx4_32s/Arista-7050DX4-32S/port_config.ini
+++ b/device/arista/x86_64-arista_7050dx4_32s/Arista-7050DX4-32S/port_config.ini
@@ -1,35 +1,35 @@
-# name          lanes                           alias        index  speed
-Ethernet0       1,2,3,4,5,6,7,8                 Ethernet1/1  1      400000
-Ethernet8       9,10,11,12,13,14,15,16          Ethernet2/1  2      400000
-Ethernet16      17,18,19,20,21,22,23,24         Ethernet3/1  3      400000
-Ethernet24      25,26,27,28,29,30,31,32         Ethernet4/1  4      400000
-Ethernet32      33,34,35,36,37,38,39,40         Ethernet5/1  5      400000
-Ethernet40      41,42,43,44,45,46,47,48         Ethernet6/1  6      400000
-Ethernet48      49,50,51,52,53,54,55,56         Ethernet7/1  7      400000
-Ethernet56      57,58,59,60,61,62,63,64         Ethernet8/1  8      400000
-Ethernet64      65,66,67,68,69,70,71,72         Ethernet9/1  9      400000
-Ethernet72      73,74,75,76,77,78,79,80         Ethernet10/1 10     400000
-Ethernet80      81,82,83,84,85,86,87,88         Ethernet11/1 11     400000
-Ethernet88      89,90,91,92,93,94,95,96         Ethernet12/1 12     400000
-Ethernet96      97,98,99,100,101,102,103,104    Ethernet13/1 13     400000
-Ethernet104     105,106,107,108,109,110,111,112 Ethernet14/1 14     400000
-Ethernet112     113,114,115,116,117,118,119,120 Ethernet15/1 15     400000
-Ethernet120     121,122,123,124,125,126,127,128 Ethernet16/1 16     400000
-Ethernet128     129,130,131,132,133,134,135,136 Ethernet17/1 17     400000
-Ethernet136     137,138,139,140,141,142,143,144 Ethernet18/1 18     400000
-Ethernet144     145,146,147,148,149,150,151,152 Ethernet19/1 19     400000
-Ethernet152     153,154,155,156,157,158,159,160 Ethernet20/1 20     400000
-Ethernet160     161,162,163,164,165,166,167,168 Ethernet21/1 21     400000
-Ethernet168     169,170,171,172,173,174,175,176 Ethernet22/1 22     400000
-Ethernet176     177,178,179,180,181,182,183,184 Ethernet23/1 23     400000
-Ethernet184     185,186,187,188,189,190,191,192 Ethernet24/1 24     400000
-Ethernet192     193,194,195,196,197,198,199,200 Ethernet25/1 25     400000
-Ethernet200     201,202,203,204,205,206,207,208 Ethernet26/1 26     400000
-Ethernet208     209,210,211,212,213,214,215,216 Ethernet27/1 27     400000
-Ethernet216     217,218,219,220,221,222,223,224 Ethernet28/1 28     400000
-Ethernet224     225,226,227,228,229,230,231,232 Ethernet29/1 29     400000
-Ethernet232     233,234,235,236,237,238,239,240 Ethernet30/1 30     400000
-Ethernet240     241,242,243,244,245,246,247,248 Ethernet31/1 31     400000
-Ethernet248     249,250,251,252,253,254,255,256 Ethernet32/1 32     400000
-Ethernet256     258                             Ethernet33   33     10000
-Ethernet257     257                             Ethernet34   34     10000
+# name          lanes                           alias        index  speed   fec
+Ethernet0       1,2,3,4,5,6,7,8                 Ethernet1/1  1      400000  rs
+Ethernet8       9,10,11,12,13,14,15,16          Ethernet2/1  2      400000  rs
+Ethernet16      17,18,19,20,21,22,23,24         Ethernet3/1  3      400000  rs
+Ethernet24      25,26,27,28,29,30,31,32         Ethernet4/1  4      400000  rs
+Ethernet32      33,34,35,36,37,38,39,40         Ethernet5/1  5      400000  rs
+Ethernet40      41,42,43,44,45,46,47,48         Ethernet6/1  6      400000  rs
+Ethernet48      49,50,51,52,53,54,55,56         Ethernet7/1  7      400000  rs
+Ethernet56      57,58,59,60,61,62,63,64         Ethernet8/1  8      400000  rs
+Ethernet64      65,66,67,68,69,70,71,72         Ethernet9/1  9      400000  rs
+Ethernet72      73,74,75,76,77,78,79,80         Ethernet10/1 10     400000  rs
+Ethernet80      81,82,83,84,85,86,87,88         Ethernet11/1 11     400000  rs
+Ethernet88      89,90,91,92,93,94,95,96         Ethernet12/1 12     400000  rs
+Ethernet96      97,98,99,100,101,102,103,104    Ethernet13/1 13     400000  rs
+Ethernet104     105,106,107,108,109,110,111,112 Ethernet14/1 14     400000  rs
+Ethernet112     113,114,115,116,117,118,119,120 Ethernet15/1 15     400000  rs
+Ethernet120     121,122,123,124,125,126,127,128 Ethernet16/1 16     400000  rs
+Ethernet128     129,130,131,132,133,134,135,136 Ethernet17/1 17     400000  rs
+Ethernet136     137,138,139,140,141,142,143,144 Ethernet18/1 18     400000  rs
+Ethernet144     145,146,147,148,149,150,151,152 Ethernet19/1 19     400000  rs
+Ethernet152     153,154,155,156,157,158,159,160 Ethernet20/1 20     400000  rs
+Ethernet160     161,162,163,164,165,166,167,168 Ethernet21/1 21     400000  rs
+Ethernet168     169,170,171,172,173,174,175,176 Ethernet22/1 22     400000  rs
+Ethernet176     177,178,179,180,181,182,183,184 Ethernet23/1 23     400000  rs
+Ethernet184     185,186,187,188,189,190,191,192 Ethernet24/1 24     400000  rs
+Ethernet192     193,194,195,196,197,198,199,200 Ethernet25/1 25     400000  rs
+Ethernet200     201,202,203,204,205,206,207,208 Ethernet26/1 26     400000  rs
+Ethernet208     209,210,211,212,213,214,215,216 Ethernet27/1 27     400000  rs
+Ethernet216     217,218,219,220,221,222,223,224 Ethernet28/1 28     400000  rs
+Ethernet224     225,226,227,228,229,230,231,232 Ethernet29/1 29     400000  rs
+Ethernet232     233,234,235,236,237,238,239,240 Ethernet30/1 30     400000  rs
+Ethernet240     241,242,243,244,245,246,247,248 Ethernet31/1 31     400000  rs
+Ethernet248     249,250,251,252,253,254,255,256 Ethernet32/1 32     400000  rs
+Ethernet256     259                             Ethernet33   33     10000   none
+Ethernet257     257                             Ethernet34   34     10000   none

--- a/device/arista/x86_64-arista_7050px4_32s/Arista-7050PX4-32S/port_config.ini
+++ b/device/arista/x86_64-arista_7050px4_32s/Arista-7050PX4-32S/port_config.ini
@@ -1,35 +1,35 @@
-# name          lanes                           alias        index  speed
-Ethernet0       1,2,3,4,5,6,7,8                 Ethernet1/1  1      400000
-Ethernet8       9,10,11,12,13,14,15,16          Ethernet2/1  2      400000
-Ethernet16      17,18,19,20,21,22,23,24         Ethernet3/1  3      400000
-Ethernet24      25,26,27,28,29,30,31,32         Ethernet4/1  4      400000
-Ethernet32      33,34,35,36,37,38,39,40         Ethernet5/1  5      400000
-Ethernet40      41,42,43,44,45,46,47,48         Ethernet6/1  6      400000
-Ethernet48      49,50,51,52,53,54,55,56         Ethernet7/1  7      400000
-Ethernet56      57,58,59,60,61,62,63,64         Ethernet8/1  8      400000
-Ethernet64      65,66,67,68,69,70,71,72         Ethernet9/1  9      400000
-Ethernet72      73,74,75,76,77,78,79,80         Ethernet10/1 10     400000
-Ethernet80      81,82,83,84,85,86,87,88         Ethernet11/1 11     400000
-Ethernet88      89,90,91,92,93,94,95,96         Ethernet12/1 12     400000
-Ethernet96      97,98,99,100,101,102,103,104    Ethernet13/1 13     400000
-Ethernet104     105,106,107,108,109,110,111,112 Ethernet14/1 14     400000
-Ethernet112     113,114,115,116,117,118,119,120 Ethernet15/1 15     400000
-Ethernet120     121,122,123,124,125,126,127,128 Ethernet16/1 16     400000
-Ethernet128     129,130,131,132,133,134,135,136 Ethernet17/1 17     400000
-Ethernet136     137,138,139,140,141,142,143,144 Ethernet18/1 18     400000
-Ethernet144     145,146,147,148,149,150,151,152 Ethernet19/1 19     400000
-Ethernet152     153,154,155,156,157,158,159,160 Ethernet20/1 20     400000
-Ethernet160     161,162,163,164,165,166,167,168 Ethernet21/1 21     400000
-Ethernet168     169,170,171,172,173,174,175,176 Ethernet22/1 22     400000
-Ethernet176     177,178,179,180,181,182,183,184 Ethernet23/1 23     400000
-Ethernet184     185,186,187,188,189,190,191,192 Ethernet24/1 24     400000
-Ethernet192     193,194,195,196,197,198,199,200 Ethernet25/1 25     400000
-Ethernet200     201,202,203,204,205,206,207,208 Ethernet26/1 26     400000
-Ethernet208     209,210,211,212,213,214,215,216 Ethernet27/1 27     400000
-Ethernet216     217,218,219,220,221,222,223,224 Ethernet28/1 28     400000
-Ethernet224     225,226,227,228,229,230,231,232 Ethernet29/1 29     400000
-Ethernet232     233,234,235,236,237,238,239,240 Ethernet30/1 30     400000
-Ethernet240     241,242,243,244,245,246,247,248 Ethernet31/1 31     400000
-Ethernet248     249,250,251,252,253,254,255,256 Ethernet32/1 32     400000
-Ethernet256     258                             Ethernet33   33     10000
-Ethernet257     257                             Ethernet34   34     10000
+# name          lanes                           alias        index  speed   fec
+Ethernet0       1,2,3,4,5,6,7,8                 Ethernet1/1  1      400000  rs
+Ethernet8       9,10,11,12,13,14,15,16          Ethernet2/1  2      400000  rs
+Ethernet16      17,18,19,20,21,22,23,24         Ethernet3/1  3      400000  rs
+Ethernet24      25,26,27,28,29,30,31,32         Ethernet4/1  4      400000  rs
+Ethernet32      33,34,35,36,37,38,39,40         Ethernet5/1  5      400000  rs
+Ethernet40      41,42,43,44,45,46,47,48         Ethernet6/1  6      400000  rs
+Ethernet48      49,50,51,52,53,54,55,56         Ethernet7/1  7      400000  rs
+Ethernet56      57,58,59,60,61,62,63,64         Ethernet8/1  8      400000  rs
+Ethernet64      65,66,67,68,69,70,71,72         Ethernet9/1  9      400000  rs
+Ethernet72      73,74,75,76,77,78,79,80         Ethernet10/1 10     400000  rs
+Ethernet80      81,82,83,84,85,86,87,88         Ethernet11/1 11     400000  rs
+Ethernet88      89,90,91,92,93,94,95,96         Ethernet12/1 12     400000  rs
+Ethernet96      97,98,99,100,101,102,103,104    Ethernet13/1 13     400000  rs
+Ethernet104     105,106,107,108,109,110,111,112 Ethernet14/1 14     400000  rs
+Ethernet112     113,114,115,116,117,118,119,120 Ethernet15/1 15     400000  rs
+Ethernet120     121,122,123,124,125,126,127,128 Ethernet16/1 16     400000  rs
+Ethernet128     129,130,131,132,133,134,135,136 Ethernet17/1 17     400000  rs
+Ethernet136     137,138,139,140,141,142,143,144 Ethernet18/1 18     400000  rs
+Ethernet144     145,146,147,148,149,150,151,152 Ethernet19/1 19     400000  rs
+Ethernet152     153,154,155,156,157,158,159,160 Ethernet20/1 20     400000  rs
+Ethernet160     161,162,163,164,165,166,167,168 Ethernet21/1 21     400000  rs
+Ethernet168     169,170,171,172,173,174,175,176 Ethernet22/1 22     400000  rs
+Ethernet176     177,178,179,180,181,182,183,184 Ethernet23/1 23     400000  rs
+Ethernet184     185,186,187,188,189,190,191,192 Ethernet24/1 24     400000  rs
+Ethernet192     193,194,195,196,197,198,199,200 Ethernet25/1 25     400000  rs
+Ethernet200     201,202,203,204,205,206,207,208 Ethernet26/1 26     400000  rs
+Ethernet208     209,210,211,212,213,214,215,216 Ethernet27/1 27     400000  rs
+Ethernet216     217,218,219,220,221,222,223,224 Ethernet28/1 28     400000  rs
+Ethernet224     225,226,227,228,229,230,231,232 Ethernet29/1 29     400000  rs
+Ethernet232     233,234,235,236,237,238,239,240 Ethernet30/1 30     400000  rs
+Ethernet240     241,242,243,244,245,246,247,248 Ethernet31/1 31     400000  rs
+Ethernet248     249,250,251,252,253,254,255,256 Ethernet32/1 32     400000  rs
+Ethernet256     259                             Ethernet33   33     10000   none
+Ethernet257     257                             Ethernet34   34     10000   none

--- a/device/arista/x86_64-arista_7050px4_32s/Arista-7050PX4-32S/sai.profile
+++ b/device/arista/x86_64-arista_7050px4_32s/Arista-7050PX4-32S/sai.profile
@@ -1,0 +1,2 @@
+SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/td4-a7050px4-32s-32x400G.config.bcm
+SAI_NUM_ECMP_MEMBERS=64

--- a/device/arista/x86_64-arista_7050px4_32s/Arista-7050PX4-32S/td4-a7050px4-32s-32x400G.config.bcm
+++ b/device/arista/x86_64-arista_7050px4_32s/Arista-7050PX4-32S/td4-a7050px4-32s-32x400G.config.bcm
@@ -61,10 +61,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x10542376
-                TX_LANE_MAP: 0x67125304
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0xff
+                RX_LANE_MAP: 0x35240617
+                TX_LANE_MAP: 0x57632401
+                RX_POLARITY_FLIP: 0xaa
+                TX_POLARITY_FLIP: 0x55
             ?
                 PC_PM_ID: 2
                 CORE_INDEX: 0
@@ -73,10 +73,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x31462057
-                TX_LANE_MAP: 0x56237014
-                RX_POLARITY_FLIP: 0xef
-                TX_POLARITY_FLIP: 0xab
+                RX_LANE_MAP: 0x50416372
+                TX_LANE_MAP: 0x76501423
+                RX_POLARITY_FLIP: 0xa2
+                TX_POLARITY_FLIP: 0x51
             ?
                 PC_PM_ID: 3
                 CORE_INDEX: 0
@@ -85,10 +85,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x54137602
-                TX_LANE_MAP: 0x12470356
-                RX_POLARITY_FLIP: 0x00
-                TX_POLARITY_FLIP: 0x01
+                RX_LANE_MAP: 0x43265017
+                TX_LANE_MAP: 0x2134657
+                RX_POLARITY_FLIP: 0x55
+                TX_POLARITY_FLIP: 0xae
             ?
                 PC_PM_ID: 4
                 CORE_INDEX: 0
@@ -97,10 +97,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x62734051
-                TX_LANE_MAP: 0x64327501
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0x7f
+                RX_LANE_MAP: 0x60425371
+                TX_LANE_MAP: 0x74650132
+                RX_POLARITY_FLIP: 0x00
+                TX_POLARITY_FLIP: 0x20
             ?
                 PC_PM_ID: 5
                 CORE_INDEX: 0
@@ -109,10 +109,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x53614072
-                TX_LANE_MAP: 0x12730465
-                RX_POLARITY_FLIP: 0x00
-                TX_POLARITY_FLIP: 0x02
+                RX_LANE_MAP: 0x45617203
+                TX_LANE_MAP: 0x2147563
+                RX_POLARITY_FLIP: 0x55
+                TX_POLARITY_FLIP: 0xa8
             ?
                 PC_PM_ID: 6
                 CORE_INDEX: 0
@@ -121,10 +121,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x2461357
-                TX_LANE_MAP: 0x74136502
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0xf7
+                RX_LANE_MAP: 0x3125647
+                TX_LANE_MAP: 0x65740312
+                RX_POLARITY_FLIP: 0x00
+                TX_POLARITY_FLIP: 0x80
             ?
                 PC_PM_ID: 7
                 CORE_INDEX: 0
@@ -133,10 +133,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x23504671
-                TX_LANE_MAP: 0x2561374
-                RX_POLARITY_FLIP: 0x00
-                TX_POLARITY_FLIP: 0x10
+                RX_LANE_MAP: 0x56407132
+                TX_LANE_MAP: 0x12035476
+                RX_POLARITY_FLIP: 0x55
+                TX_POLARITY_FLIP: 0xab
             ?
                 PC_PM_ID: 8
                 CORE_INDEX: 0
@@ -145,10 +145,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x2461357
-                TX_LANE_MAP: 0x74236501
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0xf7
+                RX_LANE_MAP: 0x3125647
+                TX_LANE_MAP: 0x64750123
+                RX_POLARITY_FLIP: 0x00
+                TX_POLARITY_FLIP: 0x80
             ?
                 PC_PM_ID: 9
                 CORE_INDEX: 0
@@ -157,10 +157,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x67140235
-                TX_LANE_MAP: 0x75316402
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0xf7
+                RX_LANE_MAP: 0x12043576
+                TX_LANE_MAP: 0x65743201
+                RX_POLARITY_FLIP: 0xaa
+                TX_POLARITY_FLIP: 0xd5
             ?
                 PC_PM_ID: 10
                 CORE_INDEX: 0
@@ -169,10 +169,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x46025713
-                TX_LANE_MAP: 0x3541276
-                RX_POLARITY_FLIP: 0x00
-                TX_POLARITY_FLIP: 0x01
+                RX_LANE_MAP: 0x47561203
+                TX_LANE_MAP: 0x13027654
+                RX_POLARITY_FLIP: 0xff
+                TX_POLARITY_FLIP: 0xfb
             ?
                 PC_PM_ID: 11
                 CORE_INDEX: 0
@@ -181,10 +181,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x67140235
-                TX_LANE_MAP: 0x75316402
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0xf7
+                RX_LANE_MAP: 0x12043576
+                TX_LANE_MAP: 0x65743201
+                RX_POLARITY_FLIP: 0xaa
+                TX_POLARITY_FLIP: 0xd5
             ?
                 PC_PM_ID: 12
                 CORE_INDEX: 0
@@ -193,10 +193,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x46025713
-                TX_LANE_MAP: 0x3541276
-                RX_POLARITY_FLIP: 0x00
-                TX_POLARITY_FLIP: 0x01
+                RX_LANE_MAP: 0x47561203
+                TX_LANE_MAP: 0x13027654
+                RX_POLARITY_FLIP: 0xff
+                TX_POLARITY_FLIP: 0xfb
             ?
                 PC_PM_ID: 13
                 CORE_INDEX: 0
@@ -205,10 +205,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x14635027
-                TX_LANE_MAP: 0x30746512
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0x3f
+                RX_LANE_MAP: 0x40165327
+                TX_LANE_MAP: 0x60357214
+                RX_POLARITY_FLIP: 0xaa
+                TX_POLARITY_FLIP: 0x35
             ?
                 PC_PM_ID: 14
                 CORE_INDEX: 0
@@ -217,10 +217,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x46215730
-                TX_LANE_MAP: 0x30561247
-                RX_POLARITY_FLIP: 0x00
-                TX_POLARITY_FLIP: 0xdc
+                RX_LANE_MAP: 0x47563120
+                TX_LANE_MAP: 0x10324756
+                RX_POLARITY_FLIP: 0xff
+                TX_POLARITY_FLIP: 0x0e
             ?
                 PC_PM_ID: 15
                 CORE_INDEX: 0
@@ -229,10 +229,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x20157346
-                TX_LANE_MAP: 0x56237014
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0xab
+                RX_LANE_MAP: 0x21340576
+                TX_LANE_MAP: 0x76502413
+                RX_POLARITY_FLIP: 0xaa
+                TX_POLARITY_FLIP: 0x04
             ?
                 PC_PM_ID: 16
                 CORE_INDEX: 0
@@ -241,10 +241,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x2461357
-                TX_LANE_MAP: 0x67135204
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0xff
+                RX_LANE_MAP: 0x3125647
+                TX_LANE_MAP: 0x57620413
+                RX_POLARITY_FLIP: 0x00
+                TX_POLARITY_FLIP: 0x00
             ?
                 PC_PM_ID: 17
                 CORE_INDEX: 0
@@ -253,10 +253,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x12357046
-                TX_LANE_MAP: 0x56107324
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0xff
+                RX_LANE_MAP: 0x13042576
+                TX_LANE_MAP: 0x76531420
+                RX_POLARITY_FLIP: 0xaa
+                TX_POLARITY_FLIP: 0x55
             ?
                 PC_PM_ID: 18
                 CORE_INDEX: 0
@@ -265,10 +265,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x31462057
-                TX_LANE_MAP: 0x67205134
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0x6d
+                RX_LANE_MAP: 0x30215647
+                TX_LANE_MAP: 0x57613420
+                RX_POLARITY_FLIP: 0x00
+                TX_POLARITY_FLIP: 0x29
             ?
                 PC_PM_ID: 19
                 CORE_INDEX: 0
@@ -277,10 +277,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x57620431
-                TX_LANE_MAP: 0x21670453
-                RX_POLARITY_FLIP: 0x00
-                TX_POLARITY_FLIP: 0x20
+                RX_LANE_MAP: 0x56437201
+                TX_LANE_MAP: 0x1246357
+                RX_POLARITY_FLIP: 0x55
+                TX_POLARITY_FLIP: 0xa2
             ?
                 PC_PM_ID: 20
                 CORE_INDEX: 0
@@ -289,10 +289,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x50271463
-                TX_LANE_MAP: 0x24136705
-                RX_POLARITY_FLIP: 0x96
-                TX_POLARITY_FLIP: 0xff
+                RX_LANE_MAP: 0x54106723
+                TX_LANE_MAP: 0x64270513
+                RX_POLARITY_FLIP: 0x33
+                TX_POLARITY_FLIP: 0x00
             ?
                 PC_PM_ID: 21
                 CORE_INDEX: 0
@@ -301,10 +301,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x63142750
-                TX_LANE_MAP: 0x1652374
-                RX_POLARITY_FLIP: 0x96
-                TX_POLARITY_FLIP: 0x20
+                RX_LANE_MAP: 0x37612450
+                TX_LANE_MAP: 0x21036475
+                RX_POLARITY_FLIP: 0x33
+                TX_POLARITY_FLIP: 0xa2
             ?
                 PC_PM_ID: 22
                 CORE_INDEX: 0
@@ -313,10 +313,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x2461357
-                TX_LANE_MAP: 0x64107325
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0x7f
+                RX_LANE_MAP: 0x3125647
+                TX_LANE_MAP: 0x74632510
+                RX_POLARITY_FLIP: 0x00
+                TX_POLARITY_FLIP: 0x20
             ?
                 PC_PM_ID: 23
                 CORE_INDEX: 0
@@ -325,10 +325,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x63514072
-                TX_LANE_MAP: 0x1652374
-                RX_POLARITY_FLIP: 0x00
-                TX_POLARITY_FLIP: 0x20
+                RX_LANE_MAP: 0x56407132
+                TX_LANE_MAP: 0x21036475
+                RX_POLARITY_FLIP: 0x55
+                TX_POLARITY_FLIP: 0xa2
             ?
                 PC_PM_ID: 24
                 CORE_INDEX: 0
@@ -337,10 +337,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x2461357
-                TX_LANE_MAP: 0x64107325
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0x7f
+                RX_LANE_MAP: 0x3125647
+                TX_LANE_MAP: 0x74632510
+                RX_POLARITY_FLIP: 0x00
+                TX_POLARITY_FLIP: 0x20
             ?
                 PC_PM_ID: 25
                 CORE_INDEX: 0
@@ -349,10 +349,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x27150436
-                TX_LANE_MAP: 0x76125403
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0xbf
+                RX_LANE_MAP: 0x12043576
+                TX_LANE_MAP: 0x56741302
+                RX_POLARITY_FLIP: 0xaa
+                TX_POLARITY_FLIP: 0x15
             ?
                 PC_PM_ID: 26
                 CORE_INDEX: 0
@@ -361,10 +361,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x46025713
-                TX_LANE_MAP: 0x13670452
-                RX_POLARITY_FLIP: 0x00
-                TX_POLARITY_FLIP: 0x20
+                RX_LANE_MAP: 0x47561203
+                TX_LANE_MAP: 0x3145267
+                RX_POLARITY_FLIP: 0xff
+                TX_POLARITY_FLIP: 0xfd
             ?
                 PC_PM_ID: 27
                 CORE_INDEX: 0
@@ -373,10 +373,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x27150436
-                TX_LANE_MAP: 0x76125403
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0xbf
+                RX_LANE_MAP: 0x12043576
+                TX_LANE_MAP: 0x56741302
+                RX_POLARITY_FLIP: 0xaa
+                TX_POLARITY_FLIP: 0x15
             ?
                 PC_PM_ID: 28
                 CORE_INDEX: 0
@@ -385,10 +385,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x46025713
-                TX_LANE_MAP: 0x13560472
-                RX_POLARITY_FLIP: 0x00
-                TX_POLARITY_FLIP: 0x10
+                RX_LANE_MAP: 0x47561203
+                TX_LANE_MAP: 0x3147256
+                RX_POLARITY_FLIP: 0xff
+                TX_POLARITY_FLIP: 0xfe
             ?
                 PC_PM_ID: 29
                 CORE_INDEX: 0
@@ -397,10 +397,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x10536274
-                TX_LANE_MAP: 0x65127403
-                RX_POLARITY_FLIP: 0xdf
-                TX_POLARITY_FLIP: 0x7f
+                RX_LANE_MAP: 0x12053647
+                TX_LANE_MAP: 0x75641302
+                RX_POLARITY_FLIP: 0xaa
+                TX_POLARITY_FLIP: 0x75
             ?
                 PC_PM_ID: 30
                 CORE_INDEX: 0
@@ -409,10 +409,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x75316420
-                TX_LANE_MAP: 0x10742563
-                RX_POLARITY_FLIP: 0x00
-                TX_POLARITY_FLIP: 0x02
+                RX_LANE_MAP: 0x74652130
+                TX_LANE_MAP: 0x20156374
+                RX_POLARITY_FLIP: 0xff
+                TX_POLARITY_FLIP: 0xf7
             ?
                 PC_PM_ID: 31
                 CORE_INDEX: 0
@@ -421,10 +421,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x23547016
-                TX_LANE_MAP: 0x75126430
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0xf4
+                RX_LANE_MAP: 0x10342657
+                TX_LANE_MAP: 0x65741032
+                RX_POLARITY_FLIP: 0xaa
+                TX_POLARITY_FLIP: 0xd3
             ?
                 PC_PM_ID: 32
                 CORE_INDEX: 0
@@ -433,10 +433,10 @@ device:
                 TX_LANE_MAP_AUTO: 0
                 RX_POLARITY_FLIP_AUTO: 0
                 TX_POLARITY_FLIP_AUTO: 0
-                RX_LANE_MAP: 0x40675213
-                TX_LANE_MAP: 0x76042513
-                RX_POLARITY_FLIP: 0xff
-                TX_POLARITY_FLIP: 0xff
+                RX_LANE_MAP: 0x35240617
+                TX_LANE_MAP: 0x26751304
+                RX_POLARITY_FLIP: 0x00
+                TX_POLARITY_FLIP: 0x00
 ...
 ---
 device:


### PR DESCRIPTION
…050px4_32s

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This change updates the config files needed for bringing up ports on Arista 7050dx4_32s and 7050px4_32s

#### How I did it

#### How to verify it
We verified that ports are up in 'show interface status'

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

