### PR TITLE
[dhcp_relay] Remove exist check while adding dhcpv6 relay

### DIFF
--- a/dockers/docker-dhcp-relay/cli-plugin-tests/conftest.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/conftest.py
@@ -19,14 +19,23 @@ def mock_cfgdb():
     }
 
     def get_entry(table, key):
+        if table not in CONFIG or key not in CONFIG[table]:
+            return {}
         return CONFIG[table][key]
 
     def set_entry(table, key, data):
         CONFIG[table].setdefault(key, {})
-        CONFIG[table][key] = data
+
+        if data is None:
+            CONFIG[table].pop(key)
+        else:
+            CONFIG[table][key] = data
+
+    def get_keys(table):
+        return CONFIG[table].keys()
 
     cfgdb.get_entry = mock.Mock(side_effect=get_entry)
     cfgdb.set_entry = mock.Mock(side_effect=set_entry)
+    cfgdb.get_keys = mock.Mock(side_effect=get_keys)
 
     yield cfgdb
-

--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_dhcp_relay.py
@@ -111,9 +111,25 @@ class TestConfigDhcpRelay(object):
         cli = mock.MagicMock()
         dhcp_relay.register(cli)
 
-    def test_config_dhcp_relay_add_del_with_nonexist_vlanid(self, ip_version, op):
+    def test_config_dhcp_relay_add_del_with_nonexist_vlanid_ipv4(self, op):
         runner = CliRunner()
 
+        ip_version = "ipv4"
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
+                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands[op], ["1001", IP_VER_TEST_PARAM_MAP[ip_version]["ips"][0]])
+            print(result.exit_code)
+            print(result.stdout)
+            assert result.exit_code != 0
+            assert "Error: Vlan1001 doesn't exist" in result.output
+            assert mock_run_command.call_count == 0
+
+    def test_config_dhcp_relay_del_with_nonexist_vlanid_ipv6(self):
+        runner = CliRunner()
+
+        op = "del"
+        ip_version = "ipv6"
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
                                    .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
@@ -262,3 +278,25 @@ class TestConfigDhcpRelay(object):
             assert result.exit_code != 0
             assert "Error: Find duplicate DHCP relay ip {} in {} list".format(test_ip, op) in result.output
             assert mock_run_command.call_count == 0
+
+    def test_config_add_dhcp_relay_ipv6_with_non_entry(self, mock_cfgdb):
+        op = "add"
+        ip_version = "ipv6"
+        test_ip = IP_VER_TEST_PARAM_MAP[ip_version]["ips"][0]
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb = mock_cfgdb
+        table = IP_VER_TEST_PARAM_MAP[ip_version]["table"]
+        db.cfgdb.set_entry(table, "Vlan1000", None)
+        assert db.cfgdb.get_entry(table, "Vlan1000") == {}
+        assert len(db.cfgdb.get_keys(table)) == 0
+
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
+                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands[op], ["1000", test_ip], obj=db)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry(table, "Vlan1000") == {"dhcpv6_servers": [test_ip]}
+            assert mock_run_command.call_count == 3


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
DHCPv6 relay config entry is not useful while del dhcpv6 relay config.

#### How I did it
Remove dhcpv6_relay entry if it is empty and not check entry exist while adding dhcpv6 relay

