### PR TITLE
[202211] Support to add SONiC OS Version in device info (#14601)

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -513,6 +513,7 @@ SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            MIRROR_URLS=$(MIRROR_URLS) \
                            MIRROR_SECURITY_URLS=$(MIRROR_SECURITY_URLS) \
                            MIRROR_SNAPSHOT=$(MIRROR_SNAPSHOT) \
+                           SONIC_OS_VERSION=$(SONIC_OS_VERSION) \
                            $(SONIC_OVERRIDE_BUILD_VARS)
 
 .PHONY: sonic-slave-build sonic-slave-bash init reset

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -573,6 +573,7 @@ export release="$(if [ -f $FILESYSTEM_ROOT/etc/sonic/sonic_release ]; then cat $
 export build_date="$(date -u)"
 export build_number="${BUILD_NUMBER:-0}"
 export built_by="$USER@$BUILD_HOSTNAME"
+export sonic_os_version="${SONIC_OS_VERSION}"
 j2 files/build_templates/sonic_version.yml.j2 | sudo tee $FILESYSTEM_ROOT/etc/sonic/sonic_version.yml
 
 ## Copy over clean-up script

--- a/files/build_templates/sonic_version.yml.j2
+++ b/files/build_templates/sonic_version.yml.j2
@@ -29,3 +29,4 @@ built_by: {{ built_by }}
 {% if ENABLE_ASAN == "y" -%}
 asan: 'yes'
 {% endif -%}
+sonic_os_version: {{ sonic_os_version }}

--- a/platform/vs/sonic-version.mk
+++ b/platform/vs/sonic-version.mk
@@ -2,9 +2,11 @@
 
 sonic_version=$(SONIC_GET_VERSION)
 sonic_asic_platform=$(CONFIGURED_PLATFORM)
+sonic_os_version=$(SONIC_OS_VERSION)
 
 export sonic_version
 export sonic_asic_platform
+export sonic_os_version
 
 SONIC_VERSION = sonic_version.yml
 $(SONIC_VERSION)_SRC_PATH = $(PLATFORM_PATH)/sonic-version

--- a/rules/config
+++ b/rules/config
@@ -269,3 +269,6 @@ ENABLE_FIPS ?= n
 
 # SONIC_SLAVE_DOCKER_DRIVER - set the sonic slave docker storage driver
 SONIC_SLAVE_DOCKER_DRIVER ?= vfs
+
+# SONIC_OS_VERSION - sonic os version
+SONIC_OS_VERSION ?= 11

--- a/slave.mk
+++ b/slave.mk
@@ -87,6 +87,7 @@ export CROSS_BUILD_ENVIRON
 export BLDENV
 export BUILD_WORKDIR
 export MIRROR_SNAPSHOT
+export SONIC_OS_VERSION
 
 ###############################################################################
 ## Utility rules


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cherry-pick https://github.com/sonic-net/sonic-buildimage/pull/14601, for code conflict.
Support to add SONiC OS Version in device info.
It will be used to display the version info in the SONiC command "show version". The version is used to do the FIPS certification. We do not do the FIPS certification on a specific release, but on the SONiC OS Version.

```
SONiC Software Version: SONiC.master-13812.218661-7d94c0c28
SONiC OS Version: 11
Distribution: Debian 11.6
Kernel: 5.10.0-18-2-amd64
```

##### Work item tracking
- Microsoft ADO **(number only)**: 17894593

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

