### PR TITLE
sonic-yang-models: WRED statistics yang

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1099,6 +1099,14 @@ The FG_NHG_PREFIX table provides the FG_NHG_PREFIX for which FG behavior is desi
 		"TUNNEL": {
 			"FLEX_COUNTER_STATUS": "enable",
 			"POLL_INTERVAL": "10000"
+		},
+		"WRED_ECN_QUEUE": {
+			"FLEX_COUNTER_STATUS": "enable",
+			"POLL_INTERVAL": "10000"
+		},
+		"WRED_ECN_PORT": {
+			"FLEX_COUNTER_STATUS": "enable",
+			"POLL_INTERVAL": "1000"
 		}
 	}
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
@@ -54,6 +54,14 @@
                 "FLOW_CNT_ROUTE": {
                     "FLEX_COUNTER_STATUS": "enable",
                     "POLL_INTERVAL": 10000
+                },
+                "WRED_ECN_QUEUE": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "WRED_ECN_PORT": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 1000
                 }
             }
         }
@@ -111,6 +119,14 @@
                     "POLL_INTERVAL": 99
                 },
                 "FLOW_CNT_ROUTE": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 99
+                },
+                "WRED_ECN_QUEUE": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 99
+                },
+                "WRED_ECN_PORT": {
                     "FLEX_COUNTER_STATUS": "enable",
                     "POLL_INTERVAL": 99
                 }

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -241,6 +241,32 @@ module sonic-flex_counter {
                 }
             }
 
+            container WRED_ECN_QUEUE {
+                /* WRED_ECN_QUEUE_FLEX_COUNTER_GROUP  */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+                leaf POLL_INTERVAL {
+                    type poll_interval;
+                }
+            }
+
+            container WRED_ECN_PORT {
+                /* WRED_ECN_QUEUE_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+                leaf POLL_INTERVAL {
+                    type poll_interval;
+                }
+            }
+
         }
         /* end of container FLEX_COUNTER_TABLE */
 


### PR DESCRIPTION
#### Why I did it
Supporting WRED and ECN statistics in SONiC

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added new flex counter groups in yang file

#### How to verify it
Compiled the sonic.bin and loaded the image to DUT with all the WRED feature changes.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
* Yang changes for WRED_ECN_QUEUE and WRED_ECN_PORT flex counter groups


#### Link to config_db schema for YANG module changes
https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#flex_counter_table



Dependent Pull Requests: 
Sonic-utilities pull request : https://github.com/sonic-net/sonic-utilities/pull/2807
Sonic-sairedis pull request : https://github.com/sonic-net/sonic-sairedis/pull/1234
Sonic-swss : pull request : https://github.com/sonic-net/sonic-swss/pull/2750
Sonic-swss common pull request : https://github.com/sonic-net/sonic-swss-common/pull/777

#### A picture of a cute animal (not mandatory but encouraged)


