### PR TITLE
Fixed the internal peer route-map policy

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/internal/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/internal/peer-group.conf.j2
@@ -3,11 +3,11 @@
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
-  address-family ipv4
-
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
     neighbor INTERNAL_PEER_V4 update-source Loopback4096
-{% elif CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
+{% endif %}
+  address-family ipv4
+{% if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
     neighbor INTERNAL_PEER_V4 route-reflector-client
 {% endif %}
     neighbor INTERNAL_PEER_V4 soft-reconfiguration inbound
@@ -15,10 +15,11 @@
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
   exit-address-family
-  address-family ipv6
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
     neighbor INTERNAL_PEER_V6 update-source Loopback4096
-{% elif CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
+{% endif %}
+  address-family ipv6
+{% if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
     neighbor INTERNAL_PEER_V6 route-reflector-client
 {% endif %}
     neighbor INTERNAL_PEER_V6 soft-reconfiguration inbound

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/internal/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/internal/peer-group.conf.j2
@@ -4,7 +4,7 @@
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
-    neighbor INTERNAL_PEER_V4 update-source Loopback4096
+  neighbor INTERNAL_PEER_V4 update-source Loopback4096
 {% endif %}
   address-family ipv4
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
@@ -16,7 +16,7 @@
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
   exit-address-family
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
-    neighbor INTERNAL_PEER_V6 update-source Loopback4096
+  neighbor INTERNAL_PEER_V6 update-source Loopback4096
 {% endif %}
   address-family ipv6
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/param_chasiss_packet.json
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/param_chasiss_packet.json
@@ -2,7 +2,7 @@
     "CONFIG_DB__DEVICE_METADATA": {
         "localhost": {
             "type": "SpineRouter",
-	        "sub_role": "BackEnd",
+	    "sub_role": "FrontEnd",
             "switch_type": "chassis-packet"
         }
     },

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chasiss_packet.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chasiss_packet.conf
@@ -3,15 +3,15 @@
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
-  address-family ipv4
     neighbor INTERNAL_PEER_V4 update-source Loopback4096 
+  address-family ipv4
     neighbor INTERNAL_PEER_V4 soft-reconfiguration inbound
     neighbor INTERNAL_PEER_V4 allowas-in 1
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
   exit-address-family
-  address-family ipv6
     neighbor INTERNAL_PEER_V6 update-source Loopback4096 
+  address-family ipv6
     neighbor INTERNAL_PEER_V6 soft-reconfiguration inbound
     neighbor INTERNAL_PEER_V6 allowas-in 1
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chasiss_packet.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chasiss_packet.conf
@@ -3,14 +3,14 @@
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
-    neighbor INTERNAL_PEER_V4 update-source Loopback4096 
+  neighbor INTERNAL_PEER_V4 update-source Loopback4096 
   address-family ipv4
     neighbor INTERNAL_PEER_V4 soft-reconfiguration inbound
     neighbor INTERNAL_PEER_V4 allowas-in 1
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
   exit-address-family
-    neighbor INTERNAL_PEER_V6 update-source Loopback4096 
+  neighbor INTERNAL_PEER_V6 update-source Loopback4096 
   address-family ipv6
     neighbor INTERNAL_PEER_V6 soft-reconfiguration inbound
     neighbor INTERNAL_PEER_V6 allowas-in 1


### PR DESCRIPTION
What I did:
In FRR command `update source <interface-name>` is not at address-family level. Because of this 
internal peer route-map for ipv6 were getting applied to ipv4 address family. As a result
TSA over iBGP for Ipv6 was not getting applied.

How I verify:

Manual Verification of TSA over both ipv4 and ipv6 after fix works fine.
Updated UT for this.

Added sonic-mgmt test gap: https://github.com/sonic-net/sonic-mgmt/issues/8170
