### PR TITLE
Voq Chassis: Add the Recirc ports to the INTERFACES table to make it routed intf

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1749,11 +1749,14 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         if inband_port in ports.keys():
             ports[inband_port]['admin_status'] = 'up'
 
-    # bring up the recirc port for voq chassis
+    # bring up the recirc port for voq chassis, Set it as routed interface
     for port, port_attributes in ports.items():
         port_role = port_attributes.get('role', None)
         if port_role == 'Rec':
             ports[port]['admin_status'] = 'up'
+
+            #Add the Recirc ports to the INTERFACES table to make it routed intf
+            results['INTERFACE'].update({port : {}})
 
     results['PORT'] = ports
     results['CONSOLE_PORT'] = console_ports

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -959,6 +959,14 @@ class TestCfgGen(TestCase):
                 "admin_status": "up"
             })
 
+        argument = ["-j", self.macsec_profile, "-m", self.sample_graph_voq, "-p", self.voq_port_config, "--var-json", "INTERFACE"]
+        output = self.run_script(argument)
+        output_dict = utils.to_dict(output.strip())
+        self.assertDictEqual(
+            output_dict['Ethernet-Rec0'],
+            {}
+        )
+
     def test_minigraph_dhcp(self):
         argument = ['-m', self.sample_graph_simple_case, '-p', self.port_config, '-v', 'DHCP_RELAY']
         output = self.run_script(argument)


### PR DESCRIPTION
#### Why I did it
Add the Recirc ports to the INTERFACES table to make it routed intf. So that there is no need to configure IP address on Recirc interface.

#### How I did it
Updated the minigraph parser to add the Ethernet-Rec0/1 to the INTERFACE table as below 

```
    "INTERFACE": {
        "v": {},
        "Ethernet64|FC00::9/126": {},
        "Ethernet64|10.0.0.4/31": {},
        "Ethernet64": {}
    },
```

#### How to verify it
Run the Everflow sonic-mgmt tests with VoQ chassis without the need to configure an IP address on Ethernet-Rec0 interface. everflow_per_interface is a known failure - to be fixed.

```
--------------------------------------------------------------------------- generated xml file: /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/logs/tr.xml ----------------------------------------------------------------------------
========================================================================================================= short test summary info ==========================================================================================================
SKIPPED [4] /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/everflow/test_everflow_testbed.py:373: Skip test as is not supported on a VoQ chassis.
SKIPPED [10] /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/everflow/everflow_test_utilities.py:597: egress ACL w/ ingress Mirroring not supported, skipping
SKIPPED [4] /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/everflow/test_everflow_testbed.py:498: Skipping test since mirror policing is not supported on broadcom j2c+ platforms
SKIPPED [10] /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/everflow/everflow_test_utilities.py:597: ingress ACL w/ egress Mirroring not supported, skipping
FAILED everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6] - AssertionError: Did not receive expected packet on any of ports [0, 1] for device 0.
===================================================================================== 1 failed, 33 passed, 28 skipped, 486 warnings in 2049.77
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

