### PR TITLE
Secure boot fix instalation with devices that used ONIE version older than 2021.11

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -435,13 +435,20 @@ bootloader_menu_config()
         mv $onie_initrd_tmp/tmp/onie-support*.tar.bz2 $demo_mnt/$image_dir/
 
         if [ "$firmware" = "uefi" ] ; then
-            secure_boot_state=$(mokutil --sb-state)
+            if command -v mokutil >/dev/null 2>&1; then
+                # The command exists, so execute it
+                secure_boot_state=$(mokutil --sb-state)
+            else
+                # The command doesn't exist, so output an error message
+                echo "mokutil not found, to enable Secure Boot required to update ONIE to at least version 2021.11"
+                secure_boot_state="SecureBoot disabled"
+            fi
             echo secure_boot_state=$secure_boot_state
             if [ "$secure_boot_state" = "SecureBoot enabled" ]; then
-                echo "UEFI Secure Boot is enabled"
+                echo "UEFI Secure Boot is enabled - Installing shim bootloader"
                 demo_install_uefi_shim "$demo_mnt" "$blk_dev"
             else
-                echo "UEFI Secure Boot is disabled"
+                echo "UEFI Secure Boot is disabled - Installing regular grub bootloader"
                 demo_install_uefi_grub "$demo_mnt" "$blk_dev"
             fi
         else


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
solution to BUG below/
https://github.com/sonic-net/sonic-buildimage/issues/14316
bug report also in this issue:
backport: secureboot support #14246
#### How I did it
When installing an image secure boot is checking if the UEFI have the secure boot flag enabled or disabled using a tool name `mokutil` this tool its not exist in ONIE version older than 2021.11 so its crasshing the install.
To fix that we add a coded that checking if the tool exist, if not exist it will assume that you ONIE its older an proceed with the installation with grub.
#### How to verify it
Install the image in a device with ONIE version older than 2021.11 and check that the installation and boot succeed (all docker up).
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [X ] 202211
- master
#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

