### PR TITLE
[Seastone] add psu fans status led available config

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/platform.json
+++ b/device/celestica/x86_64-cel_seastone-r0/platform.json
@@ -266,6 +266,9 @@
                         "name": "PSU-1 FAN-1",
                         "speed": {
                             "controllable": false
+                        },
+                        "status_led": {
+                            "available": false
                         }
                     }
                 ]
@@ -281,6 +284,9 @@
                         "name": "PSU-2 FAN-1",
                         "speed": {
                             "controllable": false
+                        },
+                        "status_led": {
+                            "available": false
                         }
                     }
                 ]


### PR DESCRIPTION
#### Why I did it
Seastone does not have the psu fans' status led, need to reflect it in platform.json.

#### How I did it
Set the psu fans status led available to false.

#### How to verify it
Verify it with platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_led case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

