### PR TITLE
[202012] Added libpci and pciutils to the pmon docker (#12684)

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -26,7 +26,8 @@ RUN apt-get update &&   \
         i2c-tools       \
         psmisc          \
         python3-jsonschema \
-        libpci3
+        libpci3         \
+        pciutils
 
 # TODO: Remove these lines once we no longer need Python 2
 RUN apt-get install -f -y python-dev python-pip
@@ -47,6 +48,9 @@ RUN pip2 install enum34
 # Barefoot platform vendors' sonic_platform packages import the Python 'thrift' library
 RUN pip2 install thrift==0.13.0
 RUN pip3 install thrift==0.13.0
+
+# We install the libpci module in order to be able to do PCI transactions
+RUN pip3 install libpci
 
 {% if docker_platform_monitor_debs.strip() -%}
 # Copy locally-built Debian package dependencies

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -50,6 +50,7 @@ RUN pip2 install thrift==0.13.0
 RUN pip3 install thrift==0.13.0
 
 # We install the libpci module in order to be able to do PCI transactions
+RUN pip2 install libpci
 RUN pip3 install libpci
 
 {% if docker_platform_monitor_debs.strip() -%}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This is part of a corresponding change to the pcie daemon that enables it to verify PCI peripherals on a platform against a preconfigured YAML file, and enables the pcied daemon to call the system commands needed for PCI peripheral verification

#### How I did it
Adding aforementioned libraries to the Dockerfile.j2 file

#### How to verify it
run 'which setpci' from the pmon docker - would show the path of the binary

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Modified pmon's Dockerfile.j2 to include pciutils and libpci libraries.

**cherry-pick of SHA: 7de04504c9518d68aa00c304b7376fdff4e1d318**

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

