### PR TITLE
sonic-buildimage Remove unused SAT port from arista configs.

### DIFF
--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -251,17 +251,6 @@ tm_port_header_type_out_202=ETH
 tm_port_header_type_in_203=INJECTED_2_PP
 tm_port_header_type_out_203=ETH
 
-### SAT
-## Enable SAT Interface. 0 - Disable, 1 - Enable (Default) 
-sat_enable=1
-ucode_port_218=SAT:core_0.218
-tm_port_header_type_out_218=CPU
-tm_port_header_type_in_218=INJECTED_2
-ucode_port_219=SAT:core_1.219
-tm_port_header_type_out_219=CPU
-tm_port_header_type_in_219=INJECTED_2
-port_init_speed_sat=400000
-
 ### RCY
 sai_recycle_port_lane_base=200
 ucode_port_49=RCY0:core_0.49

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -251,17 +251,6 @@ tm_port_header_type_out_202=ETH
 tm_port_header_type_in_203=INJECTED_2_PP
 tm_port_header_type_out_203=ETH
 
-### SAT
-## Enable SAT Interface. 0 - Disable, 1 - Enable (Default) 
-sat_enable=1
-ucode_port_218=SAT:core_0.218
-tm_port_header_type_out_218=CPU
-tm_port_header_type_in_218=INJECTED_2
-ucode_port_219=SAT:core_1.219
-tm_port_header_type_out_219=CPU
-tm_port_header_type_in_219=INJECTED_2
-port_init_speed_sat=400000
-
 ### RCY
 sai_recycle_port_lane_base=200
 ucode_port_49=RCY0:core_0.49

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -269,17 +269,6 @@ tm_port_header_type_out_202=ETH
 tm_port_header_type_in_203=INJECTED_2_PP
 tm_port_header_type_out_203=ETH
 
-### SAT
-## Enable SAT Interface. 0 - Disable, 1 - Enable (Default) 
-sat_enable=1
-ucode_port_218=SAT:core_0.218
-tm_port_header_type_out_218=CPU
-tm_port_header_type_in_218=INJECTED_2
-ucode_port_219=SAT:core_1.219
-tm_port_header_type_out_219=CPU
-tm_port_header_type_in_219=INJECTED_2
-port_init_speed_sat=400000
-
 ### RCY
 sai_recycle_port_lane_base=0
 ucode_port_221=RCY.21:core_0.221

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -269,17 +269,6 @@ tm_port_header_type_out_202=ETH
 tm_port_header_type_in_203=INJECTED_2_PP
 tm_port_header_type_out_203=ETH
 
-### SAT
-## Enable SAT Interface. 0 - Disable, 1 - Enable (Default) 
-sat_enable=1
-ucode_port_218=SAT:core_0.218
-tm_port_header_type_out_218=CPU
-tm_port_header_type_in_218=INJECTED_2
-ucode_port_219=SAT:core_1.219
-tm_port_header_type_out_219=CPU
-tm_port_header_type_in_219=INJECTED_2
-port_init_speed_sat=400000
-
 ### RCY
 sai_recycle_port_lane_base=0
 ucode_port_221=RCY.21:core_0.221

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -251,17 +251,6 @@ tm_port_header_type_out_202=ETH
 tm_port_header_type_in_203=INJECTED_2_PP
 tm_port_header_type_out_203=ETH
 
-### SAT
-## Enable SAT Interface. 0 - Disable, 1 - Enable (Default) 
-sat_enable=1
-ucode_port_218=SAT:core_0.218
-tm_port_header_type_out_218=CPU
-tm_port_header_type_in_218=INJECTED_2
-ucode_port_219=SAT:core_1.219
-tm_port_header_type_out_219=CPU
-tm_port_header_type_in_219=INJECTED_2
-port_init_speed_sat=400000
-
 ### RCY
 sai_recycle_port_lane_base=200
 ucode_port_49=RCY0:core_0.49

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -251,17 +251,6 @@ tm_port_header_type_out_202=ETH
 tm_port_header_type_in_203=INJECTED_2_PP
 tm_port_header_type_out_203=ETH
 
-### SAT
-## Enable SAT Interface. 0 - Disable, 1 - Enable (Default) 
-sat_enable=1
-ucode_port_218=SAT:core_0.218
-tm_port_header_type_out_218=CPU
-tm_port_header_type_in_218=INJECTED_2
-ucode_port_219=SAT:core_1.219
-tm_port_header_type_out_219=CPU
-tm_port_header_type_in_219=INJECTED_2
-port_init_speed_sat=400000
-
 ### RCY
 sai_recycle_port_lane_base=200
 ucode_port_49=RCY0:core_0.49


### PR DESCRIPTION
#### Why I did it

To fix https://github.com/aristanetworks/sonic/issues/85

#### How I did it

Remove unnecessary SAT ports

#### How to verify it

Speed change from 400-100g without any error.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x ] 202205
- [ ] 202211
