### PR TITLE
[yang] add NEIGH yang model

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -43,7 +43,8 @@ Table of Contents
          * [Management port](#management-port)  
          * [Management VRF](#management-vrf)  
          * [MAP_PFC_PRIORITY_TO_QUEUE](#map_pfc_priority_to_queue)  
-         * [MUX_CABLE](#muxcable)  
+         * [MUX_CABLE](#mux_cable)  
+         * [NEIGH](#neigh)
          * [NTP Global Configuration](#ntp-global-configuration)  
          * [NTP and SYSLOG servers](#ntp-and-syslog-servers)  
          * [Peer Switch](#peer-switch)  
@@ -1288,6 +1289,32 @@ The **MUX_CABLE** table is used for dualtor interface configuration. The `cable_
             "server_ipv6": "fc02:1000::30/128",
             "soc_ipv4": "192.168.0.3/32",
             "state": "auto"
+        }
+    }
+}
+```
+
+### NEIGH
+
+The **NEIGH** table is used to keep track of resolved and static neighbors.
+
+Resolve case:
+```
+{
+    "NEIGH": {
+        "Vlan100|100.1.1.3": { 
+            "family": "IPv4" 
+        }
+    }
+}
+```
+Static Nbr:
+```
+{
+    "NEIGH": {
+        "Vlan100|100.1.1.5": { 
+            "neigh": "00:02:02:03:04:05",
+            "family": "IPv4" 
         }
     }
 }

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -132,6 +132,7 @@ setup(
                          './yang-models/sonic-mirror-session.yang',
                          './yang-models/sonic-mpls-tc-map.yang',
                          './yang-models/sonic-mux-cable.yang',
+                         './yang-models/sonic-neigh.yang',
                          './yang-models/sonic-ntp.yang',
                          './yang-models/sonic-nat.yang',
                          './yang-models/sonic-nvgre-tunnel.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2097,6 +2097,15 @@
             }
         },
 
+        "NEIGH": {
+            "Vlan100|100.1.1.3": {
+                "family": "IPv4"
+            },
+            "Vlan100|100.1.1.5": {
+                "neigh": "00:02:02:03:04:05",
+                "family": "IPv4"
+            }
+        },
 
         "POLICER": {
             "everflow_static_policer": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/neigh.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/neigh.json
@@ -1,0 +1,15 @@
+{
+    "VALID_NEIGH": {
+        "desc": "Load valid neighbors"
+    },
+
+    "NEIGH_MISSING_IP": {
+        "desc": "Load NEIGH missing IP address",
+        "eStr": ["Invalid JSON data"]
+    },
+
+    "NEIGH_INVALID_VLAN": {
+        "desc": "Load NEIGH missing VLAN",
+        "eStr": ["points to a non-existing leaf."]
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/neigh.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/neigh.json
@@ -10,6 +10,6 @@
 
     "NEIGH_INVALID_VLAN": {
         "desc": "Load NEIGH missing VLAN",
-        "eStr": ["points to a non-existing leaf."]
+        "eStr": ["does not satisfy the constraint"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
@@ -1,0 +1,73 @@
+{
+    "VALID_NEIGH": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan1000"
+                    }
+                ]
+            }
+        },
+        "sonic-neigh:sonic-neigh": {
+            "sonic-neigh:NEIGH": {
+                "NEIGH_LIST": [
+                    {
+                        "vlan": "Vlan1000",
+                        "neighbor": "100.1.1.3",
+                        "neigh": "00:02:02:03:04:05",
+                        "family": "IPv4"
+                    },
+                    {
+                        "vlan": "Vlan1000",
+                        "neighbor": "100.1.1.4",
+                        "family": "IPv4"
+                    }
+                ]
+            }
+        }
+    },
+
+    "NEIGH_MISSING_IPV4": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan1000"
+                    }
+                ]
+            }
+        },
+        "sonic-neigh:sonic-neigh": {
+            "sonic-neigh:NEIGH": {
+                "NEIGH_LIST": [
+                    {
+                        "vlan": "Vlan1000",
+                        "neigh": "00:02:02:03:04:05",
+                        "family": "IPv4"
+                    }
+                ]
+            }
+        }
+    },
+
+    "NEIGH_INVALID_VLAN": {
+        "sonic-neigh:sonic-neigh": {
+            "sonic-neigh:NEIGH": {
+                "NEIGH_LIST": [
+                    {
+                        "vlan": "Vlan1000",
+                        "neighbor": "100.1.1.3",
+                        "neigh": "00:02:02:03:04:05",
+                        "family": "IPv4"
+                    },
+                    {
+                        "vlan": "Vlan1000",
+                        "neighbor": "100.1.1.4",
+                        "family": "IPv4"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
@@ -56,7 +56,7 @@
             "sonic-neigh:NEIGH": {
                 "NEIGH_LIST": [
                     {
-                        "vlan": "Vlan1000",
+                        "vlan": "INVALIDVlan",
                         "neighbor": "100.1.1.3",
                         "neigh": "00:02:02:03:04:05",
                         "family": "IPv4"

--- a/src/sonic-yang-models/yang-models/sonic-neigh.yang
+++ b/src/sonic-yang-models/yang-models/sonic-neigh.yang
@@ -1,0 +1,59 @@
+module sonic-neigh {
+	yang-version 1.1;
+	namespace "http://github.com/sonic-net/sonic-neigh";
+	prefix neigh;
+
+	import ietf-inet-types {
+		prefix inet;
+	}
+
+	import ietf-yang-types {
+		prefix yang;
+	}
+
+	import sonic-vlan {
+		prefix svlan;
+	}
+
+	organization "SONiC";
+	contact "SONiC";
+
+	description "NEIGH YANG Module for SONiC OS";
+
+	revision 2023-03-31 {
+		description "Initial Revision";
+	}
+
+	container sonic-neigh {
+		container NEIGH {
+			description "NEIGH configuration";
+			list NEIGH_LIST {
+				key "vlan neighbor";
+
+				leaf vlan {
+					description "Neighbor interface and IP address ex. Vlan1000|100.1.1.3";
+					type leafref {
+						path "/svlan:sonic-vlan/svlan:VLAN/svlan:VLAN_LIST/svlan:name";
+					}
+				}
+
+				leaf neighbor {
+					description "Neighbor interface and IP address ex. Vlan1000|100.1.1.3";
+					type inet:ip-address;
+				}
+
+				leaf neigh {
+					description "Neighbor MAC address";
+					type yang:mac-address;
+				}
+
+				leaf family {
+					description "IP family of Neighbor address";
+					type string {
+						pattern "IPv4|IPV4|IPv6|IPV6";
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/sonic-yang-models/yang-models/sonic-neigh.yang
+++ b/src/sonic-yang-models/yang-models/sonic-neigh.yang
@@ -11,10 +11,6 @@ module sonic-neigh {
 		prefix yang;
 	}
 
-	import sonic-vlan {
-		prefix svlan;
-	}
-
 	organization "SONiC";
 	contact "SONiC";
 
@@ -31,14 +27,14 @@ module sonic-neigh {
 				key "vlan neighbor";
 
 				leaf vlan {
-					description "Neighbor interface and IP address ex. Vlan1000|100.1.1.3";
-					type leafref {
-						path "/svlan:sonic-vlan/svlan:VLAN/svlan:VLAN_LIST/svlan:name";
+					description "Neighbor Vlan interface ex. Vlan1000";
+					type string {
+						pattern "Vlan[0-9]+";
 					}
 				}
 
 				leaf neighbor {
-					description "Neighbor interface and IP address ex. Vlan1000|100.1.1.3";
+					description "Neighbor IP address ex. 100.1.1.3";
 					type inet:ip-address;
 				}
 


### PR DESCRIPTION
#### Why I did it
Yang model for NEIGH table was missing
Fixed https://github.com/sonic-net/sonic-buildimage/issues/13971

#### How I did it
added sonic-neigh.yang model

#### How to verify it
make buildimage

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
Adding NEIGH yang model

#### Link to config_db schema for YANG module changes

(https://github.com/sonic-net/sonic-buildimage/blob/b721ff87b976a6a38bdd65443ea3bc686014e783/src/sonic-yang-models/doc/Configuration.md#neigh)

