### PR TITLE
Use tmpfs for /var/log on Arista 7050CX3-32S

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -524,6 +524,7 @@ write_platform_specific_cmdline() {
     fi
     if [ "$sid" = "Lodoga" ]; then
         aboot_machine=arista_7050cx3_32s
+        cmdline_add logs_inram=on
     fi
     if [ "$sid" = "Marysville" ]; then
         aboot_machine=arista_7050sx3_48yc8


### PR DESCRIPTION
This is to reduce writes to the SSD on the device.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

```
Platform: x86_64-arista_7050cx3_32s
HwSKU: Arista-7050CX3-32S-C32
```

Before:

```
admin@str2-7050cx3-acs-12:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            3.9G     0  3.9G   0% /dev
tmpfs           797M  9.0M  788M   2% /run
root-overlay    7.1G  4.9G  2.3G  69% /
/dev/mmcblk0p1  7.1G  4.9G  2.3G  69% /host
/dev/loop1      380M  138M  219M  39% /var/log
tmpfs           3.9G     0  3.9G   0% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           4.0M     0  4.0M   0% /sys/fs/cgroup
/tmp            3.9G     0  3.9G   0% /tmp/tmp.WpfOFZAt3p
```

After:

```
admin@str2-7050cx3-acs-12:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            3.9G     0  3.9G   0% /dev
tmpfs           794M   15M  779M   2% /run
root-overlay    7.1G  4.7G  2.5G  66% /
/dev/mmcblk0p1  7.1G  4.7G  2.5G  66% /host
tmpfs           400M  808K  400M   1% /var/log
tmpfs           3.9G   60K  3.9G   1% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           4.0M     0  4.0M   0% /sys/fs/cgroup
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

