### PR TITLE
Fixes #13046: Frr - SONiC time sync issue

### DIFF
--- a/rules/docker-fpm-frr.mk
+++ b/rules/docker-fpm-frr.mk
@@ -30,6 +30,8 @@ SONIC_DOCKER_DBG_IMAGES += $(DOCKER_FPM_FRR_DBG)
 $(DOCKER_FPM_FRR)_CONTAINER_NAME = bgp
 $(DOCKER_FPM_FRR)_RUN_OPT += --privileged -t
 $(DOCKER_FPM_FRR)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_FPM_FRR)_RUN_OPT += -v /etc/timezone:/etc/timezone:ro
+$(DOCKER_FPM_FRR)_RUN_OPT += -v /etc/localtime:/etc/localtime:ro
 
 $(DOCKER_FPM_FRR)_FILES += $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix the FRR and SONiC time sync issue
#### How I did it
Mounted host's filesystem on the bgp container. Following are two files which have been mounted while building the bgp container image.

/etc/localtime
/etc/timezone

#### How to verify it
Set timezone to America/Los_Angeles
root@sonic:$ timedatectl set-timezone America/Los_Angeles
root@sonic:$

Stop and start the bgp docker
root@sonic: docker stop bgp
root@sonic: docker start bgp

Flap the interface
root@sonic:~$ config interface shutdown Ethernet240

Check the time and zone
root@sonic:~$ date
Wed May 25 07:32:59 PDT 2022

Go inside vtysh and check interface link flap timestamp
root@sonic:~~$ vtysh
Hello, this is FRRouting (version 7.2.1-sonic).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

root@sonic~$ show int Ethernet240
Interface Ethernet240 is down
Link ups: 2 last: 2022/05/25 07:29:23.86
Link downs: 5 last: 2022/05/25 07:32:58.52 --------> PDT timezone in place of UTC
vrf: default
index 38 metric 0 mtu 9126 speed 0
flags: <BROADCAST,MULTICAST>
Type: Unknown
HWaddr: 00:30:64:6a:fa:a3
Interface Type Other

Check the updated timestamp in frr log files:
root@sonic:/var/log/frr~$ tail -5f zebra.log
May 25 07:21:00.733035 sonic INFO bgp~$ zebra[34]: if_zebra_speed_update: eth0 old speed: 4294967295 new speed: 1000
May 25 07:28:49.104128 sonic NOTICE bgp~$ zebra[33]: client 24 says hello and bids fair to announce only static routes vrf=0
May 25 07:28:49.390236 sonic NOTICE bgp~$ zebra[33]: client 29 says hello and bids fair to announce only bgp routes vrf=0
May 25 07:28:49.390236 sonic NOTICE bgp~$ zebra[33]: client 34 says hello and bids fair to announce only vnc routes vrf=0
May 25 07:29:03.896941 sonic INFO bgp~$ zebra[33]: if_zebra_speed_update: eth0 old speed: 4294967295 new speed: 1000
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111
- [x] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

