### PR TITLE
[Build] don't install rsync if vcache is disabled

### DIFF
--- a/src/sonic-build-hooks/scripts/pre_run_buildinfo
+++ b/src/sonic-build-hooks/scripts/pre_run_buildinfo
@@ -41,6 +41,8 @@ if [ "$ENABLE_VERSION_CONTROL_DEB" == "y" ] && [ -f $VERSION_DEB_PREFERENCE ]; t
     cp -f $VERSION_DEB_PREFERENCE /etc/apt/preferences.d/
 fi
 
-DISTRO=${DISTRO} apt-get update && apt-get install -y rsync
+if [ ! -z "$(get_version_cache_option)" ]; then
+    DISTRO=${DISTRO} apt-get update && apt-get install -y rsync
+fi
 
 exit 0


### PR DESCRIPTION

#### Why I did it

We don't need to install rsync in every docker container if vcache is disabled.

#### How I did it

Install rsync in pre_run_buildinfo script only if vcache is enabled.

#### How to verify it

