### PR TITLE
[marvell-armhf][uboot-setting] Fix the print menu for marvell-armhf print menu on Nokia-7215

### DIFF
--- a/platform/marvell-armhf/platform.conf
+++ b/platform/marvell-armhf/platform.conf
@@ -175,7 +175,7 @@ prepare_boot_menu() {
         BOOT3='echo " > Boot3: ONIE - run onie_nand_boot";echo;'
     fi
     BORDER='echo "---------------------------------------------------";echo;'
-    fw_setenv ${FW_ARG} print_menu $BORDER $BOOT1 $BOOT2 $BOOT3 $BORDER > /dev/null
+    fw_setenv ${FW_ARG} print_menu "$BORDER $BOOT1 $BOOT2 $BOOT3 $BORDER" > /dev/null
 
     fw_setenv ${FW_ARG} linuxargs "net.ifnames=0 loopfstype=squashfs loop=$image_dir/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG_SIZE loglevel=4 ${extra_cmdline_linux}" > /dev/null
     fw_setenv ${FW_ARG} linuxargs_old "net.ifnames=0 loopfstype=squashfs loop=$image_dir_old/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG_SIZE loglevel=4" > /dev/null


### PR DESCRIPTION
#### Why I did it
After sonic-install install a new image,  print_menu is set echo without any data.   No image info between ``` Hit any key to stop autoboot:  0 ``` and  ``` Start USB```
```
Board configuration detected:
Net:   
|  port  | Interface | PHY address  |
|--------|-----------|--------------|
No ethernet found.
Hit any key to stop autoboot:  0 

(Re)start USB...
USB0:   Port (usbActive) : 0    Interface (usbType = 2) : USB EHCI 1.00
scanning bus 0 for devices... 3 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
```
#### How I did it
The fw_setenv print_menu is missing the double quotes.  That causes the value is truncated.   Using double quotes to in the environment setting.

#### How to verify it
Install new image with this fix. And reboot the system. The following section should be shown:
```
No ethernet found.
Hit any key to stop autoboot:  0 
---------------------------------------------------

> Boot1: SONiC-OS-202205.0-dirty-20230220.202445 - run sonic_image_1

> Boot2: SONiC-OS-20201231.89 - run sonic_image_2

 > Boot3: ONIE - run onie_bootcmd

---------------------------------------------------

(Re)start USB...
USB0:   Port (usbActive) : 0    Interface (usbType = 2) : USB EHCI 1.00
scanning bus 0 for devices... 3 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
       scanning usb for ethernet devices... 0 Ethernet Device(s) found

```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

