### PR TITLE
  sonic-buildimage Make changes to arista config.bcm files to support max cores as 64.

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -493,15 +493,16 @@ tm_port_header_type_out_233.BCM8869X=CPU
 tm_port_header_type_in_240.BCM8869X=INJECTED_2
 tm_port_header_type_out_240.BCM8869X=RAW
 
-sai_recycle_port_lane_base=0
-ucode_port_221.BCM8869X=RCY.21:core_0.221
-ucode_port_222.BCM8869X=RCY.22:core_1.222
-tm_port_header_type_out_221.BCM8869X=ETH
-tm_port_header_type_in_221.BCM8869X=ETH
-tm_port_header_type_out_222.BCM8869X=ETH
-tm_port_header_type_in_222.BCM8869X=ETH
-port_init_speed_221.BCM8869X=400000
-port_init_speed_222.BCM8869X=400000
+#RCY
+sai_recycle_port_lane_base=200
+ucode_port_49.BCM8869X=RCY0:core_0.49
+ucode_port_50.BCM8869X=RCY1:core_1.50
+tm_port_header_type_out_49.BCM8869X=ETH
+tm_port_header_type_in_49.BCM8869X=ETH
+tm_port_header_type_out_50.BCM8869X=ETH
+tm_port_header_type_in_50.BCM8869X=ETH
+port_init_speed_49.BCM8869X=400000
+port_init_speed_50.BCM8869X=400000
 
 # fabric
 port_init_cl72_sfi=1
@@ -788,6 +789,7 @@ dport_map_direct.BCM8869X=1
 pmf_sexem3_stage.BCM8869X=IPMF3
 rif_id_max=0x6000
 
+appl_param_nof_ports_per_modid=64
 dma_desc_aggregator_chain_length_max.BCM8869X=1000
 dma_desc_aggregator_buff_size_kb.BCM8869X=100
 dma_desc_aggregator_timeout_usec.BCM8869X=1000

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/port_config.ini
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/port_config.ini
@@ -47,5 +47,5 @@ Ethernet176         54,55     Ethernet45/1        45     Ext   100000    1      
 Ethernet180         50,51     Ethernet46/1        46     Ext   100000    1          46             8
 Ethernet184         52,53     Ethernet47/1        47     Ext   100000    1          47             8
 Ethernet188         48,49     Ethernet48/1        48     Ext   100000    1          48             8
-Ethernet-Rec0       221       Recirc0/0           51     Rec   400000    0          221            8
-Ethernet-IB0        222       Recirc0/1           52     Inb   400000    1          222            8
+Ethernet-Rec0       249       Recirc0/0           51     Rec   400000    0          49             8
+Ethernet-IB0        250       Recirc0/1           52     Inb   400000    1          50             8

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -263,15 +263,15 @@ tm_port_header_type_in_219=INJECTED_2
 port_init_speed_sat=400000
 
 ### RCY
-sai_recycle_port_lane_base=0
-ucode_port_221=RCY.21:core_0.221
-ucode_port_222=RCY.22:core_1.222
-tm_port_header_type_out_221=ETH
-tm_port_header_type_in_221=ETH
-tm_port_header_type_out_222=ETH
-tm_port_header_type_in_222=ETH
-port_init_speed_221=400000
-port_init_speed_222=400000
+sai_recycle_port_lane_base=200
+ucode_port_49=RCY0:core_0.49
+ucode_port_50=RCY1:core_1.50
+tm_port_header_type_out_49=ETH
+tm_port_header_type_in_49=ETH
+tm_port_header_type_out_50=ETH
+tm_port_header_type_in_50=ETH
+port_init_speed_49=400000
+port_init_speed_50=400000
 
 #OLP port
 tm_port_header_type_in_240=INJECTED_2
@@ -981,5 +981,6 @@ serdes_tx_taps_34=nrz:-5:83:-22:0:0:0
 serdes_tx_taps_35=nrz:-4:75:-21:0:0:0
 serdes_tx_taps_36=nrz:-8:89:-29:0:0:0
 
