### PR TITLE
frrcfgd: fix incorrect rendering of route-map references

### DIFF
--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.addr_family.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.addr_family.j2
@@ -65,9 +65,7 @@
 {% for rr_key, rr_val in ROUTE_REDISTRIBUTE.items() %}
 {% if vrf == rr_key[0] and af_str == rr_key[3] %}
 {% if 'route_map' in rr_val %}
-{% for rmap in rr_val['route_map'] %}
-  redistribute {{rr_key[1]}} route-map {{rmap}}
-{% endfor %}
+  redistribute {{rr_key[1]}} route-map {{rr_val['route_map']}}
 {% else %}
   redistribute {{rr_key[1]}}
 {% endif %}

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_af.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_af.j2
@@ -112,16 +112,12 @@
 {% endif %}
 {# ------- route-map in --------------------------- #}
 {% if 'route_map_in' in n_af_val %}
-{% for map in n_af_val['route_map_in'] %}
-  neighbor {{nbr_name}} route-map {{map}} in
-{% endfor %}
+  neighbor {{nbr_name}} route-map {{n_af_val['route_map_in']}} in
 {% endif %}
 {# ------- route-map in end --------------------------- #}
 {# ------- route-map out --------------------------- #}
 {% if 'route_map_out' in n_af_val %}
-{% for map in n_af_val['route_map_out'] %}
-  neighbor {{nbr_name}} route-map {{map}} out
-{% endfor %}
+  neighbor {{nbr_name}} route-map {{n_af_val['route_map_out']}} out
 {% endif %}
 {# ------- route-map out end --------------------------- #}
 {% if 'unsuppress_map_name' in n_af_val %}


### PR DESCRIPTION
#### Why I did it

`frrcfgd` generated incorrect configuration that referred to route-maps under BGP address families, e.g.:

```
  neighbor peergroup route-map R in
  neighbor peergroup route-map M in
  neighbor peergroup route-map A in
  neighbor peergroup route-map P in
```

This happens because the Jinja2 templates looped over the string, leading to a new line for each individual character in the route-map name.

#### How I did it

Removed the `for` loops so that only a single line is being rendered.

#### How to verify it

```
sonic-db-cli CONFIG_DB HSET 'ROUTE_REDISTRIBUTE|default|connected|bgp|ipv4' route_map RMAP
docker restart bgp
sudo grep redistribute /etc/sonic/frr/bgpd.conf
vtysh -c 'sh run' | grep redistribute
```

Expected output from the last two commands:

```
  redistribute connected route-map RMAP
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211

Reason: current templates will load incorrect and quite possibly harmful configuration after the BGP container restarts.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

frrcfgd: fix incorrect rendering of route-map references

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

N/A

#### A picture of a cute animal (not mandatory but encouraged)

![bilde](https://user-images.githubusercontent.com/4557060/224029377-30c22c6e-d2dd-48a3-9158-f2872ffb108a.png)
