### PR TITLE
[Arista] Disable SSD NCQ on DCS-7050CX3-32S

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -525,6 +525,7 @@ write_platform_specific_cmdline() {
     if [ "$sid" = "Lodoga" ]; then
         aboot_machine=arista_7050cx3_32s
         cmdline_add logs_inram=on
+        cmdline_add libata.force=2.00:noncq
     fi
     if [ "$sid" = "Marysville" ]; then
         aboot_machine=arista_7050sx3_48yc8


### PR DESCRIPTION
#### Why I did it

Fix similar issue seen on #13739 but only for `DCS-7050CX3-32S`

#### How I did it

Add a kernel parameter to tell libata to disable NCQ

#### How to verify it

The message `ata2.00: FORCE: horkage modified (noncq)` should appear on the `dmesg`.

Test results using: `fio --direct=1 --rw=randrw --bs=64k --ioengine=libaio --iodepth=64 --runtime=120 --numjobs=4`

with NCQ
```
   READ: bw=26.1MiB/s (27.4MB/s), 26.1MiB/s-26.1MiB/s (27.4MB/s-27.4MB/s), io=3136MiB (3288MB), run=120053-120053msec
  WRITE: bw=26.3MiB/s (27.6MB/s), 26.3MiB/s-26.3MiB/s (27.6MB/s-27.6MB/s), io=3161MiB (3315MB), run=120053-120053msec
```
without NCQ
```
   READ: bw=22.0MiB/s (23.1MB/s), 22.0MiB/s-22.0MiB/s (23.1MB/s-23.1MB/s), io=2647MiB (2775MB), run=120069-120069msec
  WRITE: bw=22.2MiB/s (23.3MB/s), 22.2MiB/s-22.2MiB/s (23.3MB/s-23.3MB/s), io=2665MiB (2795MB), run=120069-120069msec
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog

Disable SSD NCQ on DCS-7050CX3-32S