### PR TITLE
[Edgecore][PDDF/AS5835-54T] Support PDDF

### DIFF
--- a/device/accton/x86_64-accton_as5835_54t-r0/installer.conf
+++ b/device/accton/x86_64-accton_as5835_54t-r0/installer.conf
@@ -1,3 +1,4 @@
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
 CONSOLE_SPEED=115200
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="pcie_aspm=off intel_iommu=off modprobe.blacklist=i2c-ismt,i2c_ismt,i2c-i801,i2c_i801"

--- a/device/accton/x86_64-accton_as5835_54t-r0/pcie.yaml
+++ b/device/accton/x86_64-accton_as5835_54t-r0/pcie.yaml
@@ -1,0 +1,161 @@
+- bus: '00'
+  dev: '00'
+  fn: '0'
+  id: '1980'
+  name: 'Host bridge: Intel Corporation Atom Processor C3000 Series System Agent (rev
+    11)'
+- bus: '00'
+  dev: '04'
+  fn: '0'
+  id: 19a1
+  name: 'Host bridge: Intel Corporation Atom Processor C3000 Series Error Registers
+    (rev 11)'
+- bus: '00'
+  dev: '05'
+  fn: '0'
+  id: 19a2
+  name: 'Generic system peripheral [0807]: Intel Corporation Atom Processor C3000
+    Series Root Complex Event Collector (rev 11)'
+- bus: '00'
+  dev: '06'
+  fn: '0'
+  id: 19a3
+  name: 'PCI bridge: Intel Corporation Atom Processor C3000 Series Integrated QAT
+    Root Port (rev 11)'
+- bus: '00'
+  dev: 09
+  fn: '0'
+  id: 19a4
+  name: 'PCI bridge: Intel Corporation Atom Processor C3000 Series PCI Express Root
+    Port #0 (rev 11)'
+- bus: '00'
+  dev: 0b
+  fn: '0'
+  id: 19a6
+  name: 'PCI bridge: Intel Corporation Atom Processor C3000 Series PCI Express Root
+    Port #2 (rev 11)'
+- bus: '00'
+  dev: 0e
+  fn: '0'
+  id: 19a8
+  name: 'PCI bridge: Intel Corporation Atom Processor C3000 Series PCI Express Root
+    Port #4 (rev 11)'
+- bus: '00'
+  dev: '10'
+  fn: '0'
+  id: 19aa
+  name: 'PCI bridge: Intel Corporation Atom Processor C3000 Series PCI Express Root
+    Port #6 (rev 11)'
+- bus: '00'
+  dev: '12'
+  fn: '0'
+  id: 19ac
+  name: 'System peripheral: Intel Corporation Atom Processor C3000 Series SMBus Contoller
+    - Host (rev 11)'
+- bus: '00'
+  dev: '13'
+  fn: '0'
+  id: 19b2
+  name: 'SATA controller: Intel Corporation Atom Processor C3000 Series SATA Controller
+    0 (rev 11)'
+- bus: '00'
+  dev: '15'
+  fn: '0'
+  id: 19d0
+  name: 'USB controller: Intel Corporation Atom Processor C3000 Series USB 3.0 xHCI
+    Controller (rev 11)'
+- bus: '00'
+  dev: '16'
+  fn: '0'
+  id: 19d1
+  name: 'PCI bridge: Intel Corporation Atom Processor C3000 Series Integrated LAN
+    Root Port #0 (rev 11)'
+- bus: '00'
+  dev: '17'
+  fn: '0'
+  id: 19d2
+  name: 'PCI bridge: Intel Corporation Atom Processor C3000 Series Integrated LAN
+    Root Port #1 (rev 11)'
+- bus: '00'
+  dev: '18'
+  fn: '0'
+  id: 19d3
+  name: 'Communication controller: Intel Corporation Atom Processor C3000 Series ME
+    HECI 1 (rev 11)'
+- bus: '00'
+  dev: 1a
+  fn: '0'
+  id: 19d8
+  name: 'Serial controller: Intel Corporation Atom Processor C3000 Series HSUART Controller
+    (rev 11)'
+- bus: '00'
+  dev: 1a
+  fn: '1'
+  id: 19d8
+  name: 'Serial controller: Intel Corporation Atom Processor C3000 Series HSUART Controller
+    (rev 11)'
+- bus: '00'
+  dev: 1a
+  fn: '2'
+  id: 19d8
+  name: 'Serial controller: Intel Corporation Atom Processor C3000 Series HSUART Controller
+    (rev 11)'
+- bus: '00'
+  dev: 1f
+  fn: '0'
+  id: 19dc
+  name: 'ISA bridge: Intel Corporation Atom Processor C3000 Series LPC or eSPI (rev
+    11)'
+- bus: '00'
+  dev: 1f
+  fn: '1'
+  id: 19dd
+  name: 'Memory controller: Intel Corporation Atom Processor C3000 Series Primary
+    to Side Band (P2SB) Bridge (rev 11)'
+- bus: '00'
+  dev: 1f
+  fn: '2'
+  id: 19de
+  name: 'Memory controller: Intel Corporation Atom Processor C3000 Series Power Management
+    Controller (rev 11)'
+- bus: '00'
+  dev: 1f
+  fn: '4'
+  id: 19df
+  name: 'SMBus: Intel Corporation Atom Processor C3000 Series SMBus controller (rev
+    11)'
+- bus: '00'
+  dev: 1f
+  fn: '5'
+  id: 19e0
+  name: 'Serial bus controller [0c80]: Intel Corporation Atom Processor C3000 Series
+    SPI Controller (rev 11)'
+- bus: '01'
+  dev: '00'
+  fn: '0'
+  id: 19e2
+  name: 'Co-processor: Intel Corporation Atom Processor C3000 Series QuickAssist Technology
+    (rev 11)'
+- bus: '02'
+  dev: '00'
+  fn: '0'
+  id: b771
+  name: 'Ethernet controller: Broadcom Inc. and subsidiaries Device b771 (rev 01)'
+- bus: '05'
+  dev: '00'
+  fn: '0'
+  id: '1533'
+  name: 'Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev
+    03)'
+- bus: '06'
+  dev: '00'
+  fn: '0'
+  id: 15c2
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection X553 Backplane
+    (rev 11)'
+- bus: 08
+  dev: '00'
+  fn: '0'
+  id: 15e5
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection X553 1GbE (rev
+    11)'

--- a/device/accton/x86_64-accton_as5835_54t-r0/pddf/pd-plugin.json
+++ b/device/accton/x86_64-accton_as5835_54t-r0/pddf/pd-plugin.json
@@ -1,0 +1,67 @@
+{
+    
+    "XCVR":
+    {
+        "xcvr_present":
+        {
+           "i2c":
+           {
+               "valmap-SFP": {"1":true, "0":false },
+               "valmap-SFP28": {"1":true, "0":false },
+               "valmap-QSFP28": {"1":true, "0":false}
+           }
+        }
+    },
+    "PSU":
+    {
+        "psu_present": 
+        {
+            "i2c":
+            {
+                "valmap": { "1":true, "0":false }
+            }
+        },
+
+        "psu_power_good": 
+        {
+            "i2c":
+            {
+                "valmap": { "1": true, "0":false }
+            }
+        },
+
+        "psu_fan_dir":
+        {
+            "i2c":
+            {
+                "valmap": { "F2B":"exhaust", "B2F":"intake" }
+            }
+        },
+
+        "PSU_FAN_MAX_SPEED":"18000"
+    },
+
+    "FAN":
+    {
+        "direction":
+        {
+            "i2c":
+            {
+                "valmap": {"1":"intake", "0":"exhaust"}
+            }
+        },
+
+        "present":
+        {
+            "i2c":
+            {
+                "valmap": {"1":true, "0":false}
+            }
+        },
+
+        "duty_cycle_to_pwm": "lambda dc: (dc/5)",
+
+        "pwm_to_duty_cycle": "lambda pwm: (pwm*5)"
+    }
+
+}

--- a/device/accton/x86_64-accton_as5835_54t-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as5835_54t-r0/pddf/pddf-device.json
@@ -1,0 +1,720 @@
+{
+    "PLATFORM":
+    {
+        "num_psus":2,
+        "num_fantrays":5,
+        "num_fans_pertray":2,
+        "num_ports":54,
+        "num_temps": 5,
+        "pddf_dev_types":
+        {
+            "description":"AS5835-54T - Below is the list of supported PDDF device types (chip names) for various components. If any component uses some other driver, we will create the client using 'echo <dev-address> <dev-type> > <path>/new_device' method",
+            "CPLD":
+            [
+                "i2c_cpld"
+            ],
+            "PSU":
+            [
+                "psu_eeprom",
+                "psu_pmbus"
+            ],
+            "FAN":
+            [
+                "fan_ctrl",
+                "fan_eeprom"
+            ],
+            "PORT_MODULE":
+            [
+                "pddf_xcvr"
+            ]            
+        },
+        "std_kos":
+        [
+            "i2c-i801",
+            "i2c-ismt",
+            "i2c_dev",
+            "i2c_mux_pca954x",
+            "optoe"
+        ],
+        "pddf_kos":
+        [
+            "pddf_client_module",
+            "pddf_cpld_module",
+            "pddf_cpld_driver",
+            "pddf_mux_module",
+            "pddf_xcvr_module",
+            "pddf_xcvr_driver_module",
+            "pddf_psu_driver_module",
+            "pddf_psu_module",
+            "pddf_fan_driver_module",
+            "pddf_fan_module",
+            "pddf_led_module",
+            "pddf_sysstatus_module"
+        ],
+        "custom_kos":
+        [
+            "pddf_custom_psu"
+        ]
+    },
+
+    "SYSTEM":
+    {
+        "dev_info": {"device_type":"CPU", "device_name":"ROOT_COMPLEX", "device_parent":null},
+        "i2c":
+        {
+            "CONTROLLERS":
+            [ 
+                { "dev_name":"i2c-1", "dev":"SMBUS1" }
+            ]
+        }
+    },
+    
+    "SMBUS1": 
+    {
+        "dev_info": {"device_type": "SMBUS", "device_name": "SMBUS1", "device_parent": "SYSTEM"},
+        "i2c": 
+        {
+            "topo_info": {"dev_addr": "0x1"},
+            "DEVICES": 
+            [
+                {"dev": "EEPROM1"},
+                {"dev": "CPU_CPLD"},
+                {"dev": "MUX1"}
+            ]
+        }
+    },
+  
+    "EEPROM1": 
+    {
+        "dev_info": {"device_type": "EEPROM", "device_name": "EEPROM1", "device_parent": "SMBUS1"},
+        "i2c": 
+        {
+            "topo_info": {"parent_bus": "0x1", "dev_addr": "0x57", "dev_type": "24c02"},
+            "dev_attr": {"access_mode": "BLOCK"},
+            "attr_list": [
+                {"attr_name": "eeprom"}
+            ]
+        }
+    },
+    
+    "CPU_CPLD":
+    {
+        "dev_info": { "device_type":"CPLD", "device_name":"CPU_CPLD", "device_parent":"SMBUS1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1", "dev_addr":"0x65", "dev_type":"i2c_cpld"},
+            "dev_attr": { }
+        }
+    },
+    
+    "MUX1":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX1", "device_parent":"SMBUS1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1", "dev_addr":"0x77", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x2", "idle_state":"-2"},
+             "channel":
+            [
+                { "chn":"0", "dev":"MUX2" },
+                { "chn":"0", "dev":"MUX3" },
+                { "chn":"0", "dev":"MUX4" },
+                { "chn":"1", "dev":"CPLD1" },
+                { "chn":"1", "dev":"CPLD2" },
+                { "chn":"1", "dev":"CPLD3" },
+                { "chn":"1", "dev":"FAN-CTRL" }
+            ]
+        }
+    },
+    
+    "CPLD1":
+    {
+        "dev_info": { "device_type":"CPLD", "device_name":"CPLD1", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3", "dev_addr":"0x60", "dev_type":"i2c_cpld"},
+            "dev_attr":{}
+        }
+    },
+    "CPLD2":
+    {
+        "dev_info": { "device_type":"CPLD", "device_name":"CPLD2", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3", "dev_addr":"0x61", "dev_type":"i2c_cpld"},
+            "dev_attr":{}
+        }
+    },
+    "CPLD3":
+    {
+        "dev_info": { "device_type":"CPLD", "device_name":"CPLD3", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3", "dev_addr":"0x62", "dev_type":"i2c_cpld"},
+            "dev_attr":{}
+        }
+    },
+    "FAN-CTRL":
+    {
+        "dev_info": { "device_type":"FAN", "device_name":"FAN-CTRL", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3", "dev_addr":"0x63", "dev_type":"fan_ctrl"},
+            "dev_attr": { "num_fantrays":"5"},
+            "attr_list":
+            [
+                { "attr_name":"fan1_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan2_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},               
+                { "attr_name":"fan3_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan4_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},               
+                { "attr_name":"fan5_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan6_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},               
+                { "attr_name":"fan7_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x8", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan8_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x8", "attr_cmpval":"0x0", "attr_len":"1"},               
+                { "attr_name":"fan9_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02", "attr_mask":"0x10", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan10_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x02","attr_mask":"0x10", "attr_cmpval":"0x0", "attr_len":"1"},              
+                { "attr_name":"fan1_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x1", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"fan2_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x1", "attr_cmpval":"0x1", "attr_len":"1"},               
+                { "attr_name":"fan3_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x2", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"fan4_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x2", "attr_cmpval":"0x2", "attr_len":"1"},               
+                { "attr_name":"fan5_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x4", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"fan6_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x4", "attr_cmpval":"0x4", "attr_len":"1"},               
+                { "attr_name":"fan7_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x8", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"fan8_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x8", "attr_cmpval":"0x8", "attr_len":"1"},               
+                { "attr_name":"fan9_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x10", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"fan10_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x03", "attr_mask":"0x10", "attr_cmpval":"0x10", "attr_len":"1"},               
+                { "attr_name":"fan1_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x07", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150", "attr_is_divisor":0},
+                { "attr_name":"fan2_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0C", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150", "attr_is_divisor":0},               
+                { "attr_name":"fan3_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x08", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150", "attr_is_divisor":0},
+                { "attr_name":"fan4_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0D", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150", "attr_is_divisor":0},               
+                { "attr_name":"fan5_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x09", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150", "attr_is_divisor":0},
+                { "attr_name":"fan6_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0E", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150", "attr_is_divisor":0},               
+                { "attr_name":"fan7_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0A", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150" , "attr_is_divisor":0},
+                { "attr_name":"fan8_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0F", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150" , "attr_is_divisor":0},               
+                { "attr_name":"fan9_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0B", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150" , "attr_is_divisor":0},
+                { "attr_name":"fan10_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"150" , "attr_is_divisor":0},               
+                { "attr_name":"fan1_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan2_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan3_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan4_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan5_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan6_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan7_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan8_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan9_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" },
+                { "attr_name":"fan10_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x06", "attr_mask":"0x1F", "attr_len":"1" }
+            ]
+        }
+    },
+    
+    
+    "MUX2":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX2", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2", "dev_addr":"0x70", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0xa", "idle_state":"-2"},
+            "channel":
+            [
+                { "chn":"1", "dev":"PSU1" },
+                { "chn":"2", "dev":"PSU2" }
+            ]
+        }
+    },
+     "PSU1":
+    {
+        "dev_info": { "device_type":"PSU", "device_name":"PSU1", "device_parent":"MUX2"}, 
+        "dev_attr": { "dev_idx":"1", "num_psu_fans": "1"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"pmbus", "dev":"PSU1-PMBUS" },
+                { "itf":"eeprom", "dev":"PSU1-EEPROM" }
+            ]
+        }
+    },
+
+    "PSU1-PMBUS":
+    {
+        "dev_info": { "device_type":"PSU-PMBUS", "device_name":"PSU1-PMBUS", "device_parent":"MUX2", "virt_parent":"PSU1"},
+        "i2c":
+        {
+            "topo_info":{ "parent_bus":"0xb", "dev_addr":"0x58", "dev_type":"psu_pmbus"}, 
+            "attr_list": 
+            [  
+                { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+                { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x2", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"psu_mfr_id", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+                { "attr_name":"psu_fan_dir", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
+                { "attr_name":"psu_v_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8b", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_v_out_min", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xa4", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_v_out_max", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xa5", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_i_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_p_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x96", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_p_out_max", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xa7", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_fan1_speed_rpm", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x90", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_temp1_input", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8d", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_temp1_high_threshold", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xa8", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
+            ]
+        }
+    },
+
+    "PSU1-EEPROM":
+    {
+        "dev_info": { "device_type":"PSU-EEPROM", "device_name":"PSU1-EEPROM", "device_parent":"MUX2", "virt_parent":"PSU1"},
+        "i2c":
+        {
+            "topo_info":{ "parent_bus":"0xb", "dev_addr":"0x50", "dev_type":"psu_eeprom"}, 
+            "attr_list": 
+            [  
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"19" }
+            ]
+        }
+    },
+
+    "PSU2":
+    {
+        "dev_info": { "device_type":"PSU", "device_name":"PSU2", "device_parent":"MUX2" },
+        "dev_attr": { "dev_idx":"2", "num_psu_fans":"1"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"pmbus", "dev":"PSU2-PMBUS"},
+                { "itf":"eeprom", "dev":"PSU2-EEPROM" }
+            ]
+        }
+    },
+
+    "PSU2-PMBUS":
+    {
+        "dev_info": {"device_type":"PSU-PMBUS", "device_name":"PSU2-PMBUS", "device_parent":"MUX2", "virt_parent":"PSU2"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0xc", "dev_addr":"0x5b", "dev_type":"psu_pmbus"},
+            "attr_list": 
+            [  
+                { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x10", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+                { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x20", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"psu_mfr_id", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+                { "attr_name":"psu_fan_dir", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
+                { "attr_name":"psu_v_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8b", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_v_out_min", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xa4", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_v_out_max", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xa5", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_i_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_p_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x96", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_p_out_max", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xa7", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_fan1_speed_rpm", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x90", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_temp1_input", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8d", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_temp1_high_threshold", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xa8", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
+            ]
+        }
+    },
+    
+    "PSU2-EEPROM":
+    {
+        "dev_info": { "device_type":"PSU-EEPROM", "device_name":"PSU2-EEPROM", "device_parent":"MUX2", "virt_parent":"PSU2"},
+        "i2c":
+        {
+            "topo_info":{ "parent_bus":"0xc", "dev_addr":"0x53", "dev_type":"psu_eeprom"}, 
+            "attr_list": 
+            [  
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x53", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"19" }
+            ]
+        }
+    },
+    
+    
+    "MUX4":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX4", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2", "dev_addr":"0x71", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x1a", "idle_state":"-2"},
+            "channel":
+            [               
+                { "chn":"0", "dev":"TEMP1" },
+                { "chn":"1", "dev":"TEMP2" },
+                { "chn":"2", "dev":"TEMP3" },
+                { "chn":"3", "dev":"TEMP4" }
+            ]
+        }
+    },
+    
+    "TEMP1" :
+    {
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP1", "device_parent":"MUX4"},
+        "dev_attr": { "display_name":"CB_temp(0x4B)"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1a", "dev_addr":"0x4B", "dev_type":"lm75"},
+            "attr_list":
+            [
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+                { "attr_name": "temp1_max_hyst"},
+                { "attr_name": "temp1_input"}
+            ]
+        }
+    },
+     "TEMP2" :
+    {
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP2", "device_parent":"MUX4"},
+        "dev_attr": { "display_name":"MB_FrontMiddle_temp(0x4C)"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1b", "dev_addr":"0x4C", "dev_type":"lm75"},
+            "attr_list":
+            [
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+                { "attr_name": "temp1_max_hyst"},
+                { "attr_name": "temp1_input"}
+            ]
+        }
+    },
+     "TEMP3" :
+    {
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP3", "device_parent":"MUX4"},
+        "dev_attr": { "display_name":"MB_RearLeft_temp(0x49)"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1c", "dev_addr":"0x49", "dev_type":"lm75"},
+            "attr_list":
+            [
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+                { "attr_name": "temp1_max_hyst"},
+                { "attr_name": "temp1_input"}
+            ]
+        }
+    },
+    "TEMP4" :
+    {
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP4", "device_parent":"MUX4"},
+        "dev_attr": { "display_name":"MB_RearLeft_temp(0x4A)"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1d", "dev_addr":"0x4A", "dev_type":"lm75"},
+            "attr_list":
+            [
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+                { "attr_name": "temp1_max_hyst"},
+                { "attr_name": "temp1_input"}
+            ]
+        }
+    },
+    "TEMP5" :
+    {
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP5"},
+        "dev_attr": { "display_name":"coretemp-isa-0000"},
+        "i2c":
+        {
+            "path_info": {"sysfs_base_path": "/sys/class/hwmon/hwmon1"},
+            "attr_list":
+            [
+                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp1_crit"},
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+                { "attr_name": "temp1_input"}
+            ]
+        }
+    },
+    
+     "MUX3":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX3", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2", "dev_addr":"0x72", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x12", "idle_state":"-2"},
+            "channel":
+            [
+                { "chn":"0", "dev":"PORT51" },
+                { "chn":"1", "dev":"PORT54" },
+                { "chn":"2", "dev":"PORT49" },
+                { "chn":"3", "dev":"PORT50" },
+                { "chn":"4", "dev":"PORT52" },
+                { "chn":"5", "dev":"PORT53" }
+            ]
+        }
+    },
+    
+    "PORT51":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT51", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"51"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT51-EEPROM" },
+                { "itf":"control", "dev":"PORT51-CTRL" }
+            ]
+        }
+    },
+    "PORT51-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT51-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT51"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x12", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT51-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT51-CTRL", "device_parent":"MUX3", "virt_parent":"PORT51"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x12", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x14", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x15", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x13", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_lpmode", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x16", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"}
+                
+            ]
+        }
+    },
+    
+    "PORT54":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT54", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"54"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT54-EEPROM" },
+                { "itf":"control", "dev":"PORT54-CTRL" }
+            ]
+        }
+    },
+    "PORT54-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT54-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT54"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x13", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT54-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT54-CTRL", "device_parent":"MUX3", "virt_parent":"PORT54"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x13", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x14", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x15", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x13", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_lpmode", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x16", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT49":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT49", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"49"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT49-EEPROM" },
+                { "itf":"control", "dev":"PORT49-CTRL" }
+            ]
+        }
+    },
+    "PORT49-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT49-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT49"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x14", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+    "PORT49-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT49-CTRL", "device_parent":"MUX3", "virt_parent":"PORT49"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x14", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x14", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x15", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x62", "attr_devtype":"cpld","attr_devname":"CPLD3", "attr_offset":"0x13", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_lpmode", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x16", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT50":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT50", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"50"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT50-EEPROM" },
+                { "itf":"control", "dev":"PORT50-CTRL" }
+            ]
+        }
+    },
+    "PORT50-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT50-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT50"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x15", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },
+       
+    "PORT50-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT50-CTRL", "device_parent":"MUX3", "virt_parent":"PORT50"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x15", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x14", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x15", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x62", "attr_devtype":"cpld","attr_devname":"CPLD3", "attr_offset":"0x13", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_lpmode", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x16", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT52":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT52", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"52"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT52-EEPROM" },
+                { "itf":"control", "dev":"PORT52-CTRL" }
+            ]
+        }
+    },
+    "PORT52-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT52-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT52"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x16", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT52-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT52-CTRL", "device_parent":"MUX3", "virt_parent":"PORT52"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x16", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x14", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x15", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x13", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_lpmode", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x16", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"}
+            ]
+        }
+    },
+  
+    "PORT53":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT53", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"53"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT53-EEPROM" },
+                { "itf":"control", "dev":"PORT53-CTRL" }
+            ]
+        }
+    },
+    "PORT53-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT53-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT53"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x17", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT53-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT53-CTRL", "device_parent":"MUX3", "virt_parent":"PORT53"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x17", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x14", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x15", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x13", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_lpmode", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD3", "attr_offset":"0x16", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+            ]
+        }
+    },
+        
+    "LOC_LED":
+    {
+        "dev_info": { "device_type":"LED", "device_name":"LOC_LED"},
+        "dev_attr": { "index":"0", "flag": "rw"},
+        "i2c" :
+        {
+            "attr_list":
+            [
+                {"attr_name":"amber", "descr": "Amber" , "bits" : "5:4",  "value" : "0x0", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x0A"},
+                {"attr_name":"off", "descr": "Off" , "bits" : "5:4",  "value" : "0x1", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x0A"}
+                
+            ]
+        }
+    },
+    "DIAG_LED":
+    {
+        "dev_info": { "device_type":"LED", "device_name":"DIAG_LED"},
+         "dev_attr": { "index":"0", "flag": "rw"},
+         "i2c" :
+         {
+             "attr_list":
+             [
+                 {"attr_name":"green", "descr": "Green" , "bits" : "3:2", "value" : "0x2", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x0A"},
+                 {"attr_name":"amber", "descr": "Amber" , "bits" : "3:2", "value" : "0x1", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x0A"},
+                 {"attr_name":"off",   "descr": "Off" , "bits" : "3:2", "value" : "0x3", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x0A"}
+             ]
+        }
+    }
+}

--- a/device/accton/x86_64-accton_as5835_54t-r0/pmon_daemon_control.json
+++ b/device/accton/x86_64-accton_as5835_54t-r0/pmon_daemon_control.json
@@ -1,5 +1,5 @@
 {
-    "skip_ledd": true,
-    "skip_pcied": true
+    "skip_ledd": true
+
 }
 

--- a/device/accton/x86_64-accton_as5835_54t-r0/system_health_monitoring_config.json
+++ b/device/accton/x86_64-accton_as5835_54t-r0/system_health_monitoring_config.json
@@ -1,0 +1,15 @@
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [
+        "asic",
+        "psu.voltage",
+        "psu.temperature"
+    ],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "amber",
+        "normal": "green",
+        "booting": "off"
+    }
+}

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/service/as5835-54t-pddf-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/service/as5835-54t-pddf-platform-monitor.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Accton AS5835-54T Platform Monitoring service
+Before=pmon.service
+After=pddf-platform-init.service
+DefaultDependencies=no
+
+[Service]
+ExecStart=/usr/local/bin/accton_as5835_54t_pddf_monitor.py
+KillSignal=SIGKILL
+SuccessExitStatus=SIGKILL
+
+# Resource Limitations
+LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/service/pddf-platform-init.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/service/pddf-platform-init.service
@@ -1,0 +1,1 @@
+../../../../pddf/i2c/service/pddf-platform-init.service

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/__init__.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/__init__.py
@@ -1,0 +1,3 @@
+# All the derived classes for PDDF
+__all__ = ["platform", "chassis", "sfp", "psu", "thermal", "fan"]
+from . import platform

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/chassis.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+
+#############################################################################
+# PDDF
+# Module contains an implementation of SONiC Chassis API
+#
+#############################################################################
+
+try:
+    import sys
+    from sonic_platform_pddf_base.pddf_chassis import PddfChassis
+    from .event import SfpEvent
+    from .helper import APIHelper
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+NUM_COMPONENT = 6
+HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
+PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
+REBOOT_CAUSE_FILE = "reboot-cause.txt"
+
+class Chassis(PddfChassis):
+    """
+    PDDF Platform-specific Chassis class
+    """
+
+    SYSLED_DEV_NAME = "DIAG_LED"
+
+    def __init__(self, pddf_data=None, pddf_plugin_data=None):
+        PddfChassis.__init__(self, pddf_data, pddf_plugin_data)
+        self.__initialize_components()
+        self._api_helper = APIHelper()
+        self._sfpevent = SfpEvent(self.get_all_sfps())
+
+    def __initialize_components(self):
+        from sonic_platform.component import Component
+        for index in range(NUM_COMPONENT):
+            component = Component(index)
+            self._component_list.append(component) 
+
+    # Provide the functions/variables below for which implementation is to be overwritten
+    def get_change_event(self, timeout=0):
+        return self._sfpevent.get_sfp_event(timeout)
+
+    def get_reboot_cause(self):
+        """
+        Retrieves the cause of the previous reboot
+        Returns:
+            A tuple (string, string) where the first element is a string
+            containing the cause of the previous reboot. This string must be
+            one of the predefined strings in this class. If the first string
+            is "REBOOT_CAUSE_HARDWARE_OTHER", the second string can be used
+            to pass a description of the reboot cause.
+        """
+
+        reboot_cause_path = (HOST_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE)
+        sw_reboot_cause = self._api_helper.read_txt_file(
+            reboot_cause_path) or "Unknown"
+
+
+        return ('REBOOT_CAUSE_NON_HARDWARE', sw_reboot_cause)
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device. If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of entPhysicalContainedIn is '0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
+        """
+        return -1
+
+
+    def get_sfp(self, index):
+        """
+        Retrieves sfp represented by (1-based) index <index>
+
+        Args:
+            index: An integer, the index (1-based) of the sfp to retrieve.
+            The index should be the sequence of a physical port in a chassis,
+            starting from 1.
+            For example, 1 for Ethernet0, 2 for Ethernet4 and so on.
+
+        Returns:
+            An object derived from SfpBase representing the specified sfp
+        """
+        sfp = None
+
+        try:
+            # The index will start from 1
+            sfp = self._sfp_list[index-1]
+        except IndexError:
+            sys.stderr.write("SFP index {} out of range (1-{})\n".format(
+                             index, len(self._sfp_list)))
+        return sfp
+
+    def initizalize_system_led(self):
+        return
+
+    def get_status_led(self):
+        return self.get_system_led(self.SYSLED_DEV_NAME)
+
+    def set_status_led(self, color):
+        return self.set_system_led(self.SYSLED_DEV_NAME, color)
+
+    def get_port_or_cage_type(self, port):
+        from sonic_platform_base.sfp_base import SfpBase
+        if port in range(1, 49):
+            return SfpBase.SFP_PORT_TYPE_BIT_RJ45
+        else:
+            return SfpBase.SFP_PORT_TYPE_BIT_QSFP | SfpBase.SFP_PORT_TYPE_BIT_QSFP_PLUS | SfpBase.SFP_PORT_TYPE_BIT_QSFP28
+            
+
+    def get_revision(self):
+        """
+        Retrieves the hardware revision of the device
+
+        Returns:
+            string: Revision value of device
+        """
+        return self._eeprom.label_revision_str()

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/component.py
@@ -1,0 +1,156 @@
+#############################################################################
+# 
+# Component contains an implementation of SONiC Platform Base API and
+# provides the components firmware management function
+#
+#############################################################################
+
+try:
+    import subprocess
+    from sonic_platform_base.component_base import ComponentBase
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+CPLD_ADDR_MAPPING = {
+    "MB_CPLD1": ['3', '0x60'],
+    "MB_CPLD2": ['3', '0x61'],
+    "MB_CPLD3": ['3', '0x62'],
+    "FAN_CPLD": ['3', '0x63'],
+    "CPU_CPLD": ['1', '0x65']
+}
+SYSFS_PATH = "/sys/bus/i2c/devices/"
+BIOS_VERSION_PATH = "/sys/class/dmi/id/bios_version"
+COMPONENT_LIST= [
+   ("MB_CPLD1", "Mainboard CPLD(0x60)"),
+   ("MB_CPLD2", "Mainboard CPLD(0x61)"),
+   ("MB_CPLD3", "Mainboard CPLD(0x62)"),
+   ("FAN_CPLD", "Fan board CPLD(0x63)"),
+   ("CPU_CPLD", "CPU CPLD(0x65)"),
+   ("BIOS", "Basic Input/Output System")
+   
+]
+
+class Component(ComponentBase):
+    """Platform-specific Component class"""
+
+    DEVICE_TYPE = "component"
+
+    def __init__(self, component_index=0):
+        self.index = component_index
+        self.name = self.get_name()
+
+    def __get_bios_version(self):
+        # Retrieves the BIOS firmware version
+        try:
+            with open(BIOS_VERSION_PATH, 'r') as fd:
+                bios_version = fd.read()
+                return bios_version.strip()
+        except Exception as e:
+            return None
+   
+    def __get_cpld_version(self):
+        # Retrieves the CPLD firmware version
+        cpld_version = dict()
+        for cpld_name in CPLD_ADDR_MAPPING:
+            cmd = "i2cget -f -y {0} {1} 0x1".format(CPLD_ADDR_MAPPING[cpld_name][0], CPLD_ADDR_MAPPING[cpld_name][1])
+            status, value = subprocess.getstatusoutput(cmd)
+            if not status:
+                cpld_version_raw = value.rstrip()
+                cpld_version[cpld_name] = "{}".format(int(cpld_version_raw,16))
+
+        return cpld_version
+
+    def get_name(self):
+        """
+        Retrieves the name of the component
+         Returns:
+            A string containing the name of the component
+        """
+        return COMPONENT_LIST[self.index][0]
+
+    def get_description(self):
+        """
+        Retrieves the description of the component
+            Returns:
+            A string containing the description of the component
+        """
+        return COMPONENT_LIST[self.index][1]
+
+    def get_firmware_version(self):
+        """
+        Retrieves the firmware version of module
+        Returns:
+            string: The firmware versions of the module
+        """
+        fw_version = None
+
+        if self.name == "BIOS":
+            fw_version = self.__get_bios_version()
+        elif "CPLD" in self.name:
+            cpld_version = self.__get_cpld_version()
+            fw_version = cpld_version.get(self.name)
+
+        return fw_version
+
+    def install_firmware(self, image_path):
+        """
+        Install firmware to module
+        Args:
+            image_path: A string, path to firmware image
+        Returns:
+            A boolean, True if install successfully, False if not
+        """
+        raise NotImplementedError
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the device
+        Returns:
+            bool: True if device is present, False if not
+        """
+        return True
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+        Returns:
+            string: Model/part number of device
+        """
+        return 'N/A'
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+        Returns:
+            string: Serial number of device
+        """
+        return 'N/A'
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the device
+        Returns:
+            A boolean value, True if device is operating properly, False if not
+        """
+        return True
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device.
+        If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of
+        entPhysicalContainedIn is'0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device
+            or -1 if cannot determine the position
+        """
+        return -1
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False
+

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/eeprom.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+try:
+    from sonic_platform_pddf_base.pddf_eeprom import PddfEeprom
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Eeprom(PddfEeprom):
+
+    def __init__(self, pddf_data=None, pddf_plugin_data=None):
+        PddfEeprom.__init__(self, pddf_data, pddf_plugin_data)
+
+    def label_revision_str(self):
+        (is_valid, results) = self.get_tlv_field(self.eeprom_data, self._TLV_CODE_LABEL_REVISION)
+        if not is_valid:
+            return "N/A"
+
+        return results[2].decode('ascii')
+
+
+    # Provide the functions/variables below for which implementation is to be overwritten
+    def read_eeprom(self):
+        try:
+            return super().read_eeprom()
+        except:
+            return "N/A"

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/event.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/event.py
@@ -1,0 +1,108 @@
+try:
+    import time
+    from sonic_py_common.logger import Logger
+    from .sfp import Sfp
+except ImportError as e:
+    raise ImportError(repr(e) + " - required module not found")
+
+POLL_INTERVAL_IN_SEC = 1
+
+# SFP errors that will block eeprom accessing
+SFP_BLOCKING_ERRORS = [
+    Sfp.SFP_ERROR_BIT_I2C_STUCK,
+    Sfp.SFP_ERROR_BIT_BAD_EEPROM,
+    Sfp.SFP_ERROR_BIT_UNSUPPORTED_CABLE,
+    Sfp.SFP_ERROR_BIT_HIGH_TEMP,
+    Sfp.SFP_ERROR_BIT_BAD_CABLE
+]
+
+class SfpEvent:
+    ''' Listen to insert/remove sfp events '''
+
+    def __init__(self, sfp_list):
+        self._sfp_list = sfp_list
+        self._logger = Logger()
+        self._sfp_change_event_data = {'present': 0}
+
+    def get_presence_bitmap(self):
+        bitmap = 0
+        for sfp in self._sfp_list:
+            modpres = sfp.get_presence()
+            i=sfp.get_position_in_parent() - 1
+            if modpres:
+                bitmap = bitmap | (1 << i)
+        return bitmap
+
+    def get_sfp_event(self, timeout=2000):
+        port_dict = {}
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            cd_ms = 1000
+        else:
+            cd_ms = timeout
+
+        while cd_ms > 0:
+            bitmap = self.get_presence_bitmap()
+            changed_ports = self._sfp_change_event_data['present'] ^ bitmap
+            if changed_ports != 0:
+                break
+            time.sleep(POLL_INTERVAL_IN_SEC)
+            # timeout=0 means wait for event forever
+            if timeout != 0:
+                cd_ms = cd_ms - POLL_INTERVAL_IN_SEC * 1000
+
+        if changed_ports != 0:
+            for sfp in self._sfp_list:
+                i=sfp.get_position_in_parent() - 1
+                if (changed_ports & (1 << i)) == 0:
+                    continue
+
+                if (bitmap & (1 << i)) == 0:
+                    port_dict[i+1] = '0'
+                else:
+                    sfp_state_bits = self.get_sfp_state_bits(sfp, True)
+                    sfp_state_bits = self.check_sfp_blocking_errors(sfp_state_bits)
+
+                    port_dict[i+1] = str(sfp_state_bits)
+
+            # Update the cache dict
+            self._sfp_change_event_data['present'] = bitmap
+            return True, change_dict
+        else:
+            return True, change_dict
+
+    def get_sfp_state_bits(self, sfp, present):
+        sfp_state_bits = 0
+
+        if present is True:
+            sfp_state_bits |= Sfp.SFP_STATUS_BIT_INSERTED
+        else:
+            return sfp_state_bits
+
+        status = sfp.validate_eeprom()
+        if status is None:
+            sfp_state_bits |= Sfp.SFP_ERROR_BIT_I2C_STUCK
+            return sfp_state_bits
+        elif status is not True:
+            sfp_state_bits |= Sfp.SFP_ERROR_BIT_BAD_EEPROM
+            return sfp_state_bits
+
+        status = sfp.validate_temperature()
+        if status is None:
+            sfp_state_bits |= Sfp.SFP_ERROR_BIT_I2C_STUCK
+            return sfp_state_bits
+        elif status is not True:
+            sfp_state_bits |= Sfp.SFP_ERROR_BIT_HIGH_TEMP
+            return sfp_state_bits
+
+        return sfp_state_bits
+
+    def check_sfp_blocking_errors(self, sfp_state_bits):
+        for i in SFP_BLOCKING_ERRORS:
+            if (i & sfp_state_bits) == 0:
+                continue
+            sfp_state_bits |= Sfp.SFP_ERROR_BIT_BLOCKING
+
+        return sfp_state_bits

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/fan.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_fan import PddfFan
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+FAN_NAME_LIST = ["FAN-1F", "FAN-1R", "FAN-2F", "FAN-2R",
+                 "FAN-3F", "FAN-3R", "FAN-4F", "FAN-4R",
+                 "FAN-5F", "FAN-5R"]
+
+class Fan(PddfFan):
+    """PDDF Platform-Specific Fan class"""
+
+    def __init__(self, tray_idx, fan_idx=0, pddf_data=None, pddf_plugin_data=None, is_psu_fan=False, psu_index=0):
+        # idx is 0-based 
+        PddfFan.__init__(self, tray_idx, fan_idx, pddf_data, pddf_plugin_data, is_psu_fan, psu_index)
+
+    # Provide the functions/variables below for which implementation is to be overwritten
+
+    def get_name(self):
+        """
+        Retrieves the name of the device
+            Returns:
+            string: The name of the device
+        """
+        fan_name = FAN_NAME_LIST[(self.fantray_index-1)*2 + self.fan_index-1] \
+            if not self.is_psu_fan \
+            else "PSU-{} FAN-{}".format(self.fans_psu_index, self.fan_index)
+
+        return fan_name
+
+
+
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+        Returns:
+            string: Model/part number of device
+        """
+
+        return "N/A"
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+        Returns:
+            string: Serial number of device
+        """
+        return "N/A"
+
+    def get_target_speed(self):
+        """
+        Retrieves the target (expected) speed of the fan
+
+        Returns:
+            An integer, the percentage of full fan speed, in the range 0 (off)
+                 to 100 (full speed)
+        """
+        if self.is_psu_fan:
+            return super().get_speed()
+        else:
+            return super().get_target_speed()

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/fan_drawer.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/fan_drawer.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_fan_drawer import PddfFanDrawer
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class FanDrawer(PddfFanDrawer):
+    """PDDF Platform-Specific Fan-Drawer class"""
+
+    def __init__(self, tray_idx, pddf_data=None, pddf_plugin_data=None):
+        # idx is 0-based 
+        PddfFanDrawer.__init__(self, tray_idx, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten
+    def get_name(self):
+        """
+        Retrieves the fan drawer name
+        Returns:
+            string: The name of the device
+        """
+        return "FanTray{}".format(self.fantray_index)
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+        Returns:
+            string: Model/part number of device
+        """
+        return self._fan_list[0].get_model()
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+        Returns:
+            string: Serial number of device
+        """
+        return self._fan_list[0].get_serial()
+

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/helper.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/helper.py
@@ -1,0 +1,317 @@
+import os
+import struct
+import json
+import fcntl
+from mmap import *
+from sonic_py_common import device_info
+from sonic_py_common import logger
+from threading import Lock
+from typing import cast
+from sonic_py_common.general import getstatusoutput_noshell_pipe
+from sonic_py_common.general import getstatusoutput_noshell
+
+HOST_CHK_CMD = ["docker"]
+EMPTY_STRING = ""
+
+
+class APIHelper():
+
+    def __init__(self):
+        (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
+
+    def is_host(self):
+        try:
+            status, output = getstatusoutput_noshell(HOST_CHK_CMD)
+            return status == 0
+        except Exception:
+            return False
+
+    def pci_get_value(self, resource, offset):
+        status = True
+        result = ""
+        try:
+            fd = os.open(resource, os.O_RDWR)
+            mm = mmap(fd, 0)
+            mm.seek(int(offset))
+            read_data_stream = mm.read(4)
+            result = struct.unpack('I', read_data_stream)
+        except Exception:
+            status = False
+        return status, result
+
+    def read_txt_file(self, file_path):
+        try:
+            with open(file_path, 'r', errors='replace') as fd:
+                data = fd.read()
+                ret =  data.strip()
+                if len(ret) > 0:
+                    return ret
+        except IOError:
+            pass
+        return None
+
+    def write_txt_file(self, file_path, value):
+        try:
+            with open(file_path, 'w') as fd:
+                fd.write(str(value))
+        except IOError:
+            return False
+        return True
+class FileLock:
+    """
+    Due to pmon docker not installing the py-filelock, this class
+    implements a simple file lock feature.
+    Ref: https://github.com/tox-dev/py-filelock/blob/main/src/filelock/
+    """
+
+    def __init__(self, lock_file):
+        self._lock_file = lock_file
+        self._thread_lock = Lock()
+        self.is_locked = False
+
+    def acquire(self):
+        with self._thread_lock:
+            if self.is_locked:
+                return
+
+            fd = os.open(self._lock_file, flags=(os.O_RDWR | os.O_CREAT | os.O_TRUNC))
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            self._lock_file_fd = fd
+            self.is_locked = True
+
+    def release(self):
+        with self._thread_lock:
+            if self.is_locked:
+                fd = cast(int, self._lock_file_fd)
+                self._lock_file_fd = None
+                fcntl.flock(fd, fcntl.LOCK_UN)
+                os.close(fd)
+                self.is_locked = False
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_val, traceback):
+        self.release()
+
+    def __del__(self):
+        self.release()
+
+
+DEVICE_THRESHOLD_JSON_PATH = "/tmp/device_threshold.json"
+
+class DeviceThreshold:
+    HIGH_THRESHOLD = 'high_threshold'
+    LOW_THRESHOLD = 'low_threshold'
+    HIGH_CRIT_THRESHOLD = 'high_critical_threshold'
+    LOW_CRIT_THRESHOLD = 'low_critical_threshold'
+    NOT_AVAILABLE = 'N/A'
+
+    def __init__(self, th_name = NOT_AVAILABLE):
+        self.flock = FileLock("{}.lock".format(DEVICE_THRESHOLD_JSON_PATH))
+        self.name = th_name
+        self.__log = logger.Logger(log_identifier="DeviceThreshold")
+
+        self.__db_data = {}
+        self.__db_mtime = 0
+
+    def __reload_db(self):
+        try:
+            db_data = {}
+            with self.flock:
+                with open(DEVICE_THRESHOLD_JSON_PATH, "r") as db_file:
+                    db_data = json.load(db_file)
+        except Exception as e:
+            self.__log.log_warning('{}'.format(str(e)))
+            return None
+
+        return db_data
+
+    def __get_data(self, field):
+        """
+        Retrieves data frome JSON file by field
+
+        Args :
+            field: String
+
+        Returns:
+            A string if getting is successfully, 'N/A' if not
+        """
+        if os.path.exists(DEVICE_THRESHOLD_JSON_PATH):
+            new_mtime = os.path.getmtime(DEVICE_THRESHOLD_JSON_PATH)
+            if new_mtime != self.__db_mtime:
+                new_data = self.__reload_db()
+                if new_data is not None:
+                    self.__db_data = new_data
+                    self.__db_mtime = new_mtime
+
+        if self.name not in self.__db_data.keys():
+            return self.NOT_AVAILABLE
+
+        if field not in self.__db_data[self.name].keys():
+            return self.NOT_AVAILABLE
+
+        return self.__db_data[self.name][field]
+
+    def __set_data(self, field, new_val):
+        """
+        Set data to JSON file by field
+
+        Args :
+            field: String
+            new_val: String
+
+        Returns:
+            A boolean, True if setting is set successfully, False if not
+        """
+        if self.name not in self.__db_data.keys():
+            self.__db_data[self.name] = {}
+
+        old_val = self.__db_data[self.name].get(field, None)
+        if old_val is not None and old_val == new_val:
+            return True
+
+        self.__db_data[self.name][field] = new_val
+
+        try:
+            with self.flock:
+                db_data = {}
+                mode = "r+" if os.path.exists(DEVICE_THRESHOLD_JSON_PATH) else "w+"
+                with open(DEVICE_THRESHOLD_JSON_PATH, mode) as db_file:
+                    if mode == "r+":
+                        db_data = json.load(db_file)
+
+                    if self.name not in db_data.keys():
+                        db_data[self.name] = {}
+
+                    db_data[self.name][field] = new_val
+
+                    if mode == "r+":
+                        db_file.seek(0)
+                        # erase old data
+                        db_file.truncate(0)
+                    # write all data
+                    json.dump(db_data, db_file, indent=4)
+                self.__db_mtime = os.path.getmtime(DEVICE_THRESHOLD_JSON_PATH)
+        except Exception as e:
+            self.__log.log_error('{}'.format(str(e)))
+            return False
+
+        return True
+
+    def get_high_threshold(self):
+        """
+        Retrieves the high threshold temperature from JSON file.
+
+        Returns:
+            string : the high threshold temperature of thermal,
+                     e.g. "30.125"
+        """
+        return self.__get_data(self.HIGH_THRESHOLD)
+
+    def set_high_threshold(self, temperature):
+        """
+        Sets the high threshold temperature of thermal
+        Args :
+            temperature: A string of temperature, e.g. "30.125"
+        Returns:
+            A boolean, True if threshold is set successfully, False if not
+        """
+        if isinstance(temperature, str) is not True:
+            raise TypeError('The parameter requires string type.')
+
+        try:
+            if temperature != self.NOT_AVAILABLE:
+                float(temperature)
+        except ValueError:
+            raise ValueError('The parameter requires a float string. ex:\"30.1\"')
+
+        return self.__set_data(self.HIGH_THRESHOLD, temperature)
+
+    def get_low_threshold(self):
+        """
+        Retrieves the low threshold temperature from JSON file.
+
+        Returns:
+            string : the low threshold temperature of thermal,
+                     e.g. "30.125"
+        """
+        return self.__get_data(self.LOW_THRESHOLD)
+
+    def set_low_threshold(self, temperature):
+        """
+        Sets the low threshold temperature of thermal
+        Args :
+            temperature: A string of temperature, e.g. "30.125"
+        Returns:
+            A boolean, True if threshold is set successfully, False if not
+        """
+        if isinstance(temperature, str) is not True:
+            raise TypeError('The parameter requires string type.')
+
+        try:
+            if temperature != self.NOT_AVAILABLE:
+                float(temperature)
+        except ValueError:
+            raise ValueError('The parameter requires a float string. ex:\"30.1\"')
+
+        return self.__set_data(self.LOW_THRESHOLD, temperature)
+
+    def get_high_critical_threshold(self):
+        """
+        Retrieves the high critical threshold temperature from JSON file.
+
+        Returns:
+            string : the high critical threshold temperature of thermal,
+                     e.g. "30.125"
+        """
+        return self.__get_data(self.HIGH_CRIT_THRESHOLD)
+
+    def set_high_critical_threshold(self, temperature):
+        """
+        Sets the high critical threshold temperature of thermal
+        Args :
+            temperature: A string of temperature, e.g. "30.125"
+        Returns:
+            A boolean, True if threshold is set successfully, False if not
+        """
+        if isinstance(temperature, str) is not True:
+            raise TypeError('The parameter requires string type.')
+
+        try:
+            if temperature != self.NOT_AVAILABLE:
+                float(temperature)
+        except ValueError:
+            raise ValueError('The parameter requires a float string. ex:\"30.1\"')
+
+        return self.__set_data(self.HIGH_CRIT_THRESHOLD, temperature)
+
+    def get_low_critical_threshold(self):
+        """
+        Retrieves the low critical threshold temperature from JSON file.
+
+        Returns:
+            string : the low critical threshold temperature of thermal,
+                     e.g. "30.125"
+        """
+        return self.__get_data(self.LOW_CRIT_THRESHOLD)
+
+    def set_low_critical_threshold(self, temperature):
+        """
+        Sets the low critical threshold temperature of thermal
+        Args :
+            temperature: A string of temperature, e.g. "30.125"
+        Returns:
+            A boolean, True if threshold is set successfully, False if not
+        """
+        if isinstance(temperature, str) is not True:
+            raise TypeError('The parameter requires string type.')
+
+        try:
+            if temperature != self.NOT_AVAILABLE:
+                float(temperature)
+        except ValueError:
+            raise ValueError('The parameter requires a float string. ex:\"30.1\"')
+
+        return self.__set_data(self.LOW_CRIT_THRESHOLD, temperature)

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/pcie.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/pcie.py
@@ -1,0 +1,19 @@
+#############################################################################
+# Edgecore
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the fan status which are available in the platform
+# Base PCIe class
+#############################################################################
+
+try:
+    from sonic_platform_base.sonic_pcie.pcie_common import PcieUtil
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Pcie(PcieUtil):
+    """Edgecore Platform-specific PCIe class"""
+
+    def __init__(self, platform_path):
+        PcieUtil.__init__(self, platform_path)

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/platform.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/platform.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+#############################################################################
+# PDDF
+# Module contains an implementation of SONiC Platform Base API and
+# provides the platform information
+#
+#############################################################################
+
+
+try:
+    from sonic_platform_pddf_base.pddf_platform import PddfPlatform
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Platform(PddfPlatform):
+    """
+    PDDF Platform-Specific Platform Class
+    """
+
+    def __init__(self):
+        PddfPlatform.__init__(self)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/psu.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+#
+
+
+try:
+    from sonic_platform_pddf_base.pddf_psu import PddfPsu
+except ImportError as e:
+    raise ImportError (str(e) + "- required module not found")
+
+
+class Psu(PddfPsu):
+    """PDDF Platform-Specific PSU class"""
+    
+    PLATFORM_PSU_CAPACITY = 1200
+
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
+        PddfPsu.__init__(self, index, pddf_data, pddf_plugin_data)
+        
+    # Provide the functions/variables below for which implementation is to be overwritten
+    def get_voltage_high_threshold(self):
+        """
+        Retrieves the high threshold PSU voltage output
+        Returns:
+            A float number, the high threshold output voltage in volts, 
+            e.g. 12.1 
+        """
+        return 14.72
+
+    def get_voltage_low_threshold(self):
+        """
+        Retrieves the low threshold PSU voltage output
+        Returns:
+            A float number, the low threshold output voltage in volts, 
+            e.g. 12.1 
+        """
+        return 7.68
+
+    def get_name(self):
+        return "PSU-{}".format(self.psu_index)
+
+    def get_maximum_supplied_power(self):
+        """
+        Retrieves the maximum supplied power by PSU (or PSU capacity)
+        Returns:
+            A float number, the maximum power output in Watts.
+            e.g. 1200.1
+        """
+        return float(self.PLATFORM_PSU_CAPACITY)
+
+    def get_capacity(self):
+        """
+        Gets the capacity (maximum output power) of the PSU in watts
+
+        Returns:
+            An integer, the capacity of PSU
+        """
+        return (self.PLATFORM_PSU_CAPACITY)
+
+    def get_type(self):
+        """
+        Gets the type of the PSU
+        Returns:
+        A string, the type of PSU (AC/DC)
+        """
+        return "AC"

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/sfp.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python
+
+try:
+    import natsort
+    from sonic_platform_pddf_base.pddf_sfp import PddfSfp
+    from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
+    from sonic_py_common import device_info
+except ImportError as e:
+    raise ImportError (str(e) + "- required module not found")
+
+
+class Sfp(PddfSfp):
+    """
+    PDDF Platform-Specific Sfp class
+    """
+
+    SFP_TYPE_CODE_LIST = [
+        0x03,  # SFP/SFP+/SFP28
+        0x0b   # DWDM-SFP/SFP+
+    ]
+    QSFP_TYPE_CODE_LIST = [
+        0x0c, # QSFP
+        0x0d, # QSFP+ or later
+        0x11, # QSFP28 or later
+        0xe1  # QSFP28 EDFA
+    ]
+
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
+        PddfSfp.__init__(self, index, pddf_data, pddf_plugin_data)
+        self.index = self.port_index
+
+    # Provide the functions/variables below for which implementation is to be overwritten
+    def get_position_in_parent(self):
+        """Retrieves 1-based relative physical position in parent device."""
+        return self.port_index
+
+    def __get_path_to_port_config_file(self):
+        platform, hwsku = device_info.get_platform_and_hwsku()
+        hwsku_path = "/".join(["/usr/share/sonic/platform",hwsku])
+        return "/".join([hwsku_path, "port_config.ini"])
+
+    def get_name(self):
+        """
+        Retrieves the name of the device
+            Returns:
+            string: The name of the device
+        """
+        sfputil_helper = SfpUtilHelper()
+        sfputil_helper.read_porttab_mappings(
+            self.__get_path_to_port_config_file())
+
+        logical_port_list = sfputil_helper.logical
+        logical_port_list = natsort.natsorted(logical_port_list)
+        name = logical_port_list[self.port_index-1] or "Unknown"
+
+        return name
+
+    def __validate_eeprom_sfp(self):
+        checksum_test = 0
+        eeprom_raw = self.read_eeprom(0, 96)
+        if eeprom_raw is None:
+            return None
+
+        for i in range(0, 63):
+            checksum_test = (checksum_test + eeprom_raw[i]) & 0xFF
+        else:
+            if checksum_test != eeprom_raw[63]:
+                return False
+
+        checksum_test = 0
+        for i in range(64, 95):
+            checksum_test = (checksum_test + eeprom_raw[i]) & 0xFF
+        else:
+            if checksum_test != eeprom_raw[95]:
+                return False
+
+        api = self.get_xcvr_api()
+        if api is None:
+            return False
+
+        if api.is_flat_memory():
+            return True
+
+        checksum_test = 0
+        eeprom_raw = self.read_eeprom(384, 96)
+        if eeprom_raw is None:
+            return None
+
+        for i in range(0, 95):
+            checksum_test = (checksum_test + eeprom_raw[i]) & 0xFF
+        else:
+            if checksum_test != eeprom_raw[95]:
+                return False
+
+        return True
+
+    def __validate_eeprom_qsfp(self):
+        checksum_test = 0
+        eeprom_raw = self.read_eeprom(128, 96)
+        if eeprom_raw is None:
+            return None
+
+        for i in range(0, 63):
+            checksum_test = (checksum_test + eeprom_raw[i]) & 0xFF
+        else:
+            if checksum_test != eeprom_raw[63]:
+                return False
+
+        checksum_test = 0
+        for i in range(64, 95):
+            checksum_test = (checksum_test + eeprom_raw[i]) & 0xFF
+        else:
+            if checksum_test != eeprom_raw[95]:
+                return False
+
+        api = self.get_xcvr_api()
+        if api is None:
+            return False
+
+        if api.is_flat_memory():
+            return True
+
+        return True
+
+    def validate_eeprom(self):
+        id_byte_raw = self.read_eeprom(0, 1)
+        if id_byte_raw is None:
+            return None
+
+        id = id_byte_raw[0]
+        if id in self.QSFP_TYPE_CODE_LIST:
+            return self.__validate_eeprom_qsfp()
+        elif id in self.SFP_TYPE_CODE_LIST:
+            return self.__validate_eeprom_sfp()
+        else:
+            return False
+
+    def validate_temperature(self):
+        temperature = self.get_temperature()
+        if temperature is None:
+            return None
+
+        threshold_dict = self.get_transceiver_threshold_info()
+        if threshold_dict is None:
+            return None
+
+        if isinstance(temperature, float) is not True:
+            return True
+
+        if isinstance(threshold_dict['temphighalarm'], float) is not True:
+            return True
+
+        return threshold_dict['temphighalarm'] > temperature
+
+    def __get_error_description(self):
+        if not self.get_presence():
+            return self.SFP_STATUS_UNPLUGGED
+
+        err_stat = self.SFP_STATUS_BIT_INSERTED
+
+        status = self.validate_eeprom()
+        if status is not True:
+            err_stat = (err_stat | self.SFP_ERROR_BIT_BAD_EEPROM)
+
+        status = self.validate_temperature()
+        if status is not True:
+            err_stat = (err_stat | self.SFP_ERROR_BIT_HIGH_TEMP)
+
+        if err_stat is self.SFP_STATUS_BIT_INSERTED:
+            return self.SFP_STATUS_OK
+        else:
+            err_desc = ''
+            cnt = 0
+            for key in self.SFP_ERROR_BIT_TO_DESCRIPTION_DICT:
+                if (err_stat & key) != 0:
+                    if cnt > 0:
+                        err_desc = err_desc + "|"
+                        cnt = cnt + 1
+                    err_desc = err_desc + self.SFP_ERROR_BIT_TO_DESCRIPTION_DICT[key]
+
+            return err_desc
+
+    def get_error_description(self):
+        """
+        Retrives the error descriptions of the SFP module
+        Returns:
+            String that represents the current error descriptions of vendor specific errors
+            In case there are multiple errors, they should be joined by '|',
+            like: "Bad EEPROM|Unsupported cable"
+        """
+        # RJ45 not support this feature
+        if self.index <= 48:
+            return None
+        try:
+            ret = super().get_error_description()
+            if ret is not None:
+                return ret
+        except NotImplementedError:
+            pass
+        return self.__get_error_description()
+
+    def reset(self):
+        """
+        Reset SFP and return all user module settings to their default srate.
+        Returns:
+            A boolean, True if successful, False if not
+        """
+        if self.index <= 48:
+            return False
+
+        return super().reset()
+
+    def get_lpmode(self):
+        """
+        Retrieves the lpmode (low power mode) status of this SFP
+        Returns:
+            A Boolean, True if lpmode is enabled, False if disabled
+        """
+        if self.index <= 48:
+            return False
+
+        return super().get_lpmode()
+
+    def set_lpmode(self, lpmode):
+        """
+        Sets the lpmode (low power mode) of SFP
+        Args:
+            lpmode: A Boolean, True to enable lpmode, False to disable it
+            Note  : lpmode can be overridden by set_power_override
+        Returns:
+            A boolean, True if lpmode is set successfully, False if not
+        """
+        if self.index <= 48:
+            return False
+
+        return super().set_lpmode(lpmode)
+

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/thermal.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_thermal import PddfThermal
+    from .helper import DeviceThreshold
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+NOT_AVAILABLE = DeviceThreshold.NOT_AVAILABLE
+HIGH_THRESHOLD = DeviceThreshold.HIGH_THRESHOLD
+LOW_THRESHOLD = DeviceThreshold.LOW_THRESHOLD
+HIGH_CRIT_THRESHOLD = DeviceThreshold.HIGH_CRIT_THRESHOLD
+LOW_CRIT_THRESHOLD = DeviceThreshold.LOW_CRIT_THRESHOLD
+
+DEFAULT_THRESHOLD = {
+    'CB_temp(0x4B)' : {
+        HIGH_THRESHOLD : '80.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    },
+    'MB_FrontMiddle_temp(0x4C)' : {
+        HIGH_THRESHOLD : '80.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    },
+    'MB_RearLeft_temp(0x49)' : {
+        HIGH_THRESHOLD : '80.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    },
+    'MB_RearLeft_temp(0x4A)' : {
+        HIGH_THRESHOLD : '80.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    },
+    'coretemp-isa-0000' : {
+        HIGH_THRESHOLD : '82.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : '104.0',
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    },
+    'PSU-1 temp sensor 1' : {
+        HIGH_THRESHOLD : '80.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    },
+    'PSU-2 temp sensor 1' : {
+        HIGH_THRESHOLD : '80.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    }
+}
+
+class Thermal(PddfThermal):
+    """PDDF Platform-Specific Thermal class"""
+
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None, is_psu_thermal=False, psu_index=0):
+        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data, is_psu_thermal, psu_index)
+        
+        self.pddf_obj = pddf_data
+        self.thermal_obj_name = "TEMP{}".format(self.thermal_index)
+        self.thermal_obj = self.pddf_obj.data[self.thermal_obj_name]
+        # Threshold Configuration
+        self.__conf = DeviceThreshold(self.get_name())
+        # Default threshold.
+        self.__default_threshold = DEFAULT_THRESHOLD[self.get_name()]
+        self.min_temperature = None
+        self.max_temperature = None
+
+    # Provide the functions/variables below for which implementation is to be overwritten
+    def get_name(self):
+        if self.is_psu_thermal:
+            return "PSU-{0} temp sensor 1".format(self.thermals_psu_index)
+        else:
+            if 'dev_attr' in self.thermal_obj.keys():
+                if 'display_name' in self.thermal_obj['dev_attr']:
+                    return str(self.thermal_obj['dev_attr']['display_name'])
+            
+            # In case of errors
+            return "Temp sensor {0}".format(self.thermal_index)
+
+    def get_status(self):
+        get_temp=self.get_temperature()
+
+        if get_temp is not None:
+            return True if get_temp else False
+
+    def get_temperature(self):
+        current = super().get_temperature()
+
+        if self.min_temperature is None or \
+            current < self.min_temperature:
+            self.min_temperature = current
+
+        if self.max_temperature is None or \
+           current > self.max_temperature:
+            self.max_temperature = current
+
+        return current
+
+    def set_high_threshold(self, temperature):
+        try:
+            value = float(temperature)
+        except Exception:
+            return False
+
+        # The new value can not be more than the default value.
+        default_value = self.__default_threshold[HIGH_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            if value > float(default_value):
+                return False
+
+        try:
+            self.__conf.set_high_threshold(str(value))
+        except Exception:
+            return False
+
+        return True
+
+    def get_high_threshold(self):
+        value = self.__conf.get_high_threshold()
+        if value != NOT_AVAILABLE:
+            return float(value)
+
+        default_value = self.__default_threshold[HIGH_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            return float(default_value)
+
+        return super().get_low_threshold()
+
+    def set_low_threshold(self, temperature):
+        try:
+            value = float(temperature)
+        except Exception:
+            return False
+
+        # The new value can not be less than the default value.
+        default_value = self.__default_threshold[LOW_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            if value < float(default_value):
+                return False
+
+        try:
+            self.__conf.set_low_threshold(str(value))
+        except Exception:
+            return False
+
+        return True
+
+    def get_low_threshold(self):
+        value = self.__conf.get_low_threshold()
+        if value != NOT_AVAILABLE:
+            return float(value)
+
+        default_value = self.__default_threshold[LOW_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            return float(default_value)
+
+        return super().get_low_threshold()
+
+    def get_high_critical_threshold(self):
+        value = self.__conf.get_high_critical_threshold()
+        if value != NOT_AVAILABLE:
+            return float(value)
+
+        default_value = self.__default_threshold[HIGH_CRIT_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            return float(default_value)
+
+        return super().get_high_critical_threshold()
+
+    def set_high_critical_threshold(self, temperature):
+        try:
+            value = float(temperature)
+        except Exception:
+            return False
+
+        # The new value can not be more than the default value.
+        default_value = self.__default_threshold[HIGH_CRIT_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            if value > float(default_value):
+                return False
+
+        try:
+            self.__conf.set_high_critical_threshold(str(value))
+        except Exception:
+            return False
+
+        return True
+
+    def set_low_critical_threshold(self, temperature):
+        try:
+            value = float(temperature)
+        except Exception:
+            return False
+
+        # The new value can not be less than the default value.
+        default_value = self.__default_threshold[LOW_CRIT_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            if value < float(default_value):
+                return False
+
+        try:
+            self.__conf.set_low_critical_threshold(str(value))
+        except Exception:
+            return False
+
+        return True
+
+    def get_low_critical_threshold(self):
+        value = self.__conf.get_low_critical_threshold()
+        if value != NOT_AVAILABLE:
+            return float(value)
+
+        default_value = self.__default_threshold[LOW_CRIT_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            return float(default_value)
+
+        return super().get_low_critical_threshold()
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+        Returns:
+            string: Model/part number of device
+        """
+        return 'N/A'
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+        Returns:
+            string: Serial number of device
+        """
+        return 'N/A'
+
+    def get_minimum_recorded(self):
+        """
+        Retrieves the minimum recorded temperature of thermal
+        Returns:
+            A float number, the minimum recorded temperature of thermal in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        if self.min_temperature is None:
+            self.get_temperature()
+
+        return self.min_temperature
+
+    def get_maximum_recorded(self):
+        """
+        Retrieves the maximum recorded temperature of thermal
+        Returns:
+            A float number, the maximum recorded temperature of thermal in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        if self.min_temperature is None:
+            self.get_temperature()
+
+        return self.max_temperature

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/watchdog.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/watchdog.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#############################################################################
+#
+# Module contains an implementation of platform specific watchdog API's
+#
+#############################################################################
+
+try:
+    from sonic_platform_pddf_base.pddf_watchdog import PddfWatchdog
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+class Watchdog(PddfWatchdog):
+    """
+    PDDF Platform-specific Chassis class
+    """
+
+    def __init__(self):
+        PddfWatchdog.__init__(self)
+        self.timeout= 180
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform_setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform_setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup
+
+setup(
+    name='sonic-platform',
+    version='1.0',
+    description='SONiC platform API implementation on Accton Platforms',
+    license='Apache 2.0',
+    author='SONiC Team',
+    author_email='linuxnetdev@microsoft.com',
+    url='https://github.com/Azure/sonic-buildimage',
+    packages=['sonic_platform'],
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: Plugins',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Information Technology',
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: Apache Software License',
+        'Natural Language :: English',
+        'Operating System :: POSIX :: Linux',
+        'Programming Language :: Python :: 3.7',
+        'Topic :: Utilities',
+    ],
+    keywords='sonic SONiC platform PLATFORM',
+)

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_pddf_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_pddf_monitor.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2019 Accton Technology Corporation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# ------------------------------------------------------------------
+# HISTORY:
+#    mm/dd/yyyy (A.D.)
+#    05/29/2019: Brandon Chuang, changed for as5835-54t.
+#    08/03/2020: Jostar Yang, change to call PDDF API .
+# ------------------------------------------------------------------
+
+try:
+    import sys, getopt
+    import logging
+    import logging.config
+    import time
+    import signal
+    from sonic_platform import platform
+except ImportError as e:
+    raise ImportError('%s - required module not found' % str(e))
+
+# Deafults
+VERSION = '1.0'
+FUNCTION_NAME = 'accton_as5835_54t_pddf_monitor'
+DUTY_MAX = 100
+
+platform_chassis = None
+
+test_temp = 0
+test_temp_list = [0, 0, 0, 0]
+test_temp_revert=0
+temp_test_data=0
+
+# Make a class we can use to capture stdout and sterr in the log
+class accton_as5835_54t_monitor(object):
+    # static temp var
+    _ori_temp = 0
+    _new_perc = 0
+
+    def __init__(self, log_file, log_level):
+        """Needs a logger and a logger level."""
+        # set up logging to file
+        logging.basicConfig(
+            filename=log_file,
+            filemode='w',
+            level=log_level,
+            format= '[%(asctime)s] {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s',
+            datefmt='%H:%M:%S'
+        )
+
+        # set up logging to console
+        if log_level == logging.DEBUG:
+            console = logging.StreamHandler()
+            console.setLevel(log_level)
+            formatter = logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s')
+            console.setFormatter(formatter)
+            logging.getLogger('').addHandler(console)
+
+        logging.debug('SET. logfile:%s / loglevel:%d', log_file, log_level)
+
+    def manage_fans(self):
+        global platform_chassis
+        global test_temp_list
+        global temp_test_data
+        global test_temp
+        
+        THERMAL_NUM_MAX=4
+        FAN_LEV1_UP_TEMP = 57700  # temperature
+        FAN_LEV1_SPEED_PERC = DUTY_MAX # percentage*/
+
+        FAN_LEV2_UP_TEMP = 53000
+        FAN_LEV2_DOWN_TEMP = 52700
+        FAN_LEV2_SPEED_PERC = 80
+
+        FAN_LEV3_UP_TEMP = 49500
+        FAN_LEV3_DOWN_TEMP = 47700
+        FAN_LEV3_SPEED_PERC = 65
+
+        FAN_LEV4_DOWN_TEMP = 42700
+        FAN_LEV4_SPEED_PERC = 40
+        
+        FAN_NUM=2
+        FAN_TRAY_NUM=5
+       
+        if test_temp_revert==0:
+            temp_test_data=temp_test_data+2000
+        else:            
+            temp_test_data=temp_test_data-2000
+
+        if test_temp==0:
+            temp2=platform_chassis.get_thermal(1).get_temperature()*1000
+            if temp2 is None:
+                return False
+            
+            temp3=platform_chassis.get_thermal(2).get_temperature()*1000
+            if temp3 is None:
+                return False
+
+            new_temp = (temp2 + temp3) / 2
+        else:
+            thermal_val=[0,0,0,0]
+            for i in range (THERMAL_NUM_MAX):
+                thermal_val[i]=test_temp_list[i]
+                thermal_val[i]= thermal_val[i] + temp_test_data
+            
+                
+            new_temp = (thermal_val[1] + thermal_val[2])/2
+            logging.debug("Test case:thermal_val[1]=%d, thermal_val[2]=%d, get new_temp=%d", thermal_val[1], thermal_val[2],new_temp)
+
+        for x in range(FAN_TRAY_NUM * FAN_NUM):            
+            fan_stat=True
+            if not platform_chassis.get_fan(x).get_status() or not platform_chassis.get_fan(x).get_speed_rpm():    
+                self._new_perc = FAN_LEV1_SPEED_PERC
+                logging.debug('INFO. SET new_perc to %d (FAN fault. fan_num:%d)', self._new_perc, x+1)
+                fan_stat=False
+                break
+            logging.debug('INFO. fan_stat is True (fan_num:%d)', x+1)
+
+        if fan_stat==True:
+            diff = new_temp - self._ori_temp
+            if diff  == 0:
+                logging.debug('INFO. RETURN. THERMAL temp not changed. %d / %d (new_temp / ori_temp)', new_temp, self._ori_temp)
+                return True
+            else:
+                if diff >= 0:
+                    is_up = True
+                    logging.debug('INFO. THERMAL temp UP %d / %d (new_temp / ori_temp)', new_temp, self._ori_temp)
+                else:
+                    is_up = False
+                    logging.debug('INFO. THERMAL temp DOWN %d / %d (new_temp / ori_temp)', new_temp, self._ori_temp)
+
+            if is_up is True:
+                if new_temp  >= FAN_LEV1_UP_TEMP:
+                    self._new_perc = FAN_LEV1_SPEED_PERC
+                elif new_temp  >= FAN_LEV2_UP_TEMP:
+                    self._new_perc = FAN_LEV2_SPEED_PERC
+                elif new_temp  >= FAN_LEV3_UP_TEMP:
+                    self._new_perc = FAN_LEV3_SPEED_PERC
+                else:
+                    self._new_perc = FAN_LEV4_SPEED_PERC
+                logging.debug('INFO. SET. FAN_SPEED as %d (new THERMAL temp:%d)', self._new_perc, new_temp)
+            else:
+                if new_temp <= FAN_LEV4_DOWN_TEMP:
+                    self._new_perc = FAN_LEV4_SPEED_PERC
+                elif new_temp  <= FAN_LEV3_DOWN_TEMP:
+                    self._new_perc = FAN_LEV3_SPEED_PERC
+                elif new_temp  <= FAN_LEV2_DOWN_TEMP:
+                    self._new_perc = FAN_LEV2_SPEED_PERC
+                else:
+                    self._new_perc = FAN_LEV1_SPEED_PERC
+                logging.debug('INFO. SET. FAN_SPEED as %d (new THERMAL temp:%d)', self._new_perc, new_temp)
+
+        cur_perc= platform_chassis.get_fan(0).get_speed()
+        if cur_perc == self._new_perc:
+            logging.debug('INFO. RETURN. FAN speed not changed. %d / %d (new_perc / ori_perc)', self._new_perc, cur_perc)
+            return True
+        
+        set_stat = platform_chassis.get_fan(0).set_speed(self._new_perc)
+        if set_stat is True:
+            logging.debug('INFO: PASS. set_fan_duty_cycle (%d)', self._new_perc)
+        else:
+            logging.debug('INFO: FAIL. set_fan_duty_cycle (%d)', self._new_perc)
+
+        logging.debug('INFO: GET. ori_perc is %d. ori_temp is %d', cur_perc, self._ori_temp)
+        self._ori_temp = new_temp
+        logging.debug('INFO: UPDATE. ori_perc to %d. ori_temp to %d', cur_perc, self._ori_temp)
+
+        return True
+
+def handler(signum, frame):
+    logging.debug('INFO:Cause signal %d, set fan speed max.', signum)
+    platform_chassis.get_fan(0).set_speed(DUTY_MAX)
+    sys.exit(0)
+
+def main(argv):
+    global test_temp
+    
+    log_file = '%s.log' % FUNCTION_NAME
+    log_level = logging.INFO
+    if len(sys.argv) != 1:
+        try:
+            opts, args = getopt.getopt(argv,'hdlt:',['lfile='])
+        except getopt.GetoptError:
+            print('Usage: %s [-d] [-l <log_file>]' % sys.argv[0])
+            return 0
+        for opt, arg in opts:
+            if opt == '-h':
+                print('Usage: %s [-d] [-l <log_file>]' % sys.argv[0])
+                return 0
+            elif opt in ('-d', '--debug'):
+                log_level = logging.DEBUG
+            elif opt in ('-l', '--lfile'):
+                log_file = arg
+                
+        if sys.argv[1]== '-t':
+            if len(sys.argv)!=6:
+                print("temp test, need input 4 temp")
+                return 0
+            i=0
+            for x in range(2, 6):
+               test_temp_list[i]= int(sys.argv[x])*1000
+               i=i+1
+            test_temp = 1
+            log_level = logging.DEBUG
+            print(test_temp_list)
+                
+    global platform_chassis
+    platform_chassis = platform.Platform().get_chassis()
+    
+    #for i in range(4):
+    #    print("temp-%d=%d"%(i+1, platform_chassis.get_thermal(i).get_temperature()*1000))
+    
+    signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
+    monitor = accton_as5835_54t_monitor(log_file, log_level)
+
+    # Loop forever, doing something useful hopefully:
+    while True:
+        monitor.manage_fans()
+        time.sleep(10)
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_util.py
@@ -25,20 +25,13 @@ options:
 command:
     install     : install drivers and generate related sysfs nodes
     clean       : uninstall drivers and remove related sysfs nodes
-    show        : show all systen status
-    sff         : dump SFP eeprom
-    set         : change board setting with fan|led|sfp    
 """
 
 import subprocess
 import getopt
 import sys
 import logging
-import re
 import time
-
-
-
 
 PROJECT_NAME = 'as5835_54t'
 version = '0.1.0'
@@ -54,7 +47,7 @@ FORCE = 0
 
 if DEBUG == True:
     print(sys.argv[0])
-    print('ARGV      :', sys.argv[1:])   
+    print('ARGV      :', sys.argv[1:])
 
 
 def main():
@@ -89,22 +82,6 @@ def main():
            do_install()
         elif arg == 'clean':
            do_uninstall()
-        elif arg == 'show':
-           device_traversal()
-        elif arg == 'sff':
-            if len(args)!=2:
-                show_eeprom_help()
-            elif int(args[1]) ==0 or int(args[1]) > DEVICE_NO['sfp']:              
-                show_eeprom_help()
-            else:
-                show_eeprom(args[1])  
-            return                              
-        elif arg == 'set':
-            if len(args)<3:
-                show_set_help()
-            else:
-                set_device(args[1:])                
-            return                
         else:
             show_help()
             
@@ -115,19 +92,6 @@ def show_help():
     print(__doc__ % {'scriptName' : sys.argv[0].split("/")[-1]})
     sys.exit(0)
 
-def  show_set_help():
-    cmd =  sys.argv[0].split("/")[-1]+ " "  + args[0]
-    print(cmd +" [led|sfp|fan]")
-    print("    use \""+ cmd + " led 0-4 \"  to set led color")
-    print("    use \""+ cmd + " fan 0-100\" to set fan duty percetage")    
-    print("    use \""+ cmd + " sfp 49-54 {0|1}\" to set sfp# tx_disable") 
-    sys.exit(0)  
-    
-def  show_eeprom_help():
-    cmd =  sys.argv[0].split("/")[-1]+ " "  + args[0]
-    print("    use \""+ cmd + " 1-54 \" to dump sfp# eeprom") 
-    sys.exit(0)           
-            
 def my_log(txt):
     if DEBUG == True:
         print("[Debug]"+txt)    
@@ -156,6 +120,8 @@ def driver_check():
 
 kos = [
 'modprobe i2c_dev',
+'modprobe i2c_i801',
+'modprobe i2c_ismt',
 'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
 'modprobe accton_as5835_54t_cpld'  ,
 'modprobe ym2651y'                  ,
@@ -188,11 +154,6 @@ def driver_uninstall():
             if FORCE == 0:        
                 return status              
     return 0
-
-led_prefix ='/sys/class/leds/accton_'+PROJECT_NAME+'_led::'
-hwmon_types = {'led': ['diag','fan','loc','psu1','psu2']}
-hwmon_nodes = {'led': ['brightness'] }
-hwmon_prefix ={'led': led_prefix}
 
 i2c_prefix = '/sys/bus/i2c/devices/'
 i2c_bus = {'fan': ['3-0063']                 ,
@@ -392,184 +353,6 @@ def do_uninstall():
                     
     return       
 
-def devices_info():
-    global DEVICE_NO
-    global ALL_DEVICE
-    global i2c_bus, hwmon_types
-    for key in DEVICE_NO:   
-        ALL_DEVICE[key]= {} 
-        for i in range(0,DEVICE_NO[key]):
-            ALL_DEVICE[key][key+str(i+1)] = []
-            
-    for key in i2c_bus:
-        buses = i2c_bus[key]
-        nodes = i2c_nodes[key]    
-        for i in range(0,len(buses)):
-            for j in range(0,len(nodes)):
-                if  'fan' == key:
-                    for k in range(0,DEVICE_NO[key]):
-                        node = key+str(k+1)
-                        path = i2c_prefix+ buses[i]+"/fan"+str(k+1)+"_"+ nodes[j]
-                        my_log(node+": "+ path)
-                        ALL_DEVICE[key][node].append(path) 
-                elif  'sfp' == key:
-                    for k in range(0,DEVICE_NO[key]):
-                        node = key+str(k+1)
-                        path = i2c_prefix+ str(sfp_map[k])+ buses[i]+"/"+ nodes[j]                
-                        my_log(node+": "+ path)
-                        ALL_DEVICE[key][node].append(path)                                        
-                else:
-                    node = key+str(i+1)
-                    path = i2c_prefix+ buses[i]+"/"+ nodes[j]                
-                    my_log(node+": "+ path)
-                    ALL_DEVICE[key][node].append(path)  
-                                     
-    for key in hwmon_types:
-        itypes = hwmon_types[key]
-        nodes = hwmon_nodes[key]    
-        for i in range(0,len(itypes)):
-            for j in range(0,len(nodes)): 
-                node = key+"_"+itypes[i]
-                path = hwmon_prefix[key]+ itypes[i]+"/"+ nodes[j]           
-                my_log(node+": "+ path)
-                ALL_DEVICE[key][ key+str(i+1)].append(path)                   
-    
-    #show dict all in the order
-    if DEBUG == True:
-        for i in sorted(ALL_DEVICE.keys()):
-            print((i+": "))
-            for j in sorted(ALL_DEVICE[i].keys()):    
-                print(("   "+j))
-                for k in (ALL_DEVICE[i][j]):    
-                    print(("   "+"   "+k))
-    return 
-        
-def show_eeprom(index):
-    if system_ready()==False:
-        print("System's not ready.")        
-        print("Please install first!")
-        return 
-              
-    if len(ALL_DEVICE)==0:
-        devices_info()        
-    node = ALL_DEVICE['sfp'] ['sfp'+str(index)][0]
-    node = node.replace(node.split("/")[-1], 'sfp_eeprom')
-    # check if got hexdump command in current environment
-    ret, log = log_os_system("which hexdump", 0)
-    ret, log2 = log_os_system("which busybox hexdump", 0)    
-    if len(log):
-        hex_cmd = 'hexdump'
-    elif len(log2):
-        hex_cmd = ' busybox hexdump'
-    else:
-        log = 'Failed : no hexdump cmd!!'
-        logging.info(log)
-        print(log)
-        return 1                                 
-            
-    print(node + ":")
-    ret, log = log_os_system("cat "+node+"| "+hex_cmd+" -C", 1)
-    if ret==0:                                      
-        print(log) 
-    else:
-        print("**********device no found**********")       
-    return 
-         
-def set_device(args):
-    global DEVICE_NO
-    global ALL_DEVICE
-    if system_ready()==False:
-        print("System's not ready.")        
-        print("Please install first!")
-        return     
-    
-    if len(ALL_DEVICE)==0:
-        devices_info()  
-        
-    if args[0]=='led':
-        if int(args[1])>4:
-            show_set_help()
-            return
-        #print  ALL_DEVICE['led']
-        for i in range(0,len(ALL_DEVICE['led'])):   
-            for k in (ALL_DEVICE['led']['led'+str(i+1)]):  
-                ret, log = log_os_system("echo "+args[1]+" >"+k, 1)
-                if ret:
-                    return ret  
-    elif args[0]=='fan':
-        if int(args[1])>100:
-            show_set_help()
-            return
-        #print  ALL_DEVICE['fan']
-        #fan1~5 is all fine, all fan share same setting        
-        node = ALL_DEVICE['fan'] ['fan1'][0] 
-        node = node.replace(node.split("/")[-1], 'fan_duty_cycle_percentage')
-        ret, log = log_os_system("cat "+ node, 1)            
-        if ret==0:
-            print(("Previous fan duty: " + log.strip() +"%"))            
-        ret, log = log_os_system("echo "+args[1]+" >"+node, 1)
-        if ret==0:
-            print(("Current fan duty: " + args[1] +"%"))          
-        return ret
-    elif args[0]=='sfp':
-        if int(args[1])> DEVICE_NO[args[0]] or int(args[1])==0:
-            show_set_help()
-            return     
-        if len(args)<2:
-            show_set_help()
-            return 
-                            
-        if int(args[2])>1:
-            show_set_help()
-            return
-       
-        #print  ALL_DEVICE[args[0]]   
-        for i in range(0,len(ALL_DEVICE[args[0]])):   
-            for j in ALL_DEVICE[args[0]][args[0]+str(args[1])]:        
-                if j.find('tx_disable')!= -1:  
-                    ret, log = log_os_system("echo "+args[2]+" >"+ j, 1)
-                    if ret:
-                        return ret  
-                                                                           
-    return
-    
-#get digits inside a string. 
-#Ex: 31 for "sfp31"   
-def get_value(input):
-    digit = re.findall('\d+', input)
-    return int(digit[0])
-              
-def device_traversal():
-    if system_ready()==False:
-        print("System's not ready.")        
-        print("Please install first!")
-        return 
-        
-    if len(ALL_DEVICE)==0:
-        devices_info()
-    for i in sorted(ALL_DEVICE.keys()):
-        print("============================================")        
-        print((i.upper()+": "))
-        print("============================================")
-         
-        for j in sorted(list(ALL_DEVICE[i].keys()), key=get_value):    
-            print("   "+j+":", end=' ')
-            for k in (ALL_DEVICE[i][j]):
-                ret, log = log_os_system("cat "+k, 0)
-                func = k.split("/")[-1].strip()
-                func = re.sub(j+'_','',func,1)
-                func = re.sub(i.lower()+'_','',func,1)                 
-                if ret==0:
-                    print(func+"="+log+" ", end=' ')                  
-                else:
-                    print(func+"="+"X"+" ", end=' ')
-            print()                    
-            print("----------------------------------------------------------------")
-                                              
-     
-        print()
-    return
-            
 def device_exist():
     ret1, log = log_os_system("ls "+i2c_prefix+"*0077", 0)
     ret2, log = log_os_system("ls "+i2c_prefix+"i2c-2", 0)

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/pddf_post_device_create.sh
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/pddf_post_device_create.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set_qsfp_reset_to_normal_state()
+{
+    i2cset -y -f 3 0x62 0x15 0x3f &>/dev/null
+}
+
+set_system_led_diag_loc_to_off()
+{
+    i2cset -y -f 3 0x60 0xa 0x1c &>/dev/null
+}
+
+set_qsfp_reset_to_normal_state
+set_system_led_diag_loc_to_off

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/pddf_switch_svc.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/pddf_switch_svc.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# Script to stop and start the respective platforms default services. 
+# This will be used while switching the pddf->non-pddf mode and vice versa
+from sonic_py_common.general import getstatusoutput_noshell
+
+def check_pddf_support():
+    return True
+
+def stop_platform_svc():
+    
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as5835-54t-platform-monitor-fan.service"])
+    if status:
+        print("Stop as5835-54t-platform-fan.service failed %d"%status)
+        return False
+    
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "as5835-54t-platform-monitor-psu.service"])
+    if status:
+        print("Stop as5835-54t-platform-psu.service failed %d"%status)
+        return False
+    
+    status, output = getstatusoutput_noshell(["systemctl", "stop" ,"as5835-54t-platform-monitor.service"])
+    if status:
+        print("Stop as5835-54t-platform-init.service failed %d"%status)
+        return False
+    status, output = getstatusoutput_noshell(["systemctl", "disable", "as5835-54t-platform-monitor.service"])
+    if status:
+        print("Disable as5835-54t-platform-monitor.service failed %d"%status)
+        return False
+    
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as5835_54t_util.py", "clean"])
+    if status:
+        print("accton_as5835_54t_util.py clean command failed %d"%status)
+        return False
+
+    # HACK , stop the pddf-platform-init service if it is active
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
+    if status:
+        print("Stop pddf-platform-init.service along with other platform serives failed %d"%status)
+        return False
+
+    return True
+    
+def start_platform_svc():
+    status, output = getstatusoutput_noshell(["/usr/local/bin/accton_as5835_54t_util.py", "install"])
+    if status:
+        print("accton_as5835_54t_util.py install command failed %d"%status)
+        return False
+
+    status, output = getstatusoutput_noshell(["systemctl", "enable", "as5835-54t-platform-monitor.service"])
+    if status:
+        print("Enable as5835-54t-platform-monitor.service failed %d"%status)
+        return False
+    status, output = getstatusoutput_noshell(["systemctl", "start", "as5835-54t-platform-monitor-fan.service"])
+    if status:
+        print("Start as5835-54t-platform-monitor-fan.service failed %d"%status)
+        return False
+        
+    status, output = getstatusoutput_noshell(["systemctl", "start", "as5835-54t-platform-monitor-psu.service"])
+    if status:
+        print("Start as5835-54t-platform-monitor-psu.service failed %d"%status)
+        return False
+
+    return True
+
+def start_platform_pddf():
+    status, output = getstatusoutput_noshell(["systemctl", "start", "pddf-platform-init.service"])
+    if status:
+        print("Start pddf-platform-init.service failed %d"%status)
+        return False
+    
+    return True
+
+def stop_platform_pddf():
+    status, output = getstatusoutput_noshell(["systemctl", "stop", "pddf-platform-init.service"])
+    if status:
+        print("Stop pddf-platform-init.service failed %d"%status)
+        return False
+
+    return True
+
+def main():
+   pass
+
+if __name__ == "__main__":
+    main()
+

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5835-54t.install
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5835-54t.install
@@ -1,0 +1,1 @@
+as5835-54t/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-accton_as5835_54t-r0/pddf

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5835-54t.postinst
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5835-54t.postinst
@@ -1,0 +1,9 @@
+# Special arrangement to make PDDF mode default
+# Disable monitor, monitor-fan, monitor-psu (not enabling them would imply they will be disabled by default)
+# Enable pddf-platform-monitor
+depmod -a
+systemctl enable pddf-platform-init.service
+systemctl start pddf-platform-init.service
+systemctl enable as5835-54t-pddf-platform-monitor.service
+systemctl start as5835-54t-pddf-platform-monitor.service
+


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support PDDF for AS5835-54T
#### How I did it
Implement pddf related code and files
#### How to verify it
Test show cmd, sfputil
root@as5835-54t-2:~# show platform temp
                   Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
-------------------------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
            CB_temp(0x4B)           42           80       N/A             N/A            N/A      False  20230322 08:45:28
MB_FrontMiddle_temp(0x4C)           36.5         80       N/A             N/A            N/A      False  20230322 08:45:28
   MB_RearLeft_temp(0x4A)           33           80       N/A             N/A            N/A      False  20230322 08:45:28
   MB_RearLeft_temp(0x49)           32.5         80       N/A             N/A            N/A      False  20230322 08:45:28
      PSU-1 temp sensor 1           39           80       N/A             N/A            N/A      False  20230322 08:45:28
      PSU-2 temp sensor 1           31           80       N/A             N/A            N/A      False  20230322 08:45:28
        coretemp-isa-0000           54           82       N/A           104.0            N/A      False  20230322 08:45:28
root@as5835-54t-2:~# show platform fan
  Drawer    LED          FAN    Speed    Direction    Presence    Status          Timestamp
--------  -----  -----------  -------  -----------  ----------  --------  -----------------
FanTray1  green       FAN-1F      40%      exhaust     Present        OK  20230322 08:45:28
FanTray1  green       FAN-1R      40%      exhaust     Present        OK  20230322 08:45:28
FanTray2  green       FAN-2F      40%      exhaust     Present        OK  20230322 08:45:28
FanTray2  green       FAN-2R      40%      exhaust     Present        OK  20230322 08:45:28
FanTray3  green       FAN-3F      40%      exhaust     Present        OK  20230322 08:45:28
FanTray3  green       FAN-3R      40%      exhaust     Present        OK  20230322 08:45:28
FanTray4  green       FAN-4F      40%      exhaust     Present        OK  20230322 08:45:28
FanTray4  green       FAN-4R      40%      exhaust     Present        OK  20230322 08:45:28
FanTray5  green       FAN-5F      40%      exhaust     Present        OK  20230322 08:45:28
FanTray5  green       FAN-5R      40%      exhaust     Present        OK  20230322 08:45:28
     N/A    N/A  PSU-1 FAN-1      18%      exhaust     Present        OK  20230322 08:45:28
     N/A    N/A  PSU-2 FAN-1       0%      exhaust     Present    Not OK  20230322 08:45:28
root@as5835-54t-2:~# show platform psustatus
PSU    Model     Serial              HW Rev      Voltage (V)    Current (A)    Power (W)  Status    LED
-----  --------  ------------------  --------  -------------  -------------  -----------  --------  -----
PSU 1  YM-1401A  SA060V061911000280  N/A               11.78           7.95        91.00  OK        green
PSU 2  YM-1401A  SA060V061911000266  N/A  
root@as5835-54t-2:~# sfputil show presence
Port        Presence
----------  -----------
Ethernet0   Not present
Ethernet1   Not present
Ethernet2   Not present
Ethernet3   Not present
Ethernet4   Not present
Ethernet5   Not present
Ethernet6   Not present
Ethernet7   Not present
Ethernet8   Not present
Ethernet9   Not present
Ethernet10  Not present
Ethernet11  Not present
Ethernet12  Not present
Ethernet13  Not present
Ethernet14  Not present
Ethernet15  Not present
Ethernet16  Not present
Ethernet17  Not present
Ethernet18  Not present
Ethernet19  Not present
Ethernet20  Not present
Ethernet21  Not present
Ethernet22  Not present
Ethernet23  Not present
Ethernet24  Not present
Ethernet25  Not present
Ethernet26  Not present
Ethernet27  Not present
Ethernet28  Not present
Ethernet29  Not present
Ethernet30  Not present
Ethernet31  Not present
Ethernet32  Not present
Ethernet33  Not present
Ethernet34  Not present
Ethernet35  Not present
Ethernet36  Not present
Ethernet37  Not present
Ethernet38  Not present
Ethernet39  Not present
Ethernet40  Not present
Ethernet41  Not present
Ethernet42  Not present
Ethernet43  Not present
Ethernet44  Not present
Ethernet45  Not present
Ethernet46  Not present
Ethernet47  Not present
Ethernet48  Present
Ethernet52  Present
Ethernet56  Present
Ethernet60  Present
Ethernet64  Present
Ethernet68  Present
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

