### PR TITLE
Added package "wireshark-common" into PTF docker

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -73,7 +73,8 @@ RUN apt-get update          \
         libteam-utils       \
         gdb                 \
         automake            \
-        iproute2
+        iproute2            \
+        wireshark-common
 
 # Install all python modules from pypi. python-scapy is exception, ptf debian package requires python-scapy
 # TODO: Clean up this step


### PR DESCRIPTION
#### Why I did it
We need to have "mergecap" application and use it in sonic-mgmt test infra code

#### How I did it
Added  package "wireshark-common" into PTF docker Dockerfile.j2

#### How to verify it
Bu build PTF docker

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
Added package "wireshark-common" into PTF docker
It will allow us to have application called "mergecap" - which can merge multiple .pcap files into single .pcapng file and convert it to .pcap file

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

