### PR TITLE
Fix backend port channels and routes being displayed

### DIFF
--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -354,13 +354,12 @@ def is_port_channel_internal(port_channel, namespace=None):
 
     for ns in ns_list:
         config_db = connect_config_db_for_ns(ns)
-        port_channels = config_db.get_entry(PORT_CHANNEL_CFG_DB_TABLE, port_channel)
+        port_channel_members = config_db.get_keys("PORTCHANNEL_MEMBER")
 
-        if port_channels:
-            if 'members' in port_channels:
-                members = port_channels['members']
-                if is_port_internal(members[0], namespace):
-                    return True
+        for port_channel_member in port_channel_members:
+            if port_channel_member[0] != port_channel:
+                continue
+            return is_port_internal(port_channel_member[1], namespace)
 
     return False
 
@@ -380,14 +379,14 @@ def get_back_end_interface_set(namespace=None):
         ns_list = get_namespace_list(namespace)
         for ns in ns_list:
             config_db = connect_config_db_for_ns(ns)
-            port_channels = config_db.get_table(PORT_CHANNEL_CFG_DB_TABLE)
+            port_channel_members = config_db.get_keys("PORTCHANNEL_MEMBER")
             # a back-end LAG must be configured with all of its member from back-end interfaces.
             # mixing back-end and front-end interfaces is miss configuration and not allowed.
             # To determine if a LAG is back-end LAG, just need to check its first member is back-end or not
             # is sufficient. Note that a user defined LAG may have empty members so the list expansion logic
             # need to ensure there are members before inspecting member[0].
-            bk_end_intf_list.extend([port_channel for port_channel, lag_info in port_channels.items()\
-                                if 'members' in lag_info and lag_info['members'][0] in bk_end_intf_list])
+            bk_end_intf_list.extend(set([port_channel_member[0] for port_channel_member in port_channel_members\
+                                if port_channel_member[1] in bk_end_intf_list]))
     a = set()
     a.update(bk_end_intf_list)
     return a

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -18,7 +18,7 @@ EXTERNAL_PORT = 'Ext'
 INTERNAL_PORT = 'Int'
 INBAND_PORT = 'Inb'
 RECIRC_PORT ='Rec'
-PORT_CHANNEL_CFG_DB_TABLE = 'PORTCHANNEL'
+PORT_CHANNEL_MEMBER_CFG_DB_TABLE = 'PORTCHANNEL_MEMBER'
 PORT_CFG_DB_TABLE = 'PORT'
 BGP_NEIGH_CFG_DB_TABLE = 'BGP_NEIGHBOR'
 BGP_INTERNAL_NEIGH_CFG_DB_TABLE = 'BGP_INTERNAL_NEIGHBOR'
@@ -354,7 +354,7 @@ def is_port_channel_internal(port_channel, namespace=None):
 
     for ns in ns_list:
         config_db = connect_config_db_for_ns(ns)
-        port_channel_members = config_db.get_keys("PORTCHANNEL_MEMBER")
+        port_channel_members = config_db.get_keys(PORT_CHANNEL_MEMBER_CFG_DB_TABLE)
 
         for port_channel_member in port_channel_members:
             if port_channel_member[0] != port_channel:
@@ -379,7 +379,7 @@ def get_back_end_interface_set(namespace=None):
         ns_list = get_namespace_list(namespace)
         for ns in ns_list:
             config_db = connect_config_db_for_ns(ns)
-            port_channel_members = config_db.get_keys("PORTCHANNEL_MEMBER")
+            port_channel_members = config_db.get_keys(PORT_CHANNEL_MEMBER_CFG_DB_TABLE)
             # a back-end LAG must be configured with all of its member from back-end interfaces.
             # mixing back-end and front-end interfaces is miss configuration and not allowed.
             # To determine if a LAG is back-end LAG, just need to check its first member is back-end or not


### PR DESCRIPTION
Fixes #14459.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

In `show interface portchannel` and `show ip route`, backend port channels and routes were being displayed. This is due to changes in #13660. Fix these issues by switching to reading from PORTCHANNEL_MEMBERS table instead.

#### How I did it

#### How to verify it

Replaced the `multi_asic.py` script at `/usr/local/lib/python3.9/dist-packages/sonic_py_common/multi_asic.py` with the fixed version. Verified that `show int portchannel` and `show ip route` no longer showed routes that used the backend port channels.

Current:

```
admin@xxxxx:~$ show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route, q - queued route, r - rejected route

C>*1.0.0.0/16 is directly connected, eth1, 1d17h25m
B>*10.106.28.16/31 [200/0] via 10.235.100.134, PortChannel4089, 1d16h16m
  *                        via 10.235.100.4, PortChannel4077, 1d16h16m
  *                        via 10.235.99.134, PortChannel4071, 1d16h16m
  *                        via 10.235.99.4, PortChannel4059, 1d16h16m
  *                        via 10.235.98.134, PortChannel4053, 1d16h16m
  *                        via 10.235.98.4, PortChannel4041, 1d16h16m
  *                        via 10.235.97.134, PortChannel4035, 1d16h16m
  *                        via 10.235.97.4, PortChannel4023, 1d16h16m
  *                        via 10.235.96.134, PortChannel4017, 1d16h16m
  *                        via 10.235.96.4, PortChannel4005, 1d16h16m
...
```

Fixed:

```
admin@xxxxxx:~$ show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route, q - queued route, r - rejected route

C>*1.0.0.0/16 is directly connected, eth1, 1d17h24m
B> 10.106.28.16/31 [200/0] via 25.103.166.105, (recursive) 1d16h15m
                           via 25.103.166.105, (recursive) 1d16h15m
B> 10.106.28.22/31 [200/0] via 25.103.166.105, (recursive) 1d16h15m
                           via 25.103.166.105, (recursive) 1d16h15m
B> 10.106.28.26/31 [200/0] via 25.103.166.105, (recursive) 1d16h15m
                           via 25.103.166.105, (recursive) 1d16h15m
B> 10.106.28.28/31 [200/0] via 25.103.166.105, (recursive) 1d16h15m
                           via 25.103.166.105, (recursive) 1d16h15m
C>*25.103.166.97/32 is directly connected, Loopback0, 1d17h24m
B> 25.103.166.98/32 [200/0] via 25.103.166.106, (recursive) 1d16h15m
                            via 25.103.166.105, (recursive) 1d16h15m
                            via 25.103.166.105, (recursive) 1d16h15m
                            via 25.103.166.106, (recursive) 1d16h15m
C>*25.103.166.103/32 is directly connected, Loopback4096, 1d17h24m
C>*25.103.166.104/32 is directly connected, Loopback4096, 1d17h24m
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

