### PR TITLE
[armhf][Nokia-7215] changes fstrim.timer to daily

### DIFF
--- a/platform/marvell-armhf/sonic-platform-nokia/7215/service/fstrim.timer/timer-override.conf
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/service/fstrim.timer/timer-override.conf
@@ -1,0 +1,5 @@
+[Unit]
+Description=Discard unused blocks daily
+
+[Timer]
+OnCalendar=daily

--- a/platform/marvell-armhf/sonic-platform-nokia/debian/sonic-platform-nokia-7215.install
+++ b/platform/marvell-armhf/sonic-platform-nokia/debian/sonic-platform-nokia-7215.install
@@ -1,5 +1,6 @@
 nokia-7215_plt_setup.sh usr/sbin
 7215/scripts/nokia-7215init.sh  usr/local/bin
 7215/service/nokia-7215init.service  etc/systemd/system
+7215/service/fstrim.timer/timer-override.conf  /lib/systemd/system/fstrim.timer.d
 7215/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/armhf-nokia_ixs7215_52x-r0
 inband_mgmt.sh etc/


### PR DESCRIPTION
Using override.conf, we modify the fstrim.timer service.

For armhf, Nokia-7215 platform, we modify fstrim.timer to run daily
instead of weekly.  This is required because the size of the SSD on
this platform is 16GB, which on average is nearly 10 times smaller than
most other sonic platforms.  With smaller disk and the ever increasing
level of logging done by sonic, this change is required to prevent
the SSD from entering a read-only state due to inadequate free blocks.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Required to prevent the SSD from entering a read-only state due to inadequate free blocks

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

Verified that override works.

```
admin@sonic-amazon:~$ sudo systemctl status fstrim.timer 
\u25cf fstrim.timer - Discard unused blocks daily
     Loaded: loaded (/lib/systemd/system/fstrim.timer; enabled; vendor preset: enabled)
    Drop-In: /usr/lib/systemd/system/fstrim.timer.d
             \u2514\u2500timer-override.conf
     Active: active (waiting) since Thu 2023-04-27 14:14:18 UTC; 36min ago
    Trigger: Fri 2023-04-28 00:00:00 UTC; 9h left
   Triggers: \u25cf fstrim.service
       Docs: man:fstrim

Apr 27 14:14:18 sonic systemd[1]: Started Discard unused blocks daily.
admin@sonic-amazon:~$ cat /usr/lib/systemd/system/fstrim.timer.d/timer-override.conf 
[Unit]
Description=Discard unused blocks daily

[Timer]
OnCalendar=daily
admin@sonic-amazon:~$ 
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202012
- [x] master

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

