### PR TITLE
[202211][yang]Add missing fields in PortChannel yang model (#14045)

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1365,7 +1365,9 @@ name as object key and member list as attribute.
         "members": [
             "Ethernet56"
         ],
-        "mtu": "9100"
+        "mtu": "9100",
+        "fallback": "false",
+        "fast_rate": "true"
     }
   }
 }
@@ -1938,3 +1940,5 @@ Incremental Configuration by Subscribing to ConfigDB
 Detail instruction to be added. A sample could be found in this
 [PR](https://github.com/Azure/sonic-buildimage/pull/861) that
 implemented dynamic configuration for BGP.
+=======
+# SONiC Configuration Database Manual

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1940,5 +1940,3 @@ Incremental Configuration by Subscribing to ConfigDB
 Detail instruction to be added. A sample could be found in this
 [PR](https://github.com/Azure/sonic-buildimage/pull/861) that
 implemented dynamic configuration for BGP.
-=======
-# SONiC Configuration Database Manual

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -117,7 +117,9 @@
                 ],
                 "min_links": "2",
                 "mtu": "9100",
-                "tpid": "0x8100"
+                "tpid": "0x8100",
+                "fast_rate": "false",
+                "fallback" : "true"
             }
         },
         "PORTCHANNEL_INTERFACE": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
@@ -19,6 +19,16 @@
         "eStrKey" : "Pattern",
         "eStr": ["0x8100|0x9100|0x9200|0x88a8|0x88A8"]
     },
+    "PORT_CHANNEL_INVALID_FALLBACK": {
+        "desc": "INCORRECT PORTCHANNEL FALLBACK IN PORT_CHANNEL TABLE.",
+        "eStrKey" : "Pattern",
+        "eStr": ["false|true|False|True"]
+    },
+    "PORT_CHANNEL_INVALID_FAST_RATE": {
+        "desc": "INCORRECT PORTCHANNEL FAST_RATE IN PORT_CHANNEL TABLE.",
+        "eStrKey" : "Pattern",
+        "eStr": ["false|true|False|True"]
+    },
     "PORTCHANNEL_INTERFACE_IP_ADDR_TEST": {
         "desc": "Configure IP address on PORTCHANNEL_INTERFACE table."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
@@ -28,7 +28,9 @@
                         "mtu": "9100",
                         "tpid": "0x8100",
                         "lacp_key": "auto",
-                        "name": "PortChannel0001"
+                        "name": "PortChannel0001",
+                        "fast_rate": "false",
+                        "fallback" : "false"
                     }
                 ]
             }
@@ -120,6 +122,36 @@
                         "mtu": "9100",
                         "tpid": "0x9500",
                         "name": "PortChannel0001"
+                    }
+                ]
+            }
+        }
+    },
+    "PORT_CHANNEL_INVALID_FALLBACK": {
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "mtu": "9100",
+                        "tpid": "0x9100",
+                        "name": "PortChannel0001",
+                        "fallback": "enabled"
+                    }
+                ]
+            }
+        }
+    },
+    "PORT_CHANNEL_INVALID_FAST_RATE": {
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "mtu": "9100",
+                        "tpid": "0x9100",
+                        "name": "PortChannel0001",
+                        "fast_rate": "TRUE"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -119,6 +119,15 @@ module sonic-portchannel {
                     type stypes:tpid_type;
                 }
 
+                leaf fallback {
+                    description "Enable LACP fallback feature";
+                    type stypes:boolean_type;
+                }
+                leaf fast_rate {
+                    description "Enable LACP fast rate";
+                    type stypes:boolean_type;
+                }
+
             } /* end of list PORTCHANNEL_LIST */
 
         } /* end of container PORTCHANNEL */


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Manual cherry-pick of https://github.com/sonic-net/sonic-buildimage/pull/14045
#### Why I did it
Fixing issue https://github.com/sonic-net/sonic-buildimage/issues/13983 Added Missing fields in sonic-portchannel yang model. "fallback" and "fast_rate" fields are present in configuration schema but not in yang model. This leads to traceback when yang is validated

sonic_yang(3):All Keys are not parsed in PORTCHANNEL dict_keys(['PortChannel100'])
sonic_yang(3):exceptionList:["'fast_rate'"]
sonic_yang(3):Data Loading Failed:All Keys are not parsed in PORTCHANNEL dict_keys(['PortChannel100'])
exceptionList:["'fast_rate'"]
Data Loading Failed
All Keys are not parsed in PORTCHANNEL
dict_keys(['PortChannel100'])
exceptionList:["'fast_rate'"]
ConfigMgmt Class creation failed
Failed to break out Port. Error: Failed to load the config. Error: ConfigMgmtDPB Class creation failed

#### How I did it
Updated yang model


#### How to verify it
Added tests to verify

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
Part of the PR

<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

