### PR TITLE
[Nokia-7215][uboot] Fixed the uboot setting for sonic-installer set-default form 202012 to 202205 branch.

### DIFF
--- a/platform/marvell-armhf/platform.conf
+++ b/platform/marvell-armhf/platform.conf
@@ -6,9 +6,9 @@ echo "Preparing for installation ... "
 
 # global defines
 kernel_addr=0x1100000
-fdt_addr=0x1000000
-fdt_high=0x10fffff
-initrd_addr=0x2000000
+fdt_addr=0x2800000
+fdt_high=0x28fffff
+initrd_addr=0x2900000
 
 kernel_fname="/boot/vmlinuz-4.19.0-12-2-armmp"
 initrd_fname="/boot/initrd.img-4.19.0-12-2-armmp"
@@ -175,7 +175,7 @@ prepare_boot_menu() {
         BOOT3='echo " > Boot3: ONIE - run onie_nand_boot";echo;'
     fi
     BORDER='echo "---------------------------------------------------";echo;'
-    fw_setenv ${FW_ARG} print_menu $BORDER $BOOT1 $BOOT2 $BOOT3 $BORDER > /dev/null
+    fw_setenv ${FW_ARG} print_menu "$BORDER $BOOT1 $BOOT2 $BOOT3 $BORDER" > /dev/null
 
     fw_setenv ${FW_ARG} linuxargs "net.ifnames=0 loopfstype=squashfs loop=$image_dir/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG_SIZE loglevel=4" > /dev/null
     fw_setenv ${FW_ARG} linuxargs_old "net.ifnames=0 loopfstype=squashfs loop=$image_dir_old/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG_SIZE loglevel=4" > /dev/null


### PR DESCRIPTION
#### Why I did it
When using ```sonic-install set-default``` to switch the image from 202012 to 202205.  The system will be stuck at loading kernel while reboot.

#### How I did it
The issue is caused by the kernal size related setting in uboot environment is smaller in the 202012 branch while they are larger in 202205 branch.  The "sonic-installer set-default" just changes the boot_next variable.  To fix this issue, we sync up the 202012 branch kernel related setting with the 202205 branch.  This PR is only applicable to 202012 branch.

#### How to verify it
1) Install the latest 202205 image .89 or latest and reboot
2) Install the 202012 image which contains this fix and reboot
3) using "sonic-installer set-default 202205 image and reboot
4) system should start without any issue. 
  

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

