### PR TITLE
[Seastone] fix dx010 qsfp eeprom data write issue

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/sfp.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/sfp.py
@@ -1520,7 +1520,7 @@ class Sfp(SfpBase):
             if dom_control_raw is not None:
                 dom_control_data = sfpd_obj.parse_control_bytes(
                     dom_control_raw, 0)
-                return ('On' == dom_control_data['data']['PowerOverride'])
+                return ('On' == dom_control_data['data']['PowerOverride']['value'])
             else:
                 return False
         else:


### PR DESCRIPTION
#### Why I did it
Platform cases test_tx_disable, test_tx_disable_channel, test_power_override failed in dx010.

#### How I did it
Add i2c access algorithm for CPLD i2c adapters.

#### How to verify it
Verify it with platform_tests/api/test_sfp.py::TestSfpApi test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

