### PR TITLE
[202205] Remove apt package lists and make macro to clean up apt and python cache

### DIFF
--- a/dockers/docker-base-bullseye/Dockerfile.j2
+++ b/dockers/docker-base-bullseye/Dockerfile.j2
@@ -1,5 +1,5 @@
 {% set prefix = DEFAULT_CONTAINER_REGISTRY %}
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 {% if CONFIGURED_ARCH == "armhf" and MULTIARCH_QEMU_ENVIRON == "y" %}
 FROM {{ prefix }}multiarch/debian-debootstrap:armhf-bullseye
 {% elif CONFIGURED_ARCH == "arm64" and MULTIARCH_QEMU_ENVIRON == "y" %}
@@ -92,17 +92,12 @@ RUN apt-get -y purge   \
 {{ install_debian_packages(docker_base_bullseye_debs.split(' ')) }}
 {%- endif %}
 
-# Clean up apt
-# Remove /var/lib/apt/lists/*, could be obsoleted for derived images
-RUN apt-get clean -y                     && \
-    apt-get autoclean -y                 && \
-    apt-get autoremove -y                && \
-    rm -rf /var/lib/apt/lists/* /tmp/* ~/.cache
+{{ cleanup_apt_and_python_cache() }}
 
 COPY ["etc/rsyslog.conf", "/etc/rsyslog.conf"]
 COPY ["etc/rsyslog.d/*", "/etc/rsyslog.d/"]
 COPY ["root/.vimrc", "/root/.vimrc"]
 
-RUN ln /usr/bin/vim.tiny /usr/bin/vim
+RUN ln -s /usr/bin/vim.tiny /usr/bin/vim
 
 COPY ["etc/supervisor/supervisord.conf", "/etc/supervisor/"]

--- a/dockers/docker-base-buster/Dockerfile.j2
+++ b/dockers/docker-base-buster/Dockerfile.j2
@@ -1,5 +1,5 @@
 {% set prefix = DEFAULT_CONTAINER_REGISTRY %}
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 {% if CONFIGURED_ARCH == "armhf" and MULTIARCH_QEMU_ENVIRON == "y" %}
 FROM {{ prefix }}multiarch/debian-debootstrap:armhf-buster
 {% elif CONFIGURED_ARCH == "arm64" and MULTIARCH_QEMU_ENVIRON == "y" %}
@@ -110,17 +110,12 @@ RUN apt-get -y purge   \
 {{ install_debian_packages(docker_base_buster_debs.split(' ')) }}
 {%- endif %}
 
-# Clean up apt
-# Remove /var/lib/apt/lists/*, could be obsoleted for derived images
-RUN apt-get clean -y                     && \
-    apt-get autoclean -y                 && \
-    apt-get autoremove -y                && \
-    rm -rf /var/lib/apt/lists/* /tmp/* ~/.cache/
+{{ cleanup_apt_and_python_cache() }}
 
 COPY ["etc/rsyslog.conf", "/etc/rsyslog.conf"]
 COPY ["etc/rsyslog.d/*", "/etc/rsyslog.d/"]
 COPY ["root/.vimrc", "/root/.vimrc"]
 
-RUN ln /usr/bin/vim.tiny /usr/bin/vim
+RUN ln -s /usr/bin/vim.tiny /usr/bin/vim
 
 COPY ["etc/supervisor/supervisord.conf", "/etc/supervisor/"]

--- a/dockers/docker-config-engine-bullseye/Dockerfile.j2
+++ b/dockers/docker-config-engine-bullseye/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-base-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ## Make apt-get non-interactive
@@ -45,8 +45,6 @@ COPY ["files/swss_vars.j2", "/usr/share/sonic/templates/"]
 ## Clean up
 RUN apt-get purge -y               \
         python3-dev                \
-        build-essential         && \
-    apt-get clean -y            && \
-    apt-get autoclean -y        && \
-    apt-get autoremove -y       && \
-    rm -rf /debs /python-wheels ~/.cache
+        build-essential
+
+{{ cleanup_apt_and_python_cache() }}

--- a/dockers/docker-config-engine-buster/Dockerfile.j2
+++ b/dockers/docker-config-engine-buster/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-base-buster-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ## Make apt-get non-interactive
@@ -45,8 +45,6 @@ COPY ["files/swss_vars.j2", "/usr/share/sonic/templates/"]
 ## Clean up
 RUN apt-get purge -y               \
         python3-dev                \
-        build-essential         && \
-    apt-get clean -y            && \
-    apt-get autoclean -y        && \
-    apt-get autoremove -y       && \
-    rm -rf /debs /python-wheels ~/.cache
+        build-essential
+
+{{ cleanup_apt_and_python_cache() }}

--- a/dockers/docker-database/Dockerfile.j2
+++ b/dockers/docker-database/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -21,12 +21,10 @@ RUN apt-get install -y redis-tools redis-server
 {{ install_debian_packages(docker_database_debs.split(' ')) }}
 {%- endif %}
 
-# Clean up
-RUN apt-get clean -y                                  && \
-    apt-get autoclean -y                              && \
-    apt-get autoremove -y                             && \
-    rm -rf /debs ~/.cache                             && \
-    sed -ri 's/^(save .*$)/# \1/g;                       \
+{{ cleanup_apt_and_python_cache() }}
+
+# Configure redis
+RUN sed -ri 's/^(save .*$)/# \1/g;                       \
              s/^daemonize yes$/daemonize no/;            \
              s/^logfile .*$/logfile ""/;                 \
              s/^# syslog-enabled no$/syslog-enabled no/; \

--- a/dockers/docker-dhcp-relay/Dockerfile.j2
+++ b/dockers/docker-dhcp-relay/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -22,11 +22,7 @@ RUN apt-get update
 {{ install_debian_packages(docker_dhcp_relay_debs.split(' ')) }}
 {%- endif %}
 
-# Clean up
-RUN apt-get clean -y         && \
-    apt-get autoclean -y     && \
-    apt-get autoremove -y    && \
-    rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 COPY ["docker_init.sh", "start.sh", "/usr/bin/"]
 COPY ["docker-dhcp-relay.supervisord.conf.j2", "port-name-alias-map.txt.j2", "wait_for_intf.sh.j2", "/usr/share/sonic/templates/"]

--- a/dockers/docker-fpm-frr/Dockerfile.j2
+++ b/dockers/docker-fpm-frr/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-swss-layer-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -40,11 +40,7 @@ RUN useradd -u ${frr_user_uid} -g ${frr_user_gid} -M -s /bin/false frr
 
 RUN chown -R ${frr_user_uid}:${frr_user_gid} /etc/frr/
 
-# Clean up
-RUN apt-get clean -y      && \
-    apt-get autoclean -y  && \
-    apt-get autoremove -y && \
-    rm -rf /debs ~/.cache /python-wheels
+{{ cleanup_apt_and_python_cache() }}
 
 COPY ["frr", "/usr/share/sonic/templates"]
 COPY ["docker_init.sh", "/usr/bin/"]

--- a/dockers/docker-lldp/Dockerfile.j2
+++ b/dockers/docker-lldp/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -30,13 +30,7 @@ RUN apt-get update
 {{ install_python_wheels(docker_lldp_whls.split(' ')) }}
 {% endif %}
 
-# Clean up
-RUN apt-get clean -y            && \
-    apt-get autoclean -y        && \
-    apt-get autoremove -y       && \
-    rm -rf /debs                   \
-           /python-wheels          \
-           ~/.cache
+{{ cleanup_apt_and_python_cache() }}
 
 COPY ["docker-lldp-init.sh", "/usr/bin/"]
 COPY ["start.sh", "/usr/bin/"]

--- a/dockers/docker-macsec/Dockerfile.j2
+++ b/dockers/docker-macsec/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -17,10 +17,7 @@ RUN apt-get update
 {{ install_debian_packages(docker_macsec_debs.split(' ')) }}
 {%- endif %}
 
-RUN apt-get clean -y      && \
-    apt-get autoclean -y  && \
-    apt-get autoremove -y && \
-    rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]

--- a/dockers/docker-mux/Dockerfile.j2
+++ b/dockers/docker-mux/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -19,11 +19,7 @@ RUN apt-get update &&       \
 {{ install_debian_packages(docker_mux_debs.split(' ')) }}
 {%- endif %}
 
-## Clean up
-RUN apt-get clean -y        && \
-    apt-get autoclean -y    && \
-    apt-get autoremove -y   && \
-    rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 COPY ["docker-init.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]

--- a/dockers/docker-nat/Dockerfile.j2
+++ b/dockers/docker-nat/Dockerfile.j2
@@ -1,10 +1,8 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-swss-layer-buster-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%syslogtag%/;" /etc/rsyslog.conf
-
-RUN echo
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -32,7 +30,6 @@ COPY ["restore_nat_entries.py", "/usr/bin/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-swss-layer-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -60,11 +60,9 @@ RUN apt-get remove -y gcc
 # Clean up
 RUN apt-get purge -y          \
         build-essential       \
-        python3-dev        && \
-    apt-get clean -y       && \
-    apt-get autoclean -y   && \
-    apt-get autoremove -y  && \
-    rm -rf /debs ~/.cache
+        python3-dev
+
+{{ cleanup_apt_and_python_cache() }}
 
 COPY ["files/arp_update", "/usr/bin"]
 COPY ["arp_update.conf", "files/arp_update_vars.j2", "/usr/share/sonic/templates/"]

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -73,13 +73,9 @@ RUN pip3 install libpci
 # Clean up
 RUN apt-get purge -y           \
         build-essential        \
-        python3-dev         && \
-    apt-get clean -y        && \
-    apt-get autoclean -y    && \
-    apt-get autoremove -y   && \
-    rm -rf /debs               \
-           /python-wheels      \
-           ~/.cache
+        python3-dev
+
+{{ cleanup_apt_and_python_cache() }}
 
 COPY ["lm-sensors.sh", "/usr/bin/"]
 COPY ["docker-pmon.supervisord.conf.j2", "docker_init.j2", "/usr/share/sonic/templates/"]

--- a/dockers/docker-router-advertiser/Dockerfile.j2
+++ b/dockers/docker-router-advertiser/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -25,11 +25,7 @@ RUN apt-get -y install radvd
 {{ install_debian_packages(docker_router_advertiser_debs.split(' ')) }}
 {%- endif %}
 
-# Clean up
-RUN apt-get clean -y        && \
-    apt-get autoclean -y    && \
-    apt-get autoremove -y   && \
-    rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["docker-init.sh", "/usr/bin/"]

--- a/dockers/docker-sflow/Dockerfile.j2
+++ b/dockers/docker-sflow/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-swss-layer-buster-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -20,10 +20,7 @@ RUN apt-get update      && \
 {{ install_debian_packages(docker_sflow_debs.split(' ')) }}
 {%- endif %}
 
-RUN apt-get clean -y      && \
-    apt-get autoclean -y  && \
-    apt-get autoremove -y && \
-    rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 RUN sed -ri '/^DAEMON_ARGS=""/c DAEMON_ARGS="-c /var/log/hsflowd.crash"' /etc/init.d/hsflowd
 

--- a/dockers/docker-snmp/Dockerfile.j2
+++ b/dockers/docker-snmp/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python3_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python3_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -60,12 +60,9 @@ RUN python3 -m sonic_ax_impl install
 RUN apt-get -y purge     \
         python3-dev      \
         gcc              \
-        make                && \
-    apt-get clean -y        && \
-    apt-get autoclean -y    && \
-    apt-get autoremove -y --purge && \
-    find / | grep -E "__pycache__" | xargs rm -rf && \
-    rm -rf /debs /python-wheels ~/.cache
+        make
+
+{{ cleanup_apt_and_python_cache() }}
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["snmp_yml_to_configdb.py", "/usr/bin/"]

--- a/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-buster-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -17,23 +18,17 @@ RUN pip3 install connexion==2.7.0 \
                  six==1.11.0 \
                  urllib3==1.26.5
 
-COPY \
-{% for deb in docker_sonic_mgmt_framework_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
+# Copy locally-built Debian package dependencies
+{{ copy_files("debs/", docker_sonic_mgmt_framework_debs.split(' '), "/debs/") }}
 
-RUN dpkg -i \
-{% for deb in docker_sonic_mgmt_framework_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor %}
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_sonic_mgmt_framework_debs.split(' ')) }}
 
 COPY ["start.sh", "rest-server.sh", "/usr/bin/"]
 COPY ["mgmt_vars.j2", "/usr/share/sonic/templates/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 
 RUN apt-get remove -y g++ python3-dev
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs ~/.cache
+{{ cleanup_apt_and_python_cache() }}
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-sonic-p4rt/Dockerfile.j2
+++ b/dockers/docker-sonic-p4rt/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -18,10 +18,7 @@ RUN apt-get update
 {{ install_debian_packages(docker_sonic_p4rt_debs.split(' ')) }}
 {%- endif %}
 
-RUN apt-get clean -y      && \
-    apt-get autoclean -y  && \
-    apt-get autoremove -y && \
-    rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 COPY ["start.sh", "p4rt.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]

--- a/dockers/docker-sonic-restapi/Dockerfile.j2
+++ b/dockers/docker-sonic-restapi/Dockerfile.j2
@@ -17,8 +17,7 @@ RUN apt-get update
 {{ install_debian_packages( docker_sonic_restapi_debs.split(' ')) }}
 {%- endif %}
 
-## Clean up
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
+{{ cleanup_apt_and_python_cache() }}
 
 COPY ["start.sh", "restapi.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]

--- a/dockers/docker-sonic-telemetry/Dockerfile.j2
+++ b/dockers/docker-sonic-telemetry/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -21,10 +21,7 @@ RUN apt-get update
 {{ install_debian_packages(docker_sonic_telemetry_debs.split(' ')) }}
 {%- endif %}
 
-RUN apt-get clean -y      && \
-    apt-get autoclean -   && \
-    apt-get autoremove -y && \
-    rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 COPY ["start.sh", "telemetry.sh", "dialout.sh", "/usr/bin/"]
 COPY ["telemetry_vars.j2", "/usr/share/sonic/templates/"]

--- a/dockers/docker-swss-layer-bullseye/Dockerfile.j2
+++ b/dockers/docker-swss-layer-bullseye/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ## Make apt-get non-interactive
@@ -16,9 +16,6 @@ RUN apt-get install iputils-ping
 {{ install_debian_packages(docker_swss_layer_bullseye_debs.split(' ')) }}
 {%- endif %}
 
-RUN apt-get clean -y      && \
-    apt-get autoclean -y  && \
-    apt-get autoremove -y && \
-    rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-swss-layer-buster/Dockerfile.j2
+++ b/dockers/docker-swss-layer-buster/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-buster-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ## Make apt-get non-interactive
@@ -16,9 +16,6 @@ RUN apt-get install iputils-ping
 {{ install_debian_packages(docker_swss_layer_buster_debs.split(' ')) }}
 {%- endif %}
 
-RUN apt-get clean -y      && \
-    apt-get autoclean -y  && \
-    apt-get autoremove -y && \
-    rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-teamd/Dockerfile.j2
+++ b/dockers/docker-teamd/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-swss-layer-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -17,10 +17,7 @@ RUN apt-get update
 {{ install_debian_packages(docker_teamd_debs.split(' ')) }}
 {%- endif %}
 
-RUN apt-get clean -y      && \
-    apt-get autoclean -y  && \
-    apt-get autoremove -y && \
-    rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]

--- a/dockers/dockerfile-macros.j2
+++ b/dockers/dockerfile-macros.j2
@@ -37,3 +37,10 @@ COPY \
     {%- endfor %}
     {{ dest }}
 {%- endmacro %}
+
+{% macro cleanup_apt_and_python_cache() -%}
+RUN apt-get clean -y                     && \
+    apt-get autoclean -y                 && \
+    apt-get autoremove -y                && \
+    rm -rf /debs /python-wheels /tmp/* ~/.cache /var/lib/apt/lists/*
+{%- endmacro %}

--- a/platform/broadcom/docker-syncd-brcm-dnx/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm-dnx/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -10,11 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 
-COPY \
-{% for deb in docker_syncd_brcm_dnx_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
+{{ copy_files("debs/", docker_syncd_brcm_dnx_debs.split(' '), "/debs/") }}
 
 # Install locally-built Debian packages and implicitly install their dependencies
 {{ install_debian_packages(docker_syncd_brcm_dnx_debs.split(' ')) }}
@@ -32,8 +28,6 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor/"]
 
-## Clean up
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/broadcom/docker-syncd-brcm/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -10,11 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 
-COPY \
-{% for deb in docker_syncd_brcm_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
+{{ copy_files("debs/", docker_syncd_brcm_debs.split(' '), "/debs/") }}
 
 # Install locally-built Debian packages and implicitly install their dependencies
 {{ install_debian_packages(docker_syncd_brcm_debs.split(' ')) }}
@@ -32,8 +28,6 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor/"]
 
-## Clean up
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/components/docker-gbsyncd-broncos/Dockerfile.j2
+++ b/platform/components/docker-gbsyncd-broncos/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -36,8 +37,6 @@ COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["files/dsserve", "/usr/bin/"]
 RUN chmod +x /usr/bin/dsserve
 
-## Clean up
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 ENTRYPOINT ["/usr/bin/docker-init.sh"]

--- a/platform/components/docker-gbsyncd-credo/Dockerfile.j2
+++ b/platform/components/docker-gbsyncd-credo/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -34,8 +35,6 @@ COPY ["supervisord.conf.j2", "/usr/share/sonic/templates"]
 
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 
-## Clean up
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 ENTRYPOINT ["/usr/bin/docker-init.sh"]

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -6,6 +6,7 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get update
 RUN apt-get install -y gnupg
 COPY ["sonic-dev.gpg.key", "/etc/apt/"]
 RUN apt-key add /etc/apt/sonic-dev.gpg.key

--- a/platform/vs/docker-syncd-vs/Dockerfile.j2
+++ b/platform/vs/docker-syncd-vs/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-buster-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
@@ -11,16 +12,11 @@ RUN apt-get update
 
 RUN apt-get install -f -y libcap2-bin
 
-COPY \
-{% for deb in docker_syncd_vs_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
+# Copy locally-built Debian package dependencies
+{{ copy_files("debs/", docker_sonic_vs_debs.split(' '), "/debs/") }}
 
-RUN dpkg -i \
-{% for deb in docker_syncd_vs_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor %} || apt-get install -f -y
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_syncd_vs_debs.split(' ')) }}
 
 COPY ["start.sh", "/usr/bin/"]
 
@@ -28,8 +24,6 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor/"]
 
-## Clean up
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
+{{ cleanup_apt_and_python_cache() }}
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/vs/docker-syncd-vs/Dockerfile.j2
+++ b/platform/vs/docker-syncd-vs/Dockerfile.j2
@@ -13,7 +13,7 @@ RUN apt-get update
 RUN apt-get install -f -y libcap2-bin
 
 # Copy locally-built Debian package dependencies
-{{ copy_files("debs/", docker_sonic_vs_debs.split(' '), "/debs/") }}
+{{ copy_files("debs/", docker_syncd_vs_debs.split(' '), "/debs/") }}
 
 # Install locally-built Debian packages and implicitly install their dependencies
 {{ install_debian_packages(docker_syncd_vs_debs.split(' ')) }}


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Remove the apt package lists (`/var/lib/apt/lists`) from the docker containers. This saves about 100MB.

Also, make a macro to clean up the apt and python cache that can then be used in all of the containers. This helps make the cleanup be consistent across all containers.

#### How I did it

#### How to verify it

Build an image, and note that each docker gz file is less than 200MB (current images have most of the docker gz files above 200MB):

```
-rw-r--r-- 1 sarcot sarcot  95587809 Mar 21 18:58 target/docker-base-bullseye.gz
-rw-r--r-- 1 sarcot sarcot 121847481 Mar 21 19:00 target/docker-config-engine-bullseye.gz
-rw-r--r-- 1 sarcot sarcot 122039910 Mar 21 19:02 target/docker-database.gz
-rw-r--r-- 1 sarcot sarcot 124956680 Mar 21 19:08 target/docker-dhcp-relay.gz
-rw-r--r-- 1 sarcot sarcot 135939759 Mar 21 19:07 target/docker-fpm-frr.gz
-rw-r--r-- 1 sarcot sarcot 134411584 Mar 21 20:56 target/docker-gbsyncd-broncos.gz
-rw-r--r-- 1 sarcot sarcot 127840601 Mar 21 20:56 target/docker-gbsyncd-credo.gz
-rw-r--r-- 1 sarcot sarcot 138654894 Mar 21 19:02 target/docker-lldp.gz
-rw-r--r-- 1 sarcot sarcot 132437319 Mar 21 19:08 target/docker-orchagent.gz
-rw-r--r-- 1 sarcot sarcot 163295295 Mar 21 19:05 target/docker-platform-monitor.gz
-rw-r--r-- 1 sarcot sarcot 122046052 Mar 21 19:02 target/docker-router-advertiser.gz
-rw-r--r-- 1 sarcot sarcot 137104660 Mar 21 19:05 target/docker-snmp.gz
-rw-r--r-- 1 sarcot sarcot 150472454 Mar 21 19:04 target/docker-sonic-telemetry.gz
-rw-r--r-- 1 sarcot sarcot 127343877 Mar 21 19:02 target/docker-swss-layer-bullseye.gz
-rw-r--r-- 1 sarcot sarcot 184879471 Mar 21 19:08 target/docker-syncd-brcm-dnx.gz
-rw-r--r-- 1 sarcot sarcot 192225190 Mar 21 19:05 target/docker-syncd-brcm.gz
-rw-r--r-- 1 sarcot sarcot 127573799 Mar 21 19:07 target/docker-teamd.gz
```

Also, the images themselves are smaller (this is with NAT, sflow, and sonic-mgmt-framework containers disabled):

```
-rwxr-xr-x 1 sarcot sarcot 839001796 Mar 21 21:24 target/sonic-aboot-broadcom.swi
-rwxr-xr-x 1 sarcot sarcot 838350738 Mar 21 21:05 target/sonic-broadcom.bin
```


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

