### PR TITLE
[sonic-device-data] Exclude non-hwsku directories

### DIFF
--- a/src/sonic-device-data/Makefile
+++ b/src/sonic-device-data/Makefile
@@ -15,7 +15,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	cp -r -L ../../../device/*/* ./device/
 
 	# Create hwsku for virtual switch
-	for d in `find -L ../../../device -maxdepth 3 -mindepth 3 -type d | grep -vE "(plugins|led-code)"`; do \
+	for d in `find -L ../../../device -maxdepth 3 -mindepth 3 -type d | grep -vE "(plugins|led.*-code|pddf|sonic_platform)"`; do \
 		cp -Lr $$d device/x86_64-kvm_x86_64-r0/ ; \
 		cp ./sai.vs_profile device/x86_64-kvm_x86_64-r0/$$(basename $$d)/sai.profile; \
 		cp ./sai_mlnx.vs_profile device/x86_64-kvm_x86_64-r0/$$(basename $$d)/sai_mlnx.profile; \


### PR DESCRIPTION
#### Why I did it

When using sonic-vs I discovered the directory `/usr/share/sonic/device/x86_64-kvm_x86_64-r0/sonic_platform` was full of files from various platforms mixed into a big mess.

#### How I did it

I played with different ways of figuring out which directories are HWSKUs, like looking for `port_config.ini` and/or `hwsku.json` but that ended up excluding platforms like `Arista-7800R3A-36D2-C36/0` since it has an additional level of directories.

In the end I chose to extend the existing rejection list.

#### How to verify it

The following directories are removed from being treated as HWSKUs:

```
../../../device/accton/x86_64-accton_as4630_54pe-r0/pddf
../../../device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform
../../../device/accton/x86_64-accton_as4630_54te-r0/sonic_platform
../../../device/accton/x86_64-accton_as5835_54x-r0/sonic_platform
../../../device/accton/x86_64-accton_as7116_54x-r0/sonic_platform
../../../device/accton/x86_64-accton_as7312_54x-r0/sonic_platform
../../../device/accton/x86_64-accton_as7326_56x-r0/pddf
../../../device/accton/x86_64-accton_as7326_56x-r0/sonic_platform
../../../device/accton/x86_64-accton_as7712_32x-r0/pddf
../../../device/accton/x86_64-accton_as7726_32x-r0/pddf
../../../device/accton/x86_64-accton_as7816_64x-r0/pddf
../../../device/accton/x86_64-accton_as7816_64x-r0/sonic_platform
../../../device/accton/x86_64-accton_as9716_32d-r0/pddf
../../../device/accton/x86_64-accton_as9726_32d-r0/sonic_platform
../../../device/alphanetworks/x86_64-alphanetworks_bes2348t-r0/pddf
../../../device/celestica/x86_64-cel_belgite-r0/led-source-code
../../../device/celestica/x86_64-cel_belgite-r0/pddf
../../../device/celestica/x86_64-cel_e1031-r0/sonic_platform
../../../device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config
../../../device/celestica/x86_64-cel_seastone-r0/sonic_platform
../../../device/celestica/x86_64-cel_silverstone-r0/sonic_platform
../../../device/ragile/x86_64-ragile_ra-b6510-32c-r0/pddf
../../../device/ragile/x86_64-ragile_ra-b6510-48v8c-r0/pddf
../../../device/ragile/x86_64-ragile_ra-b6510-48v8c-r0/sonic_platform_config
../../../device/ragile/x86_64-ragile_ra-b6910-64c-r0/pddf
../../../device/ragile/x86_64-ragile_ra-b6910-64c-r0/sonic_platform_config
../../../device/ragile/x86_64-ragile_ra-b6920-4s-r0/pddf
../../../device/ruijie/x86_64-ruijie_b6510-48vs8cq-r0/sonic_platform_config
../../../device/wistron/x86_64-wistron_6512_32r-r0/sonic_platform
```

#### Which release branch to backport (provide reason below if selected)


- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

- [x] master

#### Description for the changelog

N/A 

