### PR TITLE
[201911] Improve sudo cat command for RO user. (#14428)

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -40,7 +40,7 @@ Cmnd_Alias      READ_ONLY_CMDS = /sbin/brctl show, \
                                  /usr/bin/vtysh -c show bgp ipv[46] summary json, \
                                  /usr/bin/vtysh -n [0-9] -c show version, \
                                  /bin/ip netns identify [0-9]*, \
-                                 /bin/cat /var/log/syslog*, \
+                                 /bin/cat /var/log/syslog, /bin/cat /var/log/syslog.1 /var/log/syslog, /bin/cat /var/log/syslog.1, \
                                  /usr/bin/tail -F /var/log/syslog
 
 Cmnd_Alias      PASSWD_CMDS = /usr/bin/config tacacs passkey *, \


### PR DESCRIPTION
Improve sudo cat command for RO user.
Manually cherry-pick for https://github.com/sonic-net/sonic-buildimage/pull/14428

#### Why I did it
RO user can use sudo command show none syslog files.

#### How I did it
Improve sudo cat command for RO user.

#### How to verify it
Pass all UT.
Manually check fixed code work correctly.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
Improve sudo cat command for RO user.

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

