### PR TITLE
[Clock] Add timezone config YANG model

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -4,7 +4,8 @@
             "buffer_model": {% if default_buffer_model == "dynamic" %}"dynamic"{% else %}"traditional"{% endif %},
             {%- if include_p4rt == "y" %}"synchronous_mode":"enable",{% endif %}
             "default_bgp_status": {% if shutdown_bgp_on_start == "y" %}"down"{% else %}"up"{% endif %},
-            "default_pfcwd_status": {% if enable_pfcwd_on_start == "y" %}"enable"{% else %}"disable"{% endif %}
+            "default_pfcwd_status": {% if enable_pfcwd_on_start == "y" %}"enable"{% else %}"disable"{% endif %},
+            "timezone": "UTC"
         }
     },
     "CRM": {

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -927,7 +927,8 @@ instance is supported in SONiC.
         "bgp_adv_lo_prefix_as_128" : "true",
         "buffer_model": "traditional",
         "yang_config_validation": "disable",
-        "rack_mgmt_map": "dummy_value"
+        "rack_mgmt_map": "dummy_value",
+        "timezome": "Europe/Kiev"
     }
   }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -360,7 +360,8 @@
                 "dhcp_server": "disabled",
                 "bgp_adv_lo_prefix_as_128": "true",
                 "yang_config_validation": "disable",
-                "rack_mgmt_map": "dummy_value"
+                "rack_mgmt_map": "dummy_value",
+                "timezone": "Europe/Kiev"
             }
         },
         "VLAN": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -142,5 +142,12 @@
     "DEVICE_METADATA_INVALID_RACK_MGMT_MAP": {
         "desc": "Verifying invalid rack_mgmt_map configuration.",
         "eStr": "Invalid length for the rack mgmt map."
+    },
+    "DEVICE_METADATA_VALID_TIMEZONE": {
+        "desc": "Verifying valid timezone value"
+    },
+    "DEVICE_METADATA_INVALID_TIMEZONE": {
+        "desc": "Verifying invalid timezone value",
+        "eStrKey": "Range"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -372,11 +372,29 @@
             }
         }
     },
+    "DEVICE_METADATA_VALID_TIMEZONE": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "timezone": "UTC"
+                }
+            }
+        }
+    },
     "DEVICE_METADATA_INVALID_RACK_MGMT_MAP": {
         "sonic-device_metadata:sonic-device_metadata": {
             "sonic-device_metadata:DEVICE_METADATA": {
                 "sonic-device_metadata:localhost": {
                     "rack_mgmt_map": "dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_INVALID_TIMEZONE": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "timezone": ""
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -225,6 +225,15 @@ module sonic-device_metadata {
                     }
                     description "Information of rack mgmt map.";
                 }
+
+                leaf timezone {
+                    type stypes:timezone-name-type {
+                        length 1..255;
+                    }
+                    default "UTC";
+                    description "The TZ database name to use for the system, such as 'Europe/Stockholm'.";
+                    reference "IANA Time Zone Database http://www.iana.org/time-zones";
+                }
             }
             /* end of container localhost */
         }

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -334,6 +334,19 @@ module sonic-types {
         }
     }
 
+    typedef timezone-name-type {
+        type string;
+        description
+            "A time zone name as used by the Time Zone Database,
+            sometimes referred to as the 'Olson Database'.
+
+            The exact set of valid values is an implementation-specific
+            matter.  Client discovery of the exact set of time zone names
+            for a particular server is out of scope.";
+        reference
+            "BCP 175: Procedures for Maintaining the Time Zone Database";
+    }
+
     {% if yang_model_type == "cvl" %}
     /* Required for CVL */
     container operation {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
hld [#1219](https://github.com/sonic-net/SONiC/pull/1219)
closes [#1171](https://github.com/sonic-net/SONiC/issues/1171)
depends-on [#2793](https://github.com/sonic-net/sonic-utilities/pull/2793), [#57](https://github.com/sonic-net/sonic-host-services/pull/57)

#### Why I did it
* To be able to configure timezone
* To be able to show timezones

#### How I did it
* Add YANG model
* Add default value to `init_cfg.json`

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Add timezone config YANG model

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
[Device metadata configuration](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#device-metadata)

#### A picture of a cute animal (it is my cat Finn)
![PXL_20230413_140941610 PORTRAIT](https://user-images.githubusercontent.com/35844154/231862413-cb630c8f-895f-4051-85e5-86802f9ccf40.jpg)

