### PR TITLE
[Build] use snapshots of debian mirrors for sonic-slave containers

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -581,6 +581,7 @@ endif
 
 export MIRROR_URLS
 export MIRROR_SECURITY_URLS
+export MIRROR_SNAPSHOT
 export SONIC_VERSION_CONTROL_COMPONENTS
 
 %:: | sonic-build-hooks


### PR DESCRIPTION
#### Why I did it

We don't use  snapshots of debian mirrors for sonic-slave containers even if MIRROR_SNAPSHOT is enabled.

#### How I did it

Export MIRROR_SNAPSHOT in Makefile.work to generate sources.list for sonic-slave containers using debian snapshot mirror

#### How to verify it

