### PR TITLE
[202012] [qos] Update RDMA-CENTRIC lossy profile to use static threshold for Th devices

### DIFF
--- a/device/common/profiles/th/6100/RDMA-CENTRIC/buffers_defaults_t0.j2
+++ b/device/common/profiles/th/6100/RDMA-CENTRIC/buffers_defaults_t0.j2
@@ -26,7 +26,7 @@
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "dynamic_th":"3"
+            "static_th":"10875072"
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",

--- a/device/common/profiles/th/6100/RDMA-CENTRIC/buffers_defaults_t1.j2
+++ b/device/common/profiles/th/6100/RDMA-CENTRIC/buffers_defaults_t1.j2
@@ -26,7 +26,7 @@
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "dynamic_th":"3"
+            "static_th":"10875072"
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",

--- a/device/common/profiles/th/gen/RDMA-CENTRIC/buffers_defaults_t0.j2
+++ b/device/common/profiles/th/gen/RDMA-CENTRIC/buffers_defaults_t0.j2
@@ -25,7 +25,7 @@
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "dynamic_th":"3"
+            "static_th":"10875072"
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",

--- a/device/common/profiles/th/gen/RDMA-CENTRIC/buffers_defaults_t1.j2
+++ b/device/common/profiles/th/gen/RDMA-CENTRIC/buffers_defaults_t1.j2
@@ -25,7 +25,7 @@
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "dynamic_th":"3"
+            "static_th":"10875072"
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -5,6 +5,7 @@ import math
 import os
 import sys
 import json
+import subprocess
 from collections import defaultdict
 
 from lxml import etree as ET
@@ -61,6 +62,10 @@ class minigraph_encoder(json.JSONEncoder):
             )):
             return str(obj)
         return json.JSONEncoder.default(self, obj)
+
+def exec_cmd(cmd):
+    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+    outs, errs = p.communicate()
 
 def get_peer_switch_info(link_metadata, devices):
     peer_switch_table = {}
@@ -1162,7 +1167,14 @@ def select_mmu_profiles(profile, platform, hwsku):
 
     files_to_copy = ['pg_profile_lookup.ini', 'qos.json.j2', 'buffers_defaults_t0.j2', 'buffers_defaults_t1.j2']
 
-    path = os.path.join('/usr/share/sonic/device', platform, hwsku)
+    if os.environ.get("CFGGEN_UNIT_TESTING", "0") == "2":
+        for dir_path, dir_name, files in os.walk('/sonic/device'):
+            if platform in dir_path:
+                new_path = os.path.split(dir_path)[0]
+                break
+    else:
+        new_path = '/usr/share/sonic/device'
+    path = os.path.join(new_path, platform, hwsku)
 
     dir_path = os.path.join(path, profile)
     if os.path.exists(dir_path):

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -64,7 +64,7 @@ class minigraph_encoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 def exec_cmd(cmd):
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+    p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE)
     outs, errs = p.communicate()
 
 def get_peer_switch_info(link_metadata, devices):
@@ -1182,7 +1182,7 @@ def select_mmu_profiles(profile, platform, hwsku):
             file_in_dir = os.path.join(dir_path, file_item)
             if os.path.isfile(file_in_dir):
                 base_file = os.path.join(path, file_item)
-                exec_cmd("sudo cp {} {}".format(file_in_dir, base_file))
+                exec_cmd(["sudo", "cp", file_in_dir, base_file])
 
 ###############################################################################
 #

--- a/src/sonic-config-engine/tests/sample-dell-6100-t0-minigraph.xml
+++ b/src/sonic-config-engine/tests/sample-dell-6100-t0-minigraph.xml
@@ -716,6 +716,11 @@
             <a:Reference i:nil="true"/>
             <a:Value>10.0.0.16</a:Value>
           </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SonicQosProfile</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>RDMA-CENTRIC</a:Value>
+          </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
     </Devices>
@@ -730,11 +735,6 @@
             <a:Name>AutoNegotiation</a:Name>
             <a:Reference i:nil="true"/>
             <a:Value>True</a:Value>
-          </a:DeviceProperty>
-          <a:DeviceProperty>
-            <a:Name>SonicQosProfile</a:Name>
-            <a:Reference i:nil="true"/>
-            <a:Value>RDMA-CENTRIC</a:Value>
           </a:DeviceProperty>
         </a:Properties>
         <a:Key>ARISTA01T1:Ethernet1;s6100-dev-1:fortyGigE1/1/1</a:Key>

--- a/src/sonic-config-engine/tests/sample_output/py2/buffers-dell6100.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffers-dell6100.json
@@ -93,7 +93,7 @@
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "dynamic_th":"3"
+            "static_th":"10875072"
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-dell6100.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-dell6100.json
@@ -93,7 +93,7 @@
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "dynamic_th":"3"
+            "static_th":"10875072"
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -244,14 +244,18 @@ class TestJ2Files(TestCase):
         self._test_qos_render_template('dell', 'x86_64-dellemc_z9332f_d1508-r0', 'DellEMC-Z9332f-O32', 'sample-dell-9332-t1-minigraph.xml', 'qos-dell9332.json')
 
     def test_qos_dell6100_render_template(self):
-        self._test_qos_render_template('dell', 'x86_64-dell_s6100_c2538-r0', 'Force10-S6100', 'sample-dell-6100-t0-minigraph.xml', 'qos-dell6100.json')
+        self._test_qos_render_template('dell', 'x86_64-dell_s6100_c2538-r0', 'Force10-S6100', 'sample-dell-6100-t0-minigraph.xml', 'qos-dell6100.json', copy_files=True)
 
     def test_qos_arista7260_render_template(self):
         self._test_qos_render_template('arista', 'x86_64-arista_7260cx3_64', 'Arista-7260CX3-D96C16', 'sample-arista-7260-t1-minigraph-remap-disabled.xml', 'qos-arista7260.json')
 
-    def _test_qos_render_template(self, vendor, platform, sku, minigraph, expected):
+    def _test_qos_render_template(self, vendor, platform, sku, minigraph, expected, copy_files=False):
         file_exist, dir_exist = self.create_machine_conf(platform, vendor)
         dir_path = os.path.join(self.test_dir, '..', '..', '..', 'device', vendor, platform, sku)
+
+        if copy_files:
+            self.copy_mmu_templates(dir_path, revert=False)
+
         qos_file = os.path.join(dir_path, 'qos.json.j2')
         port_config_ini_file = os.path.join(dir_path, 'port_config.ini')
 
@@ -266,6 +270,8 @@ class TestJ2Files(TestCase):
         # cleanup
         qos_config_file_new = os.path.join(dir_path, 'qos_config.j2')
         os.remove(qos_config_file_new)
+        if copy_files:
+            self.copy_mmu_templates(dir_path, revert=True)
 
         self.remove_machine_conf(file_exist, dir_exist)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Backport #14372 to 202012

#### Why I did it
For better accounting purposes, updating the ingress lossy traffic profile to use static threshold. This change is only intended for Th devices using RDMA-CENTRIC profiles

#### How I did it
Update the buffer templates for Th devices in RDMA-CENTRIC folder to use the correct threshold
