### PR TITLE
[Build] Fix marvell-arm64 build redis_dump_load-1.1-py2-none-any.whl fail

### DIFF
--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -550,6 +550,7 @@ RUN pip3 install "lxml==4.9.1"
 {%- endif %}
 
 # For sonic-platform-common testing
+RUN pip2 install redis
 RUN pip3 install redis
 
 # For vs image build

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -337,6 +337,7 @@ RUN pip3 install "lxml==4.9.1"
 
 
 # For sonic-platform-common testing
+RUN pip2 install redis
 RUN pip3 install redis
 
 # For vs image build


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes #9216
#### How I did it
Add support for python2 redis to the sonic-slave-stretch and sonic-slave-buster Dockerfiles
#### How to verify it
Run build steps documented in Issue #9216

Succeeding build log after change:

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

