### PR TITLE
[202012][Mellanox] Place FW binaries under platform directory instead of squashfs

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -803,7 +803,7 @@ sudo mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/bios/
 for MLNX_BIOS_ARCHIVE in $MLNX_BIOS_ARCHIVES; do
     sudo cp $files_path/$MLNX_BIOS_ARCHIVE $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/bios/
     # Link old BIOS location to not break existing automation/scripts
-    sudo ln -s /host/image-$SONIC_IMAGE_VERSION/$PLATFORM_DIR/$MLNX_BIOS_ARCHIVE $FILESYSTEM_ROOT/etc/mlnx/bios/$MLNX_BIOS_ARCHIVE
+    sudo ln -s /host/image-$SONIC_IMAGE_VERSION/$PLATFORM_DIR/fw/bios/$MLNX_BIOS_ARCHIVE $FILESYSTEM_ROOT/etc/mlnx/bios/$MLNX_BIOS_ARCHIVE
 done
 fi
 
@@ -814,9 +814,9 @@ declare -rA FW_FILE_MAP=( \
 )
 sudo mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/asic/
 for fw_file_name in ${!FW_FILE_MAP[@]}; do
-    sudo cp $files_path/$fw_file_name $FILESYSTEM_ROOT/$PLATFORM_DIR/${FW_FILE_MAP[$fw_file_name]}
+    sudo cp $files_path/$fw_file_name $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/asic/${FW_FILE_MAP[$fw_file_name]}
     # Link old FW location to not break existing automation/scripts
-    sudo ln -s /host/image-$SONIC_IMAGE_VERSION/$PLATFORM_DIR/${FW_FILE_MAP[$fw_file_name]} $FILESYSTEM_ROOT/etc/mlnx/${FW_FILE_MAP[$fw_file_name]}
+    sudo ln -s /host/image-$SONIC_IMAGE_VERSION/$PLATFORM_DIR/fw/asic/${FW_FILE_MAP[$fw_file_name]} $FILESYSTEM_ROOT/etc/mlnx/${FW_FILE_MAP[$fw_file_name]}
 done
 sudo cp $files_path/$ISSU_VERSION_FILE $FILESYSTEM_ROOT/etc/mlnx/issu-version
 sudo cp $files_path/$MLNX_FFB_SCRIPT $FILESYSTEM_ROOT/usr/bin/mlnx-ffb.sh

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -796,15 +796,28 @@ sudo cp {{src}} $FILESYSTEM_ROOT/{{dst}}
 
 {% if sonic_asic_platform == "mellanox" %}
 sudo mkdir -p $FILESYSTEM_ROOT/etc/mlnx/
+
 if [ -n "$MLNX_BIOS_ARCHIVES" ]; then
 sudo mkdir -p $FILESYSTEM_ROOT/etc/mlnx/bios/
+sudo mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/bios/
 for MLNX_BIOS_ARCHIVE in $MLNX_BIOS_ARCHIVES; do
-    sudo cp $files_path/$MLNX_BIOS_ARCHIVE $FILESYSTEM_ROOT/etc/mlnx/bios/
+    sudo cp $files_path/$MLNX_BIOS_ARCHIVE $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/bios/
+    # Link old BIOS location to not break existing automation/scripts
+    sudo ln -s /host/image-$SONIC_IMAGE_VERSION/$PLATFORM_DIR/$MLNX_BIOS_ARCHIVE $FILESYSTEM_ROOT/etc/mlnx/bios/$MLNX_BIOS_ARCHIVE
 done
 fi
