### PR TITLE
[Edgecore][PDDF/as5835-54x] Support PDDF

### DIFF
--- a/device/accton/x86_64-accton_as5835_54x-r0/pddf/pd-plugin.json
+++ b/device/accton/x86_64-accton_as5835_54x-r0/pddf/pd-plugin.json
@@ -1,0 +1,66 @@
+{
+    
+    "XCVR":
+    {
+        "xcvr_present":
+        {
+           "i2c":
+           {
+               "valmap-SFP28": {"1":true, "0":false },
+               "valmap-QSFP28": {"1":true, "0":false}
+           }
+        }
+    },
+    "PSU":
+    {
+        "psu_present": 
+        {
+            "i2c":
+            {
+                "valmap": { "1":true, "0":false }
+            }
+        },
+
+        "psu_power_good": 
+        {
+            "i2c":
+            {
+                "valmap": { "1": true, "0":false }
+            }
+        },
+
+        "psu_fan_dir":
+        {
+            "i2c":
+            {
+                "valmap": { "F2B":"exhaust", "B2F":"intake" }
+            }
+        },
+
+        "PSU_FAN_MAX_SPEED":"18000"
+    },
+
+    "FAN":
+    {
+        "direction":
+        {
+            "i2c":
+            {
+                "valmap": {"1":"intake", "0":"exhaust"}
+            }
+        },
+
+        "present":
+        {
+            "i2c":
+            {
+                "valmap": {"1":true, "0":false}
+            }
+        },
+        
+        "duty_cycle_to_pwm": "lambda dc: (dc/5)",
+
+        "pwm_to_duty_cycle": "lambda pwm: (pwm*5)"
+    }
+
+}

