### PR TITLE
[202205] [Mellanox] Fix issue: user must set admin down before toggling LPM

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -551,8 +551,7 @@ class SFP(NvidiaSFPCommon):
 
     @classmethod
     def _set_lpmode(cls, lpmode, sdk_handle, sdk_index, slot_id):
-        print('\nNotice: please set port admin status to down before setting power mode, \
-              ignore this message if already set')
+        print('\nNotice: please set port admin status to down before setting power mode, ignore this message if already set')
         sdk_lpmode = SX_MGMT_PHY_MOD_PWR_MODE_LOW_E if lpmode else SX_MGMT_PHY_MOD_PWR_MODE_AUTO_E
         cls._set_lpmode_raw(sdk_handle,
                             sdk_index,

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -640,7 +640,7 @@ class SFP(NvidiaSFPCommon):
             return False
 
         if not lpmode and down_port_list:
-            print('Notice: Be aware you exit LPM mode but still port is in admin down state')
+            print('Notice: Be aware you exit low power mode but still port is in admin down state')
 
         sdk_lpmode = SX_MGMT_PHY_MOD_PWR_MODE_LOW_E if lpmode else SX_MGMT_PHY_MOD_PWR_MODE_AUTO_E
         cls._set_lpmode_raw(sdk_handle,

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -143,14 +143,6 @@ class TestSfp:
             handle.read.side_effect = OSError('')
             assert sfp.read_eeprom(0, 1) is None
 
-    @mock.patch('sonic_platform.sfp.SFP._fetch_port_status')
-    def test_is_port_admin_status_up(self, mock_port_status):
-        mock_port_status.return_value = (0, True)
-        assert SFP.is_port_admin_status_up(None, None)
-
-        mock_port_status.return_value = (0, False)
-        assert not SFP.is_port_admin_status_up(None, None)
-
     @mock.patch('sonic_platform.sfp.SFP._get_eeprom_path', mock.MagicMock(return_value = None))
     @mock.patch('sonic_platform.sfp.SFP._get_sfp_type_str')
     def test_is_write_protected(self, mock_get_type_str):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