#### How to verify it
1. unit test
```
2023-02-15T14:35:30.9629795Z ----------- coverage: platform linux, python 3.9.2-final-0 -----------
2023-02-15T14:35:30.9630243Z Name                                                Stmts   Miss Branch BrPart  Cover
2023-02-15T14:35:30.9630753Z -------------------------------------------------------------------------------------
2023-02-15T14:35:30.9631093Z acl_loader/__init__.py                                  0      0      0      0   100%
2023-02-15T14:35:30.9631409Z acl_loader/main.py                                    602    226    268     39    56%
2023-02-15T14:35:30.9631702Z clear/__init__.py                                       0      0      0      0   100%
2023-02-15T14:35:30.9632002Z clear/bgp_frr_v6.py                                    53     53     12      0     0%
2023-02-15T14:35:30.9632297Z clear/bgp_quagga_v4.py                                 53     53     12      0     0%
2023-02-15T14:35:30.9632605Z clear/bgp_quagga_v6.py                                 53     53     12      0     0%
2023-02-15T14:35:30.9632956Z clear/main.py                                         301    129     58      9    52%
2023-02-15T14:35:30.9633263Z clear/plugins/__init__.py                               0      0      0      0   100%
2023-02-15T14:35:30.9633565Z clear/plugins/auto/__init__.py                          0      0      0      0   100%
2023-02-15T14:35:30.9633869Z config/__init__.py                                      0      0      0      0   100%
2023-02-15T14:35:30.9634155Z config/aaa.py                                         432    163    190     39    53%
2023-02-15T14:35:30.9634456Z config/chassis_modules.py                              24      2      2      0    92%
2023-02-15T14:35:30.9634759Z config/config_mgmt.py                                 399    154    130     19    59%
2023-02-15T14:35:30.9635063Z config/console.py                                     118      1     28      0    99%
2023-02-15T14:35:30.9635347Z config/feature.py                                     104      4     34      4    94%
2023-02-15T14:35:30.9635648Z config/flow_counters.py                                93      2     36      0    98%
2023-02-15T14:35:30.9635937Z config/kdump.py                                        45      3      4      1    92%
2023-02-15T14:35:30.9636220Z config/kube.py                                         74      2      8      0    98%
2023-02-15T14:35:30.9636503Z config/main.py                                       4620   1279   1919    336    68%
2023-02-15T14:35:30.9636800Z config/mclag.py                                       234     18    108     12    91%
2023-02-15T14:35:30.9637091Z config/muxcable.py                                    795    364    232     35    49%
2023-02-15T14:35:30.9637390Z config/nat.py                                         709    569    344      0    13%
2023-02-15T14:35:30.9637677Z config/plugins/__init__.py                              0      0      0      0   100%
2023-02-15T14:35:30.9637985Z config/plugins/auto/__init__.py                         0      0      0      0   100%
2023-02-15T14:35:30.9638306Z config/plugins/auto_techsupport.py                    217    143     42      1    30%
2023-02-15T14:35:30.9638624Z config/plugins/barefoot.py                             37     22     10      1    34%
2023-02-15T14:35:30.9638929Z config/plugins/mlnx.py                                136     87     36      1    30%
2023-02-15T14:35:30.9639234Z config/plugins/nvgre_tunnel.py                        148     54     42      6    54%
2023-02-15T14:35:30.9639548Z config/plugins/pbh.py                                 618     83    254     75    82%
2023-02-15T14:35:30.9640038Z config/plugins/sonic-passwh_yang.py                   158      5     16      4    95%
2023-02-15T14:35:30.9640361Z config/syslog.py                                      204     21     80     19    86%
2023-02-15T14:35:30.9640643Z config/utils.py                                         3      0      0      0   100%
2023-02-15T14:35:30.9640966Z config/validated_config_db_connector.py                95     10     40     11    83%
2023-02-15T14:35:30.9641334Z config/vlan.py                                        154     15     68     11    88%
2023-02-15T14:35:30.9641625Z config/vxlan.py                                       258     68    112     49    68%
2023-02-15T14:35:30.9641911Z connect/__init__.py                                     0      0      0      0   100%
2023-02-15T14:35:30.9642202Z connect/main.py                                        59     59     16      0     0%
2023-02-15T14:35:30.9642491Z consutil/__init__.py                                    0      0      0      0   100%
2023-02-15T14:35:30.9642787Z consutil/lib.py                                       245      7     58      2    97%
2023-02-15T14:35:30.9643070Z consutil/main.py                                       79      3     16      1    96%
2023-02-15T14:35:30.9643364Z counterpoll/__init__.py                                 0      0      0      0   100%
2023-02-15T14:35:30.9643708Z counterpoll/main.py                                   346    115     48     17    63%
2023-02-15T14:35:30.9644012Z crm/__init__.py                                         0      0      0      0   100%
2023-02-15T14:35:30.9644293Z crm/main.py                                           475     21    116     27    92%
2023-02-15T14:35:30.9644580Z debug/__init__.py                                       0      0      0      0   100%
2023-02-15T14:35:30.9644859Z debug/main.py                                         188    188     26      0     0%
2023-02-15T14:35:30.9645146Z dump/__init__.py                                        0      0      0      0   100%
2023-02-15T14:35:30.9645425Z dump/helper.py                                         29      4     20      2    84%
2023-02-15T14:35:30.9645718Z dump/main.py                                          175     21     88     10    86%
2023-02-15T14:35:30.9646007Z dump/match_helper.py                                   67      1     26      4    95%
2023-02-15T14:35:30.9646311Z dump/match_infra.py                                   304     29    116     10    89%
2023-02-15T14:35:30.9646610Z dump/plugins/__init__.py                               10      0      4      0   100%
2023-02-15T14:35:30.9646921Z dump/plugins/acl_rule.py                               59      9     16      3    81%
2023-02-15T14:35:30.9647218Z dump/plugins/acl_table.py                              63      6     14      2    87%
2023-02-15T14:35:30.9647519Z dump/plugins/copp.py                                  235     20     74     11    90%
2023-02-15T14:35:30.9647808Z dump/plugins/evpn.py                                   88      6     28      7    89%
2023-02-15T14:35:30.9648103Z dump/plugins/executor.py                               25      4      8      2    82%
2023-02-15T14:35:30.9648396Z dump/plugins/fdb.py                                    70      4     16      4    91%
2023-02-15T14:35:30.9648690Z dump/plugins/interface.py                             161      6     46     10    92%
2023-02-15T14:35:30.9648994Z dump/plugins/port.py                                   46      0      4      0   100%
2023-02-15T14:35:30.9649293Z dump/plugins/portchannel.py                            41      0      2      0   100%
2023-02-15T14:35:30.9649614Z dump/plugins/portchannel_member.py                     57      1     10      2    96%
2023-02-15T14:35:30.9649919Z dump/plugins/route.py                                 178      7     54     12    92%
2023-02-15T14:35:30.9650218Z dump/plugins/vlan.py                                   39      0      2      0   100%
2023-02-15T14:35:30.9650512Z dump/plugins/vlan_member.py                            89      2     28      2    97%
2023-02-15T14:35:30.9650823Z dump/plugins/vxlan_tunnel.py                           80      0     24      0   100%
2023-02-15T14:35:30.9651131Z dump/plugins/vxlan_tunnel_map.py                       58      0     14      0   100%
2023-02-15T14:35:30.9651437Z fdbutil/__init__.py                                     0      0      0      0   100%
2023-02-15T14:35:30.9651739Z fdbutil/filter_fdb_entries.py                          79      7     30      4    88%
2023-02-15T14:35:30.9652100Z flow_counter_util/__init__.py                           0      0      0      0   100%
2023-02-15T14:35:30.9652401Z flow_counter_util/route.py                             52      7     16      5    82%
2023-02-15T14:35:30.9652698Z fwutil/__init__.py                                      5      5      0      0     0%
2023-02-15T14:35:30.9652977Z fwutil/lib.py                                         659    659    276      0     0%
2023-02-15T14:35:30.9653258Z fwutil/log.py                                          63     63      6      0     0%
2023-02-15T14:35:30.9653533Z fwutil/main.py                                        318    318     92      0     0%
2023-02-15T14:35:30.9653840Z generic_config_updater/__init__.py                      0      0      0      0   100%
2023-02-15T14:35:30.9654171Z generic_config_updater/change_applier.py              112     10     34      7    88%
2023-02-15T14:35:30.9654564Z generic_config_updater/generic_updater.py             285      2     46      1    99%
2023-02-15T14:35:30.9654898Z generic_config_updater/gu_common.py                   624     19    247     29    94%
2023-02-15T14:35:30.9655241Z generic_config_updater/patch_sorter.py               1097     64    542     25    93%
2023-02-15T14:35:30.9655579Z generic_config_updater/services_validator.py           54      4     26      3    91%
2023-02-15T14:35:30.9655900Z pcieutil/__init__.py                                    0      0      0      0   100%
2023-02-15T14:35:30.9656184Z pcieutil/main.py                                      175     64     54      8    63%
2023-02-15T14:35:30.9656480Z pddf_fanutil/__init__.py                                0      0      0      0   100%
2023-02-15T14:35:30.9656774Z pddf_fanutil/main.py                                  121    121     44      0     0%
2023-02-15T14:35:30.9657076Z pddf_ledutil/__init__.py                                0      0      0      0   100%
2023-02-15T14:35:30.9657372Z pddf_ledutil/main.py                                   47     47     12      0     0%
2023-02-15T14:35:30.9657679Z pddf_psuutil/__init__.py                                0      0      0      0   100%
2023-02-15T14:35:30.9657974Z pddf_psuutil/main.py                                  136    136     50      0     0%
2023-02-15T14:35:30.9658284Z pddf_thermalutil/__init__.py                            0      0      0      0   100%
2023-02-15T14:35:30.9658693Z pddf_thermalutil/main.py                               83     83     32      0     0%
2023-02-15T14:35:30.9658985Z pfc/__init__.py                                         0      0      0      0   100%
2023-02-15T14:35:30.9659273Z pfc/main.py                                           100    100     26      0     0%
2023-02-15T14:35:30.9659550Z pfcwd/__init__.py                                       0      0      0      0   100%
2023-02-15T14:35:30.9659839Z pfcwd/main.py                                         312     80    112     12    69%
2023-02-15T14:35:30.9660127Z psuutil/__init__.py                                     0      0      0      0   100%
2023-02-15T14:35:30.9660425Z psuutil/main.py                                       103     31     20      6    65%
2023-02-15T14:35:30.9660708Z scripts/aclshow                                       145     13     66      4    90%
2023-02-15T14:35:30.9661014Z scripts/coredump_gen_handler.py                        55     23     12      3    58%
2023-02-15T14:35:30.9661322Z scripts/db_migrator.py                                565    102    234     45    79%
2023-02-15T14:35:30.9661636Z scripts/db_migrator_constants.py                        3      0      0      0   100%
2023-02-15T14:35:30.9662127Z scripts/decode-syseeprom                              172     61     53     17    60%
2023-02-15T14:35:30.9662443Z scripts/disk_check.py                                 109      6     38      7    91%
2023-02-15T14:35:30.9662737Z scripts/dropconfig                                    219    104    112     15    45%
2023-02-15T14:35:30.9663041Z scripts/dropstat                                      215     18     84     17    88%
2023-02-15T14:35:30.9663393Z scripts/ecnconfig                                     247     16    138     27    89%
2023-02-15T14:35:30.9663693Z scripts/fabricstat                                    167     14     56     12    88%
2023-02-15T14:35:30.9663977Z scripts/fanshow                                        63     10     18      6    80%
2023-02-15T14:35:30.9664456Z scripts/fast-reboot-dump.py                           270    139     72     10    46%
2023-02-15T14:35:30.9664761Z scripts/fdbshow                                       117      3     54      3    96%
2023-02-15T14:35:30.9665054Z scripts/fibshow                                        72     15     28      5    74%
2023-02-15T14:35:30.9665348Z scripts/flow_counters_stat                            349     50    162     18    84%
2023-02-15T14:35:30.9665660Z scripts/gearboxutil                                   131     21     44     14    78%
2023-02-15T14:35:30.9666010Z scripts/intfstat                                      189     29     70     14    81%
2023-02-15T14:35:30.9666315Z scripts/intfutil                                      501     21    212     33    92%
2023-02-15T14:35:30.9666602Z scripts/ipintutil                                     175     15     66     10    90%
2023-02-15T14:35:30.9666896Z scripts/lldpshow                                      137     54     50      9    56%
2023-02-15T14:35:30.9667202Z scripts/mellanox_buffer_migrator.py                   396     22    216     26    92%
2023-02-15T14:35:30.9667535Z scripts/memory_threshold_check.py                     113     23     32      3    78%
2023-02-15T14:35:30.9667869Z scripts/memory_threshold_check_handler.py              27      9      8      3    60%
2023-02-15T14:35:30.9668186Z scripts/mmuconfig                                     119     29     54      7    71%
2023-02-15T14:35:30.9668488Z scripts/neighbor_advertiser                           332    170    114      7    44%
2023-02-15T14:35:30.9668793Z scripts/null_route_helper                             127      4     34      3    96%
2023-02-15T14:35:30.9669100Z scripts/pfcstat                                       146     13     48      8    89%
2023-02-15T14:35:30.9669557Z scripts/pg-drop                                       166     18     56     11    87%
2023-02-15T14:35:30.9669854Z scripts/port2alias                                     48      3     18      1    94%
2023-02-15T14:35:30.9670139Z scripts/portconfig                                    294     29    152     26    87%
2023-02-15T14:35:30.9670435Z scripts/portstat                                      336     40    120     27    84%
2023-02-15T14:35:30.9670721Z scripts/psushow                                        89      9     32      8    86%
2023-02-15T14:35:30.9671010Z scripts/queuestat                                     256     65     96     16    72%
2023-02-15T14:35:30.9671313Z scripts/route_check.py                                337      8    136     20    94%
2023-02-15T14:35:30.9671616Z scripts/sfpshow                                       314     47     94      9    86%
2023-02-15T14:35:30.9672073Z scripts/sonic-bootchart                                84      8     10      2    87%
2023-02-15T14:35:30.9672551Z scripts/sonic-kdump-config                            408    277    178      5    28%
2023-02-15T14:35:30.9672869Z scripts/sonic_sku_create.py                           637    153    244     59    73%
2023-02-15T14:35:30.9673182Z scripts/sysreadyshow                                   81     13     24      6    82%
2023-02-15T14:35:30.9673490Z scripts/techsupport_cleanup.py                         42     15     12      3    67%
2023-02-15T14:35:30.9673797Z scripts/tunnelstat                                    185     28     68     19    81%
2023-02-15T14:35:30.9674100Z scripts/vnet_route_check.py                           216     19    116     20    87%
2023-02-15T14:35:30.9674412Z scripts/voqutil                                       222     14     58     15    90%
2023-02-15T14:35:30.9674796Z scripts/watermarkstat                                 207     31     80     21    82%
2023-02-15T14:35:30.9675081Z setup.py                                                3      3      0      0     0%
2023-02-15T14:35:30.9675350Z sfputil/__init__.py                                     0      0      0      0   100%
2023-02-15T14:35:30.9675641Z sfputil/main.py                                       888    337    286     52    61%
2023-02-15T14:35:30.9675923Z show/__init__.py                                        0      0      0      0   100%
2023-02-15T14:35:30.9676210Z show/acl.py                                            24     11      6      0    43%
2023-02-15T14:35:30.9676495Z show/bgp_common.py                                    270      9    176     10    95%
2023-02-15T14:35:30.9676794Z show/bgp_frr_v4.py                                     62      2     20      1    96%
2023-02-15T14:35:30.9677129Z show/bgp_frr_v6.py                                     61      1     18      1    97%
2023-02-15T14:35:30.9677430Z show/bgp_quagga_v4.py                                  25     25      4      0     0%
2023-02-15T14:35:30.9677723Z show/bgp_quagga_v6.py                                  20     20      0      0     0%
2023-02-15T14:35:30.9678027Z show/chassis_modules.py                               116     18     36      8    80%
2023-02-15T14:35:30.9678322Z show/dropcounters.py                                   29      1      6      0    97%
2023-02-15T14:35:30.9678614Z show/fabric.py                                         36     18     10      0    39%
2023-02-15T14:35:30.9678895Z show/feature.py                                       111      1     40      1    99%
2023-02-15T14:35:30.9679177Z show/fgnhg.py                                         174     18     90      9    90%
2023-02-15T14:35:30.9679470Z show/flow_counters.py                                  64      6     16      5    86%
2023-02-15T14:35:30.9679757Z show/gearbox.py                                        19      3      0      0    84%
2023-02-15T14:35:30.9680067Z show/interfaces/__init__.py                           454    115    160     25    72%
2023-02-15T14:35:30.9680380Z show/interfaces/portchannel.py                        104      6     36      6    91%
2023-02-15T14:35:30.9680680Z show/kdump.py                                          95     74     26      0    17%
2023-02-15T14:35:30.9680955Z show/kube.py                                           46      2     10      0    96%
2023-02-15T14:35:30.9681242Z show/main.py                                         1297    397    365     44    66%
2023-02-15T14:35:30.9681533Z show/muxcable.py                                     1533    527    496     96    62%
2023-02-15T14:35:30.9681824Z show/nat.py                                            66     34      4      0    46%
2023-02-15T14:35:30.9682101Z show/platform.py                                       92     36     19      2    56%
2023-02-15T14:35:30.9682400Z show/plugins/__init__.py                                0      0      0      0   100%
2023-02-15T14:35:30.9682700Z show/plugins/auto/__init__.py                           0      0      0      0   100%
2023-02-15T14:35:30.9683017Z show/plugins/auto_techsupport.py                       67     39     18      2    38%
2023-02-15T14:35:30.9683323Z show/plugins/barefoot.py                               29     18      8      1    32%
2023-02-15T14:35:30.9683809Z show/plugins/cisco-8000.py                             14      4      4      1    61%
2023-02-15T14:35:30.9684109Z show/plugins/mlnx.py                                   88     62     22      0    25%
2023-02-15T14:35:30.9684418Z show/plugins/nvgre_tunnel.py                           49      8     18      4    76%
2023-02-15T14:35:30.9684719Z show/plugins/pbh.py                                   161      8     62     10    92%
2023-02-15T14:35:30.9685200Z show/plugins/sonic-passwh_yang.py                      25      2      4      1    90%
2023-02-15T14:35:30.9685511Z show/processes.py                                      20      7      0      0    65%
2023-02-15T14:35:30.9685858Z show/reboot_cause.py                                   64      7     18      6    84%
2023-02-15T14:35:30.9686175Z show/sflow.py                                          61      5     18      5    87%
2023-02-15T14:35:30.9686461Z show/syslog.py                                         53      2     14      2    94%
2023-02-15T14:35:30.9686751Z show/system_health.py                                 124     20     43      5    83%
2023-02-15T14:35:30.9687043Z show/vlan.py                                          107      2     40      0    99%
2023-02-15T14:35:30.9687319Z show/vnet.py                                          339    146    114      5    55%
2023-02-15T14:35:30.9687606Z show/vxlan.py                                         257     27     96     27    83%
2023-02-15T14:35:30.9687893Z show/warm_restart.py                                   96     84     34      0     9%
2023-02-15T14:35:30.9688246Z sonic_cli_gen/__init__.py                               2      0      0      0   100%
2023-02-15T14:35:30.9688550Z sonic_cli_gen/generator.py                             33      4      4      2    84%
2023-02-15T14:35:30.9688852Z sonic_cli_gen/main.py                                  25     25      2      0     0%
2023-02-15T14:35:30.9689157Z sonic_cli_gen/yang_parser.py                          189     13    108     15    90%
2023-02-15T14:35:30.9689465Z sonic_installer/__init__.py                             0      0      0      0   100%
2023-02-15T14:35:30.9689782Z sonic_installer/bootloader/__init__.py                  9      1      4      1    85%
2023-02-15T14:35:30.9690105Z sonic_installer/bootloader/aboot.py                   210    122     46      2    36%
2023-02-15T14:35:30.9690437Z sonic_installer/bootloader/bootloader.py               46     18      0      0    61%
2023-02-15T14:35:30.9690762Z sonic_installer/bootloader/grub.py                    123     45     24      3    58%
2023-02-15T14:35:30.9691090Z sonic_installer/bootloader/onie.py                     24     10      2      0    54%
2023-02-15T14:35:30.9691415Z sonic_installer/bootloader/uboot.py                    79     25     18      4    60%
2023-02-15T14:35:30.9691733Z sonic_installer/common.py                              28      8      4      1    66%
2023-02-15T14:35:30.9692031Z sonic_installer/exception.py                            2      0      0      0   100%
2023-02-15T14:35:30.9692343Z sonic_installer/main.py                               611    196    192     38    63%
2023-02-15T14:35:30.9692653Z sonic_package_manager/__init__.py                       2      0      0      0   100%
2023-02-15T14:35:30.9692976Z sonic_package_manager/constraint.py                    70      3     18      2    94%
2023-02-15T14:35:30.9693292Z sonic_package_manager/database.py                      87     25     20      1    70%
2023-02-15T14:35:30.9693616Z sonic_package_manager/dockerapi.py                    129     98     32      1    20%
2023-02-15T14:35:30.9693935Z sonic_package_manager/errors.py                        73      5     20      2    92%
2023-02-15T14:35:30.9694256Z sonic_package_manager/logger.py                        11      0      0      0   100%
2023-02-15T14:35:30.9694567Z sonic_package_manager/main.py                         242    105     54      3    50%
2023-02-15T14:35:30.9694893Z sonic_package_manager/manager.py                      453    107    142     23    74%
2023-02-15T14:35:30.9695212Z sonic_package_manager/manifest.py                      96      5     32      1    95%
2023-02-15T14:35:30.9695535Z sonic_package_manager/metadata.py                      74     33     16      3    51%
2023-02-15T14:35:30.9695853Z sonic_package_manager/package.py                       23      0     18      0   100%
2023-02-15T14:35:30.9696177Z sonic_package_manager/progress.py                      21     11      4      0    40%
2023-02-15T14:35:30.9696499Z sonic_package_manager/reference.py                     19      1      4      0    96%
2023-02-15T14:35:30.9696831Z sonic_package_manager/registry.py                      96     30     16      4    66%
2023-02-15T14:35:30.9697210Z sonic_package_manager/service_creator/__init__.py       2      0      0      0   100%
2023-02-15T14:35:30.9697567Z sonic_package_manager/service_creator/creator.py      296     32    102     20    86%
2023-02-15T14:35:30.9697918Z sonic_package_manager/service_creator/feature.py      110     10     34      3    88%
2023-02-15T14:35:30.9698279Z sonic_package_manager/service_creator/sonic_db.py      94     63     22      0    27%
2023-02-15T14:35:30.9699601Z sonic_package_manager/service_creator/utils.py          5      0      0      0   100%
2023-02-15T14:35:30.9699943Z sonic_package_manager/source.py                        62      4      8      1    93%
2023-02-15T14:35:30.9700253Z sonic_package_manager/utils.py                         10      0      4      0   100%
2023-02-15T14:35:30.9700640Z sonic_package_manager/version.py                       44      9      0      0    80%
2023-02-15T14:35:30.9700943Z ssdutil/__init__.py                                     0      0      0      0   100%
2023-02-15T14:35:30.9701222Z ssdutil/main.py                                        50     50      8      0     0%
2023-02-15T14:35:30.9701515Z syslog_util/__init__.py                                 0      0      0      0   100%
2023-02-15T14:35:30.9701808Z syslog_util/common.py                                  39      0     14      2    96%
2023-02-15T14:35:30.9702107Z undebug/__init__.py                                     0      0      0      0   100%
2023-02-15T14:35:30.9702390Z undebug/main.py                                       188    188     26      0     0%
2023-02-15T14:35:30.9702690Z utilities_common/__init__.py                            0      0      0      0   100%
2023-02-15T14:35:30.9703014Z utilities_common/auto_techsupport_helper.py           219     23     78     17    86%
2023-02-15T14:35:30.9703356Z utilities_common/bgp_util.py                          221     49     76      8    72%
2023-02-15T14:35:30.9703663Z utilities_common/chassis.py                            17      9      6      1    39%
2023-02-15T14:35:30.9703976Z utilities_common/cli.py                               400    127    222     24    63%
2023-02-15T14:35:30.9704280Z utilities_common/constants.py                          10      0      0      0   100%
2023-02-15T14:35:30.9704587Z utilities_common/db.py                                 32      2      8      1    92%
2023-02-15T14:35:30.9704893Z utilities_common/dhcp_relay_util.py                    13      2      0      0    85%
2023-02-15T14:35:30.9705211Z utilities_common/general.py                            25      1      8      1    94%
2023-02-15T14:35:30.9705509Z utilities_common/helper.py                             25      2      4      2    86%
2023-02-15T14:35:30.9705824Z utilities_common/intf_filter.py                        42     10     28      5    73%
2023-02-15T14:35:30.9706139Z utilities_common/multi_asic.py                        107     15     44      3    83%
2023-02-15T14:35:30.9706456Z utilities_common/netstat.py                            60     21     30      3    62%
2023-02-15T14:35:30.9706778Z utilities_common/platform_sfputil_helper.py            91     33     32      8    62%
2023-02-15T14:35:30.9707112Z utilities_common/sfp_helper.py                         34      2      6      2    90%
2023-02-15T14:35:30.9707421Z utilities_common/util_base.py                          53     20     10      0    62%
2023-02-15T14:35:30.9707733Z watchdogutil/__init__.py                                0      0      0      0   100%
2023-02-15T14:35:30.9708026Z watchdogutil/main.py                                   59     59     16      0     0%
2023-02-15T14:35:30.9708556Z -------------------------------------------------------------------------------------
2023-02-15T14:35:30.9708886Z TOTAL                                               39739  11403  14108   2030    68%
2023-02-15T14:35:30.9709176Z Coverage HTML written to dir htmlcov
2023-02-15T14:35:30.9709441Z Coverage XML written to file coverage.xml


2023-02-15T14:35:30.9629795Z ----------- coverage: platform linux, python 3.9.2-final-0 -----------
2023-02-15T14:35:30.9630243Z Name                                                Stmts   Miss Branch BrPart  Cover
2023-02-15T14:35:30.9630753Z -------------------------------------------------------------------------------------
2023-02-15T14:35:30.9641334Z config/vlan.py                                        154     15     68     11    88%
2023-02-15T14:35:30.9708556Z -------------------------------------------------------------------------------------
2023-02-15T14:35:30.9708886Z TOTAL                                               39739  11403  14108   2030    68%
2023-02-15T14:35:30.9709176Z Coverage HTML written to dir htmlcov
2023-02-15T14:35:30.9709441Z Coverage XML written to file coverage.xml
```
2. build image and run cli
```
admin@:~$ sudo sonic-db-cli CONFIG_DB hgetall "DHCP_RELAY|Vlan2000"
{}
admin@:~$ sudo config vlan add 2000
Restarting DHCP relay service...
admin@:~$ sudo sonic-db-cli CONFIG_DB hgetall "DHCP_RELAY|Vlan2000"
{}
admin@:~$ sudo config dhcp_relay ipv6 destination add 2000 fc02:2000::5
Added DHCP relay address [fc02:2000::5] to Vlan2000
Restarting DHCP relay service...
admin@:~$ sudo sonic-db-cli CONFIG_DB hgetall "DHCP_RELAY|Vlan2000"
{'dhcpv6_servers@': 'fc02:2000::5'}
admin@:~$ sudo sonic-db-cli CONFIG_DB hgetall "DHCP_RELAY|Vlan2000"
{}
admin@:~$ sudo config dhcp_relay ipv6 destination add 2000 fc02:2000::7
Added DHCP relay address [fc02:2000::7] to Vlan2000
Restarting DHCP relay service...
admin@:~$ sudo sonic-db-cli CONFIG_DB hgetall "DHCP_RELAY|Vlan2000"
{'dhcpv6_servers@': 'fc02:2000::7'}
admin@:~$ sudo config dhcp_relay ipv6 destination add 2000 fc02:2000::7
fc02:2000::7 is already a DHCP relay for Vlan2000
admin@:~$ sudo config dhcp_relay ipv6 destination add 2000 fc02:2000::6
Added DHCP relay address [fc02:2000::6] to Vlan2000
Restarting DHCP relay service...
admin@:~$ sudo sonic-db-cli CONFIG_DB hgetall "DHCP_RELAY|Vlan2000"
{'dhcpv6_servers@': 'fc02:2000::7,fc02:2000::6'}
```


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

