### PR TITLE
07.Version Cache - Support for PIP

### DIFF
--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -210,19 +210,37 @@ download_packages()
 
 run_pip_command()
 {
-    parameters=("$@")
+    declare -a parameters=("$@")
+    PIP_CACHE_PATH=${PKG_CACHE_PATH}/pip
+    PKG_CACHE_OPTION="--cache-dir=${PIP_CACHE_PATH}"
 
-    if [ ! -x "$REAL_COMMAND" ] && [ " $1" == "freeze" ]; then
+	if [[ ! -e ${PIP_CACHE_PATH} ]]; then
+		${SUDO} mkdir -p ${PIP_CACHE_PATH}
+		${SUDO} chmod 777 ${PIP_CACHE_PATH}
+	fi
+
+    if [ ! -x "$REAL_COMMAND" ] && [ "$1" == "freeze" ]; then
         return 1
     fi
 
-    if [ "$ENABLE_VERSION_CONTROL_PY" != "y" ]; then
+    if [[ "$SKIP_BUILD_HOOK" == y || "$ENABLE_VERSION_CONTROL_PY" != "y" ]]; then
+		if [ ! -z "$(get_version_cache_option)" ]; then
+			FLOCK ${PIP_CACHE_PATH}
+			$REAL_COMMAND ${PKG_CACHE_OPTION} "$@"
+			local result=$?
+			chmod -f -R 777 ${PIP_CACHE_PATH}
+ 			touch ${PIP_CACHE_PATH}
+			FUNLOCK ${PIP_CACHE_PATH}
+			return ${result}
+		fi
         $REAL_COMMAND "$@"
         return $?
     fi
 
+
     local found=n
     local install=n
+    local count=0
     local pip_version_file=$PIP_VERSION_FILE
     local tmp_version_file=$(mktemp)
     [ -f "$pip_version_file" ] && cp -f $pip_version_file $tmp_version_file
@@ -231,6 +249,7 @@ run_pip_command()
         ([ "$para" == "-c" ] || [ "$para" == "--constraint" ]) && found=y
         if [ "$para" == "install" ]; then
             install=y
+            parameters[${count}]=install 
         elif [[ "$para" == *.whl ]]; then
             package_name=$(echo $para | cut -d- -f1 | tr _ .)
             $SUDO sed "/^${package_name}==/d" -i $tmp_version_file
@@ -239,6 +258,7 @@ run_pip_command()
             package_name=$(echo $para | cut -d= -f1)
             $SUDO sed "/^${package_name}==/d" -i $tmp_version_file
         fi
+        (( count++ ))
     done
 
     if [ "$found" == "n" ] && [ "$install" == "y" ]; then
@@ -246,13 +266,22 @@ run_pip_command()
         parameters+=("${tmp_version_file}")
     fi
 
-    $REAL_COMMAND "${parameters[@]}"
-    local result=$?
-    if [ "$result" != 0 ]; then
-        echo "Failed to run the command with constraint, try to install with the original command" 1>&2
-        $REAL_COMMAND "$@"
-        result=$?
-    fi
+    if [ ! -z "$(get_version_cache_option)" ]; then
+        FLOCK ${PIP_CACHE_PATH}
+        $REAL_COMMAND ${PKG_CACHE_OPTION} "${parameters[@]}"
+        local result=$?
+        chmod -f -R 777 ${PIP_CACHE_PATH}
+        touch ${PIP_CACHE_PATH}
+        FUNLOCK ${PIP_CACHE_PATH}
+    else
+        $REAL_COMMAND "${parameters[@]}"
+		local result=$?
+		if [ "$result" != 0 ]; then
+			echo "Failed to run the command with constraint, try to install with the original command" 1>&2
+			$REAL_COMMAND "$@"
+			result=$?
+		fi
+	fi
     rm $tmp_version_file
     return $result
 }
@@ -278,7 +307,7 @@ check_apt_install()
 # Print warning message if a debian package version not specified when debian version control enabled.
 check_apt_version()
 {
-    VERSION_FILE="/usr/local/share/buildinfo/versions/versions-deb"
+    VERSION_FILE="${VERSION_PATH}/versions-deb"
     local install=$(check_apt_install "$@")
     if [ "$ENABLE_VERSION_CONTROL_DEB" == "y" ] && [ "$install" == "y" ]; then
         for para in "$@"


### PR DESCRIPTION
During build, lots of pip packages are getting installed through pip install command.

This feature adds support for caching all the pip packages into local cache path, so that subsequent build always loads from the cache.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

