### PR TITLE
[Nokia7215][pmon][xcvrd] Fixed the Nokia7215 PMON xcvrd FATAL issue

### DIFF
--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp.py
@@ -986,3 +986,12 @@ class Sfp(SfpBase):
             error_description = self.SFP_STATUS_OK
 
         return error_description
+
+    def get_transceiver_status(self):
+        raise NotImplementedError
+
+    def get_transceiver_pm(self):
+        raise NotImplementedError
+
+    def get_xcvr_api(self):
+        return None


### PR DESCRIPTION
#### Why I did it
The XCVRD is in the FATAL state on the Nokia7215 platform.  The following the backtrace:
```
Feb 22 23:28:12.732403 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd Traceback (most recent call last):
Feb 22 23:28:12.749189 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd   File "/usr/local/bin/xcvrd", line 8, in <module>
Feb 22 23:28:12.750669 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd     sys.exit(main())
Feb 22 23:28:12.752170 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 2526, in main
Feb 22 23:28:12.753687 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd     xcvrd.run()
Feb 22 23:28:12.757492 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 2402, in run
Feb 22 23:28:12.761559 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd     port_mapping_data, retry_eeprom_set = self.init()
Feb 22 23:28:12.771308 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 2363, in init
Feb 22 23:28:12.781805 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd     retry_eeprom_set = post_port_sfp_dom_info_to_db(is_warm_start, port_mapping_data, self.xcvr_table_helper, self.stop_event)
Feb 22 23:28:12.782045 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 570, in post_port_sfp_dom_info_to_db
Feb 22 23:28:12.783991 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd     update_port_transceiver_status_table_hw(logical_port_name,
Feb 22 23:28:12.790313 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 858, in update_port_transceiver_status_table_hw
Feb 22 23:28:12.824242 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd     transceiver_status_dict = _wrapper_get_transceiver_status(physical_port)
Feb 22 23:28:12.824966 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 199, in _wrapper_get_transceiver_status
Feb 22 23:28:12.825672 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd     return platform_chassis.get_sfp(physical_port).get_transceiver_status()
Feb 22 23:28:12.825872 ixs-7215-pizza4 INFO pmon#supervisord: xcvrd AttributeError: 'Sfp' object has no attribute 'get_transceiver_status'
```
#### How I did it
The issue is triggered by SFP refactoring support. To address this issue, we add three functions to overload them to bypass the SFP refactoring code.  

#### How to verify it
1)  Running the the new image, check the syslog, the backtrace should not be in the syslog
2) Check the xcvrd process state in PMON. It should be in RUNNING state
```
admin@ixs-7215-pizza9:~$ docker exec pmon supervisorctl status
chassis_db_init                  EXITED    Feb 24 03:44 PM
dependent-startup                EXITED    Feb 24 03:44 PM
ledd                             RUNNING   pid 33, uptime 4 days, 23:48:52
lm-sensors                       EXITED    Feb 24 03:44 PM
pcied                            RUNNING   pid 45, uptime 4 days, 23:48:51
psud                             RUNNING   pid 37, uptime 4 days, 23:48:52
rsyslogd                         RUNNING   pid 27, uptime 4 days, 23:48:56
supervisor-proc-exit-listener    RUNNING   pid 26, uptime 4 days, 23:49:00
syseepromd                       RUNNING   pid 41, uptime 4 days, 23:48:51
thermalctld                      RUNNING   pid 43, uptime 4 days, 23:48:51
xcvrd                            RUNNING   pid 703, uptime 4 days, 21:53:46
admin@ixs-7215-pizza9:~$ 

```  

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

