### PR TITLE
[yang-models]: Add YANG model for SNMP_USER table

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2213,7 +2213,16 @@
                 "TYPE": "RW"
             }
         },
-
+        "SNMP_USER": {
+            "testuser": {
+                "SNMP_USER_TYPE": "Priv",
+                "SNMP_USER_PERMISSION": "RO",
+                "SNMP_USER_AUTH_TYPE": "SHA",
+                "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                "SNMP_USER_ENCRYPTION_TYPE": "AES",
+                "SNMP_USER_ENCRYPTION_PASSWORD": "encr_pass"
+            }
+        },
         "SYSTEM_DEFAULTS": {
             "tunnel_qos_remap": {
                 "status": "enabled"

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2221,7 +2221,24 @@
                 "SNMP_USER_AUTH_PASSWORD": "auth_pass",
                 "SNMP_USER_ENCRYPTION_TYPE": "AES",
                 "SNMP_USER_ENCRYPTION_PASSWORD": "encr_pass"
+            },
+            "testuser_noAuthNoPriv": {
+                "SNMP_USER_TYPE": "Priv",
+                "SNMP_USER_PERMISSION": "RO",
+                "SNMP_USER_AUTH_TYPE": "",
+                "SNMP_USER_AUTH_PASSWORD": "",
+                "SNMP_USER_ENCRYPTION_TYPE": "",
+                "SNMP_USER_ENCRYPTION_PASSWORD": "" 
+            },
+            "testuser_AuthNoPriv": {
+                "SNMP_USER_TYPE": "Priv",
+                "SNMP_USER_PERMISSION": "RO",
+                "SNMP_USER_AUTH_TYPE": "SHA",
+                "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                "SNMP_USER_ENCRYPTION_TYPE": "",
+                "SNMP_USER_ENCRYPTION_PASSWORD": ""         
             }
+
         },
         "SYSTEM_DEFAULTS": {
             "tunnel_qos_remap": {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2223,7 +2223,7 @@
                 "SNMP_USER_ENCRYPTION_PASSWORD": "encr_pass"
             },
             "testuser_noAuthNoPriv": {
-                "SNMP_USER_TYPE": "Priv",
+                "SNMP_USER_TYPE": "noAuthNoPriv",
                 "SNMP_USER_PERMISSION": "RO",
                 "SNMP_USER_AUTH_TYPE": "",
                 "SNMP_USER_AUTH_PASSWORD": "",
@@ -2231,7 +2231,7 @@
                 "SNMP_USER_ENCRYPTION_PASSWORD": "" 
             },
             "testuser_AuthNoPriv": {
-                "SNMP_USER_TYPE": "Priv",
+                "SNMP_USER_TYPE": "AuthNoPriv",
                 "SNMP_USER_PERMISSION": "RO",
                 "SNMP_USER_AUTH_TYPE": "SHA",
                 "SNMP_USER_AUTH_PASSWORD": "auth_pass",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
@@ -24,5 +24,78 @@
     "SNMP_COMMUNITY_WRONG_TYPE_TEST": {
         "desc": "Load SNMP community string with un supported type.",
         "eStrKey": "InvalidValue"
+    },
+    "SNMP_USER_NAME_TEST": {
+        "desc": "Load valid SNMP user"
+    },
+    "SNMP_USER_NAME_MIN_NEG_TEST": {
+        "desc": "Load SNMP user with name < 4",
+        "eStrKey": "Range"
+    },
+    "SNMP_USER_NAME_INVALID_NEG_TEST": {
+        "desc": "Load SNMP user with invalid value",
+	"eStr": "Invalid snmp user string (Valid chars are ASCII printable except SPACE, single quote,\"@\", \",\" and \"\\\")"
+    },
+    "SNMP_USER_NO_USER_TYPE_NEG_TEST": {
+        "desc": "Load SNMP user with no user type",
+        "eStrKey": "Mandatory"
+    },
+    "SNMP_USER_INVALID_USER_TYPE_NEG_TEST": {
+        "desc": "Load SNMP user with invalid user type",
+        "eStrKey": "InvalidValue"
+    },
+    "SNMP_USER_NO_USER_PERM_NEG_TEST": {
+        "desc": "Load SNMP user with no user permission",
+        "eStrKey": "Mandatory"
+    },
+    "SNMP_USER_INVALID_USER_TYPE_NEG_TEST": {
+        "desc": "Load valid SNMP user with no user permission",
+        "eStrKey": "InvalidValue"
+    },
+    "SNMP_USER_AUTH_NO_PRIV_TEST": {
+        "desc": "Load valid SNMP user with user type AuthNoPriv"
+    },
+    "SNMP_USER_NO_AUTH_NO_PRIV_AUTH_TYPE_NEG_TEST": {
+        "desc": "Load SNMP user with user type noAuthNoPriv with auth type",
+        "eStrKey": "When"
+    },
+    "SNMP_USER_AUTH_NO_PRIV_NO_AUTH_PASS_NEG_TEST": {
+        "desc": "Load SNMP user with user type AuthNoPriv without auth password",
+        "eStrKey": "Mandatory"
+    },
+    "SNMP_USER_AUTH_NO_PRIV_NO_AUTH_TYPE_NEG_TEST": {
+        "desc": "Load SNMP user with user type AuthNoPriv without auth type",
+        "eStrKey": "Mandatory"
+    },
+    "SNMP_USER_AUTH_NO_PRIV_INVALID_AUTH_PASS_NEG_TEST": {
+        "desc": "Load SNMP user with user type AuthNoPriv with invalid auth password",
+        "eStr": "Invalid snmp user auth password (Valid chars are ASCII printable except \":\" and\"@\")"
+    },
+    "SNMP_USER_PRIV_TEST": {
+        "desc": "Load SNMP user with user type Priv"
+    },
+    "SNMP_USER_PRIV_NO_ENCRYPT_TYPE_NEG_TEST": {
+        "desc": "Load SNMP user with user type Priv without encyrption type",
+        "eStrKey": "Mandatory"
+    },
+    "SNMP_USER_PRIV_INVALID_ENCRYPT_TYPE_NEG_TEST": {	
+        "desc": "Load SNMP user with user type Priv with invalid encryption type",
+        "eStrKey": "InvalidValue"
+    },
+    "SNMP_USER_PRIV_NO_ENCRYPT_PASS_NEG_TEST": {
+        "desc": "Load SNMP user with user type Priv with no encryption password",
+        "eStrKey": "Mandatory"
+    },
+    "SNMP_USER_PRIV_INVALID_ENCRYPT_PASS_NEG_TEST": {
+        "desc": "Load SNMP user with user type Priv with invalid encryption password",
+        "eStr": "Invalid snmp user auth password (Valid chars are ASCII printable except \":\" and\"@\")"
+    },
+    "SNMP_USER_PRIV_SHORT_ENCRYPT_PASS_NEG_TEST": {
+        "desc": "Load SNMP user with user type Priv with short encryption password",
+        "eStrKey": "Range"
+    },
+    "SNMP_USER_PRIV_LONG_ENCRYPT_PASS_NEG_TEST": {
+        "desc": "Load SNMP user with user type Priv with long encryption password",
+        "eStrKey": "Range"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
@@ -25,8 +25,11 @@
         "desc": "Load SNMP community string with un supported type.",
         "eStrKey": "InvalidValue"
     },
-    "SNMP_USER_NAME_TEST": {
-        "desc": "Load valid SNMP user"
+    "SNMP_RO_USER_NAME_TEST": {
+        "desc": "Load valid RO SNMP user"
+    },
+    "SNMP_RW_USER_NAME_TEST": {
+        "desc": "Load valid RW SNMP user"
     },
     "SNMP_USER_NAME_MIN_NEG_TEST": {
         "desc": "Load SNMP user with name < 4",
@@ -34,7 +37,11 @@
     },
     "SNMP_USER_NAME_INVALID_NEG_TEST": {
         "desc": "Load SNMP user with invalid value",
-	"eStr": "Invalid snmp user string (Valid chars are ASCII printable except SPACE, single quote,\"@\", \",\" and \"\\\")"
+	"eStr": "Invalid snmp user string (Valid chars are ASCII printable except SPACE, single quote,\"@\", \",\", \"\\\" and \":\")"
+    },
+    "SNMP_USER_NAME_INVALID_NEG_TEST_2": {
+        "desc": "Load SNMP user with invalid value",
+        "eStr": "Invalid snmp user string (Valid chars are ASCII printable except SPACE, single quote,\"@\", \",\", \"\\\" and \":\")"
     },
     "SNMP_USER_NO_USER_TYPE_NEG_TEST": {
         "desc": "Load SNMP user with no user type",
@@ -53,7 +60,13 @@
         "eStrKey": "InvalidValue"
     },
     "SNMP_USER_AUTH_NO_PRIV_TEST": {
-        "desc": "Load valid SNMP user with user type AuthNoPriv"
+        "desc": "Load valid SNMP user with user type AuthNoPriv with SHA auth type"
+    },
+    "SNMP_USER_AUTH_NO_PRIV_TEST_2": {
+        "desc": "Load valid SNMP user with user type AuthNoPriv with MD5 auth type"
+    },
+    "SNMP_USER_AUTH_NO_PRIV_TEST_3": {
+        "desc": "Load valid SNMP user with user type AuthNoPriv with HMAC-SHA-2 auth type"
     },
     "SNMP_USER_NO_AUTH_NO_PRIV_AUTH_TYPE_NEG_TEST": {
         "desc": "Load SNMP user with user type noAuthNoPriv with auth type",
@@ -72,7 +85,10 @@
         "eStr": "Invalid snmp user authentication password (Valid chars are ASCII printable except \":\" and\"@\")"
     },
     "SNMP_USER_PRIV_TEST": {
-        "desc": "Load SNMP user with user type Priv"
+        "desc": "Load SNMP user with user type Priv with AES encryption type"
+    },
+    "SNMP_USER_PRIV_TEST": {
+        "desc": "Load SNMP user with user type Priv with DES encryption type"
     },
     "SNMP_USER_PRIV_NO_ENCRYPT_TYPE_NEG_TEST": {
         "desc": "Load SNMP user with user type Priv without encyrption type",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
@@ -69,7 +69,7 @@
     },
     "SNMP_USER_AUTH_NO_PRIV_INVALID_AUTH_PASS_NEG_TEST": {
         "desc": "Load SNMP user with user type AuthNoPriv with invalid auth password",
-        "eStr": "Invalid snmp user auth password (Valid chars are ASCII printable except \":\" and\"@\")"
+        "eStr": "Invalid snmp user authentication password (Valid chars are ASCII printable except \":\" and\"@\")"
     },
     "SNMP_USER_PRIV_TEST": {
         "desc": "Load SNMP user with user type Priv"
@@ -88,7 +88,7 @@
     },
     "SNMP_USER_PRIV_INVALID_ENCRYPT_PASS_NEG_TEST": {
         "desc": "Load SNMP user with user type Priv with invalid encryption password",
-        "eStr": "Invalid snmp user auth password (Valid chars are ASCII printable except \":\" and\"@\")"
+        "eStr": "Invalid snmp user encryption password (Valid chars are ASCII printable except \":\" and\"@\")"
     },
     "SNMP_USER_PRIV_SHORT_ENCRYPT_PASS_NEG_TEST": {
         "desc": "Load SNMP user with user type Priv with short encryption password",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
@@ -45,7 +45,7 @@
     },
     "SNMP_USER_NO_USER_TYPE_NEG_TEST": {
         "desc": "Load SNMP user with no user type",
-        "eStrKey": "Mandatory"
+        "eStrKey": "Must"
     },
     "SNMP_USER_INVALID_USER_TYPE_NEG_TEST": {
         "desc": "Load SNMP user with invalid user type",
@@ -70,15 +70,15 @@
     },
     "SNMP_USER_NO_AUTH_NO_PRIV_AUTH_TYPE_NEG_TEST": {
         "desc": "Load SNMP user with user type noAuthNoPriv with auth type",
-        "eStrKey": "When"
+        "eStrKey": "Must"
     },
     "SNMP_USER_AUTH_NO_PRIV_NO_AUTH_PASS_NEG_TEST": {
         "desc": "Load SNMP user with user type AuthNoPriv without auth password",
-        "eStrKey": "Mandatory"
+        "eStrKey": "Must"
     },
     "SNMP_USER_AUTH_NO_PRIV_NO_AUTH_TYPE_NEG_TEST": {
         "desc": "Load SNMP user with user type AuthNoPriv without auth type",
-        "eStrKey": "Mandatory"
+        "eStrKey": "Must"
     },
     "SNMP_USER_AUTH_NO_PRIV_INVALID_AUTH_PASS_NEG_TEST": {
         "desc": "Load SNMP user with user type AuthNoPriv with invalid auth password",
@@ -92,15 +92,15 @@
     },
     "SNMP_USER_PRIV_NO_ENCRYPT_TYPE_NEG_TEST": {
         "desc": "Load SNMP user with user type Priv without encyrption type",
-        "eStrKey": "Mandatory"
+        "eStrKey": "Must"
     },
     "SNMP_USER_PRIV_INVALID_ENCRYPT_TYPE_NEG_TEST": {	
         "desc": "Load SNMP user with user type Priv with invalid encryption type",
-        "eStrKey": "InvalidValue"
+        "eStrKey": "Must"
     },
     "SNMP_USER_PRIV_NO_ENCRYPT_PASS_NEG_TEST": {
         "desc": "Load SNMP user with user type Priv with no encryption password",
-        "eStrKey": "Mandatory"
+        "eStrKey": "Must"
     },
     "SNMP_USER_PRIV_INVALID_ENCRYPT_PASS_NEG_TEST": {
         "desc": "Load SNMP user with user type Priv with invalid encryption password",
@@ -108,7 +108,7 @@
     },
     "SNMP_USER_PRIV_SHORT_ENCRYPT_PASS_NEG_TEST": {
         "desc": "Load SNMP user with user type Priv with short encryption password",
-        "eStrKey": "Range"
+        "eStrKey": "Must"
     },
     "SNMP_USER_PRIV_LONG_ENCRYPT_PASS_NEG_TEST": {
         "desc": "Load SNMP user with user type Priv with long encryption password",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
@@ -80,7 +80,7 @@
             }
         }
     },
-    "SNMP_USER_NAME_TEST": {
+    "SNMP_RO_USER_NAME_TEST": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_USER": {
                 "SNMP_USER_LIST": [
@@ -88,6 +88,19 @@
                         "name": "testuser",
                         "SNMP_USER_TYPE": "noAuthNoPriv",
                         "SNMP_USER_PERMISSION": "RO"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_RW_USER_NAME_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                        "name": "testuser",
+                        "SNMP_USER_TYPE": "noAuthNoPriv",
+                        "SNMP_USER_PERMISSION": "RW"
                     }
                 ]
             }
