### PR TITLE
[Build] Remove the additional space character in the mirrors.list file

### DIFF
--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -112,7 +112,7 @@ get_version_cache_option()
 set_reproducible_mirrors()
 {
     # Remove the charater # in front of the line if matched
-    local expression="s/^#\(.*$REPR_MIRROR_URL_PATTERN\)/\1/"
+    local expression="s/^#\s*\(.*$REPR_MIRROR_URL_PATTERN\)/\1/"
     # Add the character # in front of the line, if not match the URL pattern condition
     local expression2="/^#*deb.*$REPR_MIRROR_URL_PATTERN/! s/^#*deb/#&/"
     local expression3="\$a#SET_REPR_MIRRORS"
@@ -120,7 +120,7 @@ set_reproducible_mirrors()
         # Add the charater # in front of the line if match
         expression="s/^deb.*$REPR_MIRROR_URL_PATTERN/#\0/"
         # Remove the character # in front of the line, if not match the URL pattern condition
-        expression2="/^#*deb.*$REPR_MIRROR_URL_PATTERN/! s/^#(#*deb)/\1/"
+        expression2="/^#*deb.*$REPR_MIRROR_URL_PATTERN/! s/^#\s*(#*deb)/\1/"
         expression3="/#SET_REPR_MIRRORS/d"
     fi
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix all mirror is commented out in sources.list in slave image issue. It will have an issue when installing more packages in the slave container.

It will add additional space character after running add-apt-repository command.

For example:
```
#deb [arch=amd64] http://deb.debian.org/debian/ bullseye main contrib non-free
```
add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian bullseye stable"

```
# deb [arch=amd64] http://deb.debian.org/debian/ bullseye main contrib non-free
```

#### How I did it
Fix the regex string to add the space pattern. After fixed, whether there is a space character or not, it will not be an issue.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

