### PR TITLE
show macsec:  add --profile option, include profile name in show command output

### DIFF
--- a/dockers/docker-macsec/cli-plugin-tests/config_db.json
+++ b/dockers/docker-macsec/cli-plugin-tests/config_db.json
@@ -1,0 +1,31 @@
+{
+    "MACSEC_PROFILE": {
+        "macsec_profile": {
+            "cipher_suite": "GCM-AES-XPN-256",
+            "policy": "security",
+            "primary_cak": "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+            "primary_ckn": "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435",
+            "priority": "0",
+            "rekey_period": "900",
+            "send_sci": "true"
+        }
+    },
+    "PORT": {
+        "Ethernet1": {
+            "alias": "Ethernet1/1",
+            "asic_port_name": "Eth0-ASIC0",
+            "coreid": "1",
+            "coreportid": "1",
+            "description": "Ethernet1/1",
+            "index": "1",
+            "lanes": "72,73,74,75,76,77,78,79",
+            "macsec": "macsec_profile",
+            "mtu": "9100",
+            "numvoq": "8",
+            "pfc_asym": "off",
+            "role": "Ext",
+            "speed": "400000",
+            "tpid": "0x8100"
+        }
+    }
+}

--- a/dockers/docker-macsec/cli-plugin-tests/config_db.json
+++ b/dockers/docker-macsec/cli-plugin-tests/config_db.json
@@ -1,6 +1,5 @@
 {
-    "MACSEC_PROFILE": {
-        "macsec_profile": {
+    "MACSEC_PROFILE|macsec_profile": {
             "cipher_suite": "GCM-AES-XPN-256",
             "policy": "security",
             "primary_cak": "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
@@ -8,10 +7,8 @@
             "priority": "0",
             "rekey_period": "900",
             "send_sci": "true"
-        }
     },
-    "PORT": {
-        "Ethernet1": {
+    "PORT|Ethernet0": {
             "alias": "Ethernet1/1",
             "asic_port_name": "Eth0-ASIC0",
             "coreid": "1",
@@ -26,6 +23,53 @@
             "role": "Ext",
             "speed": "400000",
             "tpid": "0x8100"
-        }
+    },
+    "PORT|Ethernet1": {
+            "alias": "Ethernet2/1",
+            "asic_port_name": "Eth0-ASIC0",
+            "coreid": "1",
+            "coreportid": "1",
+            "description": "Ethernet2/1",
+            "index": "1",
+            "lanes": "72,73,74,75,76,77,78,79",
+            "macsec": "macsec_profile",
+            "mtu": "9100",
+            "numvoq": "8",
+            "pfc_asym": "off",
+            "role": "Ext",
+            "speed": "400000",
+            "tpid": "0x8100"
+    },
+    "PORT|Ethernet4": {
+            "alias": "Ethernet5/1",
+            "asic_port_name": "Eth0-ASIC0",
+            "coreid": "1",
+            "coreportid": "1",
+            "description": "Ethernet5/1",
+            "index": "1",
+            "lanes": "72,73,74,75,76,77,78,79",
+            "macsec": "macsec_profile",
+            "mtu": "9100",
+            "numvoq": "8",
+            "pfc_asym": "off",
+            "role": "Ext",
+            "speed": "400000",
+            "tpid": "0x8100"
+     },
+    "PORT|Ethernet5": {
+            "alias": "Ethernet6/1",
+            "asic_port_name": "Eth0-ASIC0",
+            "coreid": "1",
+            "coreportid": "1",
+            "description": "Ethernet6/1",
+            "index": "1",
+            "lanes": "72,73,74,75,76,77,78,79",
+            "macsec": "macsec_profile",
+            "mtu": "9100",
+            "numvoq": "8",
+            "pfc_asym": "off",
+            "role": "Ext",
+            "speed": "400000",
+            "tpid": "0x8100"
     }
 }

--- a/dockers/docker-macsec/cli-plugin-tests/test_show_macsec.py
+++ b/dockers/docker-macsec/cli-plugin-tests/test_show_macsec.py
@@ -25,5 +25,5 @@ class TestShowMACsec(object):
 
     def test_show_profile(self):
         runner = CliRunner()
-        result = runner.invoke(show_macsec.macsec,["--"profile""])
+        result = runner.invoke(show_macsec.macsec,["--profile"])
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)

--- a/dockers/docker-macsec/cli-plugin-tests/test_show_macsec.py
+++ b/dockers/docker-macsec/cli-plugin-tests/test_show_macsec.py
@@ -23,3 +23,7 @@ class TestShowMACsec(object):
         result = runner.invoke(show_macsec.macsec,["Ethernet1"])
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
 
+    def test_show_profile(self):
+        runner = CliRunner()
+        result = runner.invoke(show_macsec.macsec,["--"profile""])
+        assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)

