### PR TITLE
SONiC YANG model support for RADIUS.

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -55,6 +55,7 @@ Table of Contents
          * [Virtual router](#virtual-router)  
          * [WRED_PROFILE](#wred_profile)  
          * [PASSWORD_HARDENING](#password_hardening)
+         * [RADIUS](#radius)
    * [For Developers](#for-developers)  
       * [Generating Application Config by Jinja2 Template](#generating-application-config-by-jinja2-template)
       * [Incremental Configuration by Subscribing to ConfigDB](#incremental-configuration-by-subscribing-to-configdb)
@@ -1712,6 +1713,29 @@ The method could be:
     }
 }
 ```
+
+### RADIUS
+
+The RADIUS and RADIUS_SERVER tables define RADIUS config paramerters. RADIUS table carries global configuration while RADIUS_SERVER table carries per server configuration.
+
+```
+"RADIUS": {
+    "global": {
+       "auth_type": "pap",
+       "timeout": "5"
+    }
+}
+
+"RADIUS_SERVER": {
+    "192.168.1.2": {
+       "priority": "4",
+       "retransmit": "2",
+       "timeout": "5"
+    }
+}
+
+```
+
 
 For Developers
 ==============

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -130,6 +130,7 @@ setup(
                          './yang-models/sonic-syslog.yang',
                          './yang-models/sonic-system-aaa.yang',
                          './yang-models/sonic-system-tacacs.yang',
+                         './yang-models/sonic-system-radius.yang',
                          './yang-models/sonic-telemetry.yang',
                          './yang-models/sonic-types.yang',
                          './yang-models/sonic-versions.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1235,6 +1235,19 @@
                 "timeout": "10"
             }
         },
+        "RADIUS": {
+            "global": {
+                "auth_type": "pap",
+                "timeout": "5"
+            }
+        },
+        "RADIUS_SERVER": {
+            "192.168.1.2": {
+                "priority": "4",
+                "retransmit": "2",
+                "timeout": "5"
+            }
+        },
         "NAT_BINDINGS": {
             "bind1": {
                 "nat_pool": "pool1",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/radius.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/radius.json
@@ -1,0 +1,36 @@
+{
+    "RADIUS_TEST": {
+        "desc": "RADIUS global configuration in the RADIUS table."
+    },
+    "RADIUS_INVALID_SRC_IP_TEST": {
+        "desc": "Radius global configuration with invalid Src IP value in RADIUS table.",
+        "eStr": "InvalidValue"
+    },
+    "RADIUS_INVALID_TIMEOUT_TEST": {
+        "desc": "Radius global configuration with invalid timeout in RADIUS table.",
+        "eStr": "RADIUS timeout must be 1..60."
+    },
+    "RADIUS_SERVER_TEST" : {
+        "desc": "Radius server configuration in RADIUS_SERVER table."
+    },
+    "RADIUS_SERVER_INVALID_PRIORITY_TEST": {
+        "desc": "Radius server configuration with invalid priority value in RADIUS_SERVER table.",
+        "eStr": "RADIUS priority must be 1..64."
+    },
+    "RADIUS_SERVER_INVALID_TIMEOUT_TEST" : {
+        "desc": "Radius server configuration with invalid timeout value in RADIUS_SERVER table.",
+        "eStr": "RADIUS timeout must be 1..60"
+    },
+    "RADIUS_SERVER_INVALID_RETRANSMIT_TEST" : {
+        "desc": "Radius server configuration with invalid retransmit value in RADIUS_SERVER table.",
+        "eStr": "RADIUS retransmit must be 0..10"
+    },
+    "RADIUS_SERVER_INVALID_AUTH_TYPE_TEST" : {
+        "desc": "Radius server configuration with invalid auth type in RADIUS_SERVER table.",
+        "eStrKey": "InvalidValue"
+    },
+    "RADIUS_SERVER_INVALID_VRF_TEST" : {
+        "desc": "Radius server configuration with invalid VRF in RADIUS_SERVER table.",
+        "eStr": "Invalid VRF name"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/radius.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/radius.json
@@ -1,0 +1,139 @@
+{
+    "RADIUS_TEST": {
+        "sonic-system-radius:sonic-system-radius": {
+            "sonic-system-radius:RADIUS": {
+                "global": {
+                        "auth_type": "chap",
+                        "timeout": 5,
+                        "passkey": "brcm123"
+                }
+            }
+        }
+    },
+
+    "RADIUS_INVALID_SRC_IP_TEST": {
+        "sonic-system-radius:sonic-system-radius": {
+            "sonic-system-radius:RADIUS": {
+                "global": {
+                        "auth_type": "chap",
+                        "src_ip": "INVALID"
+                }
+            }
+        }
+    },
+
+    "RADIUS_INVALID_TIMEOUT_TEST": {
+        "sonic-system-radius:sonic-system-radius": {
+            "sonic-system-radius:RADIUS": {
+                "global": {
+                        "auth_type": "chap",
+                        "timeout": 70
+                }
+            }
+        }
+    },
+
+    "RADIUS_SERVER_TEST": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth8",
+                    "description": "Ethernet8",
+                    "lanes": "65",
+                    "mtu": 9000,
+                    "name": "Ethernet0",
+                    "speed": 25000
+                }
+                ]
+            }
+        },
+
+        "sonic-system-radius:sonic-system-radius": {
+            "sonic-system-radius:RADIUS_SERVER": {
+                "RADIUS_SERVER_LIST": [
+                {
+                        "ipaddress": "192.168.1.1",
+                        "priority": 5,
+                        "timeout": 6,
+                        "auth_type": "chap",
+                        "passkey": "brcm123",
+                        "src_intf": "Ethernet0",
+                        "vrf": "default"
+                },
+                {
+                        "ipaddress": "10.10.10.10",
+                        "priority": 2,
+                        "timeout": 15,
+                        "auth_type": "pap",
+                        "passkey": "sonic_123",
+                        "vrf": "mgmt"
+                }
+                ]
+            }
+        }
+    },
+
+    "RADIUS_SERVER_INVALID_PRIORITY_TEST": {
+        "sonic-system-radius:sonic-system-radius": {
+            "sonic-system-radius:RADIUS_SERVER": {
+                "RADIUS_SERVER_LIST": [
+                {
+                    "ipaddress": "192.168.1.1",
+                    "priority": 70
+                }
+                ]
+            }
+        }
+    },
+    "RADIUS_SERVER_INVALID_TIMEOUT_TEST": {
+        "sonic-system-radius:sonic-system-radius": {
+            "sonic-system-radius:RADIUS_SERVER": {
+                "RADIUS_SERVER_LIST": [
+                {
+                    "ipaddress": "192.168.1.1",
+                    "timeout": 70
+                }
+                ]
+            }
+        }
+    },
+    "RADIUS_SERVER_INVALID_RETRANSMIT_TEST": {
+        "sonic-system-radius:sonic-system-radius": {
+            "sonic-system-radius:RADIUS_SERVER": {
+                "RADIUS_SERVER_LIST": [
+                {
+                    "ipaddress": "192.168.1.1",
+                    "retransmit": 20
+                }
+                ]
+            }
+        }
+    },
+    "RADIUS_SERVER_INVALID_AUTH_TYPE_TEST": {
+        "sonic-system-radius:sonic-system-radius": {
+            "sonic-system-radius:RADIUS_SERVER": {
+                "RADIUS_SERVER_LIST": [
+                {
+                    "ipaddress": "192.168.1.1",
+                    "auth_type": "123"
+                }
+                ]
+            }
+        }
+    },
+    "RADIUS_SERVER_INVALID_VRF_TEST": {
+        "sonic-system-radius:sonic-system-radius": {
+            "sonic-system-radius:RADIUS_SERVER": {
+                "RADIUS_SERVER_LIST": [
+                {
+                    "ipaddress": "192.168.1.1",
+                    "vrf": "Vrf1"
+                }
+                ]
+            }
+        }
+    }
+
+}

--- a/src/sonic-yang-models/yang-models/sonic-system-radius.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-radius.yang
@@ -1,0 +1,215 @@
+module sonic-system-radius {
+    namespace "http://github.com/sonic-net/sonic-system-radius";
+    prefix ssys;
+    yang-version 1.1;
+
+    import ietf-inet-types {
+        prefix inet;
+    }
+
+    import sonic-port {
+        prefix port;
+    }
+
+    import sonic-portchannel {
+        prefix lag;
+    }
+
+//  Comment sonic-vlan import here until libyang back-links issue is resolved for VLAN leaf reference.
+//    import sonic-vlan {
+//        prefix vlan;
+//    }
+
+    import sonic-loopback-interface {
+        prefix loopback;
+    }
+
+    import sonic-mgmt_port {
+        prefix mgmt-port;
+    }
+
+    import sonic-interface {
+        prefix interface;
+    }
+
+    description
+        "SONiC RADIUS";
+
+    revision 2022-11-11 {
+        description "Initial revision.";
+    }
+
+    typedef auth_type_enumeration {
+        type enumeration {
+            enum pap;
+            enum chap;
+            enum mschapv2;
+        }
+    }
+
+
+    container sonic-system-radius {
+
+        container RADIUS {
+
+            container global {
+
+
+                leaf passkey {
+                    type string {
+                        length "1..65";
+                        pattern "[^ #,]*" {
+                            error-message 'RADIUS shared secret (Valid chars are ASCII printable except SPACE, "#", and ",")';
+                        }
+                    }
+                    description
+                            'RADIUS global shared secret (Valid chars are ASCII printable except SPACE, "#", and ",")';
+                }
+
+                leaf auth_type {
+                    default "pap";
+                    type auth_type_enumeration;
+                    description
+                            "RADIUS global method used for authenticating the comm. mesg.";
+                }
+
+                leaf src_ip {
+                    type inet:ip-address;
+                    description
+                            "source IP address (IPv4 or IPv6) for the outgoing RADIUS pkts.";
+                }
+
+                leaf nas_ip {
+                    type inet:ip-address;
+                    description
+                            "NAS-IP|IPV6-Address attribute for the outgoing RADIUS pkts.";
+                }
+
+                leaf statistics {
+                    type boolean;
+                    description
+                            "Should statistics collection be enabled/disabled";
+                }
+
+                leaf timeout {
+                    default 5;
+                    type uint16 {
+                        range "1..60" {
+                            error-message "RADIUS timeout must be 1..60";
+                        }
+                    }
+                }
+
+                leaf retransmit {
+                    default 3;
+                    type uint8 {
+                        range "0..10" {
+                            error-message "RADIUS retransmit must be 0..10";
+                        }
+                    }
+                }
+            }
+        }
+
+        container RADIUS_SERVER {
+
+            list RADIUS_SERVER_LIST {
+                key "ipaddress";
+
+                max-elements 8;
+
+                leaf ipaddress {
+                    type inet:host;
+                    description
+                        "RADIUS server's Domain name or IP address (IPv4 or IPv6)";
+                }
+
+                leaf auth_port {
+                    default 1812;
+                    type inet:port-number;
+                    description
+                        "RADIUS authentication port number.";
+                }
+
+                leaf passkey {
+                    type string {
+                        length "1..65";
+                        pattern "[^ #,]*" {
+                            error-message 'RADIUS shared secret (Valid chars are ASCII printable except SPACE, "#", and ",")';
+                        }
+                    }
+                    description
+                            'RADIUS servers shared secret (Valid chars are ASCII printable except SPACE, "#", and ",")';
+                }
+
+                leaf auth_type {
+                    default "pap";
+                    type auth_type_enumeration;
+                    description
+                            "RADIUS server's method used for authenticating the comm. mesg.";
+                }
+
+                leaf priority {
+                    type uint8 {
+                        range "1..64" {
+                            error-message "RADIUS priority must be 1..64";
+                        }
+                    }
+                    description
+                            "RADIUS server's priority";
+                }
+
+                leaf timeout {
+                    default 5;
+                    type uint16 {
+                        range "1..60" {
+                            error-message "RADIUS timeout must be 1..60";
+                        }
+                    }
+                }
+
+                leaf retransmit {
+                    default 3;
+                    type uint8 {
+                        range "0..10" {
+                            error-message "RADIUS retransmit must be 0..10";
+                        }
+                    }
+                }
+
+                leaf vrf {
+                    type string {
+                        pattern "mgmt|default" {
+                            error-message "Error: Invalid VRF name";
+                        }
+                    }
+                    description
+                        "VRF name";
+
+                }
+
+                leaf src_intf {
+                    type union {
+                        type leafref {
+                            path "/port:sonic-port/port:PORT/port:PORT_LIST/port:name";
+                        }
+                        type leafref {
+                            path "/lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name";
+                        }
+                        type string {
+                            pattern 'Vlan([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
+                        }
+
+                        type leafref {
+                            path "/loopback:sonic-loopback-interface/loopback:LOOPBACK_INTERFACE/loopback:LOOPBACK_INTERFACE_LIST/loopback:name";
+                        }
+                        type leafref {
+                            path "/mgmt-port:sonic-mgmt_port/mgmt-port:MGMT_PORT/mgmt-port:MGMT_PORT_LIST/mgmt-port:name";
+                        }
+                    }
+                    description "Source interface to use for RADIUS server communication.";
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Added SONiC YANG model for RADIUS.

#### How I did it
Added the RADIUS and RADIUS_SERVER tables for global and per RADIUS server configuration. RADIUS statistics reside in COUNTERS_DB and are not part of the configuration. These are not a part of this PR.

#### How to verify it
Compiled sonic_yang_mgmt-1.0-py3-none-any.whl.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
SONiC YANG model for RADIUS.

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

