### PR TITLE
[Build] Change the debian mirror from debian to debian-security for host image

### DIFF
--- a/files/apt/sources.list.arm64
+++ b/files/apt/sources.list.arm64
@@ -3,11 +3,11 @@
 
 deb [arch=arm64] http://deb.debian.org/debian buster main contrib non-free
 deb-src [arch=arm64] http://deb.debian.org/debian buster main contrib non-free
-deb [arch=arm64] http://deb.debian.org/debian buster-updates main contrib non-free
-deb-src [arch=arm64] http://deb.debian.org/debian buster-updates main contrib non-free
+deb [arch=arm64] http://deb.debian.org/debian-security buster/updates main contrib non-free
+deb-src [arch=arm64] http://deb.debian.org/debian-security buster/updates main contrib non-free
 deb [arch=arm64] http://ftp.debian.org/debian buster-backports main
 deb [arch=arm64] http://packages.trafficmanager.net/debian/debian buster main contrib non-free
 deb-src [arch=arm64] http://packages.trafficmanager.net/debian/debian buster main contrib non-free
-deb [arch=arm64] http://packages.trafficmanager.net/debian/debian buster-updates main contrib non-free
-deb-src [arch=arm64] http://packages.trafficmanager.net/debian/debian buster-updates main contrib non-free
+deb [arch=arm64] http://packages.trafficmanager.net/debian/debian-security buster_updates main contrib non-free
+deb-src [arch=arm64] http://packages.trafficmanager.net/debian/debian-security buster_updates main contrib non-free
 deb [arch=arm64] http://packages.trafficmanager.net/debian/debian buster-backports main

--- a/files/apt/sources.list.armhf
+++ b/files/apt/sources.list.armhf
@@ -3,11 +3,11 @@
 
 deb [arch=armhf] http://deb.debian.org/debian buster main contrib non-free
 deb-src [arch=armhf] http://deb.debian.org/debian buster main contrib non-free
-deb [arch=armhf] http://deb.debian.org/debian buster-updates main contrib non-free
-deb-src [arch=armhf] http://deb.debian.org/debian buster-updates main contrib non-free
+deb [arch=armhf] http://deb.debian.org/debian-security buster/updates main contrib non-free
+deb-src [arch=armhf] http://deb.debian.org/debian-security buster/updates main contrib non-free
 deb [arch=armhf] http://ftp.debian.org/debian buster-backports main
 deb [arch=armhf] http://packages.trafficmanager.net/debian/debian buster main contrib non-free
 deb-src [arch=armhf] http://packages.trafficmanager.net/debian/debian buster main contrib non-free
-deb [arch=armhf] http://packages.trafficmanager.net/debian/debian buster-updates main contrib non-free
-deb-src [arch=armhf] http://packages.trafficmanager.net/debian/debian buster-updates main contrib non-free
+deb [arch=armhf] http://packages.trafficmanager.net/debian/debian-security buster_updates main contrib non-free
+deb-src [arch=armhf] http://packages.trafficmanager.net/debian/debian-security buster_updates main contrib non-free
 deb [arch=armhf] http://packages.trafficmanager.net/debian/debian buster-backports main


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Change the debian mirror from debian to debian-security for host image
1. Make sure the packages with the latest security update
2. Use the Debian mirror of armhf/arm64 the same as arm64.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