-sudo cp $files_path/$MLNX_SPC_FW_FILE $FILESYSTEM_ROOT/etc/mlnx/fw-SPC.mfa
-sudo cp $files_path/$MLNX_SPC2_FW_FILE $FILESYSTEM_ROOT/etc/mlnx/fw-SPC2.mfa
-sudo cp $files_path/$MLNX_SPC3_FW_FILE $FILESYSTEM_ROOT/etc/mlnx/fw-SPC3.mfa
+
+declare -rA FW_FILE_MAP=( \
+    [$MLNX_SPC_FW_FILE]="fw-SPC.mfa" \
+    [$MLNX_SPC2_FW_FILE]="fw-SPC2.mfa" \
+    [$MLNX_SPC3_FW_FILE]="fw-SPC3.mfa" \
+)
+sudo mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/asic/
+for fw_file_name in ${!FW_FILE_MAP[@]}; do
+    sudo cp $files_path/$fw_file_name $FILESYSTEM_ROOT/$PLATFORM_DIR/${FW_FILE_MAP[$fw_file_name]}
+    # Link old FW location to not break existing automation/scripts
+    sudo ln -s /host/image-$SONIC_IMAGE_VERSION/$PLATFORM_DIR/${FW_FILE_MAP[$fw_file_name]} $FILESYSTEM_ROOT/etc/mlnx/${FW_FILE_MAP[$fw_file_name]}
+done
 sudo cp $files_path/$ISSU_VERSION_FILE $FILESYSTEM_ROOT/etc/mlnx/issu-version
 sudo cp $files_path/$MLNX_FFB_SCRIPT $FILESYSTEM_ROOT/usr/bin/mlnx-ffb.sh
 sudo cp $files_path/$MLNX_ONIE_FW_UPDATE $FILESYSTEM_ROOT/usr/bin/$MLNX_ONIE_FW_UPDATE

--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -32,9 +32,9 @@ declare -r UNKN_ASIC="unknown"
 declare -r UNKN_MST="unknown"
 
 declare -rA FW_FILE_MAP=( \
-    [$SPC1_ASIC]="/etc/mlnx/fw-SPC.mfa" \
-    [$SPC2_ASIC]="/etc/mlnx/fw-SPC2.mfa" \
-    [$SPC3_ASIC]="/etc/mlnx/fw-SPC3.mfa" \
+    [$SPC1_ASIC]="fw-SPC.mfa" \
+    [$SPC2_ASIC]="fw-SPC2.mfa" \
+    [$SPC3_ASIC]="fw-SPC3.mfa" \
 )
 
 IMAGE_UPGRADE="${NO_PARAM}"
