### PR TITLE
Update sonic-py-common, add missing dependency to redis-dump-load.

### DIFF
--- a/src/sonic-py-common/setup.py
+++ b/src/sonic-py-common/setup.py
@@ -1,10 +1,30 @@
+from __future__ import print_function
+import sys
 from setuptools import setup
+import pkg_resources
+from packaging import version
+
+# sonic_dependencies, version requirement only supports '>='
+sonic_dependencies = ['redis-dump-load']
 
 dependencies = [
     'natsort==6.2.1', # 6.2.1 is the last version which supports Python 2
     'pyyaml',
-    'redis-dump-load',
 ]
+
+dependencies += sonic_dependencies
+for package in sonic_dependencies:
+    try:
+        package_dist = pkg_resources.get_distribution(package.split(">=")[0])
+    except pkg_resources.DistributionNotFound:
+        print(package + " is not found!", file=sys.stderr)
+        print("Please build and install SONiC python wheels dependencies from sonic-buildimage", file=sys.stderr)
+        exit(1)
+    if ">=" in package:
+        if version.parse(package_dist.version) >= version.parse(package.split(">=")[1]):
+            continue
+        print(package + " version not match!", file=sys.stderr)
+        exit(1)
 
 setup(
     name='sonic-py-common',

--- a/src/sonic-py-common/setup.py
+++ b/src/sonic-py-common/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 dependencies = [
     'natsort==6.2.1', # 6.2.1 is the last version which supports Python 2
     'pyyaml',
+    'redis-dump-load',
 ]
 
 setup(


### PR DESCRIPTION
Update sonic-py-common, add missing dependency to redis-dump-load.

#### Why I did it
The script sonic_db_dump_load.py in sonic-py-common is depends on redis-dump-load, however the dependency is missing.

#### How I did it
Add redis-dump-load dependency.

#### How to verify it
Pass all E2E test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
Update sonic-py-common, add missing dependency to redis-dump-load.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

