### PR TITLE
Fix rsyslogd start failed cause by rsyslog.conf is emtpy.

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -44,12 +44,19 @@ function updateSyslogConf()
     fi
     CONTAINER_NAME="$DOCKERNAME"
     TMP_FILE="/tmp/rsyslog.$CONTAINER_NAME.conf"
+    failed="false"
     {%- if docker_container_name == "database" %}
     python -c "import jinja2, os; paths=['/usr/share/sonic/templates']; loader = jinja2.FileSystemLoader(paths); env = jinja2.Environment(loader=loader, trim_blocks=True); template_file='/usr/share/sonic/templates/rsyslog-container.conf.j2'; template = env.get_template(os.path.basename(template_file)); data=template.render({\"target_ip\":\"$TARGET_IP\",\"container_name\":\"$CONTAINER_NAME\"}); print(data)" > $TMP_FILE
     {%- else %}
     sonic-cfggen -d -t /usr/share/sonic/templates/rsyslog-container.conf.j2 -a "{\"target_ip\": \"$TARGET_IP\", \"container_name\": \"$CONTAINER_NAME\" }"  > $TMP_FILE
+    if [ $? -ne 0 ]; then
+      echo "Error: Execute sonic-cfggen failed."
+      failed="true"
+    fi
     {%- endif %}
-    docker cp $TMP_FILE ${DOCKERNAME}:/etc/rsyslog.conf
+    if [ "$failed" == "false" ]; then
+      docker cp $TMP_FILE ${DOCKERNAME}:/etc/rsyslog.conf
+    fi
     rm -rf $TMP_FILE
 }
 function ebtables_config()

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -50,13 +50,11 @@ function updateSyslogConf()
     {%- else %}
     sonic-cfggen -d -t /usr/share/sonic/templates/rsyslog-container.conf.j2 -a "{\"target_ip\": \"$TARGET_IP\", \"container_name\": \"$CONTAINER_NAME\" }"  > $TMP_FILE
     if [ $? -ne 0 ]; then
-      echo "Error: Execute sonic-cfggen failed."
-      failed="true"
+      echo "Error: Execute sonic-cfggen -d failed. Execute without '-d'."
+      sonic-cfggen -t /usr/share/sonic/templates/rsyslog-container.conf.j2 -a "{\"target_ip\": \"$TARGET_IP\", \"container_name\": \"$CONTAINER_NAME\" }"  > $TMP_FILE
     fi
     {%- endif %}
-    if [ "$failed" == "false" ]; then
-      docker cp $TMP_FILE ${DOCKERNAME}:/etc/rsyslog.conf
-    fi
+    docker cp $TMP_FILE ${DOCKERNAME}:/etc/rsyslog.conf
     rm -rf $TMP_FILE
 }
 function ebtables_config()

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -44,7 +44,6 @@ function updateSyslogConf()
     fi
     CONTAINER_NAME="$DOCKERNAME"
     TMP_FILE="/tmp/rsyslog.$CONTAINER_NAME.conf"
-    failed="false"
     {%- if docker_container_name == "database" %}
     python -c "import jinja2, os; paths=['/usr/share/sonic/templates']; loader = jinja2.FileSystemLoader(paths); env = jinja2.Environment(loader=loader, trim_blocks=True); template_file='/usr/share/sonic/templates/rsyslog-container.conf.j2'; template = env.get_template(os.path.basename(template_file)); data=template.render({\"target_ip\":\"$TARGET_IP\",\"container_name\":\"$CONTAINER_NAME\"}); print(data)" > $TMP_FILE
     {%- else %}

--- a/files/image_config/rsyslog/rsyslog-container.conf.j2
+++ b/files/image_config/rsyslog/rsyslog-container.conf.j2
@@ -28,9 +28,13 @@ $ModLoad imuxsock # provides support for local system logging
 
 {% if rate_limit_interval is defined %}
 $SystemLogRateLimitInterval {{ rate_limit_interval }}
+{% else %}
+$SystemLogRateLimitInterval 300
 {% endif %}
 {% if rate_limit_burst is defined %}
 $SystemLogRateLimitBurst {{ rate_limit_burst }}
+{% else %}
+$SystemLogRateLimitBurst 20000
 {% endif %}
 
 #$ModLoad imklog  # provides kernel logging support


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

#### Why I did it

In to-sonic and multi-asic KVM-test, pretest sometimes failed. **Reason is rsyslogd process can not start in teamd container**. Because **rsyslog.conf is empty** caused by **sonic-cfggen execute failed**, and failed log is:

![image](https://user-images.githubusercontent.com/39114813/216872281-17d07a19-2425-4fe4-805b-0fcab12193c9.png)


#### How I did it

If `sonic-cfggen -d` execute failed, execute without `-d` because the template file has the default value.

#### How to verify it

Build image and test it over 40 times, all passed pretest.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

