### PR TITLE
[Do Not Merge] Set no ecn marking for backplane ports

### DIFF
--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -49,6 +49,11 @@
 
 {%- set require_global_dscp_to_tc_map = true -%}
 
+{%- set vars = {'backplane_port_exist': false} %}
+{% for port in PORT_ACTIVE if port.startswith('Ethernet-BP')%}
+{% if vars.update({'backplane_port_exist': true}) %} {% endif %}
+{% endfor %}
+
 {
 {% if (generate_tc_to_pg_map is defined) and tunnel_qos_remap_enable %}
     {{- generate_tc_to_pg_map() }}
@@ -296,15 +301,33 @@
             "green_drop_probability" : "5",
             "yellow_drop_probability": "5",
             "red_drop_probability"   : "5"
-        }
+        }{% if vars.backplane_port_exist %},
+        "AZURE_LOSSLESS_NO_MARK" : {
+            "wred_green_enable": "true",
+            "wred_yellow_enable": "true",
+            "ecn": "ecn_green_yellow",
+            "green_max_threshold": "6144000",
+            "green_min_threshold": "0",
+            "yellow_max_threshold": "6144000",
+            "yellow_min_threshold": "0",
+            "green_drop_probability": "0",
+            "yellow_drop_probability": "0"
+        }{% endif %}
     },
 {% endif %}
     "QUEUE": {
 {% for port in PORT_ACTIVE %}
+{% if port.startswith('Ethernet-BP') %}
+        "{{ port }}|3": {
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS_NO_MARK"
+        },
+{% else %}
         "{{ port }}|3": {
             "scheduler"   : "scheduler.1",
             "wred_profile": "AZURE_LOSSLESS"
         },
+{% endif %}
 {% endfor %}
 {% if 'resource_type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['resource_type'] in apollo_resource_types %}
 {% for port in PORT_ACTIVE %}
@@ -315,10 +338,17 @@
 {% endfor %}
 {% else %}
 {% for port in PORT_ACTIVE %}
+{% if port.startswith('Ethernet-BP') %}
+        "{{ port }}|4": {
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS_NO_MARK"
+        },
+{% else %}
         "{{ port }}|4": {
             "scheduler"   : "scheduler.1",
             "wred_profile": "AZURE_LOSSLESS"
         },
+{% endif %}
 {% endfor %}
 {% endif %}
 {% for port in PORT_ACTIVE %}

--- a/src/sonic-config-engine/tests/multi_npu_data/qos.json.j2
+++ b/src/sonic-config-engine/tests/multi_npu_data/qos.json.j2
@@ -1,0 +1,28 @@
+{%- macro generate_wred_profiles() %}
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "ecn"                    : "ecn_green_yellow",
+            "green_drop_probability" : "5",
+            "green_min_threshold"    : "1048576",
+            "green_max_threshold"    : "4194304",
+            "yellow_min_threshold"   : "0",
+            "yellow_drop_probability": "0",
+            "yellow_max_threshold"   : "6144000"
+        },
+        "AZURE_LOSSLESS_NO_MARK": {
+            "ecn": "ecn_green_yellow",
+            "green_drop_probability": "0",
+            "green_max_threshold": "6144000",
+            "green_min_threshold": "0",
+            "wred_green_enable": "true",
+            "wred_yellow_enable": "true",
+            "yellow_drop_probability": "0",
+            "yellow_max_threshold": "6144000",
+            "yellow_min_threshold": "0"
+        }
+    },
+{%- endmacro %}
+
+{%- include 'qos_config.j2' %}

--- a/src/sonic-config-engine/tests/test_multinpu_cfggen.py
+++ b/src/sonic-config-engine/tests/test_multinpu_cfggen.py
@@ -536,6 +536,219 @@ class TestMultiNpuCfgGen(TestCase):
             }
         )
 
+    def test_qos_chassis_packet_lc_template(self):
+        build_root_dir = os.path.join(
+            self.test_dir, "..", "..", ".."
+        )
+        # using T2 qos configuration
+        qos_template = os.path.join(
+            build_root_dir, "files", "build_templates", "qos_config.j2"
+        )
+        minigraph = os.path.join(
+            self.test_dir, "sample-chassis-packet-lc-graph.xml"
+        )
+        port_config_ini_asic1 = os.path.join(
+            self.test_dir, "sample-chassis-packet-lc-port-config.ini"
+        )
+        device_config_dir = self.test_data_dir
+        device_qos_template = os.path.join(
+            device_config_dir, "qos.json.j2"
+        )
+        shutil.copy2(qos_template, device_config_dir)
+        # asic1 - mix of front end and back end ports
+        argument = ["-m", minigraph, "-p", port_config_ini_asic1, "-n", "asic1", "-t", device_qos_template]
+        output = json.loads(self.run_script(argument, check_stderr=True))
+        os.remove(os.path.join(device_config_dir, "qos_config.j2"))
+        self.assertDictEqual(
+            output['QUEUE'],
+            {
+                'Ethernet-BP2320|0': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2320|1': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2320|2': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2320|3': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS_NO_MARK'
+                },
+                'Ethernet-BP2320|4': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS_NO_MARK'
+                },
+                'Ethernet-BP2320|5': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2320|6': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2502|0': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2502|1': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2502|2': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2502|3': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS_NO_MARK'
+                },
+                'Ethernet-BP2502|4': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS_NO_MARK'
+                },
+                'Ethernet-BP2502|5': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2502|6': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2504|0': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2504|1': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2504|2': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2504|3': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS_NO_MARK'
+                },
+                'Ethernet-BP2504|4': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS_NO_MARK'
+                },
+                'Ethernet-BP2504|5': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2504|6': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2506|0': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2506|1': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2506|2': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2506|3': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS_NO_MARK'
+                },
+                'Ethernet-BP2506|4': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS_NO_MARK'
+                },
+                'Ethernet-BP2506|5': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2506|6': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2508|0': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2508|1': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2508|2': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2508|3': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS_NO_MARK'
+                },
+                'Ethernet-BP2508|4': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS_NO_MARK'
+                },
+                'Ethernet-BP2508|5': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2508|6': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2510|0': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2510|1': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2510|2': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2510|3': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS_NO_MARK'
+                },
+                'Ethernet-BP2510|4': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS_NO_MARK'
+                },
+                'Ethernet-BP2510|5': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2510|6': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2516|0': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2516|1': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2516|2': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2516|3': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS_NO_MARK'
+                },
+                'Ethernet-BP2516|4': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS_NO_MARK'
+                },
+                'Ethernet-BP2516|5': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet-BP2516|6': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet47|0': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet47|1': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet47|2': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet47|3': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS'
+                },
+                'Ethernet47|4': {
+                    'scheduler': 'scheduler.1',
+                    'wred_profile': 'AZURE_LOSSLESS'
+                },
+                'Ethernet47|5': {
+                    'scheduler': 'scheduler.0'
+                },
+                'Ethernet47|6': {
+                    'scheduler': 'scheduler.0'
+                }
+            }
+        )
+
     def test_bgpd_frr_frontendasic(self):
         self.assertTrue(*self.run_frr_asic_case('bgpd/bgpd.conf.j2', 'bgpd_frr_frontend_asic.conf', "asic0", self.port_config[0]))
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
One option of ECN marking solution on Cisco T2 product, disable ECN marking on backplane ports, only do ECN marking on the chassis egress ports.

#### How I did it
Apply a different WRED profile to backplane ports.

#### How to verify it
Generate the qos config with the new qos template.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
--> 202205 branch is used for T2.
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

