### PR TITLE
[202211] Add yang model definition for CHASSIS_MODULE table (#14007)

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -18,6 +18,7 @@ Table of Contents
          * [Buffer port ingress profile list](#buffer-port-ingress-profile-list)  
          * [Buffer port egress profile list](#buffer-port-egress-profile-list)  
          * [Cable length](#cable-length)  
+         * [Chassis module](#chassis-module)  
          * [COPP_TABLE](#copp_table)  
          * [Console](#console)  
          * [CRM](#crm)  
@@ -637,6 +638,25 @@ This kind of profiles will be handled by buffer manager and won't be applied to 
         "Ethernet56": "40m"
     }
   }
+}
+
+```
+
+### Chassis Module
+
+CHASSIS_MODULE table holds the list and configuration of linecard and fabric modules in a SONiC chassis.
+It currently allows user to administratively bring down a line-card or fabric-card
+
+```
+{
+    "CHASSIS_MODULE": {
+        "LINE-CARD0": {
+            "admin_status": "down"
+        },
+        "FABRIC-CARD1": {
+            "admin_status": "down"
+        }
+    }
 }
 
 ```

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -97,6 +97,7 @@ setup(
                          './yang-models/sonic-buffer-profile.yang',
                          './yang-models/sonic-buffer-queue.yang',
                          './yang-models/sonic-cable-length.yang',
+                         './yang-models/sonic-chassis-module.yang',                         
                          './yang-models/sonic-copp.yang',
                          './yang-models/sonic-console.yang',
                          './yang-models/sonic-crm.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1476,6 +1476,14 @@
             "prefix1|1|10.0.0.0/8|8..16": {
             }
         },
+        "CHASSIS_MODULE": {
+            "LINE-CARD0": {
+                "admin_status": "down"
+            },
+            "FABRIC-CARD1": {
+                "admin_status": "down"
+            }
+        },
         "COPP_GROUP": {
             "queue1_group1": {
                 "queue": "1",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/chassis_module.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/chassis_module.json
@@ -1,0 +1,13 @@
+{
+    "CHASSIS_MODULE_WITH_DEFAULT_VALUES": {
+        "desc": "Load chassis module table with fields set to default values"
+    },
+    "CHASSIS_MODULE_WITH_LINECARD_ADMIN_DOWN": {
+        "desc": "Load chassis module table with admin_status set to down"
+    },
+    "CHASSIS_MODULE_WITH_LINECARD_ADMIN_INVALID_VALUE": {
+        "desc": "Load chassis module table with admin_status set to invalid value",
+        "eStrKey": "InvalidValue",
+        "eStr": ["admin_status"]
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/chassis_module.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/chassis_module.json
@@ -1,0 +1,54 @@
+{
+    "CHASSIS_MODULE_WITH_DEFAULT_VALUES": {
+        "sonic-chassis-module:sonic-chassis-module": {
+            "sonic-chassis-module:CHASSIS_MODULE": {
+                "CHASSIS_MODULE_LIST": [
+                    {
+                        "name": "LINE-CARD0",
+                        "admin_status": "up"
+                    },
+                    {
+                        "name": "LINE-CARD1",
+                        "admin_status": "up"
+                    },
+                    { 
+                        "name": "FABRIC-CARD0",
+                        "admin_status": "up"
+                    },
+                    {
+                        "name": "FABRIC-CARD1",
+                        "admin_status": "up"
+                    }
+                ]
+            }            
+        }
+    },
+    "CHASSIS_MODULE_WITH_LINECARD_ADMIN_DOWN": {
+        "sonic-chassis-module:sonic-chassis-module": {
+            "sonic-chassis-module:CHASSIS_MODULE": {
+                "CHASSIS_MODULE_LIST": [
+                    {
+                        "name": "LINE-CARD0",
+                        "admin_status": "down"
+                    },
+                    {
+                        "name": "FABRIC-CARD1",
+                        "admin_status": "down"
+                    }
+                ]
+            }            
+        }
+    },
+    "CHASSIS_MODULE_WITH_LINECARD_ADMIN_INVALID_VALUE": {
+        "sonic-chassis-module:sonic-chassis-module": {
+            "sonic-chassis-module:CHASSIS_MODULE": {
+                "CHASSIS_MODULE_LIST": [
+                    {
+                        "name": "LINE-CARD0",
+                        "admin_status": "false"
+                    }
+                ]
+            }            
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-chassis-module.yang
+++ b/src/sonic-yang-models/yang-models/sonic-chassis-module.yang
@@ -1,0 +1,36 @@
+module sonic-chassis-module {
+
+    yang-version 1.1;
+
+    namespace  "http://github.com/sonic-net/sonic-chassis-module";
+    prefix chassis_mod;
+    import sonic-types {
+        prefix stypes;
+    }
+    description "CHASSIS_MODULE YANG to administratively set SONIC modules state";
+
+    revision 2023-02-24 {
+        description "Initial version";
+    }
+
+    container sonic-chassis-module {
+        container CHASSIS_MODULE {
+            description "List of modules in the chassis";
+            list CHASSIS_MODULE_LIST {
+                key "name";
+                leaf name {
+                    type string {
+                        pattern "LINE-CARD[0-9]+|FABRIC-CARD[0-9]+";
+                    }
+                    description "Line-card or fabric-card module name";
+                }
+
+                leaf admin_status {
+                    type stypes:admin_status;
+                    default up;
+                    description "Administrative state of chassis module";
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Why I did it

Manual cherry-pick of https://github.com/sonic-net/sonic-buildimage/pull/14007

Add yang model definition for CHASSIS_MODULE define and implemented for sonic chassis. HLD for this configuration is included in https://github.com/sonic-net/SONiC/blob/master/doc/pmon/pmon-chassis-design.md#configuration

Fixes #12640

How I did it
Added yang model definition, unit tests, sample config and documentation for the table

How to verify it
Validated config tree generation using "pyang -Vf tree -p /usr/local/share/yang/modules/ietf ./yang-models/sonic-voq-inband-interface.yang"

Built the below python-wheels to validate unit tests and other changes target/python-wheels/bullseye/sonic_yang_mgmt-1.0-py3-none-any.whl target/python-wheels/bullseye/sonic_yang_models-1.0-py3-none-any.whl target/python-wheels/bullseye/sonic_config_engine-1.0-py3-none-any.whl

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

