### PR TITLE
[secure boot]Fix mokutil check issue with ONIE version older than 202…

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -450,7 +450,7 @@ bootloader_menu_config()
                 echo "UEFI Secure Boot is enabled - Installing shim bootloader"
                 demo_install_uefi_shim "$demo_mnt" "$blk_dev"
             else
-                echo "UEFI Secure Boot is disabled - installing regular grub bootloader"
+                echo "UEFI Secure Boot is disabled - Installing regular grub bootloader"
                 demo_install_uefi_grub "$demo_mnt" "$blk_dev"
             fi
         else

--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -435,13 +435,20 @@ bootloader_menu_config()
         mv $onie_initrd_tmp/tmp/onie-support*.tar.bz2 $demo_mnt/$image_dir/
 
         if [ "$firmware" = "uefi" ] ; then
-            secure_boot_state=$(mokutil --sb-state)
+            reg_sb_guid=$(efivar -l | grep "SecureBoot")
+            secure_boot_state=""
+            if echo "$reg_sb_guid" | grep -q "SecureBoot";then
+                secure_boot_state=$(efivar -d --name $reg_sb_guid)
+            else
+                echo "Current UEFI do not support Secure Boot feature"
+                secure_boot_state="0"
+            fi
             echo secure_boot_state=$secure_boot_state
-            if [ "$secure_boot_state" = "SecureBoot enabled" ]; then
-                echo "UEFI Secure Boot is enabled"
+            if [ "$secure_boot_state" -eq 1 ]; then
+                echo "UEFI Secure Boot is enabled - Installing shim bootloader"
                 demo_install_uefi_shim "$demo_mnt" "$blk_dev"
             else
-                echo "UEFI Secure Boot is disabled"
+                echo "UEFI Secure Boot is disabled - installing regular grub bootloader"
                 demo_install_uefi_grub "$demo_mnt" "$blk_dev"
             fi
         else

--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -435,8 +435,10 @@ bootloader_menu_config()
         mv $onie_initrd_tmp/tmp/onie-support*.tar.bz2 $demo_mnt/$image_dir/
 
         if [ "$firmware" = "uefi" ] ; then
-            reg_sb_guid=$(efivar -l | grep "SecureBoot")
             secure_boot_state=""
+            reg_sb_guid=""
+            ENABLED=1
+            reg_sb_guid=$(efivar -l | grep "SecureBoot")
             if echo "$reg_sb_guid" | grep -q "SecureBoot";then
                 secure_boot_state=$(efivar -d --name $reg_sb_guid)
             else
@@ -444,7 +446,7 @@ bootloader_menu_config()
                 secure_boot_state="0"
             fi
             echo secure_boot_state=$secure_boot_state
-            if [ "$secure_boot_state" -eq 1 ]; then
+            if [ "$secure_boot_state" -eq "$ENABLED" ]; then
                 echo "UEFI Secure Boot is enabled - Installing shim bootloader"
                 demo_install_uefi_shim "$demo_mnt" "$blk_dev"
             else

--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -434,19 +434,19 @@ bootloader_menu_config()
         ${onie_bin} onie-support /tmp
         mv $onie_initrd_tmp/tmp/onie-support*.tar.bz2 $demo_mnt/$image_dir/
 
+        echo "firmware=$firmware"
         if [ "$firmware" = "uefi" ] ; then
-            secure_boot_state=""
+            secure_boot_state=0
             reg_sb_guid=""
             ENABLED=1
-            reg_sb_guid=$(efivar -l | grep "SecureBoot")
-            if echo "$reg_sb_guid" | grep -q "SecureBoot";then
-                secure_boot_state=$(efivar -d --name $reg_sb_guid)
-            else
-                echo "Current UEFI do not support Secure Boot feature"
-                secure_boot_state="0"
+            echo "checking secure boot state"
+            reg_sb_guid=$(efivar -l | grep "SecureBoot") || echo "Secure Boot GUID not found in efivar list"
+            echo "Secure Boot GUID=$reg_sb_guid"
+            if [ -n "$reg_sb_guid" ]; then
+                secure_boot_state=$(efivar -d --name $reg_sb_guid) || echo "Could not read Secure Boot state from efivar"
             fi
             echo secure_boot_state=$secure_boot_state
-            if [ "$secure_boot_state" -eq "$ENABLED" ]; then
+            if expr "$secure_boot_state" : '[[:digit:]]\{1,\}' >/dev/null && [ "$secure_boot_state" -eq "$ENABLED" ]; then
                 echo "UEFI Secure Boot is enabled - Installing shim bootloader"
                 demo_install_uefi_shim "$demo_mnt" "$blk_dev"
             else
@@ -615,17 +615,6 @@ EOF
         umount $demo_mnt
     else
         cp $grub_cfg $onie_initrd_tmp/$demo_mnt/grub/grub.cfg
-    fi
-
-    if [ "$secure_boot_state" = "SecureBoot enabled" ]; then
-        # Secure Boot grub.cfg support
-        # Saving grub_cfg in the same place where is grubx64.efi, 
-        # this grub_cfg file will be called by first grub.cfg file from: /boot/efi/EFI/debian/grub.cfg
-        if [ -f $NVOS_BOOT_DIR/grub.cfg ]; then
-            rm $NVOS_BOOT_DIR/grub.cfg
-        fi
-
-        cp $grub_cfg $NVOS_BOOT_DIR/grub.cfg
     fi
 
     cd /

--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -440,7 +440,7 @@ bootloader_menu_config()
             reg_sb_guid=""
             ENABLED=1
             echo "checking secure boot state"
-            reg_sb_guid=$(efivar -l | grep "SecureBoot") || echo "Secure Boot GUID not found in efivar list"
+            reg_sb_guid=$(efivar -l | grep "SecureBoot$") || echo "Secure Boot GUID not found in efivar list"
             echo "Secure Boot GUID=$reg_sb_guid"
             if [ -n "$reg_sb_guid" ]; then
                 secure_boot_state=$(efivar -d --name $reg_sb_guid) || echo "Could not read Secure Boot state from efivar"

--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -570,7 +570,7 @@ echo "EXTRA_CMDLINE_LINUX=$extra_cmdline_linux"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX $extra_cmdline_linux"
 GRUB_CFG_LINUX_CMD=""
 GRUB_CFG_INITRD_CMD=""
-if [ "$firmware" = "uefi" ] ; then
+if [ "$firmware" = "uefi" ] &&  expr "$secure_boot_state" : '[[:digit:]]\{1,\}' >/dev/null && [ "$secure_boot_state" -eq "$ENABLED" ]; then
     # grub.cfg when BIOS is UEFI and support Secure Boot
     GRUB_CFG_LINUX_CMD="linuxefi"
     GRUB_CFG_INITRD_CMD="initrdefi"


### PR DESCRIPTION
…1.11 by using efivar tool instead

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
solution to BUG below/
https://github.com/sonic-net/sonic-buildimage/issues/14316
bug report also in this issue:
backport: secureboot support #14246
#### How I did it
When installing an image secure boot is checking if the UEFI have the secure boot flag enabled or disabled using a tool name `mokutil` this tool its not exist in ONIE version older than 2021.11 so its crasshing the install.
To fix that we add a coded that checking secure boot enabled/disabled by using efivar tool that should exist in any UEFI system
#### How to verify it
Install the image in a device with ONIE version older than 2021.11 and check that the installation and boot succeed (all docker up).
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [X ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

