### PR TITLE
Modify common-auth-sonic  to take care of case where no RADIUS server…

### DIFF
--- a/src/sonic-host-services-data/templates/common-auth-sonic.j2
+++ b/src/sonic-host-services-data/templates/common-auth-sonic.j2
@@ -40,7 +40,11 @@ auth	[success=1 default=ignore]	pam_exec.so /usr/sbin/cache_radius
 
 {% elif auth['login'] == 'radius,local' %}
 # root user can only be authenticated locally. Jump to local.
+{% if servers | count %}
 auth	[success={{ (servers | count) }} default=ignore]	pam_succeed_if.so user = root
+{% else %}
+auth	[success=ok default=ignore]	pam_succeed_if.so user = root
+{% endif %}
 # For the RADIUS servers, on success jump to the cache the MPL(Privilege)
 {% for server in servers %}
 auth	[success={{ (servers | count) + 1 - loop.index0 }} new_authtok_reqd=done default=ignore{{ ' auth_err=die' if not auth['failthrough'] }}]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/{{ server.ip }}_{{ server.auth_port }}.conf privilege_level protocol={{ server.auth_type }} retry={{ server.retransmit }}{% if server.nas_ip is defined %} nas_ip_address={{ server.nas_ip }}{% endif %}{% if server.nas_id is defined %} client_id={{ server.nas_id }}{% endif %}{% if debug %} debug{% endif %}{% if trace %} trace{% endif %}{% if server.statistics %} statistics={{ server.ip }}{% endif %} try_first_pass


### PR DESCRIPTION
…s are configured.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes #14277.

Fixes the inconsistent fallback behaviour for RADIUS authentication when AAA authentication is configured as "radius, local".

#### How I did it

Modified common-auth-sonic.j2 template to make sure that when no RADIUS servers are configured (with AAA authentication login method set to radius, local), the system falls back to local authentication successfully.

#### How to verify it

1. Configure authentication based on RADIUS and local.
config aaa authentication login radius local

2. Configure an unreachable RADIUS server.
config radius add 6.6.6.6

3. Try to login to switch with existing admin user credentials. This is successful.

4. Remove RADIUS server configuration.
config radius delete 6.6.6.6

5. Try to login to switch with admin user credentials. This is successful.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Update common-auth-sonic.j2 template to handle AAA authentication fallback.

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

