### PR TITLE
[201911][Arista] Disable ATA NCQ for a few products

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -309,6 +309,7 @@ platform_specific() {
     if [ "$sid" = "Lodoga" ]; then
         aboot_machine=arista_7050cx3_32s
         flash_size=3700
+        echo "libata.force=2.00:noncq" >> /tmp/append
     fi
     if [ "$sid" = "BlackhawkO" ]; then
         aboot_machine=arista_7060px4_32
@@ -337,6 +338,8 @@ platform_specific() {
     fi
     if in_array "$platform" "rook"; then
         echo "iommu=on intel_iommu=on" >>/tmp/append
+        # Currently applies to Alhambra, Blackhawk, Gardena and Mineral
+        echo "libata.force=1.00:noncq" >>/tmp/append
         read_system_eeprom
     fi
     if in_array "$platform" "crow" "woodpecker" "magpie"; then


### PR DESCRIPTION
#### Why I did it
Some products might experience an occasional IO failure in the communication between CPU and SSD. Based on some research it could be attributable to some device not handling ATA NCQ (Native Command Queue).

This issue currently affect 4 products:

DCS-7170-32C*
DCS-7170-64C
DCS-7060DX4-32
DCS-7260CX3-64
DCS-7050CX3-32S

#### How I did it
This change disable NCQ on the affected drive for a small set of products.

#### How to verify it
When the fix is applied, these 2 patterns can be found in the dmesg. ata[0-9]+.00: FORCE: horkage modified (noncq)
NCQ (not used)

Test results using: `fio --direct=1 --rw=randrw --bs=64k --ioengine=libaio --iodepth=64 --runtime=120 --numjobs=4`

with NCQ (ata1.00: 61865984 sectors, multi 1: LBA48 NCQ (depth 32), AA)
```
   READ: bw=33.9MiB/s (35.6MB/s), 33.9MiB/s-33.9MiB/s (35.6MB/s-35.6MB/s), io=4073MiB (4270MB), run=120078-120078msec
  WRITE: bw=34.1MiB/s (35.8MB/s), 34.1MiB/s-34.1MiB/s (35.8MB/s-35.8MB/s), io=4100MiB (4300MB), run=120078-120078msec
```

without NCQ (ata1.00: 61865984 sectors, multi 1: LBA48 NCQ (not used))
```
   READ: bw=31.7MiB/s (33.3MB/s), 31.7MiB/s-31.7MiB/s (33.3MB/s-33.3MB/s), io=3808MiB (3993MB), run=120083-120083msec
  WRITE: bw=31.9MiB/s (33.4MB/s), 31.9MiB/s-31.9MiB/s (33.4MB/s-33.4MB/s), io=3830MiB (4016MB), run=120083-120083msec
Which release branch to backport (provide reason below if selected)
```

with NCQ ata2.00 (DCS-7050CX3-32S)
```
   READ: bw=26.1MiB/s (27.4MB/s), 26.1MiB/s-26.1MiB/s (27.4MB/s-27.4MB/s), io=3136MiB (3288MB), run=120053-120053msec
  WRITE: bw=26.3MiB/s (27.6MB/s), 26.3MiB/s-26.3MiB/s (27.6MB/s-27.6MB/s), io=3161MiB (3315MB), run=120053-120053msec
```
without NCQ ata2.00 (DCS-7050CX3-32S)
```
   READ: bw=22.0MiB/s (23.1MB/s), 22.0MiB/s-22.0MiB/s (23.1MB/s-23.1MB/s), io=2647MiB (2775MB), run=120069-120069msec
  WRITE: bw=22.2MiB/s (23.3MB/s), 22.2MiB/s-22.2MiB/s (23.3MB/s-23.3MB/s), io=2665MiB (2795MB), run=120069-120069msec
```

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Disable ATA NCQ for a few products
