### PR TITLE
Fix thread_cancel crash

### DIFF
--- a/src/sonic-frr/patch/0014-fix-bug-of-thread_cancel-will-lead-to-core-dump.patch
+++ b/src/sonic-frr/patch/0014-fix-bug-of-thread_cancel-will-lead-to-core-dump.patch
@@ -1,0 +1,17 @@
+diff --git a/lib/thread.c b/lib/thread.c
+old mode 100644
+new mode 100755
+index b1224c02e..6ce085f11
+--- a/lib/thread.c
++++ b/lib/thread.c
+@@ -1358,8 +1358,10 @@ static void do_thread_cancel(struct thread_master *master)
+ 
+ 		if (list) {
+ 			thread_list_del(list, thread);
++			list = NULL;
+ 		} else if (thread_array) {
+ 			thread_array[thread->u.fd] = NULL;
++			thread_array = NULL;
+ 		}
+ 
+ 		if (thread->ref)

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -13,3 +13,4 @@ cross-compile-changes.patch
 0011-bgpd-enhanced-capability-is-always-turned-on-for-int.patch
 0012-Ensure-ospf_apiclient_lsa_originate-cannot-accidently-write-into-stack.patch
 0013-zebra-fix-dplane-fpm-nl-to-allow-for-fast-configuration.patch
+0014-fix-bug-of-thread_cancel-will-lead-to-core-dump.patch


### PR DESCRIPTION
#### Why I did it
fixes thread_cancel will lead to core dump, make thread pointer to NULL while deleting it.
#### How I did it
make pointer list and thr in `do_thread_cancel()` to NULL
#### How to verify it
check list and thread_array is NULL
#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [X ] 202205
- [ ] 202211

#### Description for the changelog
make pointer list and thr in `do_thread_cancel()` to NULL

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)
ｧ　 ∧＿∧　ｧ,､
,､’`（　´∀｀）　,､’`
‘` 　( ⊃ ⊂)　　’`

