### PR TITLE
SONiC Yang model support for IPv6 link local

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -34,6 +34,7 @@ Table of Contents
          * [FG_NHG_PREFIX](#fg_nhg_prefix)  
          * [FLEX_COUNTER_TABLE](#flex_counter_table)  
          * [Hash](#hash)  
+         * [IPv6 Link-local] (#ipv6-link-local)
          * [KDUMP](#kdump)  
          * [Kubernetes Master](#kubernetes-master)  
          * [L2 Neighbors](#l2-neighbors)  
@@ -1080,6 +1081,30 @@ The configuration is applied globally for each ECMP and LAG on a switch.
         }
     }
 }
+```
+
+### IPv6 Link-local
+```
+{
+    "INTERFACE": {
+        "Ethernet8": {
+            "ipv6_use_link_local_only": "disable"
+        }
+    },
+
+    "PORTCHANNEL_INTERFACE": {
+        "PortChannel01": {
+            "ipv6_use_link_local_only": "enable"
+        }
+    },
+
+    "VLAN_INTERFACE": {
+        "Vlan1000": {
+            "ipv6_use_link_local_only": "enable"
+        }
+    }
+}
+
 ```
 
 ### KDUMP

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -116,7 +116,8 @@
         "PORTCHANNEL_INTERFACE": {
                 "PortChannel0003": {
                     "nat_zone": "1",
-                    "loopback_action": "drop"
+                    "loopback_action": "drop",
+                    "ipv6_use_link_local_only": "enable"
                 },
                 "PortChannel0004": {"vrf_name": "Vrf_blue"},
                 "PortChannel42|10.1.0.1/31": {},
@@ -132,7 +133,8 @@
         "VLAN_INTERFACE": {
             "Vlan111": {
                 "nat_zone": "0",
-                "loopback_action": "forward"
+                "loopback_action": "forward",
+                "ipv6_use_link_local_only": "disable"
             },
             "Vlan777": {},
             "Vlan111|2a04:5555:45:6709::1/64": {
@@ -1039,7 +1041,8 @@
             "Ethernet16": {},
             "Ethernet18": {
                 "nat_zone": "1",
-                "loopback_action": "forward"
+                "loopback_action": "forward",
+                "ipv6_use_link_local_only": "enable"
             },
             "Ethernet112|2a04:5555:40:a709::2/126": {
                 "scope": "global",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/interface.json
@@ -22,5 +22,8 @@
         "desc": "INCORRECT LOOPBACK ACTION IN INTERFACE TABLE.",
         "eStrKey" : "Pattern",
         "eStr": ["drop|forward"]
+    },
+    "INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/interface.json
@@ -25,5 +25,10 @@
     },
     "INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
         "desc": "Enable the ipv6 link-local."
+    },
+    "INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local as true.",
+        "eStrKey" : "InvalidValue",
+        "eStr": ["enable|disable"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/interface.json
@@ -28,7 +28,6 @@
     },
     "INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
         "desc": "Enable the ipv6 link-local as true.",
-        "eStrKey" : "InvalidValue",
-        "eStr": ["enable|disable"]
+        "eStr": "Invalid value \"true\" in \"ipv6_use_link_local_only\" element."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
@@ -73,5 +73,8 @@
         "desc": "INCORRECT LOOPBACK ACTION IN PORTCHANNEL_INTERFACE TABLE.",
         "eStrKey" : "Pattern",
         "eStr": ["drop|forward"]
+    },
+    "PORTCHANNEL_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
@@ -79,7 +79,6 @@
     },
     "PORTCHANNEL_INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
         "desc": "Enable the ipv6 link-local as true.",
-        "eStrKey" : "InvalidValue",
-        "eStr": ["enable|disable"]
+        "eStr": "Invalid value \"true\" in \"ipv6_use_link_local_only\" element."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
@@ -76,5 +76,10 @@
     },
     "PORTCHANNEL_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
         "desc": "Enable the ipv6 link-local."
+    },
+    "PORTCHANNEL_INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local as true.",
+        "eStrKey" : "InvalidValue",
+        "eStr": ["enable|disable"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
@@ -79,5 +79,8 @@
         "desc": "INCORRECT LOOPBACK ACTION IN VLAN_INTERFACE TABLE.",
         "eStrKey" : "Pattern",
         "eStr": ["drop|forward"]
+    },
+    "VLAN_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
@@ -82,5 +82,10 @@
     },
     "VLAN_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
         "desc": "Enable the ipv6 link-local."
+    },
+    "VLAN_INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local as true.",
+        "eStrKey" : "InvalidValue",
+        "eStr": ["enable|disable"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
@@ -85,7 +85,6 @@
     },
     "VLAN_INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
         "desc": "Enable the ipv6 link-local as true.",
-        "eStrKey" : "InvalidValue",
-        "eStr": ["enable|disable"]
+        "eStr": "Invalid value \"true\" in \"ipv6_use_link_local_only\" element."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/interface.json
@@ -209,5 +209,33 @@
                 ]
             }
         }
+    },
+    "INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "ipv6_use_link_local_only": "enable"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet8",
+                        "fec": "rs",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet8",
+                        "speed": 25000
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/interface.json
@@ -237,5 +237,33 @@
                 ]
             }
         }
+    },
+    "INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "ipv6_use_link_local_only": "true"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet8",
+                        "fec": "rs",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet8",
+                        "speed": 25000
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
@@ -428,5 +428,42 @@
                 ]
             }
         }
+    },
+    "PORTCHANNEL_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001"
+                    }
+                ]
+            },
+            "sonic-portchannel:PORTCHANNEL_INTERFACE": {
+                "PORTCHANNEL_INTERFACE_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "ipv6_use_link_local_only": "enable"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
@@ -465,5 +465,42 @@
                 ]
             }
         }
+    },
+    "PORTCHANNEL_INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001"
+                    }
+                ]
+            },
+            "sonic-portchannel:PORTCHANNEL_INTERFACE": {
+                "PORTCHANNEL_INTERFACE_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "ipv6_use_link_local_only": "true"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
@@ -626,5 +626,49 @@
                 ]
             }
         }
+    },
+    "VLAN_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "description": "vlan_nat",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_MEMBER": {
+                "VLAN_MEMBER_LIST": [
+                    {
+                        "port": "Ethernet0",
+                        "tagging_mode": "tagged",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "ipv6_use_link_local_only": "enable"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
@@ -670,5 +670,49 @@
                 ]
             }
         }
+    },
+    "VLAN_INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "description": "vlan_nat",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_MEMBER": {
+                "VLAN_MEMBER_LIST": [
+                    {
+                        "port": "Ethernet0",
+                        "tagging_mode": "tagged",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "ipv6_use_link_local_only": "true"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-interface.yang
@@ -75,6 +75,15 @@ module sonic-interface {
 					}
 				}
 
+				leaf ipv6_use_link_local_only {
+					description "Enable/Disable IPv6 link local address on interface";
+					type enumeration {
+						enum enable;
+						enum disable;
+					}
+					default disable;
+				}
+
                 leaf loopback_action {
                     description "Packet action when a packet ingress and gets routed on the same IP interface";
                     type stypes:loopback_action;

--- a/src/sonic-yang-models/yang-models/sonic-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-interface.yang
@@ -77,10 +77,7 @@ module sonic-interface {
 
 				leaf ipv6_use_link_local_only {
 					description "Enable/Disable IPv6 link local address on interface";
-					type enumeration {
-						enum enable;
-						enum disable;
-					}
+					type mode-status;
 					default disable;
 				}
 

--- a/src/sonic-yang-models/yang-models/sonic-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-interface.yang
@@ -77,7 +77,7 @@ module sonic-interface {
 
 				leaf ipv6_use_link_local_only {
 					description "Enable/Disable IPv6 link local address on interface";
-					type mode-status;
+					type stypes:mode-status;
 					default disable;
 				}
 

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -181,6 +181,16 @@ module sonic-portchannel {
 				enum disable;
 			}
 		}
+
+		leaf ipv6_use_link_local_only {
+			description "Enable/Disable IPv6 link local address on portchannel interface";
+			type enumeration {
+				enum enable;
+				enum disable;
+			}
+			default disable;
+		}
+
             } /* end of list PORTCHANNEL_INTERFACE_LIST */
 
             list PORTCHANNEL_INTERFACE_IPPREFIX_LIST {

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -184,10 +184,7 @@ module sonic-portchannel {
 
 		leaf ipv6_use_link_local_only {
 			description "Enable/Disable IPv6 link local address on portchannel interface";
-			type enumeration {
-				enum enable;
-				enum disable;
-			}
+			type mode-status;
 			default disable;
 		}
 

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -184,7 +184,7 @@ module sonic-portchannel {
 
 		leaf ipv6_use_link_local_only {
 			description "Enable/Disable IPv6 link local address on portchannel interface";
-			type mode-status;
+			type stypes:mode-status;
 			default disable;
 		}
 

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -102,6 +102,16 @@ module sonic-vlan {
 					}
 				}
 
+				leaf ipv6_use_link_local_only {
+					description "Enable/Disable IPv6 link local address on vlan interface";
+					type enumeration {
+						enum enable;
+						enum disable;
+					}
+					default disable;
+				}
+
+
                 leaf loopback_action {
                     description "Packet action when a packet ingress and gets routed on the same IP interface";
                     type stypes:loopback_action;

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -104,10 +104,7 @@ module sonic-vlan {
 
 				leaf ipv6_use_link_local_only {
 					description "Enable/Disable IPv6 link local address on vlan interface";
-					type enumeration {
-						enum enable;
-						enum disable;
-					}
+					type mode-status;
 					default disable;
 				}
 

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -104,7 +104,7 @@ module sonic-vlan {
 
 				leaf ipv6_use_link_local_only {
 					description "Enable/Disable IPv6 link local address on vlan interface";
-					type mode-status;
+					type stypes:mode-status;
 					default disable;
 				}
 


### PR DESCRIPTION
SONiC Yang model support for IPv6 link local

What I did
Created SONiC Yang model for IPv6 link local

How I did it
Defined Yang models for IPv6 link local based on https://github.com/sonic-net/SONiC/blob/master/doc/ipv6/ipv6_link_local.md

How to verify it
Added enable test case.

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>