### PR TITLE
[write standby] force DB connections to use unix socket to connect

### DIFF
--- a/files/scripts/write_standby.py
+++ b/files/scripts/write_standby.py
@@ -36,18 +36,9 @@ class MuxStateWriter(object):
         Returns config DB connector.
         Initializes the connector during the first call
         """
-        retries = 3
-        while self.config_db_connector is None and retries > 0:
-            try:
-                self.config_db_connector = ConfigDBConnector()
-                self.config_db_connector.connect()
-            except RuntimeError as e:
-                self.config_db_connector = None
-                retries = retries - 1
-                logger.log_warning("Failed to connect to config db: {} retry remaining, error: {}".format(
-                    retries, str(e)))
-                if retries > 0:
-                    time.sleep(10)
+        if self.config_db_connector is None:
+            self.config_db_connector = ConfigDBConnector(use_unix_socket_path=True)
+            self.config_db_connector.connect()
 
         return self.config_db_connector
 
@@ -77,18 +68,9 @@ class MuxStateWriter(object):
         Returns the ASIC DB connector.
         Initializes the connector during the first call
         """
-        retries = 3
-        while self.asic_db_connector is None and retries > 0:
-            try:
-                self.asic_db_connector = SonicV2Connector()
-                self.asic_db_connector.connect('ASIC_DB')
-            except RuntimeError as e:
-                self.asic_db_connector = None
-                retries = retries - 1
-                logger.log_warning("Failed to connect to asic db: {} retry remaining, error: {}".format(
-                    retries, str(e)))
-                if retries > 0:
-                    time.sleep(10)
+        if self.asic_db_connector is None:
+            self.asic_db_connector = SonicV2Connector(use_unix_socket_path=True)
+            self.asic_db_connector.connect('ASIC_DB')
 
         return self.asic_db_connector
 

--- a/files/scripts/write_standby.py
+++ b/files/scripts/write_standby.py
@@ -36,9 +36,18 @@ class MuxStateWriter(object):
         Returns config DB connector.
         Initializes the connector during the first call
         """
-        if self.config_db_connector is None:
-            self.config_db_connector = ConfigDBConnector()
-            self.config_db_connector.connect()
+        retries = 3
+        while self.config_db_connector is None and retries > 0:
+            try:
+                self.config_db_connector = ConfigDBConnector()
+                self.config_db_connector.connect()
+            except RuntimeError as e:
+                self.config_db_connector = None
+                retries = retries - 1
+                logger.log_warning("Failed to connect to config db: {} retry remaining, error: {}".format(
+                    retries, str(e)))
+                if retries > 0:
+                    time.sleep(10)
 
         return self.config_db_connector
 
@@ -68,9 +77,18 @@ class MuxStateWriter(object):
         Returns the ASIC DB connector.
         Initializes the connector during the first call
         """
-        if self.asic_db_connector is None:
-            self.asic_db_connector = SonicV2Connector()
-            self.asic_db_connector.connect('ASIC_DB')
+        retries = 3
+        while self.asic_db_connector is None and retries > 0:
+            try:
+                self.asic_db_connector = SonicV2Connector()
+                self.asic_db_connector.connect('ASIC_DB')
+            except RuntimeError as e:
+                self.asic_db_connector = None
+                retries = retries - 1
+                logger.log_warning("Failed to connect to asic db: {} retry remaining, error: {}".format(
+                    retries, str(e)))
+                if retries > 0:
+                    time.sleep(10)
 
         return self.asic_db_connector
 


### PR DESCRIPTION
#### Why I did it
At service start up time, there are chances that the networking service is being restarted by interface-config service. When that happens, write_standby could fail to make DB connections due to loopback interface is being reconfigured.

#### How I did it
Force the db connector to use unix socket to avoid loopback reconfig timing window.

#### How to verify it
Run config reload test 20+ times and no issue encountered.