### PR TITLE
[201811] Check config file not empty after modify it in hostcfgd.

### DIFF
--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -167,10 +167,25 @@ class AaaCfg(object):
     def tacacs_server_update(self, key):
         self.modify_conf_file()
 
+    def check_file_not_empty(self, filename):
+        exists = os.path.exists(filename)
+        if not exists:
+            syslog.syslog(syslog.LOG_ERR, "file size check failed: {} is missing".format(filename))
+            return
+
+        size = os.path.getsize(filename)
+        if size == 0:
+            syslog.syslog(syslog.LOG_ERR, "file size check failed: {} is empty, file corrupted".format(filename))
+            return
+
+        syslog.syslog(syslog.LOG_INFO, "file size check pass: {} size is ({}) bytes".format(filename, size))
+
     def modify_single_file(self, filename, operations=None):
         if operations:
             cmd = "sed -e {0} {1} > {1}.new; mv -f {1} {1}.old; mv -f {1}.new {1}".format(' -e '.join(operations), filename)
             os.system(cmd)
+
+        self.check_file_not_empty(filename)
 
     def modify_conf_file(self):
         with lock_mgr():


### PR DESCRIPTION
**What I did**
Check /etc/pam.d/sshd integrity after modify it in hostcfgd.

**Why I did it**
Found some incident that /etc/pam.d/sshd become empty file during OR upgrade. 

**How I verified it**
Pass all UT.

**Details if related**
This is a manually cherry-pick PR for https://github.com/sonic-net/sonic-host-services/pull/36
