### PR TITLE
[storage_backend] Add backend acl service 

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -605,6 +605,11 @@ sudo cp $IMAGE_CONFIGS/config-chassisdb/config-chassisdb $FILESYSTEM_ROOT/usr/bi
 echo "config-chassisdb.service" | sudo tee -a $GENERATED_SERVICE_FILE
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable config-chassisdb.service
 
+# Copy backend-acl script and service file
+sudo cp $IMAGE_CONFIGS/backend_acl/backend-acl.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/backend-acl.service
+sudo cp $IMAGE_CONFIGS/backend_acl/backend_acl.py $FILESYSTEM_ROOT/usr/bin/backend_acl.py
+echo "backend-acl.service" | sudo tee -a $GENERATED_SERVICE_FILE
+
 # Copy SNMP configuration files
 sudo cp $IMAGE_CONFIGS/snmp/snmp.yml $FILESYSTEM_ROOT/etc/sonic/
 

--- a/files/image_config/backend_acl/backend-acl.service
+++ b/files/image_config/backend_acl/backend-acl.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Enable backend acl on storage backend ToRs
+After=swss.service
+BindsTo=sonic.target
+After=sonic.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/backend_acl.py
+
+[Install]
+WantedBy=sonic.target

--- a/files/image_config/backend_acl/backend_acl.py
+++ b/files/image_config/backend_acl/backend_acl.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import syslog
+import time
+
+from swsscommon.swsscommon import SonicV2Connector
+
+SYSLOG_IDENTIFIER = os.path.basename(__file__)
+
+SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
+
+def log_info(msg):
+    syslog.openlog(SYSLOG_IDENTIFIER)
+    syslog.syslog(syslog.LOG_INFO, msg)
+    syslog.closelog()
+
+def run_command(cmd, return_cmd=False):
+   log_info("executing cmd =  {}".format(cmd))
+   proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+   out, err = proc.communicate()
+   if return_cmd:
+       if err:
+           return "Unknown"
+
+       if len(out) > 0:
+           return out.strip().decode('utf-8')
+
+def _get_device_type():
+    """
+    Get device type
+    """
+    command = "{} -m -v DEVICE_METADATA.localhost.type".format(SONIC_CFGGEN_PATH)
+    device_type = run_command(command, return_cmd=True)
+    return device_type
+
+def _is_storage_device():
+    """
+    Check if the device is a storage device or not
+    """
+    command = "{} -d -v DEVICE_METADATA.localhost.storage_device".format(SONIC_CFGGEN_PATH)
+    storage_device = run_command(command, return_cmd=True)
+    return storage_device == "true"
+
+def _is_acl_table_present():
+    """
+    Check if acl table exists
+    """
+    command = "{} -d -v ACL_TABLE.DATAACL".format(SONIC_CFGGEN_PATH)
+    acl_table = run_command(command, return_cmd=True)
+    return (acl_table != "Unknown" and bool(acl_table))
+
+def _is_switch_table_present():
+    state_db = SonicV2Connector(host='127.0.0.1')
+    state_db.connect(state_db.STATE_DB, False)
+    table_present = False
+    wait_time = 0
+    TIMEOUT = 120
+    STEP = 10
+
+    while wait_time < TIMEOUT:
+        if state_db.exists(state_db.STATE_DB, 'SWITCH_CAPABILITY|switch'):
+            table_present = True
+            break
+        time.sleep(STEP)
+        wait_time += STEP
+    if not table_present:
+        log_info("Switch table not present")
+    return table_present
+
+def load_backend_acl(device_type):
+    """
+    Load acl on backend storage device
+    """
+    BACKEND_ACL_TEMPLATE_FILE = os.path.join('/', "usr", "share", "sonic", "templates", "backend_acl.j2")
+    BACKEND_ACL_FILE = os.path.join('/', "etc", "sonic", "backend_acl.json")
+
+    # this acl needs to be loaded only on a storage backend ToR. acl load will fail if the switch table isn't present
+    if _is_storage_device() and _is_acl_table_present() and _is_switch_table_present():
+        if os.path.isfile(BACKEND_ACL_TEMPLATE_FILE):
+            run_command("sudo {} -d -t {},{}".format(SONIC_CFGGEN_PATH, BACKEND_ACL_TEMPLATE_FILE, BACKEND_ACL_FILE))
+        if os.path.isfile(BACKEND_ACL_FILE):
+            run_command("acl-loader update incremental {}".format(BACKEND_ACL_FILE))
+    else:
+        log_info("Skipping backend acl load - conditions not met")
+
+def main():
+    device_type = _get_device_type()
+    if device_type == "Unknown" or device_type != "BackEndToRRouter":
+        log_info("Skipping backend acl load on unsupported device type: {}".format(device_type))
+        return
+
+    load_backend_acl(device_type)
+
+if __name__ == "__main__":
+    main()

--- a/files/image_config/backend_acl/backend_acl.py
+++ b/files/image_config/backend_acl/backend_acl.py
@@ -84,7 +84,7 @@ def load_backend_acl(device_type):
 
 def main():
     device_type = _get_device_type()
-    if device_type == "Unknown" or device_type != "BackEndToRRouter":
+    if device_type != "BackEndToRRouter":
         log_info("Skipping backend acl load on unsupported device type: {}".format(device_type))
         return
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Change in sonic-net/sonic-utilities#2236 was done to load acls on storage backend device. During conversion, it was observed that some rules were getting skipped with the following error
Mar  7 19:33:53 sonic config-setup[999]: Running command: acl-loader update incremental /etc/sonic/backend_acl.json
Mar  7 19:33:53 sonic config-setup[999]: Running command: acl-loader update incremental /etc/sonic/backend_acl.json
Mar  7 19:33:54 sonic python3: :- operator(): Key '{SWITCH_CAPABILITY|switch}' unavailable in database '{STATE_DB}'
Mar  7 19:33:54 sonic python3: :- operator(): Key '{SWITCH_CAPABILITY|switch}' unavailable in database '{STATE_DB}'
Mar  7 19:33:54 sonic /acl-loader: Error processing rule 1: Rule action ACCEPT is not supported in table DATAACL, rule 1. Skipped.
Mar  7 19:33:54 sonic /acl-loader: Error processing rule 1: Rule action ACCEPT is not supported in table DATAACL, rule 1. Skipped.

The reason for the above failure was because acl loader does some sanity checks before writing the rules into config db and depends on SWITCH_CAPABILITY|switch table in state db (https://github.com/sonic-net/sonic-utilities/blob/master/acl_loader/main.py#L451) which is not present as soon as the switch boots up resulting in the rule being invalid. 

#### Why I did it
This PR addresses the issue mentioned above by loading the acl config as a service on a storage backend device

#### How I did it
The new acl service is a oneshot service which will start after swss and does some retries to ensure that the SWITCH_CAPABILITY info is present before attempting to load the acl rules. The service is also bound to sonic targets which ensures that it gets restarted during minigraph reload and config reload

#### How to verify it
Build an image with the following changes and did the following tests
1. Verified that acl is loaded successfully on a storage backend device after a switch boot up
2. Verified that acl is loaded successfully on a storage backend ToR after minigraph load and config reload
3. Verified that acl is not loaded if the device is not a storage backend ToR or the device does not have a DATAACL table

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

