### PR TITLE
[Seastone] fix QSFP no change event issue for Seastone

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/chassis.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/chassis.py
@@ -182,8 +182,8 @@ class Chassis(ChassisBase):
         if not self.sfp_module_initialized:
             self.__initialize_sfp()
 
-        sfp_event = SfpEvent(self._sfp_list).get_sfp_event(timeout)
-        if sfp_event:
+        succeed, sfp_event = SfpEvent(self._sfp_list).get_sfp_event(timeout)
+        if succeed:
             return True, {'sfp': sfp_event}
 
         return False, {'sfp': {}}

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/event.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/event.py
@@ -1,30 +1,73 @@
 try:
     import select
+    import time
     from .helper import APIHelper
     from sonic_py_common.logger import Logger
 except ImportError as e:
     raise ImportError(repr(e) + " - required module not found")
 
 
+QSFP_MODPRS_IRQ = '/sys/devices/platform/dx010_cpld/qsfp_modprs_irq'
+GPIO_SUS6 = "/sys/devices/platform/slx-ich.0/sci_int_gpio_sus6"
+QSFP_EVENT_POLLING_MODE = True
+
+
 class SfpEvent:
     ''' Listen to insert/remove sfp events '''
-
-    QSFP_MODPRS_IRQ = '/sys/devices/platform/dx010_cpld/qsfp_modprs_irq'
-    GPIO_SUS6 = "/sys/devices/platform/slx-ich.0/sci_int_gpio_sus6"
 
     def __init__(self, sfp_list):
         self._api_helper = APIHelper()
         self._sfp_list = sfp_list
         self._logger = Logger()
 
+    sfp_change_event_data = {'valid': 0, 'last': 0, 'present': 0}
+
     def get_sfp_event(self, timeout):
-        epoll = select.epoll()
         port_dict = {}
+
+        if QSFP_EVENT_POLLING_MODE:
+            # Using polling mode
+            now = time.time()
+
+            if timeout < 1000:
+                timeout = 1000
+            timeout = timeout / float(1000)  # Convert to secs
+
+            if now < (self.sfp_change_event_data['last'] + timeout) \
+                    and self.sfp_change_event_data['valid']:
+                return True, port_dict
+
+            bitmap = 0
+            for sfp in self._sfp_list:
+                modpres = sfp.get_presence()
+                index = sfp.get_index()
+                if modpres:
+                    bitmap = bitmap | (1 << index)
+
+            changed_ports = self.sfp_change_event_data['present'] ^ bitmap
+            if changed_ports:
+                for sfp in self._sfp_list:
+                    index = sfp.get_index()
+                    if changed_ports & (1 << index):
+                        if (bitmap & (1 << index)) == 0:
+                            port_dict[str(index + 1)] = '0'
+                        else:
+                            port_dict[str(index + 1)] = '1'
+
+                # Update the cache dict
+                self.sfp_change_event_data['present'] = bitmap
+                self.sfp_change_event_data['last'] = now
+                self.sfp_change_event_data['valid'] = 1
+
+            return True, port_dict
+
+        # SFP event from GPIO interrupt pin
+        epoll = select.epoll()
         timeout_sec = timeout/1000
 
         try:
             # We get notified when there is an SCI interrupt from GPIO SUS6
-            fd = open(self.GPIO_SUS6, "r")
+            fd = open(GPIO_SUS6, "r")
             fd.read()
 
             epoll.register(fd.fileno(), select.EPOLLIN & select.EPOLLET)
@@ -32,21 +75,22 @@ class SfpEvent:
             if events:
                 # Read the QSFP ABS interrupt & status registers
                 port_changes = self._api_helper.read_one_line_file(
-                    self.QSFP_MODPRS_IRQ)
+                    QSFP_MODPRS_IRQ)
                 changes = int(port_changes, 16)
                 for sfp in self._sfp_list:
-                    change = (changes >> sfp.port_num-1) & 1
+                    index = sfp.get_index()
+                    change = (changes >> index) & 1
                     if change == 1:
-                        port_dict[str(sfp.port_num)] = str(
+                        port_dict[str(index + 1)] = str(
                             int(sfp.get_presence()))
 
-                return port_dict
+                return True, port_dict
         except Exception as e:
             self._logger.log_error("Failed to detect SfpEvent - " + repr(e))
-            return False
+            return False, port_dict
 
         finally:
             fd.close()
             epoll.close()
 
-        return False
+        return False, port_dict

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/sfp.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/sfp.py
@@ -2195,6 +2195,14 @@ class Sfp(SfpBase):
         """
         return 0
 
+    def get_index(self):
+        """
+        Retrieves current sfp index
+        Returns:
+            A int value, sfp index
+        """
+        return self._index
+
     def is_replaceable(self):
         """
         Retrieves if replaceable


### PR DESCRIPTION
#### Why I did it
Fix issue [#13581](https://github.com/sonic-net/sonic-buildimage/issues/13581), QSFP remove/insert change events not deteted for seastone

#### How I did it
Change to use polling mode to retrieve SFP insert/remove change event,
due to no SFP abs intr signal from CPLD.

#### How to verify it
After the fix, run 'show interfaces transceiver presence' and 'show interfaces transceiver eeprom'
can show the correct SFP info.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

