### PR TITLE
fix long delay of stopping syncd container in warm-reboot

### DIFF
--- a/files/scripts/syncd_common.sh
+++ b/files/scripts/syncd_common.sh
@@ -163,7 +163,7 @@ stop() {
 
     stopplatform1
 
-    /usr/bin/${SERVICE}.sh stop $DEV
+    /usr/bin/${SERVICE}.sh stop $DEV &
     debug "Stopped ${SERVICE}$DEV service..."
 
     stopplatform2

--- a/files/scripts/syncd_common.sh
+++ b/files/scripts/syncd_common.sh
@@ -163,7 +163,11 @@ stop() {
 
     stopplatform1
 
-    /usr/bin/${SERVICE}.sh stop $DEV &
+    if [[ x"$WARM_BOOT" == x"true" ]]; then
+        /usr/bin/${SERVICE}.sh stop $DEV &
+    else
+        /usr/bin/${SERVICE}.sh stop $DEV
+    fi
     debug "Stopped ${SERVICE}$DEV service..."
 
     stopplatform2

--- a/files/scripts/syncd_common.sh
+++ b/files/scripts/syncd_common.sh
@@ -163,7 +163,7 @@ stop() {
 
     stopplatform1
 
-    if [[ x"$WARM_BOOT" == x"true" ]]; then
+    if [[ x"$WARM_BOOT" == x"true" ]] && [[ x$sonic_asic_platform == x"cisco-8000" ]]; then
         /usr/bin/${SERVICE}.sh stop $DEV &
     else
         /usr/bin/${SERVICE}.sh stop $DEV


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
We have seen LACP flapping in warm-reboot testing. The reason is that the time between teamd sending the last LACPDU before going down and the 1st LACPDU after teamd coming up after warm-reboot is more than 90 seconds. One cause contributes to this long warm-reboot time is syncd container takes more than 20 seconds to be shut down:

Apr  4 20:42:01.710695 t0-yy38 NOTICE root: Stopping syncd service...
Apr  4 20:42:01.731929 t0-yy38 NOTICE root: Warm boot flag: syncd true.
Apr  4 20:42:01.735908 t0-yy38 NOTICE root: Fast boot flag: syncd false.
Apr  4 20:42:01.982858 t0-yy38 NOTICE root: warm shutdown syncd process ...
Apr  4 20:42:08.245574 t0-yy38 NOTICE root: Finished warm shutdown syncd process ...  <----- syncd process has been gracefully shut down up to this point. It takes ~7 seconds. 

Apr  4 20:42:09.532254 t0-yy38 INFO syncd#supervisord 2023-04-04 20:42:09,531 WARN received SIGTERM indicating exit request
Apr  4 20:42:09.532494 t0-yy38 INFO syncd#supervisord 2023-04-04 20:42:09,532 INFO waiting for supervisor-proc-exit-listener, rsyslogd, syncd to die
Apr  4 20:42:12.536981 t0-yy38 INFO syncd#supervisord 2023-04-04 20:42:12,536 INFO waiting for supervisor-proc-exit-listener, rsyslogd, syncd to die
Apr  4 20:42:15.541243 t0-yy38 INFO syncd#supervisord 2023-04-04 20:42:15,540 INFO waiting for supervisor-proc-exit-listener, rsyslogd, syncd to die
Apr  4 20:42:18.545492 t0-yy38 INFO syncd#supervisord 2023-04-04 20:42:18,545 INFO waiting for supervisor-proc-exit-listener, rsyslogd, syncd to die
Apr  4 20:42:21.865734 t0-yy38 INFO container: docker cmd: wait for syncd
Apr  4 20:42:21.866022 t0-yy38 INFO container: docker cmd: stop for syncd
Apr  4 20:42:21.894735 t0-yy38 NOTICE root: Stopped syncd service...

 It takes another 12 seconds to bring down the container after syncd process is gracefully shut down.

The root cause for the long delay is supervisord can't manage a run-to-complete process properly, in this case is the syncd process returned from main() after gracefully shutdown, but supervisord is still thinking syncd is RUNNING. When stopping syncd container, supervisord has to wait until timeout for SIGTERM and forcefully kill it because syncd process is no longer running.

#### How I did it
run stopping syncd container at background to not block the progress of warm-reboot. This is safe as syncd process has already gracefully shut down up to that point.

#### How to verify it
DO warm-reboot to verify lacp flapping is not seen.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

