### PR TITLE
Add Yang model support for adding Channel to PORT table

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1473,6 +1473,33 @@ optional attributes.
     }
 }
 
+2x100G port breakout
+{
+"PORT": {
+        "Ethernet0": {
+            "admin_status": "up",
+            "index": "1",
+            "lanes": "101,102,103,104",
+            "description": "etp1a",
+            "mtu": "9100",
+            "alias": "etp1a",
+            "speed": "100000",
+            "channel": 1
+        },
+        "Ethernet4": {
+            "admin_status": "up",
+            "index": "1",
+            "lanes": "105,106,107,108",
+            "description": "etp1b",
+            "mtu": "9100",
+            "alias": "etp1b",
+            "speed": "100000",
+            "channel": 2
+        },
+    }
+}
+
+
 ```
 
 ### Port Channel

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -558,6 +558,7 @@
                 "admin_status": "up",
                 "autoneg": "on",
                 "adv_speeds": "all",
+		"channel": 1,
                 "adv_interface_types": "all"
             },
             "Ethernet3": {
@@ -566,6 +567,7 @@
                 "description": "",
                 "speed": "11100",
                 "tpid": "0x88A8",
+		"channel": 4,
                 "admin_status": "up"
             },
             "Ethernet4": {
@@ -574,6 +576,7 @@
                 "description": "",
                 "speed": "11100",
                 "tpid": "0x9100",
+		"channel": 7,
                 "admin_status": "up"
             },
             "Ethernet5": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
@@ -114,6 +114,14 @@
          "desc": "PORT_INVALID_MUX_CABLE_TEST non-boolean values, expect fail",
          "eStrKey": "InvalidValue"
      },
+     "PORT_VALID_CHANNEL_NUMBER": {
+         "desc": "PORT_VALID_CHANNEL_NUMBER no failure."
+     },
+     "PORT_INVALID_CHANNEL_NUMBER": {
+         "desc": "Out of range channel number",
+         "eStrKey": "Range",
+         "eStr": "0..8"
+     },
      "PORT_VALID_MULTIASIC_TEST": {
          "desc": "PORT_VALID_MULTIASIC_TEST no failure."
      },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -500,6 +500,59 @@
         }
     },
 
+    "PORT_INVALID_CHANNEL_NUMBER": {
+         "sonic-port:sonic-port": {
+             "sonic-port:PORT": {
+                 "PORT_LIST": [
+                     {
+                         "name": "Ethernet0",
+                         "alias": "etp1d",
+                         "lanes": "60, 61",
+                         "speed": 100000,
+                         "channel": 9
+                     }
+                 ]
+             }
+         }
+     },
+
+     "PORT_VALID_CHANNEL_NUMBER": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {   
+                        "name": "Ethernet0",
+                        "alias": "etp1d",
+                        "lanes": "60, 61",
+                       "speed": 100000,
+                        "channel": 1
+                    },  
+                    {   
+                       "name": "Ethernet2",
+                        "alias": "etp2d",
+                        "lanes": "62, 63",
+                       "speed": 100000,
+                        "channel": 2
+                    },  
+                    {   
+                        "name": "Ethernet4",
+                        "alias": "etp3d",
+                        "lanes": "64, 65",
+                       "speed": 100000,
+                        "channel": 3
+                    },  
+                    {   
+                        "name": "Ethernet6",
+                        "alias": "etp4d",
+                        "lanes": "66, 67",
+                        "speed": 100000,
+                        "channel": 4
+                    }   
+                ]   
+            }   
+        }   
+    },  
+
     "PORT_INVALID_MUX_CABLE_TEST": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -121,6 +121,13 @@ module sonic-port{
 					}
 				}
 
+				leaf channel {
+					description "Logical channel(s) for physical port breakout";
+					type uint8 {
+						range 0..8;
+					}
+				}
+
 				leaf index {
 					type uint16;
 				}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add 'channel' to the CONFIG_DB PORT table. This will be needed to support PORT breakout to multiple channel ports so that Xcvrd can understand which datapath or channel to initialize on the CMIS compliant optics

#### How I did it
Add 'channel' to the CONFIG_DB PORT table. 

#### How to verify it
Added unit test for valid and invalid channel number
Channel 0 -> No breakout 
Channel 1 to 8 -> Breakout channel 1,2, ..8

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111
- [x] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

