### PR TITLE
Revert "[202211][swss.sh] optimize macsec feature state query (#12946)"

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -304,7 +304,7 @@ function check_peer_gbsyncd()
 
 function check_macsec()
 {
-    MACSEC_STATE=`$SONIC_DB_CLI CONFIG_DB hget 'FEATURE|macsec' state`
+    MACSEC_STATE=`show feature status | grep macsec | awk '{print $2}'`
 
     if [[ ${MACSEC_STATE} == 'enabled' ]]; then
         if [ "$DEV" ]; then


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#13509

PR test failed with macsec test, revert this one to take a try.