### PR TITLE
Changes to support TSA/TSB from supervisor of SONIC chassis

### DIFF
--- a/dockers/docker-fpm-frr/TS
+++ b/dockers/docker-fpm-frr/TS
@@ -4,7 +4,7 @@ switch_type=`sonic-cfggen -d -v "DEVICE_METADATA['localhost']['switch_type']"`
 # Check whether the routemap is for internal BGP sessions.
 function is_internal_route_map()
 {
-    [[ "$1" =~ .*"_INTERNAL_".* && $switch_type != "chassis-packet" ]]
+    [[ "$1" =~ .*"_INTERNAL_".* || "$1" =~ .*"VOQ_".* ]]
 }
 
 function check_not_installed()

--- a/dockers/docker-fpm-frr/base_image_files/TSA
+++ b/dockers/docker-fpm-frr/base_image_files/TSA
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [ -f /etc/sonic/chassisdb.conf ]; then
+  rexec all -c "TSA chassis"
+  echo "Please execute \"rexec all -c 'sudo config save -y'\" to preserve System mode in Maintenance after reboot\
+  or config reload on all linecards"
+  exit 0
+fi
 # toggle the mux to standby if dualtor and any mux active
 if
 [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype | tr [:upper:] [:lower:])" == *"dualtor"* ]] &&
@@ -10,4 +16,11 @@ then
 fi
 
 /usr/bin/TS TSA
-echo "Please execute 'config save' to preserve System mode in Maintenance after reboot or config reload"
+if [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.type)" == *"SpineRouter"* ]] ; then
+  if [[ "$1" != "chassis" ]] ; then
+    echo "Please execute 'sudo config save' to preserve System mode in Maintenance after reboot or config reload"
+    echo -e "\nWARNING: Please execute 'TSA' on all other linecards of the chassis to fully isolate this device"    
+  fi
+else
+  echo "Please execute 'sudo config save' to preserve System mode in Maintenance after reboot or config reload"
+fi

--- a/dockers/docker-fpm-frr/base_image_files/TSB
+++ b/dockers/docker-fpm-frr/base_image_files/TSB
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# If run on supervisor of chassis, trigger remote execution of TSB on all linecards
+if [ -f /etc/sonic/chassisdb.conf ]; then
+  rexec all -c "TSB chassis"
+  echo "Please execute \"rexec all -c 'sudo config save -y'\" to preserve System mode in Normal state after reboot\
+ or config reload on all linecards"
+  exit 0
+fi
+
 # toggle the mux to auto if dualtor
 if [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype | tr [:upper:] [:lower:])" == *"dualtor"* ]];
 then
@@ -8,4 +16,10 @@ then
 fi
 
 /usr/bin/TS TSB
-echo "Please execute 'config save' to preserve System mode in Normal state after reboot or config reload"
+if [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.type)" == *"SpineRouter"* ]] ; then
+  if [[ "$1" != "chassis" ]] ; then
+    echo "Please execute 'sudo config save' to preserve System mode in Normal state after reboot or config reload"    
+  fi
+else
+  echo "Please execute 'sudo config save' to preserve System mode in Normal state after reboot or config reload"
+fi

--- a/dockers/docker-fpm-frr/base_image_files/TSC
+++ b/dockers/docker-fpm-frr/base_image_files/TSC
@@ -1,8 +1,16 @@
 #!/bin/bash
 
-/usr/bin/TS TSC
+if [ -f /etc/sonic/chassisdb.conf ]; then
+  if [[ $1 == "no-stats" ]]; then
+    rexec all -c "TSC no-stats"
+  else
+    rexec all -c "TSC"
+  fi
+  exit 0
+fi
 
-portstat -p 5
+/usr/bin/TS TSC
+[[ $1 != "no-stats" ]] && portstat -p 5
 
 if [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype | tr [:upper:] [:lower:])" == *"dualtor"* ]]
 then

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -109,15 +109,7 @@ run_hookdir() {
 reload_minigraph()
 {
     echo "Reloading minigraph..."
-    if
-    [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype | tr [:upper:] [:lower:])" == *"dualtor"* ]] ||
-    [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.type | tr [:upper:] [:lower:])" == *"leafrouter"* ]];
-    then
-        #Keep device isolated with traffic-shift-away option on LeafRouter and Dualtor
-        config load_minigraph -y -n -t
-    else
-        config load_minigraph -y -n
-    fi
+    config load_minigraph -y -n
     config save -y
 }
 

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
@@ -90,7 +90,7 @@ class DeviceGlobalCfgMgr(Manager):
         for rm in sorted(route_map_names):
             # For packet-based chassis, the bgp session between the linecards are also considered internal sessions 
             # While isolating a single linecard, these sessions should not be skipped
-            if "_INTERNAL_" in rm and self.switch_type != "chassis-packet":
+            if "_INTERNAL_" in rm or "VOQ_" in rm:
                 continue            
             if "V4" in rm:
                 ipv="V4" ; ipp="ip"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support for SONIC chassis isolation using TSA and un-isolation using TSB from supervisor module

##### Work item tracking
- Microsoft ADO **(number only)**: 17826134

#### How I did it
When TSA is run on the supervisor, it triggers TSA on each of the linecards using the secure rexec infrastructure introduced in https://github.com/sonic-net/sonic-utilities/pull/2701. User password is requested to allow secure login to linecards through ssh, before execution of TSA/TSB on the linecards

TSA of the chassis withdraws routes from all the external BGP neighbors on each linecard, in order to isolate the entire chassis. No route withdrawal is done from the internal BGP sessions between the linecards to prevent transient drops during internal route deletion.  With these changes, complete isolation of a single linecard using TSA will not be possible (a separate CLI/script option will be introduced at a later time to achieve this)

Changes also include no-stats option with TSC for quick retrieval of the current system isolation state

This PR also reverts changes in https://github.com/sonic-net/sonic-buildimage/pull/11403

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
These changes have a dependency on https://github.com/sonic-net/sonic-utilities/pull/2701 for testing

1. Run TSA from supervisor module and ensure transition to Maintenance mode on each linecard
2. Verify that all routes are withdrawn from eBGP neighbors on all linecards
3. Run TSB from supervisor module and ensure transition to Normal mode on each linecard
4. Verify that all routes are re-advertised from eBGP neighbors on all linecards
5. Run TSC no-stats from supervisor and verify that just the system maintenance state is returned from all linecards

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x]  202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
SONIC chassis TSA/TSB support from supervisor module

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

