### PR TITLE
[202211] Update sonic-py-common, add missing dependency to redis-dump-load.

### DIFF
--- a/src/sonic-py-common/setup.py
+++ b/src/sonic-py-common/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 dependencies = [
     'natsort==6.2.1', # 6.2.1 is the last version which supports Python 2
     'pyyaml',
+    'redis-dump-load',
 ]
 
 setup(


### PR DESCRIPTION
Update sonic-py-common, add missing dependency to redis-dump-load.
This is manually cherry-pick PR for https://github.com/sonic-net/sonic-buildimage/pull/14347
After 202211, the redis-dump-load been patched by sonic, so can't cherry-pick master branch PR to 202211 branch.

#### Why I did it
The script sonic_db_dump_load.py in sonic-py-common is depends on redis-dump-load, however the dependency is missing.

#### How I did it
Add redis-dump-load dependency.

#### How to verify it
Pass all E2E test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
Update sonic-py-common, add missing dependency to redis-dump-load.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

