### PR TITLE
Modify yang model to handle subport in PORT table

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1501,7 +1501,7 @@ optional attributes.
             "mtu": "9100",
             "alias": "etp1a",
             "speed": "100000",
-            "channel": 1
+            "subport": 1
         },
         "Ethernet4": {
             "admin_status": "up",
@@ -1511,7 +1511,7 @@ optional attributes.
             "mtu": "9100",
             "alias": "etp1b",
             "speed": "100000",
-            "channel": 2
+            "subport": 2
         },
     }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -559,7 +559,7 @@
                 "autoneg": "on",
                 "adv_speeds": "all",
                 "adv_interface_types": "all",
-                "channel" : "0"
+                "subport" : "0"
             },
             "Ethernet3": {
                 "alias": "Eth1/4",
@@ -568,7 +568,7 @@
                 "speed": "11100",
                 "tpid": "0x88A8",
                 "admin_status": "up",
-                "channel": "1"
+                "subport": "1"
             },
             "Ethernet4": {
                 "alias": "Eth2/1",
@@ -577,7 +577,7 @@
                 "speed": "11100",
                 "tpid": "0x9100",
                 "admin_status": "up",
-                "channel": "2"
+                "subport": "2"
             },
             "Ethernet5": {
                 "alias": "Eth2/2",
@@ -586,7 +586,7 @@
                 "speed": "11100",
                 "tpid": "0x9200",
                 "admin_status": "up",
-                "channel": "3"
+                "subport": "3"
             },
             "Ethernet6": {
                 "alias": "Eth2/3",
@@ -595,7 +595,7 @@
                 "speed": "11100",
                 "tpid": "0x8100",
                 "admin_status": "up",
-                "channel": "4"
+                "subport": "4"
             },
             "Ethernet7": {
                 "alias": "Eth2/4",
@@ -604,7 +604,7 @@
                 "speed": "11100",
                 "tpid": "0x8100",
                 "admin_status": "up",
-                "channel": "5"
+                "subport": "5"
             },
             "Ethernet8": {
                 "alias": "Eth3/1",
@@ -613,7 +613,7 @@
                 "speed": "11100",
                 "tpid": "0x8100",
                 "admin_status": "up",
-                "channel": "6"
+                "subport": "6"
             },
             "Ethernet9": {
                 "alias": "Eth3/2",
@@ -622,7 +622,7 @@
                 "speed": "11100",
                 "tpid": "0x8100",
                 "admin_status": "up",
-                "channel": "7"
+                "subport": "7"
             },
             "Ethernet10": {
                 "alias": "Eth3/3",
@@ -631,7 +631,7 @@
                 "speed": "11100",
                 "tpid": "0x8100",
                 "admin_status": "up",
-                "channel": "8"
+                "subport": "8"
             },
             "Ethernet11": {
                 "alias": "Eth3/4",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
@@ -121,11 +121,11 @@
          "desc": "PORT_INVALID_MULTIASIC_TEST invalid role pattern, expect fail",
          "eStrKey": "Pattern"
      },
-     "PORT_VALID_CHANNEL_NUMBER": {
-         "desc": "PORT_VALID_CHANNEL_NUMBER no failure."
+     "PORT_VALID_SUBPORT_NUMBER": {
+         "desc": "PORT_VALID_SUBPORT_NUMBER no failure."
      },
-     "PORT_INVALID_CHANNEL_NUMBER": {
-         "desc": "Out of range channel number",
+     "PORT_INVALID_SUBPORT_NUMBER": {
+         "desc": "Out of range subport number",
          "eStrKey": "Range",
          "eStr": "0..8"
      }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -516,7 +516,7 @@
         }
     },
 
-    "PORT_INVALID_CHANNEL_NUMBER": {
+    "PORT_INVALID_SUBPORT_NUMBER": {
          "sonic-port:sonic-port": {
              "sonic-port:PORT": {
                  "PORT_LIST": [
@@ -525,14 +525,14 @@
                          "alias": "etp1a",
                          "lanes": "60, 61",
                          "speed": 100000,
-                         "channel": 9
+                         "subport": 9
                      }
                  ]
              }
          }
      },
 
-     "PORT_VALID_CHANNEL_NUMBER": {
+     "PORT_VALID_SUBPORT_NUMBER": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {
                 "PORT_LIST": [
@@ -541,28 +541,28 @@
                         "alias": "etp1a",
                         "lanes": "60, 61",
                         "speed": 100000,
-                        "channel": 1
+                        "subport": 1
                     },
                     {
                        "name": "Ethernet2",
                         "alias": "etp1b",
                         "lanes": "62, 63",
                         "speed": 100000,
-                        "channel": 2
+                        "subport": 2
                     },
                     {
                         "name": "Ethernet4",
                         "alias": "etp1c",
                         "lanes": "64, 65",
                         "speed": 100000,
-                        "channel": 3
+                        "subport": 3
                     },
                     {
                         "name": "Ethernet6",
                         "alias": "etp1d",
                         "lanes": "66, 67",
                         "speed": 100000,
-                        "channel": 4
+                        "subport": 4
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -121,8 +121,8 @@ module sonic-port{
 					}
 				}
 
-				leaf channel {
-					description "Logical channel(s) for physical port breakout";
+				leaf subport {
+					description "Logical subport(s) for physical port breakout";
 					type uint8 {
 						range 0..8;
 					}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Based on the [port breakout HLD](https://github.com/sonic-net/SONiC/pull/1290), we are now using `subport` instead of `channel` in the CONFIG_DB  PORT table to handle port breakout. The yang schema needs to be modified accordingly to handle the corresponding change.
The corresponding code changes have been merged through sonic-net/sonic-platform-daemons/pull/342 merged

#### How I did it
Replaced `channel` with `subport` in the Yang model handling PORT table

#### How to verify it
The corresponding unit-tests passed for this change.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