+appl_param_nof_ports_per_modid=64
 xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=2

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/port_config.ini
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/port_config.ini
@@ -17,5 +17,5 @@ Ethernet112    24,25,26,27       Ethernet15/1 15     Ext        100000      Eth1
 Ethernet120    16,17,18,19       Ethernet16/1 16     Ext        100000      Eth120-ASIC0       0           16              8
 Ethernet128    8,9,10,11         Ethernet17/1 17     Ext        100000      Eth128-ASIC0       0           17              8
 Ethernet136    0,1,2,3           Ethernet18/1 18     Ext        100000      Eth136-ASIC0       0           18              8
-Ethernet-Rec0  221               Recirc0/0    37     Rec        400000      Rcy0-ASIC0         0           221             8
-Ethernet-IB0   222               Recirc0/1    38     Inb        400000      Rcy1-ASIC0         1           222             8
+Ethernet-Rec0  249               Recirc0/0    37     Rec        400000      Rcy0-ASIC0         0           49              8
+Ethernet-IB0   250               Recirc0/1    38     Inb        400000      Rcy1-ASIC0         1           50              8

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -263,15 +263,15 @@ tm_port_header_type_in_219=INJECTED_2
 port_init_speed_sat=400000
 
 ### RCY
-sai_recycle_port_lane_base=0
-ucode_port_221=RCY.21:core_0.221
-ucode_port_222=RCY.22:core_1.222
-tm_port_header_type_out_221=ETH
-tm_port_header_type_in_221=ETH
-tm_port_header_type_out_222=ETH
-tm_port_header_type_in_222=ETH
-port_init_speed_221=400000
-port_init_speed_222=400000
+sai_recycle_port_lane_base=200
+ucode_port_49=RCY0:core_0.49
+ucode_port_50=RCY1:core_1.50
+tm_port_header_type_out_49=ETH
+tm_port_header_type_in_49=ETH
+tm_port_header_type_out_50=ETH
+tm_port_header_type_in_50=ETH
+port_init_speed_49=400000
+port_init_speed_50=400000
 
 #OLP port
 tm_port_header_type_in_240=INJECTED_2
@@ -981,5 +981,6 @@ serdes_tx_taps_34=nrz:-5:75:-20:0:0:0
 serdes_tx_taps_35=nrz:-5:80:-23:0:0:0
 serdes_tx_taps_36=nrz:-7:85:-25:0:0:0
 
+appl_param_nof_ports_per_modid=64
 xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=2

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/port_config.ini
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/port_config.ini
@@ -17,5 +17,5 @@ Ethernet256    24,25,26,27       Ethernet33/1 33     Ext        100000      Eth1
 Ethernet264    16,17,18,19       Ethernet34/1 34     Ext        100000      Eth120-ASIC1       0           16              8
 Ethernet272    8,9,10,11         Ethernet35/1 35     Ext        100000      Eth128-ASIC1       0           17              8
 Ethernet280    0,1,2,3           Ethernet36/1 36     Ext        100000      Eth136-ASIC1       0           18              8
-Ethernet-Rec1  221               Recirc0/0    39     Rec        400000      Rcy0-ASIC1         0           221             8
-Ethernet-IB1   222               Recirc0/1    40     Inb        400000      Rcy1-ASIC1         1           222             8
+Ethernet-Rec1  249               Recirc0/0    39     Rec        400000      Rcy0-ASIC1         0           49              8
+Ethernet-IB1   250               Recirc0/1    40     Inb        400000      Rcy1-ASIC1         1           50              8

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/port_config.ini
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/port_config.ini
@@ -35,7 +35,7 @@ Ethernet256    24,25,26,27       Ethernet33/1 33     Ext        100000      Eth1
 Ethernet264    16,17,18,19       Ethernet34/1 34     Ext        100000      Eth120-ASIC1       0           16              8
 Ethernet272    8,9,10,11         Ethernet35/1 35     Ext        100000      Eth128-ASIC1       0           17              8
 Ethernet280    0,1,2,3           Ethernet36/1 36     Ext        100000      Eth136-ASIC1       0           18              8
