### PR TITLE
[202211][dualtor][active-active] changing the default value of config knob for killing `radv` to be `True` (#13495)

### DIFF
--- a/files/scripts/service_mgmt.sh
+++ b/files/scripts/service_mgmt.sh
@@ -40,7 +40,7 @@ function check_redundant_type()
         ACTIVE_ACTIVE="false"
     fi
     CONFIG_KNOB=`$SONIC_DB_CLI CONFIG_DB hget "MUX_LINKMGR|SERVICE_MGMT" kill_radv`
-    if [[ x"$CONFIG_KNOB" != x"True" ]]; then
+    if [[ x"$CONFIG_KNOB" == x"False" ]]; then
         ACTIVE_ACTIVE='false'
     fi 
     debug "DEVICE_SUBTYPE: ${DEVICE_SUBTYPE}, CONFIG_KNOB: ${CONFIG_KNOB}"


### PR DESCRIPTION
Raising PR for cherry-pick conflict: https://github.com/sonic-net/sonic-buildimage/pull/13495

sign-off: Jing Zhang zhangjing@microsoft.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

