### PR TITLE
Support a new ACL table type called L3V4V6.

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -143,5 +143,8 @@
     "ACL_RULE_WRONG_AETH_SYNDROME": {
         "desc": "Configure invalid AETH_SYNDROME in decimal format.",
         "eStrKey" : "Pattern"
+    },
+    "ACL_TABLE_L3V4V6_TABLE_TYPE": {
+        "desc": "ACL_TABLE Validate type L3V4V6."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -1146,5 +1146,69 @@
                 ]
             }
         }
+    },
+    "ACL_TABLE_L3V4V6_TABLE_TYPE": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "DATA-ACL-V4V6",
+                        "IP_TYPE": "IPV4",
+                        "DST_IP": "10.186.72.64/26",
+                        "PACKET_ACTION": "FORWARD",
+                        "PRIORITY": 999960,
+                        "RULE_NAME": "Rule_40",
+                        "SRC_IP": "10.176.0.0/15"
+                    },
+                    {
+                        "ACL_TABLE_NAME": "DATA-ACL-V4V6",
+                        "DST_IPV6": "2a04:f547:43:320::/64",
+                        "IP_TYPE": "IPV6",
+                        "PACKET_ACTION": "FORWARD",
+                        "PRIORITY": 999980,
+                        "RULE_NAME": "Rule_20",
+                        "SRC_IPV6": "2a04:f547:41::/48"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "DATA-ACL-V4V6",
+                        "policy_desc": "Filter IPv4 and IPv6",
+                        "ports": [
+                            "Ethernet0",
+                            "Ethernet1"
+                        ],
+                        "stage": "EGRESS",
+                        "type": "L3V4V6"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "0,1,2,3",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    },
+                    {
+                        "admin_status": "up",
+                        "alias": "eth1",
+                        "description": "Ethernet1",
+                        "mtu": 9000,
+                        "lanes": "10,11,12,13",
+                        "name": "Ethernet1",
+                        "speed": 25000
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -88,6 +88,7 @@ module sonic-types {
             enum L2;
             enum L3;
             enum L3V6;
+            enum L3V4V6;
             enum MIRROR;
             enum MIRRORV6;
             enum MIRROR_DSCP;


### PR DESCRIPTION






#### Why I did it
Add support for a new ACL table type L3V4V6 that supports both v4 and v6 Match types.

#### How I did it
HLD: sonic-net/SONiC#1267

#### How to verify it
Added unit-tests:
```
 Test 890: ACL_TABLE Validate type L3V4V6.
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

NA (new feature)

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master SONiC.master.Innovium.0-dirty-20230418.040344


#### Description for the changelog

Add support for a new ACL table type L3V4V6 that supports both v4 and v6 Match types.