-Ethernet-Rec0  221               Recirc0/0    37     Rec        400000      Rcy0-ASIC0         0           221             8
-Ethernet-IB0   222               Recirc0/1    38     Inb        400000      Rcy1-ASIC0         1           222             8
-Ethernet-Rec1  221               Recirc0/0    39     Rec        400000      Rcy0-ASIC1         0           221             8
-Ethernet-IB1   222               Recirc0/1    40     Inb        400000      Rcy1-ASIC1         1           222             8
+Ethernet-Rec0  249               Recirc0/0    37     Rec        400000      Rcy0-ASIC0         0           49              8
+Ethernet-IB0   250               Recirc0/1    38     Inb        400000      Rcy1-ASIC0         1           50              8
+Ethernet-Rec1  249               Recirc0/0    39     Rec        400000      Rcy0-ASIC1         0           49              8
+Ethernet-IB1   250               Recirc0/1    40     Inb        400000      Rcy1-ASIC1         1           50              8

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -263,15 +263,15 @@ tm_port_header_type_in_219=INJECTED_2
 port_init_speed_sat=400000
 
 ### RCY
-sai_recycle_port_lane_base=0
-ucode_port_221=RCY.21:core_0.221
-ucode_port_222=RCY.22:core_1.222
-tm_port_header_type_out_221=ETH
-tm_port_header_type_in_221=ETH
-tm_port_header_type_out_222=ETH
-tm_port_header_type_in_222=ETH
-port_init_speed_221=400000
-port_init_speed_222=400000
+sai_recycle_port_lane_base=200
+ucode_port_49=RCY0:core_0.49
+ucode_port_50=RCY1:core_1.50
+tm_port_header_type_out_49=ETH
+tm_port_header_type_in_49=ETH
+tm_port_header_type_out_50=ETH
+tm_port_header_type_in_50=ETH
+port_init_speed_49=400000
+port_init_speed_50=400000
 
 #OLP port
 tm_port_header_type_in_240=INJECTED_2
@@ -1018,5 +1018,6 @@ serdes_tx_taps_34=pam4:-14:136:-14:2:0:-4
 serdes_tx_taps_35=pam4:-16:141:-5:3:-2:-3
 serdes_tx_taps_36=pam4:-16:137:-12:2:0:-3
 
+appl_param_nof_ports_per_modid=64
 xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/port_config.ini
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/port_config.ini
@@ -17,5 +17,5 @@ Ethernet112    24,25,26,27,28,29,30,31           Ethernet15/1 15     Ext        
 Ethernet120    16,17,18,19,20,21,22,23           Ethernet16/1 16     Ext        400000      Eth120-ASIC0       0           16              8
 Ethernet128    8,9,10,11,12,13,14,15             Ethernet17/1 17     Ext        400000      Eth128-ASIC0       0           17              8
 Ethernet136    0,1,2,3,4,5,6,7                   Ethernet18/1 18     Ext        400000      Eth136-ASIC0       0           18              8
-Ethernet-Rec0  221                               Recirc0/0    37     Rec        400000      Rcy0-ASIC0         0           221             8
-Ethernet-IB0   222                               Recirc0/1    38     Inb        400000      Rcy1-ASIC0         1           222             8
+Ethernet-Rec0  249                               Recirc0/0    37     Rec        400000      Rcy0-ASIC0         0           49              8
+Ethernet-IB0   250                               Recirc0/1    38     Inb        400000      Rcy1-ASIC0         1           50              8

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -263,15 +263,15 @@ tm_port_header_type_in_219=INJECTED_2
 port_init_speed_sat=400000
 
 ### RCY
-sai_recycle_port_lane_base=0
-ucode_port_221=RCY.21:core_0.221
-ucode_port_222=RCY.22:core_1.222
-tm_port_header_type_out_221=ETH
-tm_port_header_type_in_221=ETH
-tm_port_header_type_out_222=ETH
-tm_port_header_type_in_222=ETH
-port_init_speed_221=400000
-port_init_speed_222=400000
+sai_recycle_port_lane_base=200
+ucode_port_49=RCY0:core_0.49
+ucode_port_50=RCY1:core_1.50
+tm_port_header_type_out_49=ETH
+tm_port_header_type_in_49=ETH
+tm_port_header_type_out_50=ETH
+tm_port_header_type_in_50=ETH
+port_init_speed_49=400000
+port_init_speed_50=400000
 
 #OLP port
 tm_port_header_type_in_240=INJECTED_2
