### PR TITLE
Fix the demo_part_size not initialized issue when creating partition

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -138,6 +138,10 @@ fi
 # with "OS" or "DIAG".
 demo_type="%%DEMO_TYPE%%"
 
+# The build system prepares this script by replacing %%ONIE_IMAGE_PART_SIZE%%
+# with the partition size
+demo_part_size="%%ONIE_IMAGE_PART_SIZE%%"
+
 # The build system prepares this script by replacing %%IMAGE_VERSION%%
 # with git revision hash as a version identifier
 image_version="%%IMAGE_VERSION%%"
@@ -236,7 +240,6 @@ if [ "$install_env" = "onie" ]; then
     fi
 fi
 
-demo_part_size="%%ONIE_IMAGE_PART_SIZE%%"
 echo "ONIE_IMAGE_PART_SIZE=$demo_part_size"
 
 extra_cmdline_linux=%%EXTRA_CMDLINE_LINUX%%


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The demo_part_size should be initialized before creating partition.

#### How I did it
Move the initializing setting to the line before using it.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

