### PR TITLE
[Build][201911] Fix the jessie mirror removed issue

### DIFF
--- a/dockers/docker-base/sources.list.armhf
+++ b/dockers/docker-base/sources.list.armhf
@@ -1,7 +1,7 @@
 ## Debian mirror for ARM repo
 
 # ARMhf repo
-deb [arch=armhf] http://deb.debian.org/debian jessie main contrib non-free
-deb-src [arch=armhf] http://deb.debian.org/debian jessie main contrib non-free
-deb [arch=armhf] http://security.debian.org jessie/updates main contrib non-free
-deb-src [arch=armhf] http://security.debian.org jessie/updates main contrib non-free
+deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ jessie main contrib non-free
+deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ jessie main contrib non-free
+deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z/ jessie/updates main contrib non-free
+deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z/ jessie/updates main contrib non-free

--- a/sonic-slave-jessie/Dockerfile.j2
+++ b/sonic-slave-jessie/Dockerfile.j2
@@ -14,21 +14,21 @@ COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
 ## Remove retired jessie-updates repo
 RUN sed -i '/http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
 
-RUN echo "deb [arch=amd64] http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb-src [arch=amd64] http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb [arch=amd64] http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb-src [arch=amd64] http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free" >> /etc/apt/sources.list
+RUN echo "deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ jessie main contrib non-free" > /etc/apt/sources.list && \
+        echo "deb-src [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ jessie main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z/ jessie/updates main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb-src [arch=amd64] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z/ jessie/updates main contrib non-free" >> /etc/apt/sources.list
 
 {% if CONFIGURED_ARCH == "armhf" %}
-RUN echo "deb [arch=armhf] http://deb.debian.org/debian jessie main contrib non-free" > /etc/apt/sources.list && \
-        echo "deb-src [arch=armhf] http://deb.debian.org/debian jessie main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb [arch=armhf] http://security.debian.org jessie/updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb-src [arch=armhf] http://security.debian.org jessie/updates main contrib non-free" >> /etc/apt/sources.list
+RUN echo "deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ jessie main contrib non-free" > /etc/apt/sources.list && \
+        echo "deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ jessie main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z/ jessie/updates main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z/ jessie/updates main contrib non-free" >> /etc/apt/sources.list
 {% elif CONFIGURED_ARCH == "arm64" %}
-RUN echo "deb [arch=arm64] http://archive.debian.org/debian jessie main contrib non-free" > /etc/apt/sources.list && \
-        echo "deb-src [arch=arm64] http://archive.debian.org/debian jessie main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb-src [arch=arm64] http://archive.debian.org/debian jessie-backports main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb [arch=arm64] http://archive.debian.org/debian jessie-backports main contrib non-free" >> /etc/apt/sources.list
+RUN echo "deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ jessie main contrib non-free" > /etc/apt/sources.list && \
+        echo "deb-src [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ jessie main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb-src [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ jessie-backports main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ jessie-backports main contrib non-free" >> /etc/apt/sources.list
 {% endif %}
 
 ## Make apt-get non-interactive

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -383,7 +383,7 @@ RUN pip install setuptools==40.8.0
 RUN pip install Pympler==0.8
 
 # For mgmt-framework build
-RUN pip install mmh3
+RUN pip install mmh3==2.5.1
 
 # Install dependencies for isc-dhcp-relay build
 RUN apt-get -y build-dep isc-dhcp


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
[Build] Fix the jessie mirror removed issue.



#### How I did it
Change to use the snapshot mirror http://packages.trafficmanager.net/snapshot.

Warning: The Jessie distribution is EOL, please avoid to use it if you can. And the snapshot mirror will be removed in near future as well.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