--- a/device/accton/x86_64-accton_as5835_54x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as5835_54x-r0/pddf/pddf-device.json
@@ -1,0 +1,2819 @@
+{
+    "PLATFORM":
+    {
+        "num_psus":2,
+        "num_fantrays":5,
+        "num_fans_pertray":2,
+        "num_ports":54,
+        "num_temps": 4,
+        "pddf_dev_types":
+        {
+            "description":"AS5835-54X - Below is the list of supported PDDF device types (chip names) for various components. If any component uses some other driver, we will create the client using 'echo <dev-address> <dev-type> > <path>/new_device' method",
+            "CPLD":
+            [
+                "i2c_cpld"
+            ],
+            "PSU":
+            [
+                "psu_eeprom",
+                "psu_pmbus"
+            ],
+            "FAN":
+            [
+                "fan_ctrl",
+                "fan_eeprom"
+            ],
+            "PORT_MODULE":
+            [
+                "pddf_xcvr"
+            ]            
+        },
+        "std_kos":
+        [
+            "i2c-i801",
+            "i2c-ismt",
+            "i2c_dev",
+            "i2c_mux_pca954x",
+            "optoe"
+        ],
+        "pddf_kos":
+        [
+            "pddf_client_module",
+            "pddf_cpld_module",
+            "pddf_cpld_driver",
+            "pddf_mux_module",
+            "pddf_xcvr_module",
+            "pddf_xcvr_driver_module",
+            "pddf_psu_driver_module",
+            "pddf_psu_module",
+            "pddf_fan_driver_module",
+            "pddf_fan_module",
+            "pddf_led_module",
+            "pddf_sysstatus_module"
+        ],
+        "custom_kos":
+        [
+            "pddf_custom_psu"
+        ]
+    
+    },
+
+    "SYSTEM":
+    {
+        "dev_info": {"device_type":"CPU", "device_name":"ROOT_COMPLEX", "device_parent":null},
+        "i2c":
+        {
+            "CONTROLLERS":
+            [ 
+                { "dev_name":"i2c-1", "dev":"SMBUS1" }
+            ]
+        }
+    },
+    
+    "SMBUS1": 
+    {
+        "dev_info": {"device_type": "SMBUS", "device_name": "SMBUS1", "device_parent": "SYSTEM"},
+        "i2c": 
+        {
+            "topo_info": {"dev_addr": "0x1"},
+            "DEVICES": 
+            [
+                {"dev": "EEPROM1"},
+                {"dev": "CPU_CPLD"},
+                {"dev": "MUX1"}
+            ]
+        }
+    },
+  
+    "EEPROM1": 
+    {
+        "dev_info": {"device_type": "EEPROM", "device_name": "EEPROM1", "device_parent": "SMBUS1"},
+        "i2c": 
+        {
+            "topo_info": {"parent_bus": "0x1", "dev_addr": "0x57", "dev_type": "24c02"},
+            "dev_attr": {"access_mode": "BLOCK"},
+            "attr_list": [
+                {"attr_name": "eeprom"}
+            ]
+        }
+    },
+    
+    "CPU_CPLD":
+    {
+        "dev_info": { "device_type":"CPLD", "device_name":"CPU_CPLD", "device_parent":"SMBUS1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1", "dev_addr":"0x65", "dev_type":"i2c_cpld"},
+            "dev_attr": { }
+        }
+    },
+    
+    "MUX1":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX1", "device_parent":"SMBUS1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1", "dev_addr":"0x77", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x2", "idle_state":"-2"},
+             "channel":
+            [
+                { "chn":"0", "dev":"MUX2" },
+                { "chn":"0", "dev":"MUX3" },
+                { "chn":"0", "dev":"MUX4" },
+                { "chn":"1", "dev":"CPLD1" },
+                { "chn":"1", "dev":"CPLD2" },
+                { "chn":"1", "dev":"CPLD3" },
+                { "chn":"1", "dev":"FAN-CTRL" },
+                { "chn":"1", "dev":"MUX5" }
+            ]            
+        }
+    },
+    "MUX2":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX2", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2", "dev_addr":"0x70", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0xa", "idle_state":"-2"},
+            "channel":
+            [
+                { "chn":"1", "dev":"PSU1" },
+                { "chn":"2", "dev":"PSU2" }
+            ]
+        }
+    },
+   
+     "PSU1":
+    {
+        "dev_info": { "device_type":"PSU", "device_name":"PSU1", "device_parent":"MUX2"}, 
+        "dev_attr": { "dev_idx":"1", "num_psu_fans": "1"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"pmbus", "dev":"PSU1-PMBUS" },
+                { "itf":"eeprom", "dev":"PSU1-EEPROM" }
+            ]
+        }
+    },
+
+    "PSU1-PMBUS":
+    {
+        "dev_info": { "device_type":"PSU-PMBUS", "device_name":"PSU1-PMBUS", "device_parent":"MUX2", "virt_parent":"PSU1"},
+        "i2c":
+        {
+            "topo_info":{ "parent_bus":"0xb", "dev_addr":"0x58", "dev_type":"psu_pmbus"}, 
+            "attr_list": 
+            [  
+                { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+                { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x2", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"psu_mfr_id", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+                { "attr_name":"psu_fan_dir", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
+                { "attr_name":"psu_v_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8b", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_i_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_p_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x96", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_fan1_speed_rpm", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x90", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_temp1_input", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8d", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
+            ]
+        }
+    },
+
+    "PSU1-EEPROM":
+    {
+        "dev_info": { "device_type":"PSU-EEPROM", "device_name":"PSU1-EEPROM", "device_parent":"MUX2", "virt_parent":"PSU1"},
+        "i2c":
+        {
+            "topo_info":{ "parent_bus":"0xb", "dev_addr":"0x50", "dev_type":"psu_eeprom"}, 
+            "attr_list": 
+            [  
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"19" }
+            ]
+        }
+    },
+
+    "PSU2":
+    {
+        "dev_info": { "device_type":"PSU", "device_name":"PSU2", "device_parent":"MUX2" },
+        "dev_attr": { "dev_idx":"2", "num_psu_fans":"1"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"pmbus", "dev":"PSU2-PMBUS"},
+                { "itf":"eeprom", "dev":"PSU2-EEPROM" }
+            ]
+        }
+    },
+
+    "PSU2-PMBUS":
+    {
+        "dev_info": {"device_type":"PSU-PMBUS", "device_name":"PSU2-PMBUS", "device_parent":"MUX2", "virt_parent":"PSU2"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0xc", "dev_addr":"0x5b", "dev_type":"psu_pmbus"},
+            "attr_list": 
+            [  
+                { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x10", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+                { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x20", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"psu_mfr_id", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+                { "attr_name":"psu_fan_dir", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
+                { "attr_name":"psu_v_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8b", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_i_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_p_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x96", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_fan1_speed_rpm", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x90", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_temp1_input", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8d", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
+            ]
+        }
+    },
+    
+    "PSU2-EEPROM":
+    {
+        "dev_info": { "device_type":"PSU-EEPROM", "device_name":"PSU2-EEPROM", "device_parent":"MUX2", "virt_parent":"PSU2"},
+        "i2c":
+        {
+            "topo_info":{ "parent_bus":"0xc", "dev_addr":"0x53", "dev_type":"psu_eeprom"}, 
+            "attr_list": 
+            [  
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x53", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"19" }
+            ]
+        }
+    },
+    "MUX3":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX3", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2", "dev_addr":"0x72", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x12", "idle_state":"-2"},
+            "channel":
+            [
+                { "chn":"0", "dev":"PORT51" },
+                { "chn":"1", "dev":"PORT54" },
+                { "chn":"2", "dev":"PORT49" },
+                { "chn":"3", "dev":"PORT50" },
+                { "chn":"4", "dev":"PORT52" },
+                { "chn":"5", "dev":"PORT53" }
+            ]
+        }
+    },
+    
+    "PORT51":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT51", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"51"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT51-EEPROM" },
+                { "itf":"control", "dev":"PORT51-CTRL" }
+            ]
+        }
+    },
+    "PORT51-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT51-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT51"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x12", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT51-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT51-CTRL", "device_parent":"MUX3", "virt_parent":"PORT51"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x12", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x14", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3","attr_offset":"0x15", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3","attr_offset":"0x13", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_lpmode", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x16", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT54":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT54", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"54"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT54-EEPROM" },
+                { "itf":"control", "dev":"PORT54-CTRL" }
+            ]
+        }
+    },
+    "PORT54-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT54-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT54"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x13", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT54-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT54-CTRL", "device_parent":"MUX3", "virt_parent":"PORT54"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x13", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3","attr_offset":"0x14", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3","attr_offset":"0x15", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3","attr_offset":"0x13", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_lpmode", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x16", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT49":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT49", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"49"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT49-EEPROM" },
+                { "itf":"control", "dev":"PORT49-CTRL" }
+            ]
+        }
+    },
+    "PORT49-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT49-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT49"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x14", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT49-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT49-CTRL", "device_parent":"MUX3", "virt_parent":"PORT49"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x14", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x14", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x15", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x13", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_lpmode", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x16", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT50":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT50", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"50"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT50-EEPROM" },
+                { "itf":"control", "dev":"PORT50-CTRL" }
+            ]
+        }
+    },
+    "PORT50-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT50-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT50"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x15", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+       
+    "PORT50-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT50-CTRL", "device_parent":"MUX3", "virt_parent":"PORT50"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x15", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x14", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x15", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x13", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_lpmode", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3","attr_offset":"0x16", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT52":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT52", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"52"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT52-EEPROM" },
+                { "itf":"control", "dev":"PORT52-CTRL" }
+            ]
+        }
+    },
+    "PORT52-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT52-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT52"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x16", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT52-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT52-CTRL", "device_parent":"MUX3", "virt_parent":"PORT52"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x16", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x14", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x15", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x62", "attr_devtype":"cpld","attr_devname":"CPLD3",  "attr_offset":"0x13", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_lpmode", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x16", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"}
+            ]
+        }
+    },
+  
+    "PORT53":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT53", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"53"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT53-EEPROM" },
+                { "itf":"control", "dev":"PORT53-CTRL" }
+            ]
+        }
+    },
+    "PORT53-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT53-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT53"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x17", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT53-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT53-CTRL", "device_parent":"MUX3", "virt_parent":"PORT53"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x17", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3","attr_offset":"0x14", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x15", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x62", "attr_devtype":"cpld","attr_devname":"CPLD3", "attr_offset":"0x13", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_lpmode", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3","attr_offset":"0x16", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+            ]
+        }
+    },
+   
+   
+    "CPLD1":
+    {
+        "dev_info": { "device_type":"CPLD", "device_name":"CPLD1", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3", "dev_addr":"0x60", "dev_type":"i2c_cpld"},
+            "dev_attr":{}
+        }
+    },
+    "CPLD2":
+    {
+        "dev_info": { "device_type":"CPLD", "device_name":"CPLD2", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3", "dev_addr":"0x61", "dev_type":"i2c_cpld"},
+            "dev_attr":{}
+        }
+    },
+    "CPLD3":
+    {
+        "dev_info": { "device_type":"CPLD", "device_name":"CPLD3", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3", "dev_addr":"0x62", "dev_type":"i2c_cpld"},
+            "dev_attr":{}
+        }
+    },
+     
+     "FAN-CTRL":
+    {
+        "dev_info": { "device_type":"FAN", "device_name":"FAN-CTRL", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3", "dev_addr":"0x63", "dev_type":"fan_ctrl"},
+            "dev_attr": { "num_fantrays":"5"},
+            "attr_list":
+            [
+                { "attr_name":"fan1_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan2_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},               
+                { "attr_name":"fan3_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan4_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},               
+                { "attr_name":"fan5_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan6_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},               
+                { "attr_name":"fan7_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x8", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan8_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x8", "attr_cmpval":"0x0", "attr_len":"1"},               
+                { "attr_name":"fan9_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x10", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan10_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02","attr_mask":"0x10", "attr_cmpval":"0x0", "attr_len":"1"},              
+                { "attr_name":"fan1_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x1", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"fan2_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x1", "attr_cmpval":"0x1", "attr_len":"1"},               
+                { "attr_name":"fan3_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x2", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"fan4_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x2", "attr_cmpval":"0x2", "attr_len":"1"},               
+                { "attr_name":"fan5_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x4", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"fan6_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x4", "attr_cmpval":"0x4", "attr_len":"1"},               
+                { "attr_name":"fan7_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x8", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"fan8_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x8", "attr_cmpval":"0x8", "attr_len":"1"},               
+                { "attr_name":"fan9_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x10", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"fan10_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x10", "attr_cmpval":"0x10", "attr_len":"1"},               
+                { "attr_name":"fan1_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x07", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150", "attr_is_divisor":0},
+                { "attr_name":"fan2_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0C", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150", "attr_is_divisor":0},               
+                { "attr_name":"fan3_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x08", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150", "attr_is_divisor":0},
+                { "attr_name":"fan4_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0D", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150", "attr_is_divisor":0},               
+                { "attr_name":"fan5_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x09", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150", "attr_is_divisor":0},
+                { "attr_name":"fan6_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0E", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150", "attr_is_divisor":0},               
+                { "attr_name":"fan7_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0A", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150" , "attr_is_divisor":0},
+                { "attr_name":"fan8_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0F", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150" , "attr_is_divisor":0},               
+                { "attr_name":"fan9_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0B", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150" , "attr_is_divisor":0},
+                { "attr_name":"fan10_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150" , "attr_is_divisor":0},               
+                { "attr_name":"fan1_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan2_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan3_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan4_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan5_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan6_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan7_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan8_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan9_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan10_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" }
+            ]
+        }
+    },
+    
+    "MUX4":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX4", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2", "dev_addr":"0x71", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x1a", "idle_state":"-2"},
+            "channel":
+            [
+                { "chn":"0", "dev":"TEMP1" },
+                { "chn":"1", "dev":"TEMP2" },
+                { "chn":"2", "dev":"TEMP3" },
+                { "chn":"3", "dev":"TEMP4" }
+            ]
+        }
+    },
+    
+    "TEMP1" :
+    {
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP1", "device_parent":"MUX4"},
+        "dev_attr": { "display_name":"CpuBoard_temp(0x4B)"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1a", "dev_addr":"0x4B", "dev_type":"lm75"},
+            "attr_list":
+            [
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+                { "attr_name": "temp1_max_hyst"},
+                { "attr_name": "temp1_input"}
+            ]
+        }
+    },
+    "TEMP2" :
+    {
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP2", "device_parent":"MUX4"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1b", "dev_addr":"0x4C", "dev_type":"lm75"},
+            "attr_list":
+            [
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+                { "attr_name": "temp1_max_hyst"},
+                { "attr_name": "temp1_input"}
+            ]
+        }
+    },
+    "TEMP3" :
+    {
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP3", "device_parent":"MUX4"},
+        "dev_attr": { "display_name":"MB_RearLeft_temp(0x49)"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1c", "dev_addr":"0x49", "dev_type":"lm75"},
+            "attr_list":
+            [
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+                { "attr_name": "temp1_max_hyst"},
+                { "attr_name": "temp1_input"}
+            ]
+        }
+    },
+    "TEMP4" :
+    {
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP4", "device_parent":"MUX4"},
+        "dev_attr": { "display_name":"MB_RearLeft_temp(0x4A)"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1d", "dev_addr":"0x4A", "dev_type":"lm75"},
+            "attr_list":
+            [
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+                { "attr_name": "temp1_max_hyst"},
+                { "attr_name": "temp1_input"}
+            ]
+        }
+    },
+   
+    "SYSSTATUS":
+    {
+        "dev_info":{ "device_type":"SYSSTAT", "device_name":"SYSSTATUS"},
+        "dev_attr":{ },
+        "attr_list":
+        [
+                
+                  { "attr_name":"board_info","attr_devaddr":"0x60", "attr_offset":"0x0","attr_mask":"0xff","attr_len":"0x1"},
+                  { "attr_name":"cpld1_version","attr_devaddr":"0x60","attr_offset":"0x1","attr_mask":"0xff","attr_len":"0x1"},
+                  { "attr_name":"cpld2_version","attr_devaddr":"0x61","attr_offset":"0x1","attr_mask":"0xff","attr_len":"0x1"},
+                  { "attr_name":"cpld3version","attr_devaddr":"0x62","attr_offset":"0x1","attr_mask":"0xff","attr_len":"0x1"},
+                  { "attr_name":"fan_cpld_version","attr_devaddr":"0x63","attr_offset":"0x1","attr_mask":"0xff","attr_len":"0x1"}
+
+        ]
+    },
+   
+    "MUX5":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX5", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3", "dev_addr":"0x70", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x22", "idle_state":"-2"},
+            "channel":
+            [
+                { "chn":"0", "dev":"MUX6" },
+                { "chn":"1", "dev":"MUX7" },
+                { "chn":"2", "dev":"MUX8" },
+                { "chn":"3", "dev":"MUX9" },
+                { "chn":"4", "dev":"MUX10" },
+                { "chn":"5", "dev":"MUX11" }
+            ]
+        }
+    },
+    "MUX6":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX6", "device_parent":"MUX5"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x22", "dev_addr":"0x71", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x2a", "idle_state":"-2"},
+            "channel":
+            [
+                { "chn":"0", "dev":"PORT1" },
+                { "chn":"1", "dev":"PORT2" },
+                { "chn":"2", "dev":"PORT3" },
+                { "chn":"3", "dev":"PORT4" },
+                { "chn":"4", "dev":"PORT5" },
+                { "chn":"5", "dev":"PORT6" },
+                { "chn":"6", "dev":"PORT7" },
+                { "chn":"7", "dev":"PORT8" }     
+            ]
+        }
+    },
+    "MUX7":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX7", "device_parent":"MUX5"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x23", "dev_addr":"0x72", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x32", "idle_state":"-2"},
+            "channel":
+            [
+                { "chn":"0", "dev":"PORT9" },
+                { "chn":"1", "dev":"PORT10" },
+                { "chn":"2", "dev":"PORT11" },
+                { "chn":"3", "dev":"PORT12" },
+                { "chn":"4", "dev":"PORT13" },
+                { "chn":"5", "dev":"PORT14" },
+                { "chn":"6", "dev":"PORT15" },
+                { "chn":"7", "dev":"PORT16" }     
+            ]
+        }
+    },
+    "MUX8":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX8", "device_parent":"MUX5"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x24", "dev_addr":"0x73", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x3a", "idle_state":"-2"},
+            "channel":
+            [
+                { "chn":"0", "dev":"PORT17" },
+                { "chn":"1", "dev":"PORT18" },
+                { "chn":"2", "dev":"PORT19" },
+                { "chn":"3", "dev":"PORT20" },
+                { "chn":"4", "dev":"PORT21" },
+                { "chn":"5", "dev":"PORT22" },
+                { "chn":"6", "dev":"PORT23" },
+                { "chn":"7", "dev":"PORT24" }     
+            ]
+        }
+    },
+    "MUX9":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX9", "device_parent":"MUX5"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x25", "dev_addr":"0x74", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x42", "idle_state":"-2"},
+            "channel":
+            [
+                { "chn":"0", "dev":"PORT25" },
+                { "chn":"1", "dev":"PORT26" },
+                { "chn":"2", "dev":"PORT27" },
+                { "chn":"3", "dev":"PORT28" },
+                { "chn":"4", "dev":"PORT29" },
+                { "chn":"5", "dev":"PORT30" },
+                { "chn":"6", "dev":"PORT31" },
+                { "chn":"7", "dev":"PORT32" }     
+            ]
+        }
+    },
+    "MUX10":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX10", "device_parent":"MUX5"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x26", "dev_addr":"0x75", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x4a", "idle_state":"-2"},
+            "channel":
+            [
+                { "chn":"0", "dev":"PORT33" },
+                { "chn":"1", "dev":"PORT34" },
+                { "chn":"2", "dev":"PORT35" },
+                { "chn":"3", "dev":"PORT36" },
+                { "chn":"4", "dev":"PORT37" },
+                { "chn":"5", "dev":"PORT38" },
+                { "chn":"6", "dev":"PORT39" },
+                { "chn":"7", "dev":"PORT40" }     
+            ]
+        }
+    },
+    "MUX11":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX11", "device_parent":"MUX5"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x27", "dev_addr":"0x76", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x52", "idle_state":"-2"},
+            "channel":
+            [
+                { "chn":"0", "dev":"PORT41" },
+                { "chn":"1", "dev":"PORT42" },
+                { "chn":"2", "dev":"PORT43" },
+                { "chn":"3", "dev":"PORT44" },
+                { "chn":"4", "dev":"PORT45" },
+                { "chn":"5", "dev":"PORT46" },
+                { "chn":"6", "dev":"PORT47" },
+                { "chn":"7", "dev":"PORT48" }     
+            ]
+        }
+    },
+    
+    "PORT1":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT1", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"1"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT1-EEPROM" },
+                { "itf":"control", "dev":"PORT1-CTRL" }
+            ]
+        }
+    },
+    "PORT1-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT1-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2a", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT1-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT1-CTRL", "device_parent":"MUX6", "virt_parent":"PORT1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2a", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x8", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0D", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x12", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x17", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT2":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT2", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"2"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT2-EEPROM" },
+                { "itf":"control", "dev":"PORT2-CTRL" }
+            ]
+        }
+    },
+    "PORT2-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT2-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT2"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2b", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT2-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT2-CTRL", "device_parent":"MUX6", "virt_parent":"PORT2"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2b", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x8", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0D", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x12", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x17", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT3":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT3", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"3"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT3-EEPROM" },
+                { "itf":"control", "dev":"PORT3-CTRL" }
+            ]
+        }
+    },
+    "PORT3-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT3-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT3"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2c", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT3-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT3-CTRL", "device_parent":"MUX6", "virt_parent":"PORT3"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2c", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x8", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0D", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x12", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x17", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT4":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT4", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"4"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT4-EEPROM" },
+                { "itf":"control", "dev":"PORT4-CTRL" }
+            ]
+        }
+    },
+    "PORT4-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT4-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT4"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2d", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT4-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT4-CTRL", "device_parent":"MUX6", "virt_parent":"PORT4"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2d", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x8", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0D", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x12", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x17", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT5":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT5", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"5"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT5-EEPROM" },
+                { "itf":"control", "dev":"PORT5-CTRL" }
+            ]
+        }
+    },
+    "PORT5-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT5-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT5"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2e", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT5-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT5-CTRL", "device_parent":"MUX6", "virt_parent":"PORT5"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2e", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x8", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0D", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x12", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x17", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT6":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT6", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"6"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT6-EEPROM" },
+                { "itf":"control", "dev":"PORT6-CTRL" }
+            ]
+        }
+    },
+    "PORT6-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT6-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT6"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2f", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT6-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT6-CTRL", "device_parent":"MUX6", "virt_parent":"PORT6"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2f", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x8", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0D", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x12", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x17", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT7":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT7", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"7"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT7-EEPROM" },
+                { "itf":"control", "dev":"PORT7-CTRL" }
+            ]
+        }
+    },
+    "PORT7-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT7-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT7"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x30", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT7-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT7-CTRL", "device_parent":"MUX6", "virt_parent":"PORT7"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x30", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x8", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0D", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x12", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x17", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT8":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT8", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"8"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT8-EEPROM" },
+                { "itf":"control", "dev":"PORT8-CTRL" }
+            ]
+        }
+    },
+    "PORT8-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT8-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT8"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x31", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT8-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT8-CTRL", "device_parent":"MUX6", "virt_parent":"PORT8"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x31", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x8", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0D", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x12", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x17", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT9":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT9", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"9"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT9-EEPROM" },
+                { "itf":"control", "dev":"PORT9-CTRL" }
+            ]
+        }
+    },
+    "PORT9-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT9-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT9"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x32", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT9-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT9-CTRL", "device_parent":"MUX7", "virt_parent":"PORT9"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x32", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x09", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0E", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x13", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x18", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT10":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT10", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"10"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT10-EEPROM" },
+                { "itf":"control", "dev":"PORT10-CTRL" }
+            ]
+        }
+    },
+    "PORT10-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT10-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT10"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x33", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT10-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT10-CTRL", "device_parent":"MUX7", "virt_parent":"PORT10"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x33", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x09", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0E", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x13", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x18", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT11":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT11", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"11"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT11-EEPROM" },
+                { "itf":"control", "dev":"PORT11-CTRL" }
+            ]
+        }
+    },
+    "PORT11-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT11-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT11"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x34", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT11-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT11-CTRL", "device_parent":"MUX7", "virt_parent":"PORT11"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x34", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x09", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0E", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x13", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x18", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"}
+            ]
+        }
+    },
+     
+    "PORT12":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT12", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"12"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT12-EEPROM" },
+                { "itf":"control", "dev":"PORT12-CTRL" }
+            ]
+        }
+    },
+    "PORT12-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT12-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT12"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x35", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT12-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT12-CTRL", "device_parent":"MUX7", "virt_parent":"PORT12"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x35", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x09", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0E", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x13", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x18", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT13":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT13", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"13"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT13-EEPROM" },
+                { "itf":"control", "dev":"PORT13-CTRL" }
+            ]
+        }
+    },
+    "PORT13-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT13-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT13"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x36", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT13-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT13-CTRL", "device_parent":"MUX7", "virt_parent":"PORT13"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x36", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x09", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0E", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x13", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x18", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT14":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT14", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"14"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT14-EEPROM" },
+                { "itf":"control", "dev":"PORT14-CTRL" }
+            ]
+        }
+    },
+    "PORT14-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT14-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT14"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x37", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT14-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT14-CTRL", "device_parent":"MUX7", "virt_parent":"PORT14"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x37", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x09", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0E", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x13", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x18", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT15":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT15", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"15"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT15-EEPROM" },
+                { "itf":"control", "dev":"PORT15-CTRL" }
+            ]
+        }
+    },
+    "PORT15-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT15-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT15"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x38", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT15-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT15-CTRL", "device_parent":"MUX7", "virt_parent":"PORT15"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x38", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x09", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0E", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x13", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x18", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT16":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT16", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"16"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT16-EEPROM" },
+                { "itf":"control", "dev":"PORT16-CTRL" }
+            ]
+        }
+    },
+    "PORT16-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT16-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT16"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x39", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT16-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT16-CTRL", "device_parent":"MUX7", "virt_parent":"PORT16"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x39", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x09", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0E", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x13", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x18", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT17":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT17", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"17"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT17-EEPROM" },
+                { "itf":"control", "dev":"PORT17-CTRL" }
+            ]
+        }
+    },
+    "PORT17-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT17-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT17"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3a", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT17-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT17-CTRL", "device_parent":"MUX8", "virt_parent":"PORT17"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3a", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0A", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0F", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x14", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x19", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT18":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT18", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"18"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT18-EEPROM" },
+                { "itf":"control", "dev":"PORT18-CTRL" }
+            ]
+        }
+    },
+    "PORT18-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT18-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT18"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3b", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT18-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT18-CTRL", "device_parent":"MUX8", "virt_parent":"PORT18"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3b", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0A", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0F", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x14", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x19", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT19":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT19", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"19"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT19-EEPROM" },
+                { "itf":"control", "dev":"PORT19-CTRL" }
+            ]
+        }
+    },
+    "PORT19-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT19-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT19"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3c", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT19-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT19-CTRL", "device_parent":"MUX8", "virt_parent":"PORT19"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3c", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0A", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0F", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x14", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x19", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT20":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT20", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"20"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT20-EEPROM" },
+                { "itf":"control", "dev":"PORT20-CTRL" }
+            ]
+        }
+    },
+    "PORT20-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT20-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT20"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3d", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT20-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT20-CTRL", "device_parent":"MUX8", "virt_parent":"PORT20"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3d", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0A", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0F", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x14", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x19", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT21":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT21", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"21"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT21-EEPROM" },
+                { "itf":"control", "dev":"PORT21-CTRL" }
+            ]
+        }
+    },
+    "PORT21-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT21-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT21"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3e", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT21-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT21-CTRL", "device_parent":"MUX8", "virt_parent":"PORT21"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3e", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0A", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0F", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x14", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x19", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT22":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT22", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"22"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT22-EEPROM" },
+                { "itf":"control", "dev":"PORT22-CTRL" }
+            ]
+        }
+    },
+    "PORT22-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT22-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT22"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3f", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT22-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT22-CTRL", "device_parent":"MUX8", "virt_parent":"PORT22"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3f", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0A", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0F", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x14", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x19", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT23":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT23", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"23"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT23-EEPROM" },
+                { "itf":"control", "dev":"PORT23-CTRL" }
+            ]
+        }
+    },
+    "PORT23-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT23-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT23"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x40", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT23-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT23-CTRL", "device_parent":"MUX8", "virt_parent":"PORT23"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x40", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0A", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0F", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x14", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x19", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT24":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT24", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"24"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT24-EEPROM" },
+                { "itf":"control", "dev":"PORT24-CTRL" }
+            ]
+        }
+    },
+    "PORT24-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT24-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT24"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x41", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT24-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT24-CTRL", "device_parent":"MUX8", "virt_parent":"PORT24"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x41", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0A", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0F", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x14", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x19", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT25":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT25", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"25"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT25-EEPROM" },
+                { "itf":"control", "dev":"PORT25-CTRL" }
+            ]
+        }
+    },
+    "PORT25-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT25-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT25"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x42", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT25-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT25-CTRL", "device_parent":"MUX9", "virt_parent":"PORT25"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x42", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x0B", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x10", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x15", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x1A", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT26":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT26", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"26"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT26-EEPROM" },
+                { "itf":"control", "dev":"PORT26-CTRL" }
+            ]
+        }
+    },
+    "PORT26-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT26-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT26"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x43", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT26-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT26-CTRL", "device_parent":"MUX9", "virt_parent":"PORT26"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x43", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x0B", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x10", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x15", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x1A", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT27":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT27", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"27"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT27-EEPROM" },
+                { "itf":"control", "dev":"PORT27-CTRL" }
+            ]
+        }
+    },
+    "PORT27-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT27-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT27"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x44", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT27-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT27-CTRL", "device_parent":"MUX9", "virt_parent":"PORT27"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x44", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x0B", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x10", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld","attr_devname":"CPLD2", "attr_offset":"0x15", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x1A", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT28":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT28", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"28"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT28-EEPROM" },
+                { "itf":"control", "dev":"PORT28-CTRL" }
+            ]
+        }
+    },
+    "PORT28-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT28-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT28"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x45", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT28-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT28-CTRL", "device_parent":"MUX9", "virt_parent":"PORT28"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x45", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x0B", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x10", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x15", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x1A", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT29":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT29", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"29"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT29-EEPROM" },
+                { "itf":"control", "dev":"PORT29-CTRL" }
+            ]
+        }
+    },
+    "PORT29-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT29-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT29"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x46", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT29-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT29-CTRL", "device_parent":"MUX9", "virt_parent":"PORT29"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x46", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x0B", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x10", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x15", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x1A", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT30":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT30", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"30"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT30-EEPROM" },
+                { "itf":"control", "dev":"PORT30-CTRL" }
+            ]
+        }
+    },
+    "PORT30-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT30-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT30"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x47", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT30-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT30-CTRL", "device_parent":"MUX9", "virt_parent":"PORT30"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x47", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0B", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x10", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld","attr_devname":"CPLD2", "attr_offset":"0x15", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x1A", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT31":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT31", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"31"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT31-EEPROM" },
+                { "itf":"control", "dev":"PORT31-CTRL" }
+            ]
+        }
+    },
+    "PORT31-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT31-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT31"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x48", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT31-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT31-CTRL", "device_parent":"MUX9", "virt_parent":"PORT31"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x48", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x0B", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x10", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x15", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0x1A", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT32":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT32", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"32"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT32-EEPROM" },
+                { "itf":"control", "dev":"PORT32-CTRL" }
+            ]
+        }
+    },
+    "PORT32-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT32-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT32"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x49", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT32-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT32-CTRL", "device_parent":"MUX9", "virt_parent":"PORT32"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x49", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0B", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x10", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld","attr_devname":"CPLD2", "attr_offset":"0x15", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x1A", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT33":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT33", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"33"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT33-EEPROM" },
+                { "itf":"control", "dev":"PORT33-CTRL" }
+            ]
+        }
+    },
+    "PORT33-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT33-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT33"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4a", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT33-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT33-CTRL", "device_parent":"MUX10", "virt_parent":"PORT33"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4a", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0C", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x11", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x16", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x1B", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT34":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT34", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"34"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT34-EEPROM" },
+                { "itf":"control", "dev":"PORT34-CTRL" }
+            ]
+        }
+    },
+    "PORT34-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT34-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT34"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4b", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT34-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT34-CTRL", "device_parent":"MUX10", "virt_parent":"PORT34"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4b", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0C", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x11", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x16", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x1B", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT35":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT35", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"35"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT35-EEPROM" },
+                { "itf":"control", "dev":"PORT35-CTRL" }
+            ]
+        }
+    },
+    "PORT35-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT35-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT35"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4c", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT35-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT35-CTRL", "device_parent":"MUX10", "virt_parent":"PORT35"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4c", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0C", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x11", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x16", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x1B", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT36":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT36", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"36"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT36-EEPROM" },
+                { "itf":"control", "dev":"PORT36-CTRL" }
+            ]
+        }
+    },
+    "PORT36-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT36-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT36"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4d", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT36-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT36-CTRL", "device_parent":"MUX10", "virt_parent":"PORT36"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4d", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0C", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x11", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x16", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x1B", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT37":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT37", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"37"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT37-EEPROM" },
+                { "itf":"control", "dev":"PORT37-CTRL" }
+            ]
+        }
+    },
+    "PORT37-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT37-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT37"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4e", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT37-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT37-CTRL", "device_parent":"MUX10", "virt_parent":"PORT37"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4e", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0C", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x11", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x16", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x1B", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT38":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT38", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"38"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT38-EEPROM" },
+                { "itf":"control", "dev":"PORT38-CTRL" }
+            ]
+        }
+    },
+    "PORT38-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT38-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT38"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4f", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT38-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT38-CTRL", "device_parent":"MUX10", "virt_parent":"PORT38"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4f", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x0C", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x11", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x16", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x61", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x1B", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT39":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT39", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"39"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT39-EEPROM" },
+                { "itf":"control", "dev":"PORT39-CTRL" }
+            ]
+        }
+    },
+    "PORT39-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT39-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT39"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x50", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT39-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT39-CTRL", "device_parent":"MUX10", "virt_parent":"PORT39"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x50", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x06", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x09", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0C", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0F", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT40":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT40", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"40"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT40-EEPROM" },
+                { "itf":"control", "dev":"PORT40-CTRL" }
+            ]
+        }
+    },
+    "PORT40-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT40-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT40"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x51", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT40-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT40-CTRL", "device_parent":"MUX10", "virt_parent":"PORT40"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x51", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                 { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x06", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x09", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0C", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0F", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT41":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT41", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"41"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT41-EEPROM" },
+                { "itf":"control", "dev":"PORT41-CTRL" }
+            ]
+        }
+    },
+    "PORT41-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT41-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT41"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x52", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT41-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT41-CTRL", "device_parent":"MUX11", "virt_parent":"PORT41"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x52", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                 { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x06", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x09", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0C", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0F", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT42":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT42", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"42"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT42-EEPROM" },
+                { "itf":"control", "dev":"PORT42-CTRL" }
+            ]
+        }
+    },
+    "PORT42-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT42-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT42"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x53", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT42-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT42-CTRL", "device_parent":"MUX11", "virt_parent":"PORT42"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x53", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x06", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x09", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0C", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0F", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT43":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT43", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"43"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT43-EEPROM" },
+                { "itf":"control", "dev":"PORT43-CTRL" }
+            ]
+        }
+    },
+    "PORT43-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT43-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT43"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x54", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT43-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT43-CTRL", "device_parent":"MUX11", "virt_parent":"PORT43"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x54", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3","attr_offset":"0x06", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3","attr_offset":"0x09", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3","attr_offset":"0x0C", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3","attr_offset":"0x0F", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT44":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT44", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"44"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT44-EEPROM" },
+                { "itf":"control", "dev":"PORT44-CTRL" }
+            ]
+        }
+    },
+    "PORT44-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT44-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT44"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x55", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT44-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT44-CTRL", "device_parent":"MUX11", "virt_parent":"PORT44"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x55", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x06", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x09", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0C", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0F", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT45":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT45", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"45"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT45-EEPROM" },
+                { "itf":"control", "dev":"PORT45-CTRL" }
+            ]
+        }
+    },
+    "PORT45-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT45-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT45"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x56", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT45-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT45-CTRL", "device_parent":"MUX11", "virt_parent":"PORT45"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x56", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x06", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x09", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0C", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0F", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT46":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT46", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"46"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT46-EEPROM" },
+                { "itf":"control", "dev":"PORT46-CTRL" }
+            ]
+        }
+    },
+    "PORT46-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT46-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT46"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x57", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT46-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT46-CTRL", "device_parent":"MUX11", "virt_parent":"PORT46"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x57", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x06", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x09", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0C", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0F", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT47":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT47", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"47"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT47-EEPROM" },
+                { "itf":"control", "dev":"PORT47-CTRL" }
+            ]
+        }
+    },
+    "PORT47-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT47-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT47"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x58", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT47-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT47-CTRL", "device_parent":"MUX11", "virt_parent":"PORT47"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x58", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x07", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0A", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0D", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x10", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT48":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT48", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"48"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT48-EEPROM" },
+                { "itf":"control", "dev":"PORT48-CTRL" }
+            ]
+        }
+    },
+    "PORT48-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT48-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT48"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x59", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT48-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT48-CTRL", "device_parent":"MUX11", "virt_parent":"PORT48"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x59", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x07", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0A", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x0D", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x10", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+        
+    "LOC_LED":
+    {
+        "dev_info": { "device_type":"LED", "device_name":"LOC_LED"},
+        "dev_attr": { "index":"0"},
+        "i2c" :
+        {
+            "attr_list":
+            [
+                {"attr_name":"amber", "descr": "" , "bits" : "5:4",  "value" : "0x0", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x0A"},
+                {"attr_name":"off", "descr": "" , "bits" : "5:4",  "value" : "0x1", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x0A"}
+                
+            ]
+        }
+    },
+    "DIAG_LED":
+    {
+        "dev_info": { "device_type":"LED", "device_name":"DIAG_LED"},
+         "dev_attr": { "index":"0"},
+         "i2c" :
+         {
+             "attr_list":
+             [
+                 {"attr_name":"green", "descr": "" , "bits" : "3:2", "value" : "0x2", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x0A"},
+                 {"attr_name":"amber", "descr": "" , "bits" : "3:2", "value" : "0x1", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x0A"},
+                 {"attr_name":"off",   "descr": "" , "bits" : "3:2", "value" : "0x3", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x0A"}
+             ]
+        }
+    }
+}

--- a/device/accton/x86_64-accton_as5835_54x-r0/pmon_daemon_control.json
+++ b/device/accton/x86_64-accton_as5835_54x-r0/pmon_daemon_control.json
@@ -1,5 +1,5 @@
 {
-    "skip_ledd": true,
-    "skip_pcied": true
+    "skip_ledd": true
+
 }
 

--- a/device/accton/x86_64-accton_as5835_54x-r0/sensors.conf
+++ b/device/accton/x86_64-accton_as5835_54x-r0/sensors.conf
@@ -39,13 +39,13 @@ chip "as5835_54x_fan-*"
 
 
 chip "lm75-i2c-*-49"
-    label temp1 "Main Board Temperature"
+    label temp1 "MB_RearLeft_temp"
 
 chip "lm75-i2c-*-4a"
-    label temp1 "Main Board Temperature"
+    label temp1 "MB_RearRight_temp"
 
 chip "lm75-i2c-*-4c"
-    label temp1 "Main Board Temperature"
+    label temp1 "MB_FrontMiddle_temp"
 
 chip "lm75-i2c-*-4b"
-    label temp1 "CPU Board Temperature"
+    label temp1 "CpuBoard_temp"

--- a/device/accton/x86_64-accton_as5835_54x-r0/system_health_monitoring_config.json
+++ b/device/accton/x86_64-accton_as5835_54x-r0/system_health_monitoring_config.json
@@ -2,8 +2,10 @@
     "services_to_ignore": [],
     "devices_to_ignore": [
         "asic",
-	    "psu.temperature"
-	    
+        "psu.voltage",
+        "psu.temperature",
+        "PSU1_FAN1.speed",
+        "PSU2_FAN1.speed"
     ],
     "user_defined_checkers": [],
     "polling_interval": 60,

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/Makefile
@@ -1,8 +1,11 @@
 ifneq ($(KERNELRELEASE),)
 obj-m:= accton_as5835_54x_cpld.o accton_as5835_54x_psu.o  \
         accton_as5835_54x_fan.o accton_as5835_54x_leds.o \
-        ym2651y.o
+        ym2651y.o pddf_custom_psu.o
          
+CFLAGS_pddf_custom_psu.o := -I$(M)/../../../../pddf/i2c/modules/include
+KBUILD_EXTRA_SYMBOLS := $(M)/../../../../pddf/i2c/Module.symvers.PDDF
+
 else
 ifeq (,$(KERNEL_SRC))
 $(error KERNEL_SRC is not defined)

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/pddf_custom_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/pddf_custom_psu.c
@@ -1,0 +1,117 @@
+#include <linux/module.h>
+#include <linux/jiffies.h>
+#include <linux/i2c.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/err.h>
+#include <linux/delay.h>
+#include <linux/mutex.h>
+#include <linux/sysfs.h>
+#include <linux/slab.h>
+#include <linux/dmi.h>
+#include "pddf_psu_defs.h"
+
+ssize_t pddf_show_custom_psu_v_out(struct device *dev, struct device_attribute *da, char *buf);
+extern PSU_SYSFS_ATTR_DATA access_psu_v_out;
+
+static int two_complement_to_int(u16 data, u8 valid_bit, int mask)
+{
+	u16  valid_data  = data & mask;
+	bool is_negative = valid_data >> (valid_bit - 1);
+
+	return is_negative ? (-(((~valid_data) & mask) + 1)) : valid_data;
+}
+
+static u8 psu_get_vout_mode(struct i2c_client *client)
+{
+	u8 status = 0, retry = 10;
+	uint8_t offset = 0x20; // VOUT_MODE
+
+	while (retry) {
+		status = i2c_smbus_read_byte_data((struct i2c_client *)client, offset);
+		if (unlikely(status < 0)) {
+			msleep(60);
+			retry--;
+			continue;
+		}
+		break;
+	}
+
+	if (status < 0)
+	{
+		printk(KERN_ERR "%s: Get PSU Vout mode failed\n", __func__);
+		return 0;
+	}
+	else
+	{
+		/*printk(KERN_ERR "%s: vout_mode reg value 0x%x\n", __func__, status);*/
+		return status;
+	}
+}
+
+static u16 psu_get_v_out(struct i2c_client *client)
+{
+	u16 status = 0, retry = 10;
+	uint8_t offset = 0x8b; // READ_VOUT
+
+	while (retry) {
+		status = i2c_smbus_read_word_data((struct i2c_client *)client, offset);
+		if (unlikely(status < 0)) {
+			msleep(60);
+			retry--;
+			continue;
+		}
+		break;
+	}
+
+	if (status < 0)
+	{
+		printk(KERN_ERR "%s: Get PSU Vout failed\n", __func__);
+		return 0;
+	}
+	else
+	{
+		/*printk(KERN_ERR "%s: vout reg value 0x%x\n", __func__, status);*/
+		return status;
+	}
+}
+
+ssize_t pddf_show_custom_psu_v_out(struct device *dev, struct device_attribute *da, char *buf)
+{
+	struct i2c_client *client = to_i2c_client(dev);
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	int exponent, mantissa;
+	int multiplier = 1000;
+
+	u16 value = psu_get_v_out(client);
+	u8 vout_mode = psu_get_vout_mode(client);
+
+	exponent = two_complement_to_int(vout_mode, 5, 0x1f);
+	mantissa = value;
+	if (exponent >= 0)
+		return sprintf(buf, "%d\n", (mantissa << exponent) * multiplier);
+	else
+		return sprintf(buf, "%d\n", (mantissa * multiplier) / (1 << -exponent));
+}
+
+
+
+static int __init pddf_custom_psu_init(void)
+{
+    access_psu_v_out.show = pddf_show_custom_psu_v_out;
+    access_psu_v_out.do_get = NULL;
+    return 0;
+}
+
+static void __exit pddf_custom_psu_exit(void)
+{
+    return;
+}
+
+MODULE_AUTHOR("Broadcom");
+MODULE_DESCRIPTION("pddf custom psu api");
+MODULE_LICENSE("GPL");
+
+module_init(pddf_custom_psu_init);
+module_exit(pddf_custom_psu_exit);
+

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/service/as5835-54x-pddf-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/service/as5835-54x-pddf-platform-monitor.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Accton AS5835-54X Platform Monitoring service
+Before=pmon.service
+After=pddf-platform-init.service
+DefaultDependencies=no
+
+[Service]
+ExecStart=/usr/local/bin/accton_as5835_54x_pddf_monitor.py
+KillSignal=SIGKILL
+SuccessExitStatus=SIGKILL
+
+# Resource Limitations
+LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/service/pddf-platform-init.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/service/pddf-platform-init.service
@@ -1,0 +1,1 @@
+../../../../pddf/i2c/service/pddf-platform-init.service

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/__init__.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/__init__.py
@@ -1,0 +1,3 @@
+# All the derived classes for PDDF
+__all__ = ["platform", "chassis", "sfp", "psu", "thermal", "fan"]
+from . import platform

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/chassis.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+
+#############################################################################
+# PDDF
+# Module contains an implementation of SONiC Chassis API
+#
+#############################################################################
+
+try:
+    import sys
+    from sonic_platform_pddf_base.pddf_chassis import PddfChassis
+    from .event import SfpEvent
+    from .helper import APIHelper
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+NUM_COMPONENT = 6
+HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
+PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
+REBOOT_CAUSE_FILE = "reboot-cause.txt"
+
+class Chassis(PddfChassis):
+    """
+    PDDF Platform-specific Chassis class
+    """
+
+    SYSLED_DEV_NAME = "DIAG_LED"
+
+    def __init__(self, pddf_data=None, pddf_plugin_data=None):
+        PddfChassis.__init__(self, pddf_data, pddf_plugin_data)
+        self.__initialize_components()
+        self._api_helper = APIHelper()
+        self._sfpevent = SfpEvent(self.get_all_sfps())
+
+    def __initialize_components(self):
+        from sonic_platform.component import Component
+        for index in range(NUM_COMPONENT):
+            component = Component(index)
+            self._component_list.append(component) 
+
+    # Provide the functions/variables below for which implementation is to be overwritten
+    def get_change_event(self, timeout=0):
+        return self._sfpevent.get_sfp_event(timeout)
+
+    def get_reboot_cause(self):
+        """
+        Retrieves the cause of the previous reboot
+        Returns:
+            A tuple (string, string) where the first element is a string
+            containing the cause of the previous reboot. This string must be
+            one of the predefined strings in this class. If the first string
+            is "REBOOT_CAUSE_HARDWARE_OTHER", the second string can be used
+            to pass a description of the reboot cause.
+        """
+
+        reboot_cause_path = (HOST_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE)
+        sw_reboot_cause = self._api_helper.read_txt_file(
+            reboot_cause_path) or "Unknown"
+
+
+        return ('REBOOT_CAUSE_NON_HARDWARE', sw_reboot_cause)
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device. If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of entPhysicalContainedIn is '0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
+        """
+        return -1
+
+
+    def get_sfp(self, index):
+        """
+        Retrieves sfp represented by (1-based) index <index>
+
+        Args:
+            index: An integer, the index (1-based) of the sfp to retrieve.
+            The index should be the sequence of a physical port in a chassis,
+            starting from 1.
+            For example, 1 for Ethernet0, 2 for Ethernet4 and so on.
+
+        Returns:
+            An object derived from SfpBase representing the specified sfp
+        """
+        sfp = None
+
+        try:
+            # The index will start from 1
+            sfp = self._sfp_list[index-1]
+        except IndexError:
+            sys.stderr.write("SFP index {} out of range (1-{})\n".format(
+                             index, len(self._sfp_list)))
+        return sfp
+
+    def initizalize_system_led(self):
+        return
+
+    def get_status_led(self):
+        return self.get_system_led(self.SYSLED_DEV_NAME)
+
+    def set_status_led(self, color):
+        return self.set_system_led(self.SYSLED_DEV_NAME, color)
+
+    def get_port_or_cage_type(self, port):
+        from sonic_platform_base.sfp_base import SfpBase
+        if port in range(1, 48):
+            return SfpBase.SFP_PORT_TYPE_BIT_SFP | SfpBase.SFP_PORT_TYPE_BIT_SFP_PLUS
+        else:
+            return SfpBase.SFP_PORT_TYPE_BIT_QSFP | SfpBase.SFP_PORT_TYPE_BIT_QSFP_PLUS | SfpBase.SFP_PORT_TYPE_BIT_QSFP28
+            

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/component.py
@@ -1,0 +1,172 @@
+#############################################################################
+# 
+# Component contains an implementation of SONiC Platform Base API and
+# provides the components firmware management function
+#
+#############################################################################
+
+try:
+    import subprocess
+    from sonic_platform_base.component_base import ComponentBase
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+CPLD_ADDR_MAPPING = {
+    "MB CPLD1": ['3', '0x60'],
+    "MB CPLD2": ['3', '0x61'],
+    "MB CPLD3": ['3', '0x62'],
+    "FAN CPLD": ['3', '0x63'],
+    "CPU CPLD": ['1', '0x65']
+}
+SYSFS_PATH = "/sys/bus/i2c/devices/"
+BIOS_VERSION_PATH = "/sys/class/dmi/id/bios_version"
+COMPONENT_LIST= [
+   ("MB CPLD1", "Mainboard CPLD 1"),
+   ("MB CPLD2", "Mainboard CPLD 2"),
+   ("MB CPLD3", "Mainboard CPLD 3"),
+   ("FAN CPLD", "Fan board CPLD"),
+   ("CPU CPLD", "CPU CPLD"),
+   ("BIOS", "Basic Input/Output System")
+   
+]
+
+class Component(ComponentBase):
+    """Platform-specific Component class"""
+
+    DEVICE_TYPE = "component"
+
+    def __init__(self, component_index=0):
+        self.index = component_index
+        self.name = self.get_name()
+
+    def __run_command(self, command):
+        # Run bash command and print output to stdout
+        try:
+            process = subprocess.Popen(
+                shlex.split(command), stdout=subprocess.PIPE)
+            while True:
+                output = process.stdout.readline()
+                if output == '' and process.poll() is not None:
+                    break
+            rc = process.poll()
+            if rc != 0:
+                return False
+        except Exception:
+            return False
+        return True
+
+    def __get_bios_version(self):
+        # Retrieves the BIOS firmware version
+        try:
+            with open(BIOS_VERSION_PATH, 'r') as fd:
+                bios_version = fd.read()
+                return bios_version.strip()
+        except Exception as e:
+            return None
+   
+    def __get_cpld_version(self):
+        # Retrieves the CPLD firmware version
+        cpld_version = dict()
+        for cpld_name in CPLD_ADDR_MAPPING:
+            cmd = "i2cget -f -y {0} {1} 0x1".format(CPLD_ADDR_MAPPING[cpld_name][0], CPLD_ADDR_MAPPING[cpld_name][1])
+            status, value = subprocess.getstatusoutput(cmd)
+            if not status:
+                cpld_version_raw = value.rstrip()
+                cpld_version[cpld_name] = "{}".format(int(cpld_version_raw,16))
+
+        return cpld_version
+
+    def get_name(self):
+        """
+        Retrieves the name of the component
+         Returns:
+            A string containing the name of the component
+        """
+        return COMPONENT_LIST[self.index][0]
+
+    def get_description(self):
+        """
+        Retrieves the description of the component
+            Returns:
+            A string containing the description of the component
+        """
+        return COMPONENT_LIST[self.index][1]
+
+    def get_firmware_version(self):
+        """
+        Retrieves the firmware version of module
+        Returns:
+            string: The firmware versions of the module
+        """
+        fw_version = None
+
+        if self.name == "BIOS":
+            fw_version = self.__get_bios_version()
+        elif "CPLD" in self.name:
+            cpld_version = self.__get_cpld_version()
+            fw_version = cpld_version.get(self.name)
+
+        return fw_version
+
+    def install_firmware(self, image_path):
+        """
+        Install firmware to module
+        Args:
+            image_path: A string, path to firmware image
+        Returns:
+            A boolean, True if install successfully, False if not
+        """
+        raise NotImplementedError
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the device
+        Returns:
+            bool: True if device is present, False if not
+        """
+        return True
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+        Returns:
+            string: Model/part number of device
+        """
+        return 'N/A'
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+        Returns:
+            string: Serial number of device
+        """
+        return 'N/A'
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the device
+        Returns:
+            A boolean value, True if device is operating properly, False if not
+        """
+        return True
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device.
+        If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of
+        entPhysicalContainedIn is'0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device
+            or -1 if cannot determine the position
+        """
+        return -1
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False
+

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/eeprom.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+try:
+    from sonic_platform_pddf_base.pddf_eeprom import PddfEeprom
+    import os
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+CACHE_ROOT = '/var/cache/sonic/decode-syseeprom'
+CACHE_FILE = 'syseeprom_cache'
+
+class Eeprom(PddfEeprom):
+    _TLV_INFO_MAX_LEN = 256
+    pddf_obj = {}
+    plugin_data = {}
+
+    def __init__(self, pddf_data=None, pddf_plugin_data=None):
+        #PddfEeprom.__init__(self, pddf_data, pddf_plugin_data)
+        if not pddf_data or not pddf_plugin_data:
+            raise ValueError('PDDF JSON data error')
+
+        self.pddf_obj = pddf_data
+        self.plugin_data = pddf_plugin_data
+
+        # system EEPROM always has device name EEPROM1
+        self.eeprom_path = self.pddf_obj.get_path("EEPROM1", "eeprom")
+        if self.eeprom_path is None:
+            return
+
+        super(PddfEeprom, self).__init__(self.eeprom_path, 0, '', True)
+        self.eeprom_tlv_dict = dict()
+
+        # Create the cache directory if not created
+        if not os.path.exists(CACHE_ROOT):
+            try:
+                os.makedirs(CACHE_ROOT)
+            except Exception as e:
+                print("Error in creating Eeprom cache directory - {}".format(str(e)))
+
+        # Assign cache_name in eeprom_base.py
+        try:
+            self.set_cache_name(os.path.join(CACHE_ROOT, CACHE_FILE))
+        except:
+            pass
+
+        try:
+            self.eeprom_data = self.read_eeprom()
+        except Exception as e:
+            self.eeprom_data = "N/A"
+            raise RuntimeError("Eeprom is not Programmed - Error: {}".format(str(e)))
+        else:
+            eeprom = self.eeprom_data
+
+            try:
+                self.update_cache(eeprom)
+            except:
+                pass
+
+            if not self.is_valid_tlvinfo_header(eeprom):
+                return
+
+            total_length = ((eeprom[9]) << 8) | (eeprom[10])
+            tlv_index = self._TLV_INFO_HDR_LEN
+            tlv_end = self._TLV_INFO_HDR_LEN + total_length
+
+            while (tlv_index + 2) < len(eeprom) and tlv_index < tlv_end:
+                if not self.is_valid_tlv(eeprom[tlv_index:]):
+                    break
+
+                tlv = eeprom[tlv_index:tlv_index + 2
+                             + (eeprom[tlv_index + 1])]
+                code = "0x%02X" % ((tlv[0]))
+
+                if (tlv[0]) == self._TLV_CODE_VENDOR_EXT:
+                    value = str(((tlv[2]) << 24) | ((tlv[3]) << 16) |
+                                ((tlv[4]) << 8) | (tlv[5]))
+                    value += str(tlv[6:6 + (tlv[1])])
+                else:
+                    name, value = self.decoder(None, tlv)
+
+                self.eeprom_tlv_dict[code] = value
+                if (eeprom[tlv_index]) == self._TLV_CODE_CRC_32:
+                    break
+
+                tlv_index += (eeprom[tlv_index+1]) + 2
+
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/event.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/event.py
@@ -1,0 +1,60 @@
+try:
+    import time
+    from sonic_py_common.logger import Logger
+except ImportError as e:
+    raise ImportError(repr(e) + " - required module not found")
+
+POLL_INTERVAL_IN_SEC = 1
+
+class SfpEvent:
+    ''' Listen to insert/remove sfp events '''
+
+    def __init__(self, sfp_list):
+        self._sfp_list = sfp_list
+        self._logger = Logger()
+        self._sfp_change_event_data = {'present': 0}
+
+    def get_presence_bitmap(self):
+        bitmap = 0
+        for sfp in self._sfp_list:
+            modpres = sfp.get_presence()
+            i=sfp.get_position_in_parent() - 1
+            if modpres:
+                bitmap = bitmap | (1 << i)
+        return bitmap
+
+    def get_sfp_event(self, timeout=2000):
+        port_dict = {}
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            cd_ms = 1000
+        else:
+            cd_ms = timeout
+
+        while cd_ms > 0:
+            bitmap = self.get_presence_bitmap()
+            changed_ports = self._sfp_change_event_data['present'] ^ bitmap
+            if changed_ports != 0:
+                break
+            time.sleep(POLL_INTERVAL_IN_SEC)
+            # timeout=0 means wait for event forever
+            if timeout != 0:
+                cd_ms = cd_ms - POLL_INTERVAL_IN_SEC * 1000
+
+        if changed_ports != 0:
+            for sfp in self._sfp_list:
+                i=sfp.get_position_in_parent() - 1
+                if (changed_ports & (1 << i)):
+                    if (bitmap & (1 << i)) == 0:
+                        port_dict[i+1] = '0'
+                    else:
+                        port_dict[i+1] = '1'
+
+
+            # Update the cache dict
+            self._sfp_change_event_data['present'] = bitmap
+            return True, change_dict
+        else:
+            return True, change_dict

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/fan.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_fan import PddfFan
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+FAN_NAME_LIST = ["FAN-1F", "FAN-1R", "FAN-2F", "FAN-2R",
+                 "FAN-3F", "FAN-3R", "FAN-4F", "FAN-4R",
+                 "FAN-5F", "FAN-5R"]
+
+class Fan(PddfFan):
+    """PDDF Platform-Specific Fan class"""
+
+    def __init__(self, tray_idx, fan_idx=0, pddf_data=None, pddf_plugin_data=None, is_psu_fan=False, psu_index=0):
+        # idx is 0-based 
+        PddfFan.__init__(self, tray_idx, fan_idx, pddf_data, pddf_plugin_data, is_psu_fan, psu_index)
+
+    # Provide the functions/variables below for which implementation is to be overwritten
+
+    def get_name(self):
+        """
+        Retrieves the name of the device
+            Returns:
+            string: The name of the device
+        """
+        fan_name = FAN_NAME_LIST[(self.fantray_index-1)*2 + self.fan_index-1] \
+            if not self.is_psu_fan \
+            else "PSU-{} FAN-{}".format(self.fans_psu_index, self.fan_index)
+
+        return fan_name

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/fan_drawer.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/fan_drawer.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_fan_drawer import PddfFanDrawer
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class FanDrawer(PddfFanDrawer):
+    """PDDF Platform-Specific Fan-Drawer class"""
+
+    def __init__(self, tray_idx, pddf_data=None, pddf_plugin_data=None):
+        # idx is 0-based 
+        PddfFanDrawer.__init__(self, tray_idx, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten
+    def get_name(self):
+        """
+        Retrieves the fan drawer name
+        Returns:
+            string: The name of the device
+        """
+        return "FanTray{}".format(self.fantray_index)

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/helper.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/helper.py
@@ -1,0 +1,121 @@
+import os
+import struct
+import subprocess
+from mmap import *
+from sonic_py_common import device_info
+
+HOST_CHK_CMD = ["docker"]
+EMPTY_STRING = ""
+
+
+class APIHelper():
+
+    def __init__(self):
+        (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
+
+    def is_host(self):
+        try:
+            status, output = getstatusoutput_noshell(HOST_CHK_CMD)
+            return status == 0
+        except Exception:
+            return False
+
+    def pci_get_value(self, resource, offset):
+        status = True
+        result = ""
+        try:
+            fd = os.open(resource, os.O_RDWR)
+            mm = mmap(fd, 0)
+            mm.seek(int(offset))
+            read_data_stream = mm.read(4)
+            result = struct.unpack('I', read_data_stream)
+        except Exception:
+            status = False
+        return status, result
+
+    def run_command(self, cmd):
+        status = True
+        result = ""
+        try:
+            p = subprocess.Popen(
+                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            raw_data, err = p.communicate()
+            if err == '':
+                result = raw_data.strip()
+        except Exception:
+            status = False
+        return status, result
+
+    def run_interactive_command(self, cmd):
+        try:
+            os.system(cmd)
+        except Exception:
+            return False
+        return True
+
+    def read_txt_file(self, file_path):
+        try:
+            with open(file_path, 'r', errors='replace') as fd:
+                data = fd.read()
+                return data.strip()
+        except IOError:
+            pass
+        return None
+
+    def write_txt_file(self, file_path, value):
+        try:
+            with open(file_path, 'w') as fd:
+                fd.write(str(value))
+        except IOError:
+            return False
+        return True
+
+    def ipmi_raw(self, netfn, cmd):
+        status = True
+        result = ""
+        try:
+            cmd = "ipmitool raw {} {}".format(str(netfn), str(cmd))
+            p = subprocess.Popen(
+                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            raw_data, err = p.communicate()
+            if err == '':
+                result = raw_data.strip()
+            else:
+                status = False
+        except Exception:
+            status = False
+        return status, result
+
+    def ipmi_fru_id(self, id, key=None):
+        status = True
+        result = ""
+        try:
+            cmd = "ipmitool fru print {}".format(str(
+                id)) if not key else "ipmitool fru print {0} | grep '{1}' ".format(str(id), str(key))
+
+            p = subprocess.Popen(
+                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            raw_data, err = p.communicate()
+            if err == '':
+                result = raw_data.strip()
+            else:
+                status = False
+        except Exception:
+            status = False
+        return status, result
+
+    def ipmi_set_ss_thres(self, id, threshold_key, value):
+        status = True
+        result = ""
+        try:
+            cmd = "ipmitool sensor thresh '{}' {} {}".format(str(id), str(threshold_key), str(value))
+            p = subprocess.Popen(
+                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            raw_data, err = p.communicate()
+            if err == '':
+                result = raw_data.strip()
+            else:
+                status = False
+        except Exception:
+            status = False
+        return status, result

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/pcie.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/pcie.py
@@ -1,0 +1,19 @@
+#############################################################################
+# Edgecore
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the fan status which are available in the platform
+# Base PCIe class
+#############################################################################
+
+try:
+    from sonic_platform_base.sonic_pcie.pcie_common import PcieUtil
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Pcie(PcieUtil):
+    """Edgecore Platform-specific PCIe class"""
+
+    def __init__(self, platform_path):
+        PcieUtil.__init__(self, platform_path)

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/platform.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/platform.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+#############################################################################
+# PDDF
+# Module contains an implementation of SONiC Platform Base API and
+# provides the platform information
+#
+#############################################################################
+
+
+try:
+    from sonic_platform_pddf_base.pddf_platform import PddfPlatform
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Platform(PddfPlatform):
+    """
+    PDDF Platform-Specific Platform Class
+    """
+
+    def __init__(self):
+        PddfPlatform.__init__(self)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/psu.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+#
+
+
+try:
+    from sonic_platform_pddf_base.pddf_psu import PddfPsu
+except ImportError as e:
+    raise ImportError (str(e) + "- required module not found")
+
+
+class Psu(PddfPsu):
+    """PDDF Platform-Specific PSU class"""
+    
+    PLATFORM_PSU_CAPACITY = 1200
+
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
+        PddfPsu.__init__(self, index, pddf_data, pddf_plugin_data)
+        
+    # Provide the functions/variables below for which implementation is to be overwritten
+    def get_voltage_high_threshold(self):
+        """
+        Retrieves the high threshold PSU voltage output
+        Returns:
+            A float number, the high threshold output voltage in volts, 
+            e.g. 12.1 
+        """
+        return 14.72
+
+    def get_voltage_low_threshold(self):
+        """
+        Retrieves the low threshold PSU voltage output
+        Returns:
+            A float number, the low threshold output voltage in volts, 
+            e.g. 12.1 
+        """
+        return 7.68
+
+    def get_name(self):
+        return "PSU-{}".format(self.psu_index)
+
+    def get_maximum_supplied_power(self):
+        """
+        Retrieves the maximum supplied power by PSU (or PSU capacity)
+        Returns:
+            A float number, the maximum power output in Watts.
+            e.g. 1200.1
+        """
+        return float(self.PLATFORM_PSU_CAPACITY)
+
+    def get_capacity(self):
+        """
+        Gets the capacity (maximum output power) of the PSU in watts
+
+        Returns:
+            An integer, the capacity of PSU
+        """
+        return (self.PLATFORM_PSU_CAPACITY)
+
+    def get_type(self):
+        """
+        Gets the type of the PSU
+        Returns:
+        A string, the type of PSU (AC/DC)
+        """
+        return "AC"

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/sfp.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+try:
+    import natsort
+    from sonic_platform_pddf_base.pddf_sfp import PddfSfp
+    from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
+    from sonic_py_common import device_info
+except ImportError as e:
+    raise ImportError (str(e) + "- required module not found")
+
+
+class Sfp(PddfSfp):
+    """
+    PDDF Platform-Specific Sfp class
+    """
+
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
+        PddfSfp.__init__(self, index, pddf_data, pddf_plugin_data)
+        self.index = index + 1
+
+    # Provide the functions/variables below for which implementation is to be overwritten
+    def __get_path_to_port_config_file(self):
+        platform, hwsku = device_info.get_platform_and_hwsku()
+        hwsku_path = "/".join(["/usr/share/sonic/platform",hwsku])
+        return "/".join([hwsku_path, "port_config.ini"])
+
+    def get_name(self):
+        """
+        Retrieves the name of the device
+            Returns:
+            string: The name of the device
+        """                
+        sfputil_helper = SfpUtilHelper()
+        sfputil_helper.read_porttab_mappings(
+            self.__get_path_to_port_config_file())
+
+        logical_port_list = sfputil_helper.logical
+        logical_port_list = natsort.natsorted(logical_port_list)
+        name = logical_port_list[self.port_index-1] or "Unknown"
+
+        return name
+
+    def get_position_in_parent(self):
+        """Retrieves 1-based relative physical position in parent device."""
+        return self.port_index
+
+    def get_error_description(self):
+        """
+        Retrives the error descriptions of the SFP module
+
+        Returns:
+            String that represents the current error descriptions of vendor specific errors
+            In case there are multiple errors, they should be joined by '|',
+            like: "Bad EEPROM|Unsupported cable"
+        """
+        raise NotImplementedError
+

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/thermal.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_thermal import PddfThermal
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Thermal(PddfThermal):
+    """PDDF Platform-Specific Thermal class"""
+
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None, is_psu_thermal=False, psu_index=0):
+        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data, is_psu_thermal, psu_index)
+        
+        self.pddf_obj = pddf_data
+        self.thermal_obj_name = "TEMP{}".format(self.thermal_index)
+        self.thermal_obj = self.pddf_obj.data[self.thermal_obj_name]
+
+    # Provide the functions/variables below for which implementation is to be overwritten
+    def get_name(self):
+        if self.is_psu_thermal:
+            return "PSU-{0} temp sensor 1".format(self.thermals_psu_index)
+        else:
+            if 'dev_attr' in self.thermal_obj.keys():
+                if 'display_name' in self.thermal_obj['dev_attr']:
+                    return str(self.thermal_obj['dev_attr']['display_name'])
+            # In case of errors
+            #return (self.thermal_obj_name)
+            return "Temp sensor {0}".format(self.thermal_index)
+
+    #def get_name(self):
+    #    if self.is_psu_thermal:
+    #        return "PSU-{0} temp sensor 1".format(self.thermals_psu_index)
+    #    else:
+    #        return "Temp sensor {0}".format(self.thermal_index)
+
+    def get_status(self):
+        get_temp=self.get_temperature()
+
+        if get_temp is not None:
+            return True if get_temp else False

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/watchdog.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/watchdog.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#############################################################################
+#
+# Module contains an implementation of platform specific watchdog API's
+#
+#############################################################################
+
+try:
+    from sonic_platform_pddf_base.pddf_watchdog import PddfWatchdog
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+class Watchdog(PddfWatchdog):
+    """
+    PDDF Platform-specific Chassis class
+    """
+
+    def __init__(self):
+        PddfWatchdog.__init__(self)
+        self.timeout= 180
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform_setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform_setup.py
@@ -1,8 +1,5 @@
 from setuptools import setup
 
-DEVICE_NAME = 'accton'
-HW_SKU = 'x86_64-accton_as5835_54x-r0'  
-
 setup(
     name='sonic-platform',
     version='1.0',
@@ -11,13 +8,7 @@ setup(
     author='SONiC Team',
     author_email='linuxnetdev@microsoft.com',
     url='https://github.com/Azure/sonic-buildimage',
-    maintainer='Jostar Yang',
-    maintainer_email='jostar_yang@accton.com',
-    packages=[
-        'sonic_platform',
-    ],
-    package_dir={
-        'sonic_platform': '../../../../device/{}/{}/sonic_platform'.format(DEVICE_NAME, HW_SKU)},
+    packages=['sonic_platform'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Plugins',

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_pddf_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_pddf_monitor.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2019 Accton Technology Corporation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# ------------------------------------------------------------------
+# HISTORY:
+#    mm/dd/yyyy (A.D.)
+#    05/29/2019: Brandon Chuang, changed for as5835-54x.
+#    08/03/2020: Jostar Yang, change to call PDDF API .
+# ------------------------------------------------------------------
+
+try:
+    import sys, getopt
+    import logging
+    import logging.config
+    import time
+    import signal
+    from sonic_platform import platform
+except ImportError as e:
+    raise ImportError('%s - required module not found' % str(e))
+
+# Deafults
+VERSION = '1.0'
+FUNCTION_NAME = 'accton_as5835_54x_monitor'
+DUTY_MAX = 100
+
+platform_chassis = None
+
+test_temp = 0
+test_temp_list = [0, 0, 0, 0]
+test_temp_revert=0
+temp_test_data=0
+
+# Make a class we can use to capture stdout and sterr in the log
+class accton_as5835_54x_monitor(object):
+    # static temp var
+    _ori_temp = 0
+    _new_perc = 0
+
+    def __init__(self, log_file, log_level):
+        """Needs a logger and a logger level."""
+        # set up logging to file
+        logging.basicConfig(
+            filename=log_file,
+            filemode='w',
+            level=log_level,
+            format= '[%(asctime)s] {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s',
+            datefmt='%H:%M:%S'
+        )
+
+        # set up logging to console
+        if log_level == logging.DEBUG:
+            console = logging.StreamHandler()
+            console.setLevel(log_level)
+            formatter = logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s')
+            console.setFormatter(formatter)
+            logging.getLogger('').addHandler(console)
+
+        logging.debug('SET. logfile:%s / loglevel:%d', log_file, log_level)
+
+    def manage_fans(self):
+        global platform_chassis
+        global test_temp_list
+        global temp_test_data
+        global test_temp
+        
+        THERMAL_NUM_MAX=4
+        FAN_LEV1_UP_TEMP = 57700  # temperature
+        FAN_LEV1_SPEED_PERC = DUTY_MAX # percentage*/
+
+        FAN_LEV2_UP_TEMP = 53000
+        FAN_LEV2_DOWN_TEMP = 52700
+        FAN_LEV2_SPEED_PERC = 80
+
+        FAN_LEV3_UP_TEMP = 49500
+        FAN_LEV3_DOWN_TEMP = 47700
+        FAN_LEV3_SPEED_PERC = 65
+
+        FAN_LEV4_DOWN_TEMP = 42700
+        FAN_LEV4_SPEED_PERC = 40
+        
+        FAN_NUM=2
+        FAN_TRAY_NUM=5
+
+        if test_temp_revert==0:
+            temp_test_data=temp_test_data+2000
+        else:            
+            temp_test_data=temp_test_data-2000
+
+        if test_temp==0:
+            temp2=platform_chassis.get_thermal(1).get_temperature()*1000
+            if temp2 is None:
+                return False
+
+            temp3=platform_chassis.get_thermal(2).get_temperature()*1000
+            if temp3 is None:
+                return False
+
+            new_temp = (temp2 + temp3) / 2
+        else:
+            thermal_val=[0,0,0,0]
+            for i in range (THERMAL_NUM_MAX):
+                thermal_val[i]=test_temp_list[i]
+                thermal_val[i]= thermal_val[i] + temp_test_data
+            
+                
+            new_temp = (thermal_val[1] + thermal_val[2])/2
+            logging.debug("Test case:thermal_val[1]=%d, thermal_val[2]=%d, get new_temp=%d", thermal_val[1], thermal_val[2],new_temp)
+
+        for x in range(FAN_TRAY_NUM * FAN_NUM):
+            #fan_stat = platform_chassis.get_fan(x).get_status() or not platform_chassis.get_fan(x).get_speed_rpm()
+            
+            #if fan_stat is None:
+            #    return False
+            #if fan_stat is False:
+            fan_stat=True
+            if not platform_chassis.get_fan(x).get_status() or not platform_chassis.get_fan(x).get_speed_rpm():    
+                self._new_perc = FAN_LEV1_SPEED_PERC
+                logging.debug('INFO. SET new_perc to %d (FAN fault. fan_num:%d)', self._new_perc, x+1)
+                fan_stat=False
+                break
+            logging.debug('INFO. fan_stat is True (fan_num:%d)', x+1)
+
+        if fan_stat==True:
+            diff = new_temp - self._ori_temp
+            if diff  == 0:
+                logging.debug('INFO. RETURN. THERMAL temp not changed. %d / %d (new_temp / ori_temp)', new_temp, self._ori_temp)
+                return True
+            else:
+                if diff >= 0:
+                    is_up = True
+                    logging.debug('INFO. THERMAL temp UP %d / %d (new_temp / ori_temp)', new_temp, self._ori_temp)
+                else:
+                    is_up = False
+                    logging.debug('INFO. THERMAL temp DOWN %d / %d (new_temp / ori_temp)', new_temp, self._ori_temp)
+
+            if is_up is True:
+                if new_temp  >= FAN_LEV1_UP_TEMP:
+                    self._new_perc = FAN_LEV1_SPEED_PERC
+                elif new_temp  >= FAN_LEV2_UP_TEMP:
+                    self._new_perc = FAN_LEV2_SPEED_PERC
+                elif new_temp  >= FAN_LEV3_UP_TEMP:
+                    self._new_perc = FAN_LEV3_SPEED_PERC
+                else:
+                    self._new_perc = FAN_LEV4_SPEED_PERC
+                logging.debug('INFO. SET. FAN_SPEED as %d (new THERMAL temp:%d)', self._new_perc, new_temp)
+            else:
+                if new_temp <= FAN_LEV4_DOWN_TEMP:
+                    self._new_perc = FAN_LEV4_SPEED_PERC
+                elif new_temp  <= FAN_LEV3_DOWN_TEMP:
+                    self._new_perc = FAN_LEV3_SPEED_PERC
+                elif new_temp  <= FAN_LEV2_DOWN_TEMP:
+                    self._new_perc = FAN_LEV2_SPEED_PERC
+                else:
+                    self._new_perc = FAN_LEV1_SPEED_PERC
+                logging.debug('INFO. SET. FAN_SPEED as %d (new THERMAL temp:%d)', self._new_perc, new_temp)
+
+        cur_perc= platform_chassis.get_fan(0).get_speed()
+        #cur_perc = fan.get_fan_duty_cycle()
+        if cur_perc == self._new_perc:
+            logging.debug('INFO. RETURN. FAN speed not changed. %d / %d (new_perc / ori_perc)', self._new_perc, cur_perc)
+            return True
+
+        #set_stat = fan.set_fan_duty_cycle(self._new_perc)
+        set_stat = platform_chassis.get_fan(0).set_speed(self._new_perc)
+        if set_stat is True:
+            logging.debug('INFO: PASS. set_fan_duty_cycle (%d)', self._new_perc)
+        else:
+            logging.debug('INFO: FAIL. set_fan_duty_cycle (%d)', self._new_perc)
+
+        logging.debug('INFO: GET. ori_perc is %d. ori_temp is %d', cur_perc, self._ori_temp)
+        self._ori_temp = new_temp
+        logging.debug('INFO: UPDATE. ori_perc to %d. ori_temp to %d', cur_perc, self._ori_temp)
+
+        return True
+
+def handler(signum, frame):
+    logging.debug('INFO:Cause signal %d, set fan speed max.', signum)
+    platform_chassis.get_fan(0).set_speed(DUTY_MAX)
+    sys.exit(0)
+
+def main(argv):
+    global test_temp
+    
+    log_file = '%s.log' % FUNCTION_NAME
+    log_level = logging.INFO
+    if len(sys.argv) != 1:
+        try:
+            opts, args = getopt.getopt(argv,'hdlt:',['lfile='])
+        except getopt.GetoptError:
+            print('Usage: %s [-d] [-l <log_file>]' % sys.argv[0])
+            return 0
+        for opt, arg in opts:
+            if opt == '-h':
+                print('Usage: %s [-d] [-l <log_file>]' % sys.argv[0])
+                return 0
+            elif opt in ('-d', '--debug'):
+                log_level = logging.DEBUG
+            elif opt in ('-l', '--lfile'):
+                log_file = arg
+                
+        if sys.argv[1]== '-t':
+            if len(sys.argv)!=6:
+                print("temp test, need input 4 temp")
+                return 0
+            i=0
+            for x in range(2, 6):
+               test_temp_list[i]= int(sys.argv[x])*1000
+               i=i+1
+            test_temp = 1
+            log_level = logging.DEBUG
+            print(test_temp_list)
+                
+    global platform_chassis
+    platform_chassis = platform.Platform().get_chassis()
+    
+    
+    signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
+    monitor = accton_as5835_54x_monitor(log_file, log_level)
+
+    # Loop forever, doing something useful hopefully:
+    while True:
+        monitor.manage_fans()
+        time.sleep(10)
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/pddf_post_device_create.sh
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/pddf_post_device_create.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set_qsfp_reset_to_normal_state()
+{
+    i2cset -y -f 3 0x62 0x15 0x3f &>/dev/null
+}
+
+
+set_sfp_tx_disable_to_disable()
+{
+    i2cset -y -f 3 0x61 0x12 0x0 &>/dev/null
+    i2cset -y -f 3 0x61 0x13 0x0 &>/dev/null
+    i2cset -y -f 3 0x61 0x14 0x0 &>/dev/null
+    i2cset -y -f 3 0x61 0x15 0x0 &>/dev/null
+    i2cset -y -f 3 0x61 0x16 0x0 &>/dev/null
+    i2cset -y -f 3 0x62 0xc 0x0  &>/dev/null
+    i2cset -y -f 3 0x62 0xd 0x0  &>/dev/null
+}
+
+set_system_led_diag_loc_to_off()
+{
+    i2cset -y -f 3 0x60 0xa 0x1c &>/dev/null
+}
+
+set_qsfp_reset_to_normal_state
+set_sfp_tx_disable_to_disable
+set_system_led_diag_loc_to_off

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/pddf_switch_svc.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/pddf_switch_svc.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# Script to stop and start the respective platforms default services. 
+# This will be used while switching the pddf->non-pddf mode and vice versa
+from sonic_py_common.general import getstatusoutput_noshell
+
+def check_pddf_support():
+    return True
+
+def stop_platform_svc():
+    
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as5835-54x-platform-monitor-fan.service"])
+    if status:
+        print("Stop as5835-54x-platform-fan.service failed %d"%status)
+        return False
+    
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as5835-54x-platform-monitor-psu.service"])
+    if status:
+        print("Stop as5835-54x-platform-psu.service failed %d"%status)
+        return False
+    
+    status, output = getstatusoutput_noshell(["systemctl",  "stop", "as5835-54x-platform-monitor.service"])
+    if status:
+        print("Stop as5835-54x-platform-init.service failed %d"%status)
+        return False
+    status, output = getstatusoutput_noshell(["systemctl", "disable", "as5835-54x-platform-monitor.service"])
+    if status:
+        print("Disable as5835-54x-platform-monitor.service failed %d"%status)
+        return False
+    
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as5835_54x_util.py", "clean"])
+    if status:
+        print("accton_as5835_54x_util.py clean command failed %d"%status)
+        return False
+
+    # HACK , stop the pddf-platform-init service if it is active
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
+    if status:
+        print("Stop pddf-platform-init.service along with other platform serives failed %d"%status)
+        return False
+
+    return True
+    
+def start_platform_svc():
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as5835_54x_util.py", "install"])
+    if status:
+        print("accton_as5835_54x_util.py install command failed %d"%status)
+        return False
+
+    status, output = getstatusoutput_noshell(["systemctl", "enable", "as5835-54x-platform-monitor.service"])
+    if status:
+        print("Enable as5835-54x-platform-monitor.service failed %d"%status)
+        return False
+    status, output = getstatusoutput_noshell(["systemctl", "start" ,"as5835-54x-platform-monitor-fan.service"])
+    if status:
+        print("Start as5835-54x-platform-monitor-fan.service failed %d"%status)
+        return False
+        
+    status, output = getstatusoutput_noshell(["systemctl", "start", "as5835-54x-platform-monitor-psu.service"])
+    if status:
+        print("Start as5835-54x-platform-monitor-psu.service failed %d"%status)
+        return False
+
+    return True
+
+def start_platform_pddf():
+    status, output = getstatusoutput_noshell(["systemctl", "start", "pddf-platform-init.service"])
+    if status:
+        print("Start pddf-platform-init.service failed %d"%status)
+        return False
+    
+    return True
+
+def stop_platform_pddf():
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
+    if status:
+        print("Stop pddf-platform-init.service failed %d"%status)
+        return False
+
+    return True
+
+def main():
+    pass
+
+if __name__ == "__main__":
+    main()
+

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5835-54x.install
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5835-54x.install
@@ -1,2 +1,1 @@
-as5835-54x/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-accton_as5835_54x-r0
-
+as5835-54x/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-accton_as5835_54x-r0/pddf

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5835-54x.postinst
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5835-54x.postinst
@@ -1,0 +1,9 @@
+# Special arrangement to make PDDF mode default
+# Disable monitor, monitor-fan, monitor-psu (not enabling them would imply they will be disabled by default)
+# Enable pddf-platform-monitor
+depmod -a
+depmod -a
+systemctl enable pddf-platform-init.service
+systemctl start pddf-platform-init.service
+systemctl enable as5835-54x-pddf-platform-monitor.service
+systemctl start as5835-54x-pddf-platform-monitor.service


### PR DESCRIPTION
Signed-off-by: jostar-yang <jostar_yang@edge-core.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support PDDF to as5835-54x
#### How I did it
Implement PDDF related code.
#### How to verify it
Test show cmd and they all work.
root@as5835-54x:/home/admin# sensors

fan_ctrl-i2c-3-63
Adapter: i2c-1-mux (chan_id 1)
fan1:           0 RPM
fan2:           0 RPM
fan3:        20400 RPM
fan4:        17850 RPM
fan5:        20550 RPM
fan6:        17700 RPM
fan7:        20700 RPM
fan8:        18000 RPM
fan9:        21300 RPM
fan10:       17700 RPM

lm75-i2c-29-4a
Adapter: i2c-2-mux (chan_id 3)
MB_RearRight_temp:  +25.0 C  (high = +80.0 C, hyst = +75.0 C)

lm75-i2c-28-49
Adapter: i2c-2-mux (chan_id 2)
MB_RearLeft_temp:  +26.0 C  (high = +80.0 C, hyst = +75.0 C)

psu_pmbus-i2c-12-5b
Adapter: i2c-2-mux (chan_id 2)
in3:          11.82 V
fan1:        3100 RPM
temp1:        +31.0 C
power2:      150.00 W
curr2:        10.67 A

psu_pmbus-i2c-11-58
Adapter: i2c-2-mux (chan_id 1)
in3:           1.02 kV
fan1:           0 RPM
temp1:         +0.0 C
power2:        0.00 W
curr2:         0.00 A

acpitz-acpi-0
Adapter: ACPI interface
temp1:         +0.0 C  (crit = +91.0 C)

lm75-i2c-27-4c
Adapter: i2c-2-mux (chan_id 1)
MB_FrontMiddle_temp:  +23.5 C  (high = +80.0 C, hyst = +75.0 C)

lm75-i2c-26-4b
Adapter: i2c-2-mux (chan_id 0)
CpuBoard_temp:  +27.5 C  (high = +80.0 C, hyst = +75.0 C)

coretemp-isa-0000
Adapter: ISA adapter
Package id 0:  +32.0 C  (high = +71.0 C, crit = +91.0 C)
Core 2:        +32.0 C  (high = +71.0 C, crit = +91.0 C)
Core 6:        +29.0 C  (high = +71.0 C, crit = +91.0 C)
Core 8:        +30.0 C  (high = +71.0 C, crit = +91.0 C)
Core 12:       +31.0 C  (high = +71.0 C, crit = +91.0 C)

root@as5835-54x:/home/admin#
root@as5835-54x:/home/admin# show platform fan
  Drawer    LED          FAN    Speed    Direction     Presence    Status          Timestamp
--------  -----  -----------  -------  -----------  -----------  --------  -----------------
FanTray1  green       FAN-1F      N/A          N/A  Not Present       N/A  20230207 07:35:34
FanTray1  green       FAN-1R      N/A          N/A  Not Present       N/A  20230207 07:35:34
FanTray2  green       FAN-2F     100%      exhaust      Present        OK  20230207 07:35:34
FanTray2  green       FAN-2R     100%      exhaust      Present        OK  20230207 07:35:34
FanTray3  green       FAN-3F     100%      exhaust      Present        OK  20230207 07:35:34
FanTray3  green       FAN-3R     100%      exhaust      Present        OK  20230207 07:35:34
FanTray4  green       FAN-4F     100%      exhaust      Present        OK  20230207 07:35:34
FanTray4  green       FAN-4R     100%      exhaust      Present        OK  20230207 07:35:34
FanTray5  green       FAN-5F     100%      exhaust      Present        OK  20230207 07:35:34
FanTray5  green       FAN-5R     100%      exhaust      Present        OK  20230207 07:35:34
     N/A    off  PSU-1 FAN-1       0%                   Present    Not OK  20230207 07:35:36
     N/A  green  PSU-2 FAN-1      17%      exhaust      Present        OK  20230207 07:35:36



root@as5835-54x:~# show platform firmware status
Chassis          Module    Component    Version       Description
---------------  --------  -----------  ------------  -------------------------
5835-54X-O-AC-F  N/A       MB CPLD1     2             Mainboard CPLD 1
                           MB CPLD2     2             Mainboard CPLD 2
                           MB CPLD3     2             Mainboard CPLD 3
                           FAN CPLD     1             Fan board CPLD
                           CPU CPLD     1             CPU CPLD
                           BIOS         v37.0b.01.02  Basic Input/Output System
root@as5835-54x:~#
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