--- a/dockers/docker-macsec/cli/show/plugins/show_macsec.py
+++ b/dockers/docker-macsec/cli/show/plugins/show_macsec.py
@@ -17,7 +17,19 @@ CACHE_FILE = os.path.join(CACHE_MANAGER.get_directory(), "macsecstats{}")
 
 DB_CONNECTOR = None
 COUNTER_TABLE = None
+macsec_profiles = []
 
+class MACsecCfgMeta(object):
+    def __init__(self, *args) -> None:
+        SEPARATOR = DB_CONNECTOR.get_db_separator(DB_CONNECTOR.CONFIG_DB)
+        self.key = self.__class__.get_cfg_table_name() + SEPARATOR + \
+            SEPARATOR.join(args)
+        self.cfgMeta = DB_CONNECTOR.get_all(
+            DB_CONNECTOR.CONFIG_DB, self.key)
+        if len(self.cfgMeta) == 0:
+            raise ValueError("No such MACsecCfgMeta: {}".format(self.key))
+        for k, v in self.cfgMeta.items():
+            setattr(self, k, v)
 
 class MACsecAppMeta(object):
     def __init__(self, *args) -> None:
@@ -126,23 +138,50 @@ class MACsecEgressSC(MACsecSC):
         return "MACsec Egress SC ({})\n".format(self.sci)
 
 
-class MACsecPort(MACsecAppMeta):
+class MACsecPort(MACsecAppMeta, MACsecCfgMeta):
     def __init__(self,  port_name: str) -> None:
         self.port_name = port_name
-        super(MACsecPort, self).__init__(port_name)
+        MACsecAppMeta.__init__(self, port_name)
+        MACsecCfgMeta.__init__(self, port_name)
 
     @classmethod
     def get_appl_table_name(cls) -> str:
         return "MACSEC_PORT_TABLE"
 
+    @classmethod
+    def get_cfg_table_name(cls) -> str:
+        return "PORT"
+
     def dump_str(self, cache = None) -> str:
         buffer = self.get_header()
+
+        # Add the profile information to the meta dict from config meta dict
+        self.meta["profile"] = self.cfgMeta["macsec"]
+
         buffer += tabulate(sorted(self.meta.items(), key=lambda x: x[0]))
         return buffer
 
     def get_header(self) -> str:
         return "MACsec port({})\n".format(self.port_name)
 
+class MACsecProfile(MACsecCfgMeta):
+    def __init__(self, profile_name: str) -> None:
+        self.profile_name = profile_name
+        super(MACsecProfile, self).__init__(profile_name)
+
+    @classmethod
+    def get_cfg_table_name(cls) -> str:
+        return "MACSEC_PROFILE"
+
+    def dump_str(self, cache = None) -> str:
+        buffer = self.get_header()
+        t_buffer = tabulate(sorted(self.cfgMeta.items(), key=lambda x: x[0]))
+        t_buffer = "\n".join(["\t" + line for line in t_buffer.splitlines()])
+        buffer += t_buffer
+        return buffer
+
+    def get_header(self) -> str:
+        return "MACsec profile : {}\n".format(self.profile_name)
 
 def create_macsec_obj(key: str) -> MACsecAppMeta:
     attr = key.split(":")
@@ -161,6 +200,14 @@ def create_macsec_obj(key: str) -> MACsecAppMeta:
     except ValueError as e:
         return None
 
+def create_macsec_profile_obj(key: str) -> MACsecCfgMeta:
+    attr = key.split("|")
+    try:
+        if attr[0] == MACsecProfile.get_cfg_table_name():
+            return MACsecProfile(attr[1])
+        raise TypeError("Unknown MACsec object type")
+    except ValueError as e:
+        return None
 
 def create_macsec_objs(interface_name: str) -> typing.List[MACsecAppMeta]:
     objs = []
@@ -192,6 +239,12 @@ def create_macsec_objs(interface_name: str) -> typing.List[MACsecAppMeta]:
     return objs
 
 
+def create_macsec_profiles_objs(profile_name: str) -> typing.List[MACsecCfgMeta]:
+    objs = []
+    objs.append(create_macsec_profile_obj(MACsecProfile.get_cfg_table_name() + "|" + profile_name))
+    return objs
+
+
 def cache_find(cache: dict, target: MACsecAppMeta) -> MACsecAppMeta:
     if not cache or not cache["objs"]:
         return None
