### PR TITLE
[Mellanox] [202205] Add sodimm sensor

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -227,6 +227,11 @@ class DeviceDataManager:
 
     @classmethod
     @utils.read_only_cache()
+    def get_sodimm_thermal_count(cls):
+        return len(glob.glob('/run/hw-management/thermal/sodimm*_temp_input'))
+
+    @classmethod
+    @utils.read_only_cache()
     def get_minimum_table(cls):
         platform_data = DEVICE_DATA.get(cls.get_platform_name(), None)
         if not platform_data:

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -125,7 +125,7 @@ THERMAL_NAMING_RULE = {
             "temperature": "sodimm{}_temp_input",
             "high_threshold": "sodimm{}_temp_max",
             "high_critical_threshold": "sodimm{}_temp_crit",
-            "type": "indexable",
+            "type": "indexable"
         }
     ],
     'linecard thermals': {

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -119,6 +119,13 @@ THERMAL_NAMING_RULE = {
             "name": "Ambient Switch Board Temp",
             "temperature": "swb_amb",
             "default_present": False
+        },
+        {
+            "name": "SODIMM {} Temp",
+            "temperature": "sodimm{}_temp_input",
+            "high_threshold": "sodimm{}_temp_max",
+            "high_critical_threshold": "sodimm{}_temp_crit",
+            "type": "indexable",
         }
     ],
     'linecard thermals': {
@@ -161,6 +168,8 @@ def initialize_chassis_thermals():
                 count = DeviceDataManager.get_gearbox_count('/run/hw-management/config')
             elif 'CPU Core' in rule['name']:
                 count = DeviceDataManager.get_cpu_thermal_count()
+            elif 'SODIMM' in rule['name']:
+                count = DeviceDataManager.get_sodimm_thermal_count()
             if count == 0:
                 logger.log_debug('Failed to get thermal object count for {}'.format(rule['name']))
                 continue


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Backport sodimm sensor from PR https://github.com/sonic-net/sonic-buildimage/pull/12671
Depends on  https://github.com/sonic-net/sonic-buildimage/pull/13372 to be cherry picked to 202205.

#### Why I did it

Add sodimm sensor 

#### How I did it

Add sodimm sensor 

#### How to verify it

Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