@@ -112,6 +125,19 @@
                 "SNMP_USER_LIST": [
                     {
                        "name": "test@user",
+                       "SNMP_USER_TYPE": "noAuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RO"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_NAME_INVALID_NEG_TEST_2": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "test:user",
                        "SNMP_USER_TYPE": "noAuthNoPriv",
                        "SNMP_USER_PERMISSION": "RO"
                     }
@@ -179,6 +205,36 @@
                        "SNMP_USER_PERMISSION": "RW",
                        "SNMP_USER_AUTH_PASSWORD": "auth_pass",
                        "SNMP_USER_AUTH_TYPE": "SHA"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_AUTH_NO_PRIV_TEST_2": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "AuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "MD5"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_AUTH_NO_PRIV_TEST_3": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "AuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2"
                     }
                 ]
             }
@@ -267,6 +323,23 @@
                        "SNMP_USER_AUTH_PASSWORD": "auth_pass",
                        "SNMP_USER_AUTH_TYPE": "SHA",
                        "SNMP_USER_ENCRYPTION_TYPE": "AES",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": "encry_pass"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_PRIV_TEST_2": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "Priv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "DES",
                        "SNMP_USER_ENCRYPTION_PASSWORD": "encry_pass"
                     }
                 ]

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
@@ -79,5 +79,298 @@
                 ]
             }
         }
