### PR TITLE
[chassis][lldp] Fix the lldp error log in host instance which doesn't contain front panel ports

### DIFF
--- a/dockers/docker-lldp/lldpmgrd
+++ b/dockers/docker-lldp/lldpmgrd
@@ -23,6 +23,8 @@ try:
     from sonic_py_common import daemon_base
     from swsscommon import swsscommon
     from sonic_py_common.interface import inband_prefix, recirc_prefix
+    from sonic_py_common import device_info
+
 except ImportError as err:
     raise ImportError("%s - required module not found" % str(err))
 
@@ -267,6 +269,15 @@ class LldpManager(daemon_base.DaemonBase):
         elif key == "PortConfigDone":
             self.port_config_done = True
 
+    def appdb_contains_lldp_port(self):
+        if device_info.is_supervisor():
+            return False
+        if device_info.is_multi_npu():
+            namespace_id = os.getenv("NAMESPACE_ID")
+            if not namespace_id:
+               return False
+        return True
+
     def run(self):
         """
         Subscribes to notifications of changes in the PORT table
@@ -357,7 +368,8 @@ def run_cmd(self, cmd):
 
 def check_timeout(self, start_time):
     if time.time() - start_time > PORT_INIT_TIMEOUT:
-        self.log_error("Port init timeout reached ({} seconds), resuming lldpd...".format(PORT_INIT_TIMEOUT))
+        if self.appdb_contains_lldp_port():
+            self.log_error("Port init timeout reached ({} seconds), resuming lldpd...".format(PORT_INIT_TIMEOUT))
         return True
     return False
 

--- a/dockers/docker-lldp/lldpmgrd
+++ b/dockers/docker-lldp/lldpmgrd
@@ -269,15 +269,6 @@ class LldpManager(daemon_base.DaemonBase):
         elif key == "PortConfigDone":
             self.port_config_done = True
 
-    def appdb_contains_lldp_port(self):
-        if device_info.is_supervisor():
-            return False
-        if device_info.is_multi_npu():
-            namespace_id = os.getenv("NAMESPACE_ID")
-            if not namespace_id:
-               return False
-        return True
-
     def run(self):
         """
         Subscribes to notifications of changes in the PORT table
@@ -368,7 +359,7 @@ def run_cmd(self, cmd):
 
 def check_timeout(self, start_time):
     if time.time() - start_time > PORT_INIT_TIMEOUT:
-        if self.appdb_contains_lldp_port():
+        if device_info.is_frontend_port_present_in_host():
             self.log_error("Port init timeout reached ({} seconds), resuming lldpd...".format(PORT_INIT_TIMEOUT))
         return True
     return False

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -713,3 +713,13 @@ def is_fast_reboot_enabled():
 
     state_db.close(state_db.STATE_DB)
     return fb_enable_state
+
+
+def is_frontend_port_present_in_host():
+    if is_supervisor():
+        return False
+    if is_multi_npu():
+        namespace_id = os.getenv("NAMESPACE_ID")
+        if not namespace_id:
+            return False
+    return True


### PR DESCRIPTION
#### Why I did it
Fix issue #14251
In multiasic platform, there is NO front panel port in the host lldp docker.  Because of there is NO front panel port,  the host APPL_DB database will not genernate the "PORT_CONFIG_DONE" and "PORT_INIT_DONE" event.   Therefore, the lldpmgrd  log the error log - ``` Port init timeout reached (300 seconds), resuming lldpd...``` in syslog.
``` 
Apr 18 01:57:03.993698 ixre-cpm-chassis9 ERR lldp#lldpmgrd[29]: Port init timeout reached (300 seconds), resuming lldpd...
```
OC test case failed-- autorestart/test_container_autorestart.py::test_containers_autorestart[ixre-cpm-chassis9-10-snmp

##### Work item tracking
- Microsoft ADO **https://msazure.visualstudio.com/One/_workitems/edit/17966117**:

#### How I did it
Since there is NO front panel ports in the host database in the multiasic platform ,  there won't be PORT_CONFIG_DONE and PORT_INIT_DONE event from the APPL_DB.  The error log ``Port init timeout reached (300 seconds), resuming lldpd...``` is not applicable to the host lldp.  In or to suppress this error message, add function appdb_contains_lldp_port() to return False for the supervisor card and host instance in the multasic platform which NAMESPACE_ID is none.  And use this function to determine and not to log this error log for the supervisor card and host database in the multasic platform.

#### How to verify it
Running image with this fix in the multiasic platform, verify this error log ```Port init timeout reached (300 seconds), resuming lldpd...``` should not be logged in the syslog.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

