### PR TITLE
[201911] Updated Broadcom SAI3.7 Debian package.

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
-BRCM_SAI = libsaibcm_3.7.6.1-2_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.6.1-2_amd64.deb?sv=2015-04-05&sr=b&sig=feV68rm1rnQzVyEFQjE5ceusSIqtIzlyUX7mPEmio%2B0%3D&se=2038-12-30T22%3A23%3A47Z&sp=r"
-BRCM_SAI_DEV = libsaibcm-dev_3.7.6.1-2_amd64.deb
+BRCM_SAI = libsaibcm_3.7.6.1-3_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.6.1-3_amd64.deb?sv=2015-04-05&sr=b&sig=UT0aePCjoT%2Fu0dtTgoGUgvzSJSN8DPh62jDm%2FECPkQA%3D&se=2026-07-30T17%3A27%3A51Z&sp=r"
+BRCM_SAI_DEV = libsaibcm-dev_3.7.6.1-3_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.6.1-2_amd64.deb?sv=2015-04-05&sr=b&sig=80L3rvMTgilj61D4HCLKOjE2of2SgZF3128JmHYTunc%3D&se=2038-12-30T22%3A24%3A53Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.6.1-3_amd64.deb?sv=2015-04-05&sr=b&sig=Cd5GpQyd5epuMD%2BGuprH79IK8ZWlX5T9dAoL7j23Ceo%3D&se=2026-07-30T17%3A29%3A46Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
What I did:

Upgrade BRCM SAI to Debian package SAI 3.7.6.1-3.

Why I did:

Fix TX queue for control packets to use Queue 7 for Control packets on TD2 platforms.

How I verify:
Manual Verification by @prabhataravind 