### PR TITLE
[Build] disable DOCKER_BUILDKIT if SONIC_USE_DOCKER_BUILDKIT is not set

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -453,6 +453,8 @@ include Makefile.cache
 ifeq ($(SONIC_USE_DOCKER_BUILDKIT),y)
 $(warning "Using SONIC_USE_DOCKER_BUILDKIT will produce larger installable SONiC image because of a docker bug (more details: https://github.com/moby/moby/issues/38903)")
 export DOCKER_BUILDKIT=1
+else
+export DOCKER_BUILDKIT=0
 endif
 
 


### PR DESCRIPTION

#### Why I did it

Fix #14081
By default DOCKER_BUILDKIT is enabled after docker version 23.0.0
So we need to disable it explicitly if SONIC_USE_DOCKER_BUILDKIT is not set.
Otherwise it will produce larger installable images.

#### How I did it

set DOCKER_BUILDKIT=0 in slave.mk

#### How to verify it
