### PR TITLE
[DellEMC] S6100 -  Adding logger to fetch SSD FW Upgrade status

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_ssd_upgrade_status.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_ssd_upgrade_status.sh
@@ -36,6 +36,7 @@ if [ -e $SSD_FW_UPGRADE/GPIO7_pending_upgrade ]; then
 fi
 
 echo "$0 `date` SSD FW upgrade logs post reboot." >> $SSD_UPGRADE_LOG
+logger -p user.crit -t DELL_S6100_SSD_MON "SSD FW upgrade logs post reboot."
 
 SSD_UPGRADE_STATUS1=`io_rd_wr.py --set --val 06 --offset 210; io_rd_wr.py --set --val 09 --offset 211; io_rd_wr.py --get --offset 212`
 SSD_UPGRADE_STATUS1=$(echo "$SSD_UPGRADE_STATUS1" | awk '{print $NF}')
@@ -71,11 +72,14 @@ elif [ $SSD_FW_VERSION == "s210506g" ] || [ $SSD_FW_VERSION == "s16425cg" ]; the
         rm -rf $SSD_FW_UPGRADE/GPIO7_*
         touch $SSD_FW_UPGRADE/GPIO7_high
         systemctl start --no-block s6100-ssd-monitor.timer
+        logger -p user.crit -t DELL_S6100_SSD_MON "SSD FW upgraded already."
         if [ $SSD_UPGRADE_STATUS1 == "0" ]; then
             if [ $SSD_MODEL  == "3IE" ];then
                 echo "$0 `date` SSD FW upgraded from S141002C to S210506G in first mp_64." >> $SSD_UPGRADE_LOG
+                logger -p user.crit -t DELL_S6100_SSD_MON "SSD FW upgraded from S141002C to S210506G"
             else
                 echo "$0 `date` SSD FW upgraded from S16425c1 to S16425cG in first mp_64." >> $SSD_UPGRADE_LOG
+                logger -p user.crit -t DELL_S6100_SSD_MON "SSD FW upgraded from S16425c1 to S16425cG"
             fi
         elif [ $SSD_MODEL == "3IE3" ] && [ $SSD_UPGRADE_STATUS2 == "1" ]; then
             rm -rf $SSD_FW_UPGRADE/GPIO7_*
@@ -93,6 +97,7 @@ else
         touch $SSD_FW_UPGRADE/GPIO7_pending_upgrade
 
         echo "$0 `date` SSD upgrade didn’t happen." >> $SSD_UPGRADE_LOG
+        logger -p user.crit -t DELL_S6100_SSD_MON "No SSD upgrade attempted."
 
     elif [ $SSD_UPGRADE_STATUS1 == "1" ]; then
         rm -rf $SSD_FW_UPGRADE/GPIO7_*

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_ssd_upgrade_status.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_ssd_upgrade_status.sh
@@ -23,14 +23,19 @@ SMART_CMD=`smartctl -a /dev/sda`
 SSD_FW_VERSION=$(echo "$iSMART_CMD" | grep "FW Version" | awk '{print $NF}')
 SSD_FW_VERSION=${SSD_FW_VERSION,,}
 SSD_MODEL=$(echo "$iSMART_CMD" | grep "Model" | awk '{print $NF}')
+logger -p user.crit -t DELL_S6100_SSD_MON "SSD Model = $SSD_MODEL ; FWVERSION = $SSD_FW_VERSION"
 
 if [ -e $SSD_FW_UPGRADE/GPIO7_pending_upgrade ]; then
     if [ $SSD_MODEL == "3IE" ] && [ $SSD_FW_VERSION == "s141002c" ]; then
         # If SSD Firmware is not upgraded
+        logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is running older firmware. Do not power-cycle/reboot this unit."
+        logger -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
         exit 0
     fi
     if [ $SSD_FW_VERSION == "s16425c1" ] || [ $SSD_FW_VERSION == "s16425cq" ]; then
         # If SSD Firmware is not upgraded
+        logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is running older firmware. Do not power-cycle/reboot this unit."
+        logger -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
         exit 0
     fi
 fi
@@ -43,6 +48,7 @@ SSD_UPGRADE_STATUS1=$(echo "$SSD_UPGRADE_STATUS1" | awk '{print $NF}')
 
 SSD_UPGRADE_STATUS2=`io_rd_wr.py --set --val 06 --offset 210; io_rd_wr.py --set --val 0A --offset 211; io_rd_wr.py --get --offset 212`
 SSD_UPGRADE_STATUS2=$(echo "$SSD_UPGRADE_STATUS2" | awk '{print $NF}')
+logger -p user.crit -t DELL_S6100_SSD_MON "SSD Status REG1 = $SSD_UPGRADE_STATUS1 ; REG2 = $SSD_UPGRADE_STATUS2"
 
 if [ $SSD_UPGRADE_STATUS1 == "2" ]; then
     rm -rf $SSD_FW_UPGRADE/GPIO7_*


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- To log SSD FW upgrade attempts in syslog.

#### How I did it
- Adding logger.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [x] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [x] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

