### PR TITLE
Midstone Compilation Error in master branch

### DIFF
--- a/platform/innovium/sonic-platform-modules-cel/midstone-200i/modules/mc24lc64t.c
+++ b/platform/innovium/sonic-platform-modules-cel/midstone-200i/modules/mc24lc64t.c
@@ -94,7 +94,7 @@ static int mc24lc64t_probe(struct i2c_client *client,
                         sizeof(struct mc24lc64t_data), GFP_KERNEL)))
                 return -ENOMEM;
 
-        drvdata->fake_client = i2c_new_dummy(client->adapter, client->addr + 1);
+        drvdata->fake_client = i2c_new_dummy_device(client->adapter, client->addr + 1);
         if (!drvdata->fake_client)
                 return -ENOMEM;
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Midstone platform has compilation error in master branch, fixed the same.

#### How I did it
Due to bullseye migration i2c_new_dummy API is deprecated modified with i2c_new_dummy_device.

#### How to verify it
Verified target/debs/bullseye/platform-modules-midstone-200i_0.2.2_amd64.deb is generated

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