@@ -207,10 +260,14 @@ def cache_find(cache: dict, target: MACsecAppMeta) -> MACsecAppMeta:
 
 @click.command()
 @click.argument('interface_name', required=False)
-@click.option('--dump-file', is_flag=True, required=False, default=False)
+@click.option('--profile', is_flag=True, required=False, default=False, help="show all macsec profiles")
+@click.option('--dump-file', is_flag=True, required=False, default=False, help="store show output to a file")
 @multi_asic_util.multi_asic_click_options
-def macsec(interface_name, dump_file, namespace, display):
-    MacsecContext(namespace, display).show(interface_name, dump_file)
+def macsec(interface_name, dump_file, namespace, display, profile):
+    if interface_name is not None and profile is not None:
+        click.echo('Interface name is not valid with profile option')
+        return
+    MacsecContext(namespace, display).show(interface_name, dump_file, profile)
 
 class MacsecContext(object):
 
@@ -220,21 +277,34 @@ class MacsecContext(object):
             display_option, namespace_option)
 
     @multi_asic_util.run_on_multi_asic
-    def show(self, interface_name, dump_file):
+    def show(self, interface_name, dump_file, profile):
         global DB_CONNECTOR
         global COUNTER_TABLE
+        global macsec_profiles
         DB_CONNECTOR = self.db
-        COUNTER_TABLE = CounterTable(self.db.get_redis_client(self.db.COUNTERS_DB))
 
-        interface_names = [name.split(":")[1] for name in self.db.keys(self.db.APPL_DB, "MACSEC_PORT*")]
-        if interface_name is not None:
-            if interface_name not in interface_names:
-                return
-            interface_names = [interface_name]
-        objs = []
+        if not profile: 
+            COUNTER_TABLE = CounterTable(self.db.get_redis_client(self.db.COUNTERS_DB))
 
-        for interface_name in natsorted(interface_names):
-            objs += create_macsec_objs(interface_name)
+            interface_names = [name.split(":")[1] for name in self.db.keys(self.db.APPL_DB, "MACSEC_PORT*")]
+            if interface_name is not None:
+                if interface_name not in interface_names:
+                    return
+                interface_names = [interface_name]
+            objs = []
+        
+            for interface_name in natsorted(interface_names):
+                objs += create_macsec_objs(interface_name)
+        else:
+            profile_names = [name.split("|")[1] for name in self.db.keys(self.db.CONFIG_DB, "MACSEC_PROFILE*")]
+            objs = []
+        
+            for profile_name in natsorted(profile_names):
+                # Check if this macsec profile is already added to profile list. This is in case of
+                # multi-asic devices where all namespaces will have the same macsec profile defined.
+                if profile_name not in macsec_profiles and not dump_file:
+                    macsec_profiles.append(profile_name)
+                    objs += create_macsec_profiles_objs(profile_name)
 
         cache = {}
         if os.path.isfile(CACHE_FILE.format(self.multi_asic.current_namespace)):

--- a/dockers/docker-macsec/cli/show/plugins/show_macsec.py
+++ b/dockers/docker-macsec/cli/show/plugins/show_macsec.py
@@ -264,7 +264,7 @@ def cache_find(cache: dict, target: MACsecAppMeta) -> MACsecAppMeta:
 @click.option('--dump-file', is_flag=True, required=False, default=False, help="store show output to a file")
 @multi_asic_util.multi_asic_click_options
 def macsec(interface_name, dump_file, namespace, display, profile):
-    if interface_name is not None and profile is not None:
+    if interface_name is not None and profile:
         click.echo('Interface name is not valid with profile option')
         return
     MacsecContext(namespace, display).show(interface_name, dump_file, profile)

--- a/dockers/docker-macsec/cli/show/plugins/show_macsec.py
+++ b/dockers/docker-macsec/cli/show/plugins/show_macsec.py
@@ -175,6 +175,11 @@ class MACsecProfile(MACsecCfgMeta):
 
     def dump_str(self, cache = None) -> str:
         buffer = self.get_header()
+
+        # Don't display the primary and fallback CAK
+        if 'primary_cak' in self.cfgMeta: del self.cfgMeta['primary_cak']
+        if 'fallback_cak' in self.cfgMeta: del self.cfgMeta['fallback_cak']
+
         t_buffer = tabulate(sorted(self.cfgMeta.items(), key=lambda x: x[0]))
         t_buffer = "\n".join(["\t" + line for line in t_buffer.splitlines()])
         buffer += t_buffer


