### PR TITLE
Add sonic-launch-shell to invoke appropriate shell based upon user's …

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/base_image_files/sonic-launch-shell
+++ b/dockers/docker-sonic-mgmt-framework/base_image_files/sonic-launch-shell
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Launch the "preferred" shell based on the groups that the user belongs to.
+# The preferred shell is either:
+#    /bin/bash:          If the user belongs to group "admin"
+#    /usr/bin/sonic-cli: Otherwise
+
+# Uncomment "set -x" for debugging
+#set -x
+
+if /usr/bin/id -Gn | tr " " "\n" | /bin/grep -qw "^admin$"; then
+    exec /bin/bash "$@"
+else
+    exec /usr/bin/sonic-cli
+fi

--- a/rules/docker-sonic-mgmt-framework.mk
+++ b/rules/docker-sonic-mgmt-framework.mk
@@ -36,6 +36,7 @@ $(DOCKER_MGMT_FRAMEWORK)_RUN_OPT += -v /var/run/dbus:/var/run/dbus:rw
 $(DOCKER_MGMT_FRAMEWORK)_RUN_OPT += --mount type=bind,source="/var/platform/",target="/mnt/platform/"
 
 $(DOCKER_MGMT_FRAMEWORK)_BASE_IMAGE_FILES += sonic-cli:/usr/bin/sonic-cli
+$(DOCKER_MGMT_FRAMEWORK)_BASE_IMAGE_FILES += sonic-launch-shell:/usr/bin/sonic-launch-shell
 
 SONIC_BUSTER_DOCKERS += $(DOCKER_MGMT_FRAMEWORK)
 SONIC_BUSTER_DBG_DOCKERS += $(DOCKER_MGMT_FRAMEWORK_DBG)


### PR DESCRIPTION
…privilege level.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fixes  #11352. 
Login to switch via RADIUS authentication fails due to missing sonic-launch-shell script that invokes appropriate shell for the user based upon privilege level.

#### How I did it
Added sonic-launch-shell script that checks the user's privilege level and loads the appropriate shell for the user.

Admin users will be presented the /bin/bash shell. Operator users (non-admin users) are presented sonic-cli. 
Note that sonic-cli invocation currently fails as shown below. Until this is fixed, non-admin users will not get access to the switch.

:~$ sonic-cli
Error: Unresolved PTYPE "MCLAG_KA_INTERVAL_RANGE" in PARAM "KA"
:~$ 

#### How to verify it

1. Configure Radius Server with admin user.

2. Configure aaa authentication on Sonic Switch
config aaa authentication login radius local

3. Config radius server on Sonic Switch
config radius add {RadiusServerIP} -k {RadiusServerPassword} 

4. Try to connect by ssh to Sonic Switch with admin user credentials.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
Added sonic-launch-shell to invoke appropriate shell for the user post authentication.

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

