### PR TITLE
[Build] Support to use loosen version when failed to install python packages

### DIFF
--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -248,6 +248,11 @@ run_pip_command()
 
     $REAL_COMMAND "${parameters[@]}"
     local result=$?
+    if [ "$result" !=0 ]; then
+        echo "Failed to run the command with constraint, try to install with the original command" 1>&2
+        $REAL_COMMAND "$@"
+        result=$?
+    fi
     rm $tmp_version_file
     return $result
 }

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -248,7 +248,7 @@ run_pip_command()
 
     $REAL_COMMAND "${parameters[@]}"
     local result=$?
-    if [ "$result" !=0 ]; then
+    if [ "$result" != 0 ]; then
         echo "Failed to run the command with constraint, try to install with the original command" 1>&2
         $REAL_COMMAND "$@"
         result=$?


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
[Build] Support to use loosen version when failed to install python packages
It is to fix the issue https://github.com/sonic-net/sonic-buildimage/issues/14012

#### How I did it
Try to use the installation command without constraint

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

