### PR TITLE
[pddf] Enable deselect logic for CPLDMUX

### DIFF
--- a/platform/pddf/i2c/modules/cpldmux/driver/pddf_cpldmux_driver.c
+++ b/platform/pddf/i2c/modules/cpldmux/driver/pddf_cpldmux_driver.c
@@ -27,12 +27,40 @@
 
 extern PDDF_CPLDMUX_DATA pddf_cpldmux_data;
 
-/* Users may overwrite these select and delsect functions as per their requirements 
- * by overwriting them in custom driver
+/* Users may overwrite these select and delsect functions as per their requirements
+ * by overwriting them in custom driver.
+ *
+ * Example driver skeleton:
+ *
+ * #include <linux/module.h>
+ * #include <linux/i2c.h>
+ * ..
+ * ..
+ * #include "pddf_cpldmux_defs.h"
+ *
+ * extern PDDF_CPLDMUX_OPS pddf_cpldmux_ops;
+ *
+ * int cpldmux_byte_write(struct i2c_client *client, u8 regaddr, u8 val)
+ * {
+ *     // Provide custom implementation here
+ * }
+ *
+ * int pddf_cpldmux_deselect(struct i2c_mux_core *muxc, uint32_t chan)
+ * {
+ *     // Provide the custom implementation here
+ * }
+ *
+ * static int __init pddf_custom_cpldmux_init(void)
+ * {
+ *     pddf_cpldmux_ops.deselect = pddf_cpldmux_deselect;
+ *     pddf_cpldmux_ops.byte_write = cpldmux_byte_write;
+ *     return 0;
+ * }
  */
+
 PDDF_CPLDMUX_OPS pddf_cpldmux_ops = {
     .select = pddf_cpldmux_select_default,
-    .deselect = NULL, /* pddf_cpldmux_deselct_default */
+    .deselect = pddf_cpldmux_deselect_default,
 };
 EXPORT_SYMBOL(pddf_cpldmux_ops);
 
@@ -69,7 +97,7 @@ int pddf_cpldmux_select_default(struct i2c_mux_core *muxc, uint32_t chan)
     if ( (pdata->chan_cache!=1) || (private->last_chan!=chan) )
     {
         sdata = &pdata->chan_data[chan];
-        pddf_dbg(CPLDMUX, KERN_ERR "%s: Writing 0x%x at 0x%x offset of cpld 0x%x to enable chan %d\n", __FUNCTION__, sdata->cpld_sel, sdata->cpld_offset, sdata->cpld_devaddr, chan);
+        pddf_dbg(CPLDMUX, KERN_INFO "%s: Writing 0x%x at 0x%x offset of cpld 0x%x to enable chan %d\n", __FUNCTION__, sdata->cpld_sel, sdata->cpld_offset, sdata->cpld_devaddr, chan);
         ret =  cpldmux_byte_write(pdata->cpld, sdata->cpld_offset,  (uint8_t)(sdata->cpld_sel & 0xff));
         private->last_chan = chan;
     }
@@ -93,7 +121,7 @@ int pddf_cpldmux_deselect_default(struct i2c_mux_core *muxc, uint32_t chan)
     }
     sdata = &pdata->chan_data[chan];
 
-    pddf_dbg(CPLDMUX, KERN_ERR "%s: Writing 0x%x at 0x%x offset of cpld 0x%x to disable chan %d", __FUNCTION__, sdata->cpld_desel, sdata->cpld_offset, sdata->cpld_devaddr, chan);
+    pddf_dbg(CPLDMUX, KERN_INFO "%s: Writing 0x%x at 0x%x offset of cpld 0x%x to disable chan %d", __FUNCTION__, sdata->cpld_desel, sdata->cpld_offset, sdata->cpld_devaddr, chan);
     ret = cpldmux_byte_write(pdata->cpld, sdata->cpld_offset,  (uint8_t)(sdata->cpld_desel));
     return ret;
 }


### PR DESCRIPTION
#### Why I did it

This feature was meant to be enabled but was accidentally left disabled.

I also changed the default log level for normal usage to KERN_INFO as the log spam can be quite severe otherwise.

##### Work item tracking

Fixes #14546.

#### How I did it

Enabled the option by default.

#### How to verify it

 - Requires a PDDF CPLDMUX driver.
 - Access an I2C bus through the CPLDMUX
 - Observe the message that the bus was deselected.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

I am working on stabilizing 202211 for our internal needs, so I would prefer if the change can be backported so I do not have to carry the patch internally as well.

#### Tested branch (Please provide the tested image version)

202211 internal build.

#### Description for the changelog

- [pddf] CPLDMUX now correctly allows usage of deselect logic.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

![image](https://user-images.githubusercontent.com/149442/231532223-8c7bbfc3-9183-4ad3-b3f9-3f80aa6dfec9.png)
