### PR TITLE
Bump lxml from 4.6.5 to 4.9.1 in /src/sonic-config-engine

### DIFF
--- a/files/build/versions/dockers/docker-config-engine-bullseye-sonic/versions-py3
+++ b/files/build/versions/dockers/docker-config-engine-bullseye-sonic/versions-py3
@@ -2,7 +2,7 @@ bitarray==1.5.3
 ijson==2.6.1
 ipaddress==1.0.23
 jsondiff==2.0.0
-lxml==4.6.5
+lxml==4.9.1
 natsort==6.2.1
 netaddr==0.8.0
 pyang==2.5.3

--- a/files/build/versions/dockers/docker-config-engine-bullseye/versions-py3
+++ b/files/build/versions/dockers/docker-config-engine-bullseye/versions-py3
@@ -2,7 +2,7 @@ bitarray==1.5.3
 ijson==2.6.1
 ipaddress==1.0.23
 jsondiff==2.0.0
-lxml==4.6.5
+lxml==4.9.1
 natsort==6.2.1
 netaddr==0.8.0
 pyang==2.5.3

--- a/files/build/versions/dockers/docker-config-engine-buster-sonic/versions-py3
+++ b/files/build/versions/dockers/docker-config-engine-buster-sonic/versions-py3
@@ -2,7 +2,7 @@ bitarray==1.5.3
 ijson==2.6.1
 ipaddress==1.0.23
 jsondiff==2.0.0
-lxml==4.6.5
+lxml==4.9.1
 natsort==6.2.1
 netaddr==0.8.0
 pyang==2.5.3

--- a/files/build/versions/dockers/docker-config-engine-buster/versions-py3
+++ b/files/build/versions/dockers/docker-config-engine-buster/versions-py3
@@ -2,7 +2,7 @@ bitarray==1.5.3
 ijson==2.6.1
 ipaddress==1.0.23
 jsondiff==2.0.0
-lxml==4.6.5
+lxml==4.9.1
 natsort==6.2.1
 netaddr==0.8.0
 pyang==2.5.3

--- a/files/build/versions/host-image/versions-py3
+++ b/files/build/versions/host-image/versions-py3
@@ -28,7 +28,7 @@ jsonpatch==1.32
 jsonpointer==2.3
 jsonschema==2.6.0
 lazy-object-proxy==1.9.0
-lxml==4.6.5
+lxml==4.9.1
 m2crypto==0.38.0
 markupsafe==2.1.2
 natsort==6.2.1

--- a/src/sonic-config-engine/setup.py
+++ b/src/sonic-config-engine/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 dependencies = [
     'bitarray==1.5.3',
     'ipaddress==1.0.23',
-    'lxml==4.6.5',
+    'lxml==4.9.1',
     'netaddr==0.8.0',
     'pyyaml==5.4.1',
     'sonic-py-common',


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
It is to fix the security alert CVE-2022-2309, see https://security-tracker.debian.org/tracker/CVE-2022-2309
The fix has already merged in master, See detail in PR https://github.com/sonic-net/sonic-buildimage/pull/11366

#### How I did it
Upgrade version to 4.9.1

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

