### PR TITLE
[ci] Migrate test jobs to vmss agent pool to increase node limit.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,8 +176,7 @@ stages:
         section: part-2
 
   - job: t0_testbedv2
-    pool:
-      vmImage: 'ubuntu-20.04'
+    pool: ubuntu-20.04
     displayName: "kvmtest-t0 by TestbedV2"
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.BUILD_IMG_RUN_TESTBEDV2_TEST, 'YES'))
@@ -190,8 +189,7 @@ stages:
         MAX_WORKER: $(T0_INSTANCE_NUM)
 
   - job: t0_2vlans_testbedv2
-    pool:
-      vmImage: 'ubuntu-20.04'
+    pool: ubuntu-20.04
     displayName: "kvmtest-t0-2vlans by TestbedV2"
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.BUILD_IMG_RUN_TESTBEDV2_TEST, 'YES'))
@@ -254,8 +252,7 @@ stages:
         vmtype: ceos
 
   - job: t1_lag_testbedv2
-    pool:
-      vmImage: 'ubuntu-20.04'
+    pool: ubuntu-20.04
     displayName: "kvmtest-t1-lag by TestbedV2"
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.BUILD_IMG_RUN_TESTBEDV2_TEST, 'YES'))
@@ -321,8 +318,7 @@ stages:
 
   - job: multi_asic_testbedv2
     displayName: "kvmtest-multi-asic-t1-lag by TestbedV2"
-    pool:
-      vmImage: 'ubuntu-20.04'
+    pool: ubuntu-20.04
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.BUILD_IMG_RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -336,8 +332,7 @@ stages:
           NUM_ASIC: 4
 
   - job: dualtor_testbedv2
-    pool:
-      vmImage: 'ubuntu-20.04'
+    pool: ubuntu-20.04
     displayName: "kvmtest-dualtor-t0 by TestbedV2"
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.BUILD_IMG_RUN_TESTBEDV2_TEST, 'YES'))
@@ -352,8 +347,7 @@ stages:
 
   - job: sonic_t0_testbedv2
     displayName: "kvmtest-t0-sonic by TestbedV2"
-    pool:
-      vmImage: 'ubuntu-20.04'
+    pool: ubuntu-20.04
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.BUILD_IMG_RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false
@@ -370,8 +364,7 @@ stages:
 
   - job: wan_testbedv2
     displayName: "kvmtest-wan by TestbedV2"
-    pool:
-      vmImage: 'ubuntu-20.04'
+    pool: ubuntu-20.04
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.BUILD_IMG_RUN_TESTBEDV2_TEST, 'YES'))
     continueOnError: false


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
original ubuntu-20.04 agent pool has a node limit 35.
Use vmss agent pool to get higher node limit.
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

