### PR TITLE
[Mellanox] Support per PSU slope value for PSU power threshold

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -220,7 +220,7 @@ class Psu(FixedPsu):
     FAN_AMBIENT_TEMP = os.path.join(PSU_PATH, "thermal/fan_amb")
     AMBIENT_TEMP_CRITICAL_THRESHOLD = os.path.join(PSU_PATH, "config/amb_tmp_crit_limit")
     AMBIENT_TEMP_WARNING_THRESHOLD = os.path.join(PSU_PATH, "config/amb_tmp_warn_limit")
-    PSU_POWER_SLOPE = os.path.join(PSU_PATH, "config/psu_power_slope")
+    PSU_POWER_SLOPE = os.path.join(PSU_PATH, "config/psu{}_power_slope")
 
     shared_led = None
 
@@ -244,6 +244,8 @@ class Psu(FixedPsu):
 
         self.psu_temp = os.path.join(PSU_PATH, 'thermal/psu{}_temp'.format(self.index))
         self.psu_temp_threshold = os.path.join(PSU_PATH, 'thermal/psu{}_temp_max'.format(self.index))
+
+        self.psu_power_slope = os.path.join(PSU_PATH, self.PSU_POWER_SLOPE.format(self.index))
 
         from .fan import PsuFan
         self._fan_list.append(PsuFan(psu_index, 1, self))
@@ -529,7 +531,7 @@ class Psu(FixedPsu):
                 if ambient_temp < temp_threshold:
                     power_threshold = power_max_capacity
                 else:
-                    slope = utils.read_int_from_file(Psu.PSU_POWER_SLOPE)
+                    slope = utils.read_int_from_file(self.psu_power_slope)
                     power_threshold = power_max_capacity - (ambient_temp - temp_threshold) * slope
                 if power_threshold <= 0:
                     logger.log_warning('Got negative PSU power threshold {} for {}'.format(power_threshold, self.get_name()))

--- a/platform/mellanox/mlnx-platform-api/tests/test_psu.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_psu.py
@@ -172,7 +172,7 @@ class TestPsu:
             psu.psu_power_max_capacity: 100000000,
             psu.AMBIENT_TEMP_CRITICAL_THRESHOLD: 65000,
             psu.AMBIENT_TEMP_WARNING_THRESHOLD: 55000,
-            psu.PSU_POWER_SLOPE: 2000
+            psu.psu_power_slope: 2000
             }
         normal_data = {
             psu.PORT_AMBIENT_TEMP: 55000,


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Support per PSU slope value for PSU power threshold according to hardware team requirement

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

Pass the PSU number as a parameter when fetching the slope value of PSU.

#### How to verify it

Running regression and manul test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