+    },
+    "SNMP_USER_NAME_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                        "name": "testuser",
+                        "SNMP_USER_TYPE": "noAuthNoPriv",
+                        "SNMP_USER_PERMISSION": "RO"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_NAME_MIN_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "tes",
+                       "SNMP_USER_TYPE": "noAuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RO"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_NAME_INVALID_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "test@user",
+                       "SNMP_USER_TYPE": "noAuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RO"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_NO_USER_TYPE_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_PERMISSION": "RO"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_INVALID_USER_TYPE_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "randomUserType",
+                       "SNMP_USER_PERMISSION": "RO"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_NO_USER_PERM_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "noAuthNoPriv"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_INVALID_USER_TYPE_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "noAuthNoPriv",
+                       "SNMP_USER_PERMISSION": "WR"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_AUTH_NO_PRIV_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "AuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "SHA"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_NO_AUTH_NO_PRIV_AUTH_TYPE_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "noAuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_TYPE": "SHA"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_AUTH_NO_PRIV_NO_AUTH_PASS_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "AuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_TYPE": "SHA"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_AUTH_NO_PRIV_NO_AUTH_TYPE_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "AuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_AUTH_NO_PRIV_INVALID_AUTH_TYPE_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "AuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "SAH"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_AUTH_NO_PRIV_INVALID_AUTH_PASS_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "AuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth:pass",
+                       "SNMP_USER_AUTH_TYPE": "SHA"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_PRIV_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "Priv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "AES",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": "encry_pass"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_PRIV_NO_ENCRYPT_TYPE_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "Priv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": "encry_pass"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_PRIV_INVALID_ENCRYPT_TYPE_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "Priv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "DSE",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": "encry_pass"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_PRIV_NO_ENCRYPT_PASS_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "Priv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "AES"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_PRIV_INVALID_ENCRYPT_PASS_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "Priv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "AES",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": "encry@pass"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_PRIV_SHORT_ENCRYPT_PASS_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "Priv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "AES",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": "en"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_PRIV_LONG_ENCRYPT_PASS_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "Priv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "AES",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": "encryption_password_longer_than_64_characters_is_not_a_valid_password"
+                    }
+                ]
+            }
+         }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
@@ -87,7 +87,11 @@
                     {
                         "name": "testuser",
                         "SNMP_USER_TYPE": "noAuthNoPriv",
-                        "SNMP_USER_PERMISSION": "RO"
+                        "SNMP_USER_PERMISSION": "RO",
+                        "SNMP_USER_AUTH_TYPE": "",
+                        "SNMP_USER_AUTH_PASSWORD": "",
+                        "SNMP_USER_ENCRYPTION_TYPE": "",
+                        "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -100,7 +104,11 @@
                     {
                         "name": "testuser",
                         "SNMP_USER_TYPE": "noAuthNoPriv",
-                        "SNMP_USER_PERMISSION": "RW"
+                        "SNMP_USER_PERMISSION": "RW",
+                        "SNMP_USER_AUTH_TYPE": "",
+                        "SNMP_USER_AUTH_PASSWORD": "",
+                        "SNMP_USER_ENCRYPTION_TYPE": "",
+                        "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -113,7 +121,11 @@
                     {
                        "name": "tes",
                        "SNMP_USER_TYPE": "noAuthNoPriv",
-                       "SNMP_USER_PERMISSION": "RO"
+                       "SNMP_USER_PERMISSION": "RO",
+                       "SNMP_USER_AUTH_TYPE": "",
+                       "SNMP_USER_AUTH_PASSWORD": "",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -126,7 +138,12 @@
                     {
                        "name": "test@user",
                        "SNMP_USER_TYPE": "noAuthNoPriv",
-                       "SNMP_USER_PERMISSION": "RO"
+                       "SNMP_USER_PERMISSION": "RO",
+                       "SNMP_USER_AUTH_TYPE": "",
+                       "SNMP_USER_AUTH_PASSWORD": "",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
+
                     }
                 ]
             }
@@ -139,7 +156,11 @@
                     {
                        "name": "test:user",
                        "SNMP_USER_TYPE": "noAuthNoPriv",
-                       "SNMP_USER_PERMISSION": "RO"
+                       "SNMP_USER_PERMISSION": "RO",
+                       "SNMP_USER_AUTH_TYPE": "",
+                       "SNMP_USER_AUTH_PASSWORD": "",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -151,7 +172,11 @@
                 "SNMP_USER_LIST": [
                     {
                        "name": "testuser",
-                       "SNMP_USER_PERMISSION": "RO"
+                       "SNMP_USER_PERMISSION": "RO",
+                       "SNMP_USER_AUTH_TYPE": "",
+                       "SNMP_USER_AUTH_PASSWORD": "",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -164,7 +189,11 @@
                     {
                        "name": "testuser",
                        "SNMP_USER_TYPE": "randomUserType",
-                       "SNMP_USER_PERMISSION": "RO"
+                       "SNMP_USER_PERMISSION": "RO",
+                       "SNMP_USER_AUTH_TYPE": "",
+                       "SNMP_USER_AUTH_PASSWORD": "",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -176,7 +205,11 @@
                 "SNMP_USER_LIST": [
                     {
                        "name": "testuser",
-                       "SNMP_USER_TYPE": "noAuthNoPriv"
+                       "SNMP_USER_TYPE": "noAuthNoPriv",
+                       "SNMP_USER_AUTH_TYPE": "",
+                       "SNMP_USER_AUTH_PASSWORD": "",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -189,7 +222,11 @@
                     {
                        "name": "testuser",
                        "SNMP_USER_TYPE": "noAuthNoPriv",
-                       "SNMP_USER_PERMISSION": "WR"
+                       "SNMP_USER_PERMISSION": "WR",
+                       "SNMP_USER_AUTH_TYPE": "",
+                       "SNMP_USER_AUTH_PASSWORD": "",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -203,8 +240,10 @@
                        "name": "testuser",
                        "SNMP_USER_TYPE": "AuthNoPriv",
                        "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
                        "SNMP_USER_AUTH_PASSWORD": "auth_pass",
-                       "SNMP_USER_AUTH_TYPE": "SHA"
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -219,7 +258,9 @@
                        "SNMP_USER_TYPE": "AuthNoPriv",
                        "SNMP_USER_PERMISSION": "RW",
                        "SNMP_USER_AUTH_PASSWORD": "auth_pass",
-                       "SNMP_USER_AUTH_TYPE": "MD5"
+                       "SNMP_USER_AUTH_TYPE": "MD5",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -234,7 +275,9 @@
                        "SNMP_USER_TYPE": "AuthNoPriv",
                        "SNMP_USER_PERMISSION": "RW",
                        "SNMP_USER_AUTH_PASSWORD": "auth_pass",
-                       "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2"
+                       "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -248,7 +291,10 @@
                        "name": "testuser",
                        "SNMP_USER_TYPE": "noAuthNoPriv",
                        "SNMP_USER_PERMISSION": "RW",
-                       "SNMP_USER_AUTH_TYPE": "SHA"
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+		       "SNMP_USER_AUTH_PASSWORD": "",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -262,7 +308,10 @@
                        "name": "testuser",
                        "SNMP_USER_TYPE": "AuthNoPriv",
                        "SNMP_USER_PERMISSION": "RW",
-                       "SNMP_USER_AUTH_TYPE": "SHA"
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+		       "SNMP_USER_AUTH_PASSWORD": "",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -276,7 +325,9 @@
                        "name": "testuser",
                        "SNMP_USER_TYPE": "AuthNoPriv",
                        "SNMP_USER_PERMISSION": "RW",
-                       "SNMP_USER_AUTH_PASSWORD": "auth_pass"
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -291,7 +342,9 @@
                        "SNMP_USER_TYPE": "AuthNoPriv",
                        "SNMP_USER_PERMISSION": "RW",
                        "SNMP_USER_AUTH_PASSWORD": "auth_pass",
-                       "SNMP_USER_AUTH_TYPE": "SAH"
+                       "SNMP_USER_AUTH_TYPE": "SAH",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -306,7 +359,9 @@
                        "SNMP_USER_TYPE": "AuthNoPriv",
                        "SNMP_USER_PERMISSION": "RW",
                        "SNMP_USER_AUTH_PASSWORD": "auth:pass",
-                       "SNMP_USER_AUTH_TYPE": "SHA"
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }
@@ -356,7 +411,8 @@
                        "SNMP_USER_PERMISSION": "RW",
                        "SNMP_USER_AUTH_PASSWORD": "auth_pass",
                        "SNMP_USER_AUTH_TYPE": "SHA",
-                       "SNMP_USER_ENCRYPTION_PASSWORD": "encry_pass"
+                       "SNMP_USER_ENCRYPTION_PASSWORD": "encry_pass",
+                       "SNMP_USER_ENCRYPTION_TYPE": ""
                     }
                 ]
             }
@@ -389,7 +445,8 @@
                        "SNMP_USER_PERMISSION": "RW",
                        "SNMP_USER_AUTH_PASSWORD": "auth_pass",
                        "SNMP_USER_AUTH_TYPE": "SHA",
-                       "SNMP_USER_ENCRYPTION_TYPE": "AES"
+                       "SNMP_USER_ENCRYPTION_TYPE": "AES",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -79,8 +79,8 @@ module sonic-snmp {
         leaf name {
           type string {
               length "4..32";
-              pattern '[^ @,\\' +"']*" {
-                  error-message 'Invalid snmp user string (Valid chars are ASCII printable except SPACE, single quote,"@", "," and "\")';
+              pattern '[^ :@,\\' +"']*" {
+                  error-message 'Invalid snmp user string (Valid chars are ASCII printable except SPACE, single quote,"@", ",", "\" and ":")';
               }
           }
           description

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -70,5 +70,89 @@ module sonic-snmp {
         }
       }
     }
+    container SNMP_USER {
+      list SNMP_USER_LIST {
+        key name;
+        description
+          "List of users.";
+
+        leaf name {
+          mandatory true;
+          type string {
+              length "4..32";
+              pattern '[^ @,\\' +"']*" {
+                  error-message 'Invalid snmp user string (Valid chars are ASCII printable except SPACE, single quote,"@", "," and "\")';
+              }
+          }
+          description
+            "Index into the user list which must be the user name.";
+        }
+
+        leaf SNMP_USER_TYPE {
+          mandatory true;
+          type enumeration {
+            enum noAuthNoPriv;
+            enum AuthNoPriv;
+            enum Priv;
+          }
+          description
+            "Authentication and encryption method used for the user, can be noAuthNoPriv,AuthNoPriv or Priv";
+        }
+        leaf SNMP_USER_PERMISSION {
+          mandatory true;
+          type enumeration {
+            enum RO;
+            enum RW;
+          }
+          description
+            "Specify if the user permission can be Read only or Read write user, can be RO or RW";
+        }
+        leaf SNMP_USER_AUTH_TYPE {
+          when "current()/../SNMP_USER_TYPE != 'noAuthNoPriv'";
+          mandatory true;
+          type enumeration {
+            enum MD5;
+            enum SHA;
+            enum HMAC-SHA-2;
+          }
+          description
+            "Specify authentication type used for user, can be MD5, SHA or HMAC-SHA-2";
+        }
+        leaf SNMP_USER_AUTH_PASSWORD {
+          when "current()/../SNMP_USER_TYPE != 'noAuthNoPriv'";
+          mandatory true;
+          type string {
+              length "8..64";
+              pattern '[^ @:]*' {
+                  error-message 'Invalid snmp user auth password (Valid chars are ASCII printable except ":" and"@")';
+              }
+          }
+          description
+            "Authentication password for the user.";
+        }
+        leaf SNMP_USER_ENCRYPTION_TYPE {
+          when "current()/../SNMP_USER_TYPE = 'Priv'";
+          mandatory true;
+          type enumeration {
+            enum DES;
+            enum AES;
+          }
+          description
+            "Specify encryption type used for user, can be AES or DES";
+        }
+        leaf SNMP_USER_ENCRYPTION_PASSWORD {
+          when "current()/../SNMP_USER_TYPE = 'Priv'";
+          mandatory true;
+          type string {
+              length "8..64";
+              pattern '[^ @:]*' {
+                  error-message 'Invalid snmp user encryption password (Valid chars are ASCII printable except ":" and"@")';
+              }
+          }
+          description
+            "Encryption password for the user.";
+        }
+      }
+    }
   }
 }

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -77,7 +77,6 @@ module sonic-snmp {
           "List of users.";
 
         leaf name {
-          mandatory true;
           type string {
               length "4..32";
               pattern '[^ @,\\' +"']*" {
@@ -85,7 +84,7 @@ module sonic-snmp {
               }
           }
           description
-            "Index into the user list which must be the user name.";
+            "Name defining the SNMP User.";
         }
 
         leaf SNMP_USER_TYPE {
@@ -124,7 +123,7 @@ module sonic-snmp {
           type string {
               length "8..64";
               pattern '[^ @:]*' {
-                  error-message 'Invalid snmp user auth password (Valid chars are ASCII printable except ":" and"@")';
+                  error-message 'Invalid snmp user authentication password (Valid chars are ASCII printable except ":" and"@")';
               }
           }
           description

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -80,7 +80,8 @@ module sonic-snmp {
           type string {
               length "4..32";
               pattern '[^ :@,\\' +"']*" {
-                  error-message 'Invalid snmp user string (Valid chars are ASCII printable except SPACE, single quote,"@", ",", "\" and ":")';
+                  error-message 'Invalid snmp user string (Valid chars are ASCII printable except \
+                                 SPACE, single quote,"@", ",", "\" and ":")';
               }
           }
           description
@@ -107,47 +108,49 @@ module sonic-snmp {
             "Specify if the user permission can be Read only or Read write user, can be RO or RW";
         }
         leaf SNMP_USER_AUTH_TYPE {
-          when "current()/../SNMP_USER_TYPE != 'noAuthNoPriv'";
-          mandatory true;
-          type enumeration {
-            enum MD5;
-            enum SHA;
-            enum HMAC-SHA-2;
-          }
+          type string;
+          must "(current()/../SNMP_USER_TYPE = 'noAuthNoPriv' and current() = '') or 
+                ((current()/../SNMP_USER_TYPE = 'AuthNoPriv' or current()/../SNMP_USER_TYPE = 'Priv') 
+                and (current() = 'SHA' or current() = 'MD5' or current() = 'HMAC-SHA-2'))";
+          default "";
           description
             "Specify authentication type used for user, can be MD5, SHA or HMAC-SHA-2";
         }
         leaf SNMP_USER_AUTH_PASSWORD {
-          when "current()/../SNMP_USER_TYPE != 'noAuthNoPriv'";
-          mandatory true;
           type string {
-              length "8..64";
+              length "0..64";
               pattern '[^ @:]*' {
-                  error-message 'Invalid snmp user authentication password (Valid chars are ASCII printable except ":" and"@")';
+                  error-message 'Invalid snmp user authentication password (Valid chars are ASCII 
+                                 printable except ":" and"@")';
               }
           }
+          must "(current()/../SNMP_USER_TYPE = 'AuthNoPriv' and string-length(current()) >= 8) or 
+                (current()/../SNMP_USER_TYPE = 'Priv' and string-length(current()) >= 8) or 
+                (current()/../SNMP_USER_TYPE = 'noAuthNoPriv' and current() = '')";
           description
             "Authentication password for the user.";
         }
         leaf SNMP_USER_ENCRYPTION_TYPE {
-          when "current()/../SNMP_USER_TYPE = 'Priv'";
-          mandatory true;
-          type enumeration {
-            enum DES;
-            enum AES;
-          }
+          type string;
+          must "(current()/../SNMP_USER_TYPE = 'noAuthNoPriv' and current() = '') or 
+                (current()/../SNMP_USER_TYPE = 'AuthNoPriv' and current() = '') or 
+                (current()/../SNMP_USER_TYPE = 'Priv' and (current() = 'DES' or current() = 'AES'))";
+          default "";
           description
-            "Specify encryption type used for user, can be AES or DES";
+            "Specify encrytion type used for user, can be AES or DES";
         }
         leaf SNMP_USER_ENCRYPTION_PASSWORD {
-          when "current()/../SNMP_USER_TYPE = 'Priv'";
           mandatory true;
           type string {
-              length "8..64";
+              length "0..64";
               pattern '[^ @:]*' {
-                  error-message 'Invalid snmp user encryption password (Valid chars are ASCII printable except ":" and"@")';
+                  error-message 'Invalid snmp user encryption password (Valid chars are ASCII \
+                                 printable except ":" and"@")';
               }
           }
+          must "(current()/../SNMP_USER_TYPE = 'noAuthNoPriv' and current() = '') or 
+                (current()/../SNMP_USER_TYPE = 'AuthNoPriv' and current() = '') or 
+                (current()/../SNMP_USER_TYPE = 'Priv' and string-length(current()) >= 8)";
           description
             "Encryption password for the user.";
         }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add YANG model for SNMP_USER table defined in the document: https://github.com/sonic-net/SONiC/blob/master/doc/snmp/snmp-schema-addition.md

#### How I did it

#### How to verify it
Passed unit-test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

