### PR TITLE
Fix swsscommon psubscribe code break in frrcfgd

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1483,7 +1483,7 @@ class ExtConfigDBConnector(ConfigDBConnector):
         """
         self.pubsub = self.get_redis_client(self.db_name).pubsub()
         self.pubsub.psubscribe("__keyspace@{}__:*".format(self.get_dbid(self.db_name)))
-        self.sub_thread = threading.Thread(target=listen_thread, args=(self, 0.01))
+        self.sub_thread = threading.Thread(target=self.listen_thread, args=(0.01,))
         self.sub_thread.start()
 
     @staticmethod

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1445,7 +1445,7 @@ class ExtConfigDBConnector(ConfigDBConnector):
     def __init__(self, ns_attrs = None):
         super(ExtConfigDBConnector, self).__init__()
         self.nosort_attrs = ns_attrs if ns_attrs is not None else {}
-        self.sub_thread_running = False
+        self.__listen_thread_running = False
     def raw_to_typed(self, raw_data, table = ''):
         if len(raw_data) == 0:
             raw_data = None
@@ -1472,10 +1472,10 @@ class ExtConfigDBConnector(ConfigDBConnector):
                 logging.exception(e)
 
     def listen_thread(self, timeout):
-        self.sub_thread_running = True
+        self.__listen_thread_running = True
         sub_key_space = "__keyspace@{}__:*".format(self.get_dbid(self.db_name))
         self.pubsub.psubscribe(sub_key_space)
-        while self.sub_thread_running:
+        while self.__listen_thread_running:
             msg = self.pubsub.get_message(timeout, True)
             if msg:
                 self.sub_msg_handler(msg)
@@ -1490,7 +1490,7 @@ class ExtConfigDBConnector(ConfigDBConnector):
         self.sub_thread.start()
 
     def stop_listen(self):
-        self.sub_thread_running = False
+        self.__listen_thread_running = False
 
     @staticmethod
     def get_table_key(table, key):

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -14,10 +14,10 @@ def test_contructor():
     for table, hdlr in daemon.table_handler_list:
         daemon.config_db.subscribe.assert_any_call(table, hdlr)
     daemon.config_db.pubsub.psubscribe.assert_called_once()
+    assert(daemon.config_db.sub_thread.is_alive() == True)
     daemon.stop()
-    daemon.config_db.sub_thread.stop.assert_called()
-    daemon.config_db.sub_thread.is_alive.assert_called_once()
-    daemon.config_db.sub_thread.join.assert_called_once()
+    daemon.config_db.pubsub.punsubscribe.assert_called_once()
+    assert(daemon.config_db.sub_thread.is_alive() == False)
 
 class CmdMapTestInfo:
     data_buf = {}


### PR DESCRIPTION
Fix swsscommon psubscribe code break in frrcfgd

#### Why I did it
Fix frrcfgd psubscribe code break: https://github.com/sonic-net/sonic-buildimage/issues/13109
The code issue caused by API change when migrate from swsssdk to swsscommon

#### How I did it
Fix frrcfgd code to use swsscommon psubscribe API.

#### How to verify it
Pass all UT.
Manually check fixed code work correctly.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Description for the changelog
Fix frrcfgd psubscribe code break: https://github.com/sonic-net/sonic-buildimage/issues/13109

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

