### PR TITLE
[202205][Mellanox] Install python2 on syncd

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -32,7 +32,6 @@ RUN apt-get update && \
 	python-dev \
         python3-pip  \
         python3-dev \
-        python-is-python3 \
 {%- if ENABLE_ASAN == "y" %}
         libasan6 \
 {%- endif %}

--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -29,16 +29,20 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y \
         libxml2     \
+	python-dev \
         python3-pip  \
         python3-dev \
         python-is-python3 \
 {%- if ENABLE_ASAN == "y" %}
         libasan6 \
 {%- endif %}
+	python-setuptools \
         python3-setuptools
 
 RUN pip3 install --upgrade pip
-RUN apt-get purge -y python-pip
+RUN apt-get purge -y python-pi
+
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py \&& python2 get-pip.pyp
 
 {% if docker_syncd_mlnx_debs.strip() -%}
 # Copy locally-built Debian package dependencies

--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -40,7 +40,7 @@ RUN apt-get update && \
         python3-setuptools
 
 RUN pip3 install --upgrade pip
-RUN apt-get purge -y python-pi
+RUN apt-get purge -y python-pip
 
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py \&& python2 get-pip.pyp
 

--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -41,7 +41,7 @@ RUN apt-get update && \
 RUN pip3 install --upgrade pip
 RUN apt-get purge -y python-pip
 
-RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py \&& python2 get-pip.pyp
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
 
 {% if docker_syncd_mlnx_debs.strip() -%}
 # Copy locally-built Debian package dependencies


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Some scripts on syncd require Python2 support.

#### How I did it

Add Python2 to syncd docker

#### How to verify it
Run manually python scripts under Nvidia SDK debug to ensure they are working

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

