### PR TITLE
Added vni field in VRF Yang for VxLAN L3 VNI Support #13456

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1882,6 +1882,7 @@ table allow to change properties of a virtual router. Attributes:
     packets with IP options
 -   'l3_mc_action' contains packet action. Defines the action for
     unknown L3 multicast packets
+-   'vni' contains L3 VNI value. VNI associated Virtual router instance.
 
 The packet action could be:
 
@@ -1903,7 +1904,8 @@ The packet action could be:
 	'src_mac': '02:04:05:06:07:08',
 	'ttl_action': 'copy',
 	'ip_opt_action': 'deny',
-	'l3_mc_action': 'drop'
+	'l3_mc_action': 'drop',
+	'vni': '100'
 }
 ```
 

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2,6 +2,7 @@
     "SAMPLE_CONFIG_DB_JSON": {
         "VRF": {
                 "Vrf_blue": {
+                    "vni" : "100"
                 }
         },
         "DHCP_SERVER": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vrf.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vrf.json
@@ -11,5 +11,9 @@
     },
     "VRF_TEST_WITH_VNI": {
         "desc": "Configure VRF with VNI in VRF table."
+    },
+    "VRF_TEST_WITH_VNI_OOR": {
+        "desc": "Configure VRF with out of range VNI in VRF table.",
+        "eStrKey": "Range"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vrf.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vrf.json
@@ -8,5 +8,8 @@
     },
     "VRF_TEST_WITH_FALLBACK": {
         "desc": "Configure VRF with fallback in VRF table."
+    },
+    "VRF_TEST_WITH_VNI": {
+        "desc": "Configure VRF with VNI in VRF table."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vrf.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vrf.json
@@ -39,5 +39,16 @@
                 }]
             }
         }
+    },
+
+    "VRF_TEST_WITH_VNI_OOR": {
+        "sonic-vrf:sonic-vrf": {
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [{
+                        "name": "Vrf_blue",
+                        "vni": "16777216"
+                }]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vrf.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vrf.json
@@ -28,5 +28,16 @@
                 }]
             }
         }
+    },
+
+    "VRF_TEST_WITH_VNI": {
+        "sonic-vrf:sonic-vrf": {
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [{
+                        "name": "Vrf_blue",
+                        "vni": "100"
+                }]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-vrf.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vrf.yang
@@ -45,10 +45,7 @@ module sonic-vrf {
 
                 leaf vni {
                     type uint32 {
-                        range "0..16777215" {
-                            error-message "VNI ID out of range";
-                            error-app-tag vnid-invalid;
-                        }
+                        range "0..16777215";
                     }
                     default 0;
                     description

--- a/src/sonic-yang-models/yang-models/sonic-vrf.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vrf.yang
@@ -43,6 +43,17 @@ module sonic-vrf {
                         "Enable/disable fallback feature which is useful for specified VRF user to access internet through global/main route.";
                 }
 
+                leaf vni {
+                    type uint32 {
+                        range "0..16777215" {
+                            error-message "VNI ID out of range";
+                            error-app-tag vnid-invalid;
+                        }
+                    }
+                    default 0;
+                    description
+                        "VNI mapped to VRF";
+                }
             } /* end of list VRF_LISt */
         } /* end of container VRf */
     } /* end of container sonic-vrf */


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Added vni field in VRF Yang for VxLAN L3 VNI Support.

The VRF table schema as per EVPN HLD is below
https://github.com/sonic-net/SONiC/blob/master/doc/vxlan/EVPN/EVPN_VXLAN_HLD.md

Addresses Issue #13456

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

