### PR TITLE
Misc platform improvements for DCS-7060DX5-64S

### DIFF
--- a/device/arista/x86_64-arista_7060dx5_64s/Arista-7060DX5-64S/hwsku.json
+++ b/device/arista/x86_64-arista_7060dx5_64s/Arista-7060DX5-64S/hwsku.json
@@ -255,6 +255,14 @@
         "Ethernet504": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G]",
             "fec": "rs"
+        },
+        "Ethernet512": {
+            "default_brkout_mode": "1x10G",
+            "fec": "none"
+        },
+        "Ethernet513": {
+            "default_brkout_mode": "1x10G",
+            "fec": "none"
         }
     }
 }

--- a/device/arista/x86_64-arista_7060dx5_64s/Arista-7060DX5-64S/port_config.ini
+++ b/device/arista/x86_64-arista_7060dx5_64s/Arista-7060DX5-64S/port_config.ini
@@ -63,3 +63,5 @@ Ethernet480     237,238,239,240,241,242,243,244 Ethernet61/1 61     400000    rs
 Ethernet488     229,230,231,232,233,234,235,236 Ethernet62/1 62     400000    rs
 Ethernet496     249,250,251,252,253,254,255,256 Ethernet63/1 63     400000    rs
 Ethernet504     245,246,247,248,249,250,251,252 Ethernet64/1 64     400000    rs
+Ethernet512     258                             Ethernet65   65     10000     none
+Ethernet513     257                             Ethernet66   66     10000     none

--- a/device/arista/x86_64-arista_7060dx5_64s/Arista-7060DX5-64S/th4-a7060dx5-64s.config.bcm
+++ b/device/arista/x86_64-arista_7060dx5_64s/Arista-7060DX5-64S/th4-a7060dx5-64s.config.bcm
@@ -34,7 +34,7 @@ bcm_device:
             sai_field_group_auto_prioritize: 1
             #l3_intf_vlan_split_egress for MTU at L3IF
             l3_intf_vlan_split_egress : 1
-
+            bcm_tunnel_term_compatible_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060dx5_64s/Arista-7060DX5-64S/th4-a7060dx5-64s.config.bcm
+++ b/device/arista/x86_64-arista_7060dx5_64s/Arista-7060DX5-64S/th4-a7060dx5-64s.config.bcm
@@ -1103,7 +1103,7 @@ device:
                           [238, 241],
                           [255, 258]]
             :
-                ENABLE: 1
+                ENABLE: 0
                 SPEED: 400000
                 NUM_LANES: 8
                 FEC_MODE: PC_FEC_RS544_2XN

--- a/device/arista/x86_64-arista_7060dx5_64s/Arista-7060DX5-64S/th4-a7060dx5-64s.config.bcm
+++ b/device/arista/x86_64-arista_7060dx5_64s/Arista-7060DX5-64S/th4-a7060dx5-64s.config.bcm
@@ -1073,6 +1073,14 @@ device:
                 PORT_ID: 258
             :
                 PC_PHYS_PORT_ID: 253
+            ?
+                PORT_ID: 152
+            :
+                PC_PHYS_PORT_ID: 257
+            ?
+                PORT_ID: 50
+            :
+                PC_PHYS_PORT_ID: 258
 ...
 ---
 device:
@@ -1083,6 +1091,13 @@ device:
             :
                 &port_mode_10g
                 ENABLE: 1
+                SPEED: 10000
+                NUM_LANES: 1
+            ?
+                PORT_ID: [[50, 50], [152, 152]]
+            :
+                ENABLE: 1
+                MAX_FRAME_SIZE: 9416
                 SPEED: 10000
                 NUM_LANES: 1
             ?

--- a/device/arista/x86_64-arista_7060dx5_64s/platform.json
+++ b/device/arista/x86_64-arista_7060dx5_64s/platform.json
@@ -49,52 +49,52 @@
         ],
         "thermals": [
             {
-                "name": "Cpu temp sensor"
+                "name": "Board sensor",
+                "controllable": false
             },
             {
-                "name": "CPU board temp sensor"
+                "name": "TH4 exhaust temp sensor",
+                "controllable": false
             },
             {
-                "name": "Back-panel temp sensor"
+                "name": "Inlet temp sensor",
+                "controllable": false
             },
             {
-                "name": "Board sensor"
+                "name": "CPU board temp sensor",
+                "controllable": false
             },
             {
-                "name": "Switch board middle sensor"
+                "name": "Back panel temp sensor",
+                "controllable": false
             },
             {
-                "name": "Switch board left sensor"
+                "name": "Front panel temp sensor",
+                "controllable": false
             },
             {
-                "name": "Front-panel temp sensor"
+                "name": "Power supply 1 hotspot sensor",
+                "controllable": false
             },
             {
-                "name": "Switch chip diode 1 sensor"
+                "name": "Power supply 1 inlet temp sensor",
+                "controllable": false
             },
             {
-                "name": "Switch chip diode 2 sensor"
+                "name": "Power supply 1 exhaust temp sensor",
+                "controllable": false
             },
             {
-                "name": "Front-panel temp sensor"
+                "name": "Power supply 2 hotspot sensor",
+                "controllable": false
             },
             {
-                "name": "Power supply 1 inlet temp sensor"
+                "name": "Power supply 2 inlet temp sensor",
+                "controllable": false
             },
             {
-                "name": "Power supply 1 secondary hotspot sensor"
-            },
-            {
-                "name": "Power supply 1 primary hotspot sensor"
-            },
-            {
-                "name": "Power supply 2 inlet temp sensor"
-            },
-            {
-                "name": "Power supply 2 secondary hotspot sensor"
-            },
-            {
-                "name": "Power supply 2 primary hotspot sensor"
+                "name": "Power supply 2 exhaust temp sensor",
+                "controllable": false
             }
         ],
         "sfps": [

--- a/device/arista/x86_64-arista_7060dx5_64s/platform.json
+++ b/device/arista/x86_64-arista_7060dx5_64s/platform.json
@@ -2154,6 +2154,24 @@
                     "Ethernet64/8"
                 ]
             }
