### PR TITLE
Update MMU and ECN settings for T2 chassis

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/buffers_defaults_t2.j2
@@ -1,5 +1,14 @@
 {%- set default_cable = '300m' %}
 
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
     {%- for port_idx in range(0,192,4) %}

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/qos.json.j2
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/qos.json.j2
@@ -1,1 +1,21 @@
+{%- macro generate_wred_profiles() %}
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "wred_red_enable"        : "true",
+            "ecn"                    : "ecn_all",
+            "green_max_threshold"    : "10000000",
+            "green_min_threshold"    : "2000000",
+            "yellow_max_threshold"   : "2097152",
+            "yellow_min_threshold"   : "1048576",
+            "red_max_threshold"      : "2097152",
+            "red_min_threshold"      : "1048576",
+            "green_drop_probability" : "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability"   : "5"
+        }
+    },
+{%- endmacro %}
+
 {%- include 'qos_config.j2' %}

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/buffers_defaults_t2.j2
@@ -1,5 +1,14 @@
 {%- set default_cable = '300m' %}
 
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
     {%- for port_idx in range(0,192,4) %}

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/qos.json.j2
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/qos.json.j2
@@ -1,1 +1,21 @@
+{%- macro generate_wred_profiles() %}
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "wred_red_enable"        : "true",
+            "ecn"                    : "ecn_all",
+            "green_max_threshold"    : "10000000",
+            "green_min_threshold"    : "2000000",
+            "yellow_max_threshold"   : "2097152",
+            "yellow_min_threshold"   : "1048576",
+            "red_max_threshold"      : "2097152",
+            "red_min_threshold"      : "1048576",
+            "green_drop_probability" : "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability"   : "5"
+        }
+    },
+{%- endmacro %}
+
 {%- include 'qos_config.j2' %}

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/buffers_defaults_t2.j2
@@ -1,5 +1,14 @@
 {%- set default_cable = '300m' %}
 
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
     {%- for port_idx in range(0,144,8) %}

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/qos.json.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/qos.json.j2
@@ -1,1 +1,21 @@
+{%- macro generate_wred_profiles() %}
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "wred_red_enable"        : "true",
+            "ecn"                    : "ecn_all",
+            "green_max_threshold"    : "10000000",
+            "green_min_threshold"    : "2000000",
+            "yellow_max_threshold"   : "2097152",
+            "yellow_min_threshold"   : "1048576",
+            "red_max_threshold"      : "2097152",
+            "red_min_threshold"      : "1048576",
+            "green_drop_probability" : "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability"   : "5"
+        }
+    },
+{%- endmacro %}
+
 {%- include 'qos_config.j2' %}

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/buffers_defaults_t2.j2
@@ -1,5 +1,14 @@
 {%- set default_cable = '300m' %}
 
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
     {%- for port_idx in range(144,288,8) %}

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/qos.json.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/qos.json.j2
@@ -1,1 +1,21 @@
+{%- macro generate_wred_profiles() %}
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "wred_red_enable"        : "true",
+            "ecn"                    : "ecn_all",
+            "green_max_threshold"    : "10000000",
+            "green_min_threshold"    : "2000000",
+            "yellow_max_threshold"   : "2097152",
+            "yellow_min_threshold"   : "1048576",
+            "red_max_threshold"      : "2097152",
+            "red_min_threshold"      : "1048576",
+            "green_drop_probability" : "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability"   : "5"
+        }
+    },
+{%- endmacro %}
+
 {%- include 'qos_config.j2' %}

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/buffers_defaults_t2.j2
@@ -1,5 +1,14 @@
 {%- set default_cable = '300m' %}
 
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
     {%- for port_idx in range(0,144,4) %}

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/qos.json.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/qos.json.j2
@@ -1,1 +1,20 @@
+{%- macro generate_wred_profiles() %}
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "wred_red_enable"        : "true",
+            "ecn"                    : "ecn_all",
+            "green_max_threshold"    : "10000000",
+            "green_min_threshold"    : "2000000",
+            "yellow_max_threshold"   : "2097152",
+            "yellow_min_threshold"   : "1048576",
+            "red_max_threshold"      : "2097152",
+            "red_min_threshold"      : "1048576",
+            "green_drop_probability" : "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability"   : "5"
+        }
+    },
+{%- endmacro %}
 {%- include 'qos_config.j2' %}

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/buffers_defaults_t2.j2
@@ -1,5 +1,14 @@
 {%- set default_cable = '300m' %}
 
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
     {%- for port_idx in range(0,144,4) %}

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/qos.json.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/qos.json.j2
@@ -1,1 +1,20 @@
+{%- macro generate_wred_profiles() %}
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "wred_red_enable"        : "true",
+            "ecn"                    : "ecn_all",
+            "green_max_threshold"    : "10000000",
+            "green_min_threshold"    : "2000000",
+            "yellow_max_threshold"   : "2097152",
+            "yellow_min_threshold"   : "1048576",
+            "red_max_threshold"      : "2097152",
+            "red_min_threshold"      : "1048576",
+            "green_drop_probability" : "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability"   : "5"
+        }
+    },
+{%- endmacro %}
 {%- include 'qos_config.j2' %}

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/buffers_defaults_t2.j2
@@ -1,5 +1,14 @@
 {%- set default_cable = '300m' %}
 
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
     {%- for port_idx in range(0,144,8) %}

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/qos.json.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/qos.json.j2
@@ -1,1 +1,21 @@
+{%- macro generate_wred_profiles() %}
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "wred_red_enable"        : "true",
+            "ecn"                    : "ecn_all",
+            "green_max_threshold"    : "10000000",
+            "green_min_threshold"    : "2000000",
+            "yellow_max_threshold"   : "2097152",
+            "yellow_min_threshold"   : "1048576",
+            "red_max_threshold"      : "2097152",
+            "red_min_threshold"      : "1048576",
+            "green_drop_probability" : "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability"   : "5"
+        }
+    },
+{%- endmacro %}
+
 {%- include 'qos_config.j2' %}

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/buffers_defaults_t2.j2
@@ -1,5 +1,14 @@
 {%- set default_cable = '300m' %}
 
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
     {%- for port_idx in range(144,288,8) %}

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/qos.json.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/qos.json.j2
@@ -1,1 +1,21 @@
+{%- macro generate_wred_profiles() %}
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "wred_red_enable"        : "true",
+            "ecn"                    : "ecn_all",
+            "green_max_threshold"    : "10000000",
+            "green_min_threshold"    : "2000000",
+            "yellow_max_threshold"   : "2097152",
+            "yellow_min_threshold"   : "1048576",
+            "red_max_threshold"      : "2097152",
+            "red_min_threshold"      : "1048576",
+            "green_drop_probability" : "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability"   : "5"
+        }
+    },
+{%- endmacro %}
+
 {%- include 'qos_config.j2' %}

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/buffers_defaults_t2.j2
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/buffers_defaults_t2.j2
@@ -1,5 +1,14 @@
 {%- set default_cable = '300m' %}
 
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
     {%- for port_idx in range(0,36) %}

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/qos.json.j2
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/qos.json.j2
@@ -1,1 +1,21 @@
+{%- macro generate_wred_profiles() %}
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "wred_red_enable"        : "true",
+            "ecn"                    : "ecn_all",
+            "green_max_threshold"    : "10000000",
+            "green_min_threshold"    : "2000000",
+            "yellow_max_threshold"   : "2097152",
+            "yellow_min_threshold"   : "1048576",
+            "red_max_threshold"      : "2097152",
+            "red_min_threshold"      : "1048576",
+            "green_drop_probability" : "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability"   : "5"
+        }
+    },
+{%- endmacro %}
+
 {%- include 'qos_config.j2' %}

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/buffers_defaults_t2.j2
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/buffers_defaults_t2.j2
@@ -1,5 +1,14 @@
 {%- set default_cable = '300m' %}
 
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
     {%- for port_idx in range(0,36) %}

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/qos.json.j2
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/qos.json.j2
@@ -1,1 +1,21 @@
+{%- macro generate_wred_profiles() %}
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "wred_red_enable"        : "true",
+            "ecn"                    : "ecn_all",
+            "green_max_threshold"    : "10000000",
+            "green_min_threshold"    : "2000000",
+            "yellow_max_threshold"   : "2097152",
+            "yellow_min_threshold"   : "1048576",
+            "red_max_threshold"      : "2097152",
+            "red_min_threshold"      : "1048576",
+            "green_drop_probability" : "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability"   : "5"
+        }
+    },
+{%- endmacro %}
+
 {%- include 'qos_config.j2' %}

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/buffers_defaults_t2.j2
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/buffers_defaults_t2.j2
@@ -1,5 +1,14 @@
 {%- set default_cable = '300m' %}
 
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
     {%- for port_idx in range(0,36) %}

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/qos.json.j2
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/qos.json.j2
@@ -1,1 +1,21 @@
+{%- macro generate_wred_profiles() %}
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "wred_red_enable"        : "true",
+            "ecn"                    : "ecn_all",
+            "green_max_threshold"    : "10000000",
+            "green_min_threshold"    : "2000000",
+            "yellow_max_threshold"   : "2097152",
+            "yellow_min_threshold"   : "1048576",
+            "red_max_threshold"      : "2097152",
+            "red_min_threshold"      : "1048576",
+            "green_drop_probability" : "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability"   : "5"
+        }
+    },
+{%- endmacro %}
+
 {%- include 'qos_config.j2' %}

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/buffers_defaults_t2.j2
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/buffers_defaults_t2.j2
@@ -1,5 +1,14 @@
 {%- set default_cable = '300m' %}
 
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
     {%- for port_idx in range(0,36) %}

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/qos.json.j2
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/qos.json.j2
@@ -1,1 +1,21 @@
+{%- macro generate_wred_profiles() %}
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "wred_red_enable"        : "true",
+            "ecn"                    : "ecn_all",
+            "green_max_threshold"    : "10000000",
+            "green_min_threshold"    : "2000000",
+            "yellow_max_threshold"   : "2097152",
+            "yellow_min_threshold"   : "1048576",
+            "red_max_threshold"      : "2097152",
+            "red_min_threshold"      : "1048576",
+            "green_drop_probability" : "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability"   : "5"
+        }
+    },
+{%- endmacro %}
+
 {%- include 'qos_config.j2' %}

--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -41,7 +41,9 @@ def
             'internal'               : '5m',
             'torrouter_server'       : '5m',
             'leafrouter_torrouter'   : '40m',
-            'spinerouter_leafrouter' : '300m'
+            'spinerouter_leafrouter' : '300m',
+            'regionalhub_spinerouter': '80000m',
+            'aznghub_spinerouter'    : '80000m'
             }
     -%}
 {%- endif %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. Update per VSQ headroom size based on port speed/cable length for uplink and downlink ports
2. Update total headroom pool size based on uplink/downlink line card type
3. Update ECN settings for 2MB/10MB/5% (min/max/drop probability)
4. Update dynamic threshold (alpha) to limit max VoQ length based on production settings.
5. Remove any reserved space per VSQ/VoQ as low alpha value will protect buffer starvation for different flows.
6. Update VoQ drop threshold to max. VSQ drop/flow control threshold to be used for buffer management.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

