### PR TITLE
[Build] use sources.list for SLAVE_TAG

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -245,6 +245,7 @@ SLAVE_BASE_TAG = $(shell \
 SLAVE_TAG = $(shell \
 	(cat $(SLAVE_DIR)/Dockerfile.user \
 		 $(SLAVE_DIR)/Dockerfile \
+		 $(SLAVE_DIR)/sources.list.* \
 		 $(SLAVE_DIR)/buildinfo/versions/versions-* \
 	&& echo $(USER)/$(PWD)/$(CONFIGURED_PLATFORM)) \
 	| sha1sum \


### PR DESCRIPTION

#### Why I did it

This is a fix for c63e9fe59c32add15fb5a1876987
SLAVE_TAG should include all dependencies used for SLAVE_BASE_TAG

#### How I did it

Take sources.list.* into account when calculate SLAVE_TAG

#### How to verify it
