### PR TITLE
[Fast-boot] Clear teamd-timer when finalizing fast-reboot

### DIFF
--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -112,6 +112,7 @@ function finalize_fast_reboot()
 {
     debug "Finalizing fast-reboot..."
     sonic-db-cli STATE_DB hset "FAST_RESTART_ENABLE_TABLE|system" "enable" "false" &>/dev/null
+    sonic-db-cli CONFIG_DB DEL "WARM_RESTART|teamd" &>/dev/null
 }
 
 function stop_control_plane_assistant()
@@ -170,10 +171,6 @@ if [[ (x"${WARM_BOOT}" == x"true") && (x"${FAST_REBOOT}" != x"true") ]]; then
    stop_control_plane_assistant
 fi
 
-# Save DB after stopped control plane assistant to avoid extra entries
-debug "Save in-memory database after warm/fast reboot ..."
-config save -y
-
 if [[ -n "${list}" ]]; then
     debug "Some components didn't finish reconcile: ${list} ..."
 fi
@@ -185,3 +182,7 @@ fi
 if [ x"${WARM_BOOT}" == x"true" ]; then
     finalize_warm_boot
 fi
+
+# Save DB after stopped control plane assistant to avoid extra entries
+debug "Save in-memory database after warm/fast reboot ..."
+config save -y


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Part of https://github.com/sonic-net/sonic-utilities/pull/2760
Similar to https://github.com/sonic-net/sonic-buildimage/pull/14295

#### Why I did it
To clear teamd timer when fast-reboot is finalized to prevent any further affect.

#### How I did it
Deleted teamd timer from config-db in fast-reboot finalizer.
config save call is moved to after clearing teamd-timer so it won't have any further affect as well.

#### How to verify it
Verified manually that entry was deleted after fast-reboot was finailized.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

