### PR TITLE
Updated format of generating BUFFER_QUEUE in buffers_defaults templates for wedge100bf-65x

### DIFF
--- a/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/buffers_defaults_t0.j2
+++ b/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/buffers_defaults_t0.j2
@@ -63,21 +63,17 @@
     },
 {%- endmacro %}
 
-{%- macro generate_pg_profils(port_names) %}
-    "BUFFER_PG": {
-        "{{ port_names }}|3-4": {
-            "profile" : "ingress_lossless_profile"
-        }
-    },
-{%- endmacro %}
-
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
-        "{{ port_names }}|3-4": {
-            "profile" : "egress_lossless_profile"
-        },
-        "{{ port_names }}|0-1": {
+{% for port in port_names.split(',') %}
+        "{{ port }}|0-2": {
             "profile" : "q_lossy_profile"
-        }
+        },
+{% endfor %}
+{% for port in port_names.split(',') %}
+        "{{ port }}|3-4": {
+            "profile" : "egress_lossless_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
     }
 {%- endmacro %}

--- a/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/buffers_defaults_t1.j2
+++ b/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/buffers_defaults_t1.j2
@@ -63,21 +63,17 @@
     },
 {%- endmacro %}
 
-{%- macro generate_pg_profils(port_names) %}
-    "BUFFER_PG": {
-        "{{ port_names }}|3-4": {
-            "profile" : "ingress_lossless_profile"
-        }
-    },
-{%- endmacro %}
-
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
-        "{{ port_names }}|3-4": {
-            "profile" : "egress_lossless_profile"
-        },
-        "{{ port_names }}|0-1": {
+{% for port in port_names.split(',') %}
+        "{{ port }}|0-2": {
             "profile" : "q_lossy_profile"
-        }
+        },
+{% endfor %}
+{% for port in port_names.split(',') %}
+        "{{ port }}|3-4": {
+            "profile" : "egress_lossless_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
     }
 {%- endmacro %}


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The BUFFER_QUEUE field generated to config_db.json of wedge100bf-65x needs to fit the definition of yang model. 
Otherwise, the generic config updater will throw error in current templates:
```
Error: Given patch will produce invalid config. Error: Data Loading Failed
Value "Ethernet112,Ethernet116,Ethernet12,Ethernet120,Ethernet124,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet4,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet8,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96" does not satisfy the constraint "1..128" (range, length, or pattern).
```

#### How I did it
Same as #9850, but modified for wedge100bf-65x

#### How to verify it
Deploy the topology, and check config_db.json file.