### PR DESCRIPTION
#### Why I did it

This PR is to add the following 
1. Add a new options "--profile" to the show macsec command, to show all profiles in device
2. Update the currentl show macsec command, to show profile in each interface o/p. This will tell which macsec profile the interface is attached to.

#### How I did it
update the show cli plugin in macsec docker 

#### How to verify it
The following is the test o/p 

```
admin@str2--lc1-2:~$ show macsec 
Last cached time was 2023-02-22 19:48:18.106529
MACsec port(Ethernet184)
---------------------  ---------------
cipher_suite           GCM-AES-XPN-256
enable                 true
enable_encrypt         true
enable_protect         true
enable_replay_protect  false
profile                macsec_profile
replay_window          0
send_sci               true
---------------------  ---------------
        MACsec Egress SC (a47b2ce5940f0001)
        -----------  -
        encoding_an  1
        -----------  -
                MACsec Egress SA (1)
                -------------------------------------  ----------------------------------------------------------------
                auth_key                               D9E31955071DF44227EB6B0F23037B0D
                next_pn                                1
                sak                                    01B9F39545F90AC1D167D1CE37D872E9849DD0A870CA0CD0B12111E41990A4AE
                salt                                   D83322A67A3A358FC1B90B0C
                ssci                                   2
                SAI_MACSEC_SA_ATTR_CURRENT_XPN         31
                SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED    1306697
                SAI_MACSEC_SA_STAT_OCTETS_PROTECTED    0
                SAI_MACSEC_SA_STAT_OUT_PKTS_ENCRYPTED  30
                SAI_MACSEC_SA_STAT_OUT_PKTS_PROTECTED  0
                -------------------------------------  ------------------------------------------------------------------------  ----------------------------------------------------------------
                auth_key  D9E31955071DF44227EB6B0F23037B0D
                next_pn   1
                sak       01B9F39545F90AC1D167D1CE37D872E9849DD0A870CA0CD0B12111E41990A4AE
                salt      D83322A67A3A358FC1B90B0C
                ssci      2
                --------  ----------------------------------------------------------------
        MACsec Ingress SC (ded295f92a090001)
                MACsec Ingress SA (1)
                ---------------------------------------  ----------------------------------------------------------------
                active                                   true
                auth_key                                 D9E31955071DF44227EB6B0F23037B0D
                lowest_acceptable_pn                     1
                sak                                      01B9F39545F90AC1D167D1CE37D872E9849DD0A870CA0CD0B12111E41990A4AE
                salt                                     D83322A67A3A358FC1B90B0C
                ssci                                     1
                SAI_MACSEC_SA_ATTR_CURRENT_XPN           9922
                SAI_MACSEC_SA_STAT_IN_PKTS_DELAYED       0
                SAI_MACSEC_SA_STAT_IN_PKTS_INVALID       0
                SAI_MACSEC_SA_STAT_IN_PKTS_LATE          0
                SAI_MACSEC_SA_STAT_IN_PKTS_NOT_USING_SA  0
                SAI_MACSEC_SA_STAT_IN_PKTS_NOT_VALID     0
                SAI_MACSEC_SA_STAT_IN_PKTS_OK            30
                SAI_MACSEC_SA_STAT_IN_PKTS_UNCHECKED     0
                SAI_MACSEC_SA_STAT_IN_PKTS_UNUSED_SA     0
                SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED      1289369
                SAI_MACSEC_SA_STAT_OCTETS_PROTECTED      0
                ---------------------------------------  ------------------------------------------------------------------------------------  ----------------------------------------------------------------
                active                true
                auth_key              D9E31955071DF44227EB6B0F23037B0D
                lowest_acceptable_pn  1
                sak                   01B9F39545F90AC1D167D1CE37D872E9849DD0A870CA0CD0B12111E41990A4AE
                salt                  D83322A67A3A358FC1B90B0C
                ssci                  1
                --------------------  ----------------------------------------------------------------
admin@str2--lc1-2:~$ show macsec Ethernet184
Last cached time was 2023-02-22 19:48:18.106529
MACsec port(Ethernet184)
---------------------  ---------------
cipher_suite           GCM-AES-XPN-256
enable                 true
enable_encrypt         true
enable_protect         true
enable_replay_protect  false
profile                macsec_profile
replay_window          0
send_sci               true
---------------------  ---------------
        MACsec Egress SC (a47b2ce5940f0001)
        -----------  -
        encoding_an  1
        -----------  -
                MACsec Egress SA (1)
                -------------------------------------  ----------------------------------------------------------------
                auth_key                               D9E31955071DF44227EB6B0F23037B0D
                next_pn                                1
                sak                                    01B9F39545F90AC1D167D1CE37D872E9849DD0A870CA0CD0B12111E41990A4AE
                salt                                   D83322A67A3A358FC1B90B0C
                ssci                                   2
                SAI_MACSEC_SA_ATTR_CURRENT_XPN         31
                SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED    1306697
                SAI_MACSEC_SA_STAT_OCTETS_PROTECTED    0
                SAI_MACSEC_SA_STAT_OUT_PKTS_ENCRYPTED  30
                SAI_MACSEC_SA_STAT_OUT_PKTS_PROTECTED  0
                -------------------------------------  ------------------------------------------------------------------------  ----------------------------------------------------------------
                auth_key  D9E31955071DF44227EB6B0F23037B0D
                next_pn   1
                sak       01B9F39545F90AC1D167D1CE37D872E9849DD0A870CA0CD0B12111E41990A4AE
                salt      D83322A67A3A358FC1B90B0C
                ssci      2
                --------  ----------------------------------------------------------------
        MACsec Ingress SC (ded295f92a090001)
                MACsec Ingress SA (1)
                ---------------------------------------  ----------------------------------------------------------------
                active                                   true
                auth_key                                 D9E31955071DF44227EB6B0F23037B0D
                lowest_acceptable_pn                     1
                sak                                      01B9F39545F90AC1D167D1CE37D872E9849DD0A870CA0CD0B12111E41990A4AE
                salt                                     D83322A67A3A358FC1B90B0C
                ssci                                     1
                SAI_MACSEC_SA_ATTR_CURRENT_XPN           9922
                SAI_MACSEC_SA_STAT_IN_PKTS_DELAYED       0
                SAI_MACSEC_SA_STAT_IN_PKTS_INVALID       0
                SAI_MACSEC_SA_STAT_IN_PKTS_LATE          0
                SAI_MACSEC_SA_STAT_IN_PKTS_NOT_USING_SA  0
                SAI_MACSEC_SA_STAT_IN_PKTS_NOT_VALID     0
                SAI_MACSEC_SA_STAT_IN_PKTS_OK            30
                SAI_MACSEC_SA_STAT_IN_PKTS_UNCHECKED     0
                SAI_MACSEC_SA_STAT_IN_PKTS_UNUSED_SA     0
                SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED      1289369
                SAI_MACSEC_SA_STAT_OCTETS_PROTECTED      0
                ---------------------------------------  ------------------------------------------------------------------------------------  ----------------------------------------------------------------
                active                true
                auth_key              D9E31955071DF44227EB6B0F23037B0D
                lowest_acceptable_pn  1
                sak                   01B9F39545F90AC1D167D1CE37D872E9849DD0A870CA0CD0B12111E41990A4AE
                salt                  D83322A67A3A358FC1B90B0C
                ssci                  1
                --------------------  ----------------------------------------------------------------
admin@str2--lc1-2:~$ show macsec --profile
Last cached time was 2023-02-22 19:48:18.104093
MACsec profile : macsec_profile
        ------------  ----------------------------------------------------------------
        cipher_suite  GCM-AES-XPN-256
        policy        security
        primary_ckn   6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435
        priority      0
        rekey_period  900
        send_sci      true
        ------------  ----------------------------------------------------------------
admin@str2--lc1-2:~$ show macsec --profile -n asic0
Last cached time was 2023-02-22 19:48:18.104093
MACsec profile : macsec_profile
        ------------  ----------------------------------------------------------------
        cipher_suite  GCM-AES-XPN-256
        policy        security
        primary_ckn   6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435
        priority      0
        rekey_period  900
        send_sci      true
        ------------  ----------------------------------------------------------------
admin@str2--lc1-2:~$ show macsec --profile -n asic1
Last cached time was 2023-02-22 19:48:18.106529
MACsec profile : macsec_profile
        ------------  ----------------------------------------------------------------
        cipher_suite  GCM-AES-XPN-256
        policy        security
        primary_ckn   6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435
        priority      0
        rekey_period  900
        send_sci      true
        ------------  ----------------------------------------------------------------
admin@str2--lc1-2:~$ show macsec --profile Ethernet184
Interface name is not valid with profile option
admin@str2--lc1-2:~$ show macsec Ethernet184 --profile
Interface name is not valid with profile option

```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

