### PR TITLE
[build] Fix reproducible build version issue when failed to download web file

### DIFF
--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -151,7 +151,7 @@ set_reproducible_mirrors()
 download_packages()
 {
     local parameters=("$@")
-    local filenames=
+    unset filenames
     declare -A filenames
     for (( i=0; i<${#parameters[@]}; i++ ))
     do
@@ -185,15 +185,16 @@ download_packages()
                 else
                     real_version=$(get_url_version $url) || { echo "get_url_version $url failed"; exit 1; }
                     if [ "$real_version" != "$version" ]; then
-                        log_err "Failed to verify url: $url, real hash value: $real_version, expected value: $version_filename" 1>&2
-                       exit 1
+                       log_err "Warning: Failed to verify url: $url, real hash value: $real_version, expected value: $version_filename" 1>&2
+                       continue
                     fi
                 fi
             else
                 real_version=$(get_url_version $url) || { echo "get_url_version $url failed"; exit 1; }
             fi
-
-            echo "$url==$real_version" >> ${BUILD_WEB_VERSION_FILE}
+            # ignore md5sum for string ""
+            # echo -n "" | md5sum    ==   d41d8cd98f00b204e9800998ecf8427e
+            [[ $real_version == "d41d8cd98f00b204e9800998ecf8427e" ]] || echo "$url==$real_version" >> ${BUILD_WEB_VERSION_FILE}
         fi
     done
 

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -151,7 +151,6 @@ set_reproducible_mirrors()
 download_packages()
 {
     local parameters=("$@")
-    unset filenames
     declare -A filenames
     for (( i=0; i<${#parameters[@]}; i++ ))
     do
@@ -171,7 +170,7 @@ download_packages()
                 local filename=$(echo $url | awk -F"/" '{print $NF}' | cut -d? -f1 | cut -d# -f1)
                 [ -f $WEB_VERSION_FILE ] && version=$(grep "^${url}=" $WEB_VERSION_FILE | awk -F"==" '{print $NF}')
                 if [ -z "$version" ]; then
-                    log_err "Warning: Failed to verify the package: $url, the version is not specified" 1>&2
+                    log_err "Warning: Failed to verify the package: $url, the version is not specified"
                     continue
                 fi
 
@@ -185,7 +184,7 @@ download_packages()
                 else
                     real_version=$(get_url_version $url) || { echo "get_url_version $url failed"; exit 1; }
                     if [ "$real_version" != "$version" ]; then
-                       log_err "Warning: Failed to verify url: $url, real hash value: $real_version, expected value: $version_filename" 1>&2
+                       log_err "Warning: Failed to verify url: $url, real hash value: $real_version, expected value: $version_filename"
                        continue
                     fi
                 fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
refine reproducible build.
#### How I did it
1. Fix reset map variable in bash.
2. Ignore empty web file md5sum value.
3. If web file didn't backup in azure storage, use file on web.
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

