### PR TITLE
[yang]Update VxLAN yang model to include IPv6 source in VxLAN tunnel

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vxlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vxlan.json
@@ -2,6 +2,9 @@
     "VXLAN_VALID_TEST": {
         "desc": "Valid VXLAN Configuration."
     },
+    "VXLAN_VALID_V6_TUNNEL_TEST": {
+        "desc": "Valid VXLAN V6 Configuration."
+    },
     "VXLAN_EVPN_NVO_WITHOUT_VTEP": {
         "desc": "Configure EVPN_NVO without VXLAN_TUNNEL entry",
 	    "eStrKey" : "LeafRef"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vxlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vxlan.json
@@ -38,6 +38,45 @@
              }
          }
     },
+    "VXLAN_VALID_V6_TUNNEL_TEST": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan100"
+                    }
+                ]
+            }
+         },
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "2001::1:2:3:4"
+                    }
+                ]
+             },
+            "sonic-vxlan:VXLAN_EVPN_NVO": {
+                "VXLAN_EVPN_NVO_LIST": [
+                    {
+                        "name": "nvo1",
+                        "source_vtep": "vtep1"
+                    }
+                ]
+             },
+            "sonic-vxlan:VXLAN_TUNNEL_MAP": {
+                "VXLAN_TUNNEL_MAP_LIST": [
+                    {
+                        "name": "vtep1",
+                        "mapname": "map_100_Vlan100",
+                        "vlan": "Vlan100",
+                        "vni": "100"
+                    }
+                ]
+             }
+         }
+    },
     "VXLAN_EVPN_NVO_WITHOUT_VTEP": {
         "sonic-vxlan:sonic-vxlan": {
             "sonic-vxlan:VXLAN_EVPN_NVO": {

--- a/src/sonic-yang-models/yang-models/sonic-vxlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vxlan.yang
@@ -60,7 +60,7 @@ module sonic-vxlan {
                 }
 
                 leaf src_ip {
-                    type inet:ipv4-address;
+                    type inet:ip-address;
                 }
             }
         }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Update VxLAN yang model to include IPv6 source in VxLAN tunnel. The src_ip field can include both ipv4 as well as ipv6 address


#### How I did it
Updated yang model.


#### How to verify it
Added UT to verify


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

