### PR TITLE
[Profiler] Add ability to print elapsed build time for target packages

### DIFF
--- a/rules/functions
+++ b/rules/functions
@@ -53,6 +53,9 @@ LOG = < /dev/null |& $(PROJECT_ROOT)/scripts/process_log.sh $(PROCESS_LOG_OPTION
 ###############################################################################
 ## Header and footer for each target
 ###############################################################################
+START_TIME = echo Build start time: $$(date -ud "@$($@_TSTMP_ST)") $(LOG)
+END_TIME = echo Build end time: $$(date -ud "@$($@_TSTMP_END)") $(LOG)
+ELAPSED_TIME = echo Elapsed time: $$(date -ud "@$$(( $($@_TSTMP_END) - $($@_TSTMP_ST) ))" +'%-Hh %-Mm %-Ss') $(LOG)
 
 # Dump targets taht current depends on
 ifeq ($(SONIC_CONFIG_PRINT_DEPENDENCIES),y)
@@ -64,11 +67,16 @@ define HEADER
 @
 $(PRINT_DEPENDENCIES)
 $(FLUSH_LOG)
+$(eval $@_TSTMP_ST := $(shell date +%s))
+$(START_TIME)
 ./update_screen.sh -a $@ $*
 endef
 
 # footer for each rule
 define FOOTER
+$(eval $@_TSTMP_END := `date +%s`)
+$(END_TIME)
+$(ELAPSED_TIME)
 ./update_screen.sh -d $@ $($*_CACHE_LOADED)
 endef
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To be able to see how much time was consumed to build a specific target.
A newly added code does those things:
* Print build start time for target
* Print build end time for target
* Print elapsed time for target

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
* Add a macro to record the time
* Add macros to print end time and elapsed time

#### How to verify it
Just build an image and check any *.log file

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (it is my cat Finn)
![PXL_20230413_140941610 PORTRAIT](https://user-images.githubusercontent.com/35844154/231862413-cb630c8f-895f-4051-85e5-86802f9ccf40.jpg)