### PR TITLE
Fix telemetry.sh passing in null as log level value

### DIFF
--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -63,10 +63,10 @@ if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then
 fi
 
 LOG_LEVEL=$(echo $GNMI | jq -r '.log_level')
-if [ -z $LOG_LEVEL ] || [ $LOG_LEVEL == "null" ]; then
-    TELEMETRY_ARGS+=" -v=2"
-else
+if [[ $LOG_LEVEL =~ ^[0-9]+$ ]]; then
     TELEMETRY_ARGS+=" -v=$LOG_LEVEL"
+else
+    TELEMETRY_ARGS+=" -v=2"
 fi
 
 exec /usr/sbin/telemetry ${TELEMETRY_ARGS}

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -63,10 +63,10 @@ if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then
 fi
 
 LOG_LEVEL=$(echo $GNMI | jq -r '.log_level')
-if [ ! -z $LOG_LEVEL ]; then
-    TELEMETRY_ARGS+=" -v=$LOG_LEVEL"
-else
+if [ -z $LOG_LEVEL ] || [ $LOG_LEVEL == "null" ]; then
     TELEMETRY_ARGS+=" -v=2"
+else
+    TELEMETRY_ARGS+=" -v=$LOG_LEVEL"
 fi
 
 exec /usr/sbin/telemetry ${TELEMETRY_ARGS}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Bug in script that was passing in null as log level value if missing from config_db

#### How I did it

Added more robust conditional statement

#### How to verify it

1) Remove log_level from config db
2) config reload -y
3) telemetry should not crash

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

