### PR TITLE
[build] Do not ignore well-known debian files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,12 @@ platform/**/*.egg-info
 platform/**/*-none-any.whl
 platform/**/.pybuild
 platform/**/debian/*
+!platform/**/debian/control
+!platform/**/debian/rules
+!platform/**/debian/changelog
+!platform/**/debian/compat
+!platform/**/debian/*.postinst
+!platform/**/debian/*.install
 platform/**/build
 platform/**/*.ko
 platform/**/*.mod.c


### PR DESCRIPTION
Includes the common debian files that we always want to include.

This mitigates but does not fully solve #7683 as it could be more files that are ignored by this default rule.

#### Why I did it

 - I spent a few hours debugging an issue that turns out was due to me missing to add a few ignored files in a `debian/` subdirectory.

#### How I did it

 - Looked at common `debian` files that we always want to include

#### How to verify it

 - Create e.g. `debian/sonic-platform-foobar.postinst` in a platform directory and it will show up in `git status`.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

I am working with 202211 so backports would be appreciated.

#### Description for the changelog

N/A

#### A picture of a cute animal (not mandatory but encouraged)
![image](https://user-images.githubusercontent.com/149442/230623206-93d6cbd1-9dc8-4bb2-8367-1cdcbc8a6ffe.png)