+        },
+        "Ethernet512": {
+            "index": "65",
+            "lanes": "258",
+            "breakout_modes": {
+                "1x10G": [
+                    "Ethernet65"
+                ]
+            }
+        },
+        "Ethernet513": {
+            "index": "66",
+            "lanes": "257",
+            "breakout_modes": {
+                "1x10G": [
+                    "Ethernet66"
+                ]
+            }
         }
     }
 }

--- a/device/arista/x86_64-arista_7060px5_64s/Arista-7060PX5-64S/blackhawk.xml
+++ b/device/arista/x86_64-arista_7060px5_64s/Arista-7060PX5-64S/blackhawk.xml
@@ -4,12 +4,6 @@
   <phy_addr>0</phy_addr>
   <mode>retimer</mode>
   <topology>1</topology>
-  <tx-taps>
-      <PAM4>2,-8,17,0,0</PAM4>
-      <NRZ>0,-8,17,0,0</NRZ>
-   </tx-taps>
-   <tx-taps-scale>0,0,1,0,0</tx-taps-scale>
-
   <lane id="0" tx-polarity="0" rx-polarity="0" />
   <lane id="1" tx-polarity="0" rx-polarity="0" />
   <lane id="2" tx-polarity="0" rx-polarity="0" />
@@ -26,4 +20,23 @@
   <lane id="13" tx-polarity="0" rx-polarity="0" />
   <lane id="14" tx-polarity="0" rx-polarity="0" />
   <lane id="15" tx-polarity="0" rx-polarity="0" />
+
+  <PAM4>
+    <lane id="0" tx-taps="0,0,-8,117,-2,0,0"/>
+    <lane id="1" tx-taps="0,0,-8,117,-2,0,0"/>
+    <lane id="2" tx-taps="0,0,-8,117,-2,0,0"/>
+    <lane id="3" tx-taps="0,0,-8,117,-2,0,0"/>
+    <lane id="4" tx-taps="0,0,-8,117,-2,0,0"/>
+    <lane id="5" tx-taps="0,0,-8,117,-2,0,0"/>
+    <lane id="6" tx-taps="0,0,-8,117,-2,0,0"/>
+    <lane id="7" tx-taps="0,0,-8,117,-2,0,0"/>
+    <lane id="8" tx-taps="0,10,-22,93,-2,0,0"/>
+    <lane id="9" tx-taps="0,10,-22,93,-2,0,0"/>
+    <lane id="10" tx-taps="0,10,-22,93,-2,0,0"/>
+    <lane id="11" tx-taps="0,10,-22,93,-2,0,0"/>
+    <lane id="12" tx-taps="0,10,-22,93,-2,0,0"/>
+    <lane id="13" tx-taps="0,10,-22,93,-2,0,0"/>
+    <lane id="14" tx-taps="0,10,-22,93,-2,0,0"/>
+    <lane id="15" tx-taps="0,10,-22,93,-2,0,0"/>
+  </PAM4>
 </root>

--- a/device/arista/x86_64-arista_7060px5_64s/sensors.conf
+++ b/device/arista/x86_64-arista_7060px5_64s/sensors.conf
@@ -7,20 +7,15 @@ bus "i2c-23" "SCD 0000:01:00.0 SMBus master 1 bus 4"
 bus "i2c-24" "SCD 0000:01:00.0 SMBus master 1 bus 5"
 bus "i2c-107" "SCD 0000:00:18.7 SMBus master 0 bus 0"
 
-chip "max6581-i2c-19-4d"
+chip "tmp464-i2c-19-48"
     label temp1 "Board sensor"
     label temp2 "TH4 exhaust temp sensor"
-    label temp3 "Left edge PCB rear temp sensor"
-    label temp4 "Inlet temp sensor"
-    ignore temp5
-    ignore temp6
-    label temp7 "Diode temp sensor 1"
-    label temp8 "Diode temp sensor 2"
+    label temp3 "Inlet temp sensor"
 
 chip "dps800-i2c-22-58"
     label temp1 "Power supply 1 hotspot sensor"
     label temp2 "Power supply 1 inlet temp sensor"
-    label temp3 "Power supply 1 exhaust temp sensor"
+    ignore temp3 "Power supply 1 exhaust temp sensor"
 
 chip "dps800-i2c-23-58"
     label temp1 "Power supply 2 hotspot sensor"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Misc platform improvements for DCS-7060DX5-64S.

Includes changes for:
* Add 7060DX5-64S brcm tunnel config support
* Set port config ENABLE:0 in 7060DX5-64S brcm config
* Sensor.conf fixes
* SFP port support
* Add copper 50g tuning to babbagelp

#### How I did it
Commits describe the changes

#### How to verify it
Fixes have been uncovered and validated in our in house testing and running sonic-mgmt testing on DCS-7060DX5-64S.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Misc platform improvements for DCS-7060DX5-64S.

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