@@ -1018,5 +1018,6 @@ serdes_tx_taps_34=pam4:-14:136:-14:2:0:-4
 serdes_tx_taps_35=pam4:-16:141:-5:3:-2:-3
 serdes_tx_taps_36=pam4:-16:137:-12:2:0:-3
 
+appl_param_nof_ports_per_modid=64
 xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/port_config.ini
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/port_config.ini
@@ -17,5 +17,5 @@ Ethernet256    24,25,26,27,28,29,30,31           Ethernet33/1 33     Ext        
 Ethernet264    16,17,18,19,20,21,22,23           Ethernet34/1 34     Ext        400000      Eth120-ASIC1       0           16              8
 Ethernet272    8,9,10,11,12,13,14,15             Ethernet35/1 35     Ext        400000      Eth128-ASIC1       0           17              8
 Ethernet280    0,1,2,3,4,5,6,7                   Ethernet36/1 36     Ext        400000      Eth136-ASIC1       0           18              8
-Ethernet-Rec1  221                               Recirc0/0    39     Rec        400000      Rcy0-ASIC1         0           221             8
-Ethernet-IB1   222                               Recirc0/1    40     Inb        400000      Rcy1-ASIC1         1           222             8
+Ethernet-Rec1  249                               Recirc0/0    39     Rec        400000      Rcy0-ASIC1         0           49              8
+Ethernet-IB1   250                               Recirc0/1    40     Inb        400000      Rcy1-ASIC1         1           50              8

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/port_config.ini
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/port_config.ini
@@ -35,7 +35,7 @@ Ethernet256    24,25,26,27,28,29,30,31           Ethernet33/1 33     Ext        
 Ethernet264    16,17,18,19,20,21,22,23           Ethernet34/1 34     Ext        400000      Eth120-ASIC1       0           16              8
 Ethernet272    8,9,10,11,12,13,14,15             Ethernet35/1 35     Ext        400000      Eth128-ASIC1       0           17              8
 Ethernet280    0,1,2,3,4,5,6,7                   Ethernet36/1 36     Ext        400000      Eth136-ASIC1       0           18              8
-Ethernet-Rec0  221                               Recirc0/0    37     Rec        400000      Rcy0-ASIC0         0           221             8
-Ethernet-IB0   222                               Recirc0/1    38     Inb        400000      Rcy1-ASIC0         1           222             8
-Ethernet-Rec1  221                               Recirc0/0    39     Rec        400000      Rcy0-ASIC1         0           221             8
-Ethernet-IB1   222                               Recirc0/1    40     Inb        400000      Rcy1-ASIC1         1           222             8
+Ethernet-Rec0  249                               Recirc0/0    37     Rec        400000      Rcy0-ASIC0         0           49              8
+Ethernet-IB0   250                               Recirc0/1    38     Inb        400000      Rcy1-ASIC0         1           50              8
+Ethernet-Rec1  249                               Recirc0/0    39     Rec        400000      Rcy0-ASIC1         0           49              8
+Ethernet-IB1   250                               Recirc0/1    40     Inb        400000      Rcy1-ASIC1         1           50              8

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -332,3 +332,4 @@ sai_mdio_access_clause22
 cmic_dma_abort_in_cold_boot
 hybrid_pfc_deadlock_enable
 sai_pfc_dlr_init_capability
+appl_param_nof_ports_per_modid


### PR DESCRIPTION
#### Why I did it

To support 64 cores on arista skus. Fixes https://github.com/aristanetworks/sonic/issues/77

#### How I did it

Remapped recycle ports to lowers core port ids and set appl_param_nof_ports_per_modid to 64.

#### How to verify it

Ran everflow tests on 202205 with these changes and verified IBGP sessions are up with max_cores set to 64 

#### Which release branch to backport (provide reason below if selected)
- [ x ] 202205