### PR TITLE
[202205][dhcp_relay] Remove exist check while adding dhcpv6 relay

### DIFF
--- a/dockers/docker-dhcp-relay/cli-plugin-tests/conftest.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/conftest.py
@@ -19,14 +19,23 @@ def mock_cfgdb():
     }
 
     def get_entry(table, key):
+        if table not in CONFIG or key not in CONFIG[table]:
+            return {}
         return CONFIG[table][key]
 
     def set_entry(table, key, data):
         CONFIG[table].setdefault(key, {})
-        CONFIG[table][key] = data
+
+        if data is None:
+            CONFIG[table].pop(key)
+        else:
+            CONFIG[table][key] = data
+
+    def get_keys(table):
+        return CONFIG[table].keys()
 
     cfgdb.get_entry = mock.Mock(side_effect=get_entry)
     cfgdb.set_entry = mock.Mock(side_effect=set_entry)
+    cfgdb.get_keys = mock.Mock(side_effect=get_keys)
 
     yield cfgdb
-

--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_dhcp_relay.py
@@ -111,9 +111,25 @@ class TestConfigDhcpRelay(object):
         cli = mock.MagicMock()
         dhcp_relay.register(cli)
 
-    def test_config_dhcp_relay_add_del_with_nonexist_vlanid(self, ip_version, op):
+    def test_config_dhcp_relay_add_del_with_nonexist_vlanid_ipv4(self, op):
         runner = CliRunner()
 
+        ip_version = "ipv4"
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
+                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands[op], ["1001", IP_VER_TEST_PARAM_MAP[ip_version]["ips"][0]])
+            print(result.exit_code)
+            print(result.stdout)
+            assert result.exit_code != 0
+            assert "Error: Vlan1001 doesn't exist" in result.output
+            assert mock_run_command.call_count == 0
+
+    def test_config_dhcp_relay_del_with_nonexist_vlanid_ipv6(self):
+        runner = CliRunner()
+
+        op = "del"
+        ip_version = "ipv6"
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
                                    .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
@@ -262,3 +278,25 @@ class TestConfigDhcpRelay(object):
             assert result.exit_code != 0
             assert "Error: Find duplicate DHCP relay ip {} in {} list".format(test_ip, op) in result.output
             assert mock_run_command.call_count == 0
+
+    def test_config_add_dhcp_relay_ipv6_with_non_entry(self, mock_cfgdb):
+        op = "add"
+        ip_version = "ipv6"
+        test_ip = IP_VER_TEST_PARAM_MAP[ip_version]["ips"][0]
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb = mock_cfgdb
+        table = IP_VER_TEST_PARAM_MAP[ip_version]["table"]
+        db.cfgdb.set_entry(table, "Vlan1000", None)
+        assert db.cfgdb.get_entry(table, "Vlan1000") == {}
+        assert len(db.cfgdb.get_keys(table)) == 0
+
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
+                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands[op], ["1000", test_ip], obj=db)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry(table, "Vlan1000") == {"dhcpv6_servers": [test_ip]}
+            assert mock_run_command.call_count == 3


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cherry-pick of this PR: https://github.com/sonic-net/sonic-buildimage/pull/13822/commits

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

