### PR TITLE
[DNS] yang model for static DNS

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -66,8 +66,9 @@ Table of Contents
          * [LOGGER](#logger)           
          * [WRED_PROFILE](#wred_profile)  
          * [PASSWORD_HARDENING](#password_hardening)  
-         * [SYSTEM_DEFAULTS table](#systemdefaults-table)
-         * [RADIUS](#radius)
+         * [SYSTEM_DEFAULTS table](#systemdefaults-table)  
+         * [RADIUS](#radius)  
+         * [Static DNS](#static-dns)  
    * [For Developers](#for-developers)  
       * [Generating Application Config by Jinja2 Template](#generating-application-config-by-jinja2-template)
       * [Incremental Configuration by Subscribing to ConfigDB](#incremental-configuration-by-subscribing-to-configdb)
@@ -2094,6 +2095,19 @@ The RADIUS and RADIUS_SERVER tables define RADIUS configuration parameters. RADI
                "timeout": "5"
         }
     }
+```
+
+### Static DNS
+
+The DNS_NAMESERVER table introduces static DNS nameservers configuration.
+
+```json
+{
+	"DNS_NAMESERVER": {
+		"1.1.1.1": {},
+		"fe80:1000:2000:3000::1": {}
+	},
+}
 ```
 
 #### 5.2.3 Update value directly in db memory

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -107,6 +107,7 @@ setup(
                          './yang-models/sonic-device_neighbor_metadata.yang',
                          './yang-models/sonic-dhcp-server.yang',
                          './yang-models/sonic-dhcpv6-relay.yang',
+                         './yang-models/sonic-dns.yang',
                          './yang-models/sonic-events-bgp.yang',
                          './yang-models/sonic-events-common.yang',
                          './yang-models/sonic-events-dhcp-relay.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -8,6 +8,10 @@
             "192.0.0.8": {},
             "192.0.0.8": {}
         },
+        "DNS_NAMESERVER": {
+            "1.1.1.1": {},
+            "fe80:1000:2000:3000::1": {}
+        },
         "BUFFER_POOL": {
             "ingress_lossy_pool": {
                "mode": "static",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/dns.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/dns.json
@@ -1,0 +1,13 @@
+{
+    "DNS_NAMESERVER_TEST" : {
+        "desc": "DNS nameserver configuration in DNS_NAMESERVER table."
+    },
+    "DNS_NAMESERVER_TEST_INVALID_IP" : {
+        "desc": "DNS nameserver configuration with invalid IP value in DNS_NAMESERVER table.",
+        "eStr": "Invalid value"
+    },
+    "DNS_NAMESERVER_TEST_MAX_IP_NUMBER" : {
+        "desc": "DNS nameserver configuration exceeds the maximum IPs in DNS_NAMESERVER table.",
+        "eStr": "Too many elements."
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/dns.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/dns.json
@@ -1,0 +1,47 @@
+{
+    "DNS_NAMESERVER_TEST": {
+        "sonic-dns:sonic-dns": {
+            "sonic-dns:DNS_NAMESERVER": {
+                "DNS_NAMESERVER_LIST": [
+                    {
+                        "ip": "192.168.1.1"
+                    },
+                    {
+                        "ip": "fe80:1000:2000:3000::1"
+                    }
+                ]
+            }
+        }
+    },
+    "DNS_NAMESERVER_TEST_INVALID_IP": {
+        "sonic-dns:sonic-dns": {
+            "sonic-dns:DNS_NAMESERVER": {
+                "DNS_NAMESERVER_LIST": [
+                    {
+                        "ip": "1.x.2.x"
+                    }
+                ]
+            }
+        }
+    },
+    "DNS_NAMESERVER_TEST_MAX_IP_NUMBER": {
+        "sonic-dns:sonic-dns": {
+            "sonic-dns:DNS_NAMESERVER": {
+                "DNS_NAMESERVER_LIST": [
+                    {
+                        "ip": "192.168.1.1"
+                    },
+                    {
+                        "ip": "fe80:1000:2000:3000::2"
+                    },
+                    {
+                        "ip": "192.168.1.3"
+                    },
+                    {
+                        "ip": "fe80:1000:2000:3000::4"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-dns.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dns.yang
@@ -1,0 +1,45 @@
+module sonic-dns {
+
+    namespace  "http://github.com/sonic-net/sonic-dns";
+    yang-version 1.1;
+    prefix dns;
+
+    import ietf-inet-types {
+        prefix inet;
+    }
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description "DNS YANG module for SONiC OS";
+
+    revision 2023-02-14 {
+        description "Initial version";
+    }
+
+    container sonic-dns {
+
+        container DNS_NAMESERVER {
+
+            description "DNS_NAMESERVER part of config_db.json";
+
+            list DNS_NAMESERVER_LIST {
+                max-elements 3;
+                description "List of nameservers IPs";
+
+                key "ip";
+
+                leaf ip {
+                    description "IP as DHCP_SERVER";
+                    type inet:ip-address;
+                }
+            } /* end of list DNS_NAMESERVER_LIST */
+
+        } /* end of container DNS_NAMESERVER */
+
+    } /* end of container sonic-dns */
+
+} /* end of module sonic-dns */


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add SONiC YANG model for DNS to provide the possibility to configure static DNS entries in Config DB.

#### How I did it
Added sonic-dns.yang file that contains the YANG model for the static DNS configuration.

#### How to verify it
This PR extends YANG model tests to cover DNS configuration.
To run the test sonic_yang_models-1.0-py3-none-any.whl should be compiled.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