@@ -181,17 +181,17 @@ function RunCmd() {
 }
 
 function UpgradeFW() {
-    local -r _FS_MOUNTPOINT="$1"
+    local -r _FW_BIN_PATH="$1"
 
     local -r _ASIC_TYPE="$(GetAsicType)"
     if [[ "${_ASIC_TYPE}" = "${UNKN_ASIC}" ]]; then
         ExitFailure "failed to detect ASIC type"
     fi
 
-    if [ ! -z "${_FS_MOUNTPOINT}" ]; then
-        local -r _FW_FILE="${_FS_MOUNTPOINT}/${FW_FILE_MAP[$_ASIC_TYPE]}"
+    if [ ! -z "${_FW_BIN_PATH}" ]; then
+        local -r _FW_FILE="${_FW_BIN_PATH}/${FW_FILE_MAP[$_ASIC_TYPE]}"
     else
-        local -r _FW_FILE="${FW_FILE_MAP[$_ASIC_TYPE]}"
+        local -r _FW_FILE="/etc/mlnx/${FW_FILE_MAP[$_ASIC_TYPE]}"
     fi
 
     if [ ! -f "${_FW_FILE}" ]; then
@@ -239,11 +239,27 @@ function UpgradeFWFromImage() {
 
     if [[ "${_CURRENT_SONIC_IMAGE}" == "${_NEXT_SONIC_IMAGE}" ]]; then
         ExitSuccess "firmware is up to date"
+    fi
+
+    # /host/image-<version>/platform/fw/asic is now the new location for FW binaries.
+    # Prefere this path and if it does not exist use squashfs as a fallback.
+    local -r _NEXT_IMAGE_FW_BIN_PATH="/host/image-${_NEXT_SONIC_IMAGE#SONiC-OS-}/platform/fw/asic/"
+
+    if [[ -d "${_NEXT_IMAGE_FW_BIN_PATH}" ]]; then
+        LogInfo "Using FW binaries from ${_NEXT_IMAGE_FW_BIN_PATH}"
+
+        UpgradeFW "${_NEXT_IMAGE_FW_BIN_PATH}"
     else
+        local -r _FS_PATH="/host/image-${_NEXT_SONIC_IMAGE#SONiC-OS-}/fs.squashfs"
+        local -r _FS_MOUNTPOINT="/tmp/image-${_NEXT_SONIC_IMAGE#SONiC-OS-}-fs"
+        local -r _FW_BIN_PATH="${_FS_MOUNTPOINT}/etc/mlnx/"
+
+        LogInfo "Using FW binaries from ${_FW_BIN_PATH}"
+
         mkdir -p "${_FS_MOUNTPOINT}"
         mount -t squashfs "${_FS_PATH}" "${_FS_MOUNTPOINT}"
 
-        UpgradeFW "${_FS_MOUNTPOINT}"
+        UpgradeFW "${_FW_BIN_PATH}"
 
         umount -rf "${_FS_MOUNTPOINT}"
         rm -rf "${_FS_MOUNTPOINT}"

--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -243,12 +243,12 @@ function UpgradeFWFromImage() {
 
     # /host/image-<version>/platform/fw/asic is now the new location for FW binaries.
     # Prefere this path and if it does not exist use squashfs as a fallback.
-    local -r _NEXT_IMAGE_FW_BIN_PATH="/host/image-${_NEXT_SONIC_IMAGE#SONiC-OS-}/platform/fw/asic/"
+    local -r _PLATFORM_FW_BIN_PATH="/host/image-${_NEXT_SONIC_IMAGE#SONiC-OS-}/platform/fw/asic/"
 
-    if [[ -d "${_NEXT_IMAGE_FW_BIN_PATH}" ]]; then
-        LogInfo "Using FW binaries from ${_NEXT_IMAGE_FW_BIN_PATH}"
+    if [[ -d "${_PLATFORM_FW_BIN_PATH}" ]]; then
+        LogInfo "Using FW binaries from ${_PLATFORM_FW_BIN_PATH}"
 
-        UpgradeFW "${_NEXT_IMAGE_FW_BIN_PATH}"
+        UpgradeFW "${_PLATFORM_FW_BIN_PATH}"
     else
         local -r _FS_PATH="/host/image-${_NEXT_SONIC_IMAGE#SONiC-OS-}/fs.squashfs"
         local -r _FS_MOUNTPOINT="/tmp/image-${_NEXT_SONIC_IMAGE#SONiC-OS-}-fs"


### PR DESCRIPTION
Upgrade from old image always requires squashfs mount to get the next image FW binary. This can be avoided if we put FW binary under platform directory which is easily accessible after installation:

```
admin@r-spider-05:~$ ls /host/image-fw-new-loc.0-dirty-20230208.193534/platform/fw-SPC.mfa
/host/image-fw-new-loc.0-dirty-20230208.193534/platform/fw-SPC.mfa
admin@r-spider-05:~$ ls -al /tmp/image-fw-new-loc.0-dirty-20230208.193534-fs/etc/mlnx/fw-SPC.mfa
lrwxrwxrwx 1 root root 66 Feb  8 17:57 /tmp/image-fw-new-loc.0-dirty-20230208.193534-fs/etc/mlnx/fw-SPC.mfa -> /host/image-fw-new-loc.0-dirty-20230208.193534/platform/fw-SPC.mfa
```

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

202211 and above uses different squashfs compression type that 201911 kernel can not handle. Therefore, we avoid mounting squashfs altogather with this change.

#### How I did it

- Place FW binary under /host/image-<version>/platform/mlnx/, soft links in /etc/mlnx are created to avoid breaking existing scripts/automation.
- /etc/mlnx/fw-SPCX.mfa is a soft link always pointing to the FW that should be used in current image
- mlnx-fw-upgrade.sh is updated to prefer /host/image-<version>/platform/mlnx location and fallback to /etc/mlnx in squashfs in case new location does not exist. This is neccessary to do image downgrade.

#### How to verify it

- Upgrade from 201911 to master
- master to 201911 downgrade
- master -> master reboot
- ONIE -> master boot (First FW burn)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

