### PR TITLE
Fix VOQ_CHASSIS_V6_PEER route-map config

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/peer-group.conf.j2
@@ -20,8 +20,8 @@
     neighbor VOQ_CHASSIS_V6_PEER activate
     neighbor VOQ_CHASSIS_V6_PEER addpath-tx-all-paths
     neighbor VOQ_CHASSIS_V6_PEER soft-reconfiguration inbound
-    neighbor VOQ_CHASSIS_V4_PEER route-map FROM_VOQ_CHASSIS_V6_PEER in
-    neighbor VOQ_CHASSIS_V4_PEER route-map TO_VOQ_CHASSIS_V6_PEER out
+    neighbor VOQ_CHASSIS_V6_PEER route-map FROM_VOQ_CHASSIS_V6_PEER in
+    neighbor VOQ_CHASSIS_V6_PEER route-map TO_VOQ_CHASSIS_V6_PEER out
   exit-address-family
 !
 ! end of template: bgpd/templates/voq_chassis/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/peer-group.conf/result_all.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/peer-group.conf/result_all.conf
@@ -16,8 +16,8 @@
     neighbor VOQ_CHASSIS_V6_PEER activate
     neighbor VOQ_CHASSIS_V6_PEER addpath-tx-all-paths
     neighbor VOQ_CHASSIS_V6_PEER soft-reconfiguration inbound
-    neighbor VOQ_CHASSIS_V4_PEER route-map FROM_VOQ_CHASSIS_V6_PEER in
-    neighbor VOQ_CHASSIS_V4_PEER route-map TO_VOQ_CHASSIS_V6_PEER out
+    neighbor VOQ_CHASSIS_V6_PEER route-map FROM_VOQ_CHASSIS_V6_PEER in
+    neighbor VOQ_CHASSIS_V6_PEER route-map TO_VOQ_CHASSIS_V6_PEER out
   exit-address-family
 !
 ! end of template: bgpd/templates/voq_chassis/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/peer-group.conf/result_base.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/peer-group.conf/result_base.conf
@@ -14,8 +14,8 @@
     neighbor VOQ_CHASSIS_V6_PEER activate
     neighbor VOQ_CHASSIS_V6_PEER addpath-tx-all-paths
     neighbor VOQ_CHASSIS_V6_PEER soft-reconfiguration inbound
-    neighbor VOQ_CHASSIS_V4_PEER route-map FROM_VOQ_CHASSIS_V6_PEER in
-    neighbor VOQ_CHASSIS_V4_PEER route-map TO_VOQ_CHASSIS_V6_PEER out
+    neighbor VOQ_CHASSIS_V6_PEER route-map FROM_VOQ_CHASSIS_V6_PEER in
+    neighbor VOQ_CHASSIS_V6_PEER route-map TO_VOQ_CHASSIS_V6_PEER out
   exit-address-family
 !
 ! end of template: bgpd/templates/voq_chassis/peer-group.conf.j2


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently on a VOQ chassis, ipv6 iBGP neighbors do not have any route-map associated, due to typo in the route-map configuration. This results in route-map policies (like TSA) not getting applied to V6 iBGP neighbors, hence not isolating ipv6 iBGP sessions.

#### How I did it
Fixed VOQ policy template file to associate the correct V6 route-map to iBGP v6 peer-group

#### How to verify it
In vtysh,
1.  'show run bgp' should display the correct route-map association
2.  After running TSA on a voq chassis linecard, advertised ipv6 routes to iBGP neighbors should have only the loopback ip address

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

