### PR TITLE
[202205] Added changes in caclmgrd for chassis

### DIFF
--- a/src/sonic-host-services/scripts/caclmgrd
+++ b/src/sonic-host-services/scripts/caclmgrd
@@ -102,7 +102,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         },
         "EXTERNAL_CLIENT": {
             "ip_protocols": ["tcp"],
-            "multi_asic_ns_to_host_fwd":True
+            "multi_asic_ns_to_host_fwd":False
         },
         "ANY": {
             "ip_protocols": ["any"],
@@ -275,14 +275,23 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
 
         return block_ip2me_cmds
 
-    def check_chassis_midplane_interface_exist(self):
-        return self.run_commands(["ip link show" + " | grep -w 'eth1-midplane'" ], ignore_error=True)
+    def get_chassis_midplane_interface_ip(self):
+
+        chassis_midplane_ip_command = "ip -4 -o addr show " + "eth1-midplane" +\
+                                 " | awk '{print $4}' | cut -d'/' -f1 | head -1"
+        return self.run_commands([chassis_midplane_ip_command])
+
 
     def generate_allow_internal_chasis_midplane_traffic(self, namespace):
-        if not namespace and self.check_chassis_midplane_interface_exist():
-            return ["iptables -A INPUT -i eth1-midplane -j ACCEPT"]
-        else:
-            return []
+        allow_internal_chassis_midplane_traffic = []
+        if not namespace:
+            chassis_midplane_ip = self.get_chassis_midplane_interface_ip()
+            if not chassis_midplane_ip:
+                return allow_internal_chassis_midplane_traffic
+            allow_internal_chassis_midplane_traffic.append("iptables -A INPUT -s {} -d {} -j ACCEPT".format(chassis_midplane_ip, chassis_midplane_ip))
+            allow_internal_chassis_midplane_traffic.append("iptables -A INPUT -i eth1-midplane -j ACCEPT")
+
+        return allow_internal_chassis_midplane_traffic
 
     def generate_allow_internal_docker_ip_traffic_commands(self, namespace):
         allow_internal_docker_ip_cmds = []

--- a/src/sonic-host-services/tests/caclmgrd/cacl_external_client_acl_test.py
+++ b/src/sonic-host-services/tests/caclmgrd/cacl_external_client_acl_test.py
@@ -38,7 +38,7 @@ class TestCaclmgrdExternalClientAcl(TestCase):
         self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock()
         self.caclmgrd.ControlPlaneAclManager.generate_block_ip2me_traffic_iptables_commands = mock.MagicMock(return_value=[])
         self.caclmgrd.ControlPlaneAclManager.get_chain_list = mock.MagicMock(return_value=["INPUT", "FORWARD", "OUTPUT"])
-        self.caclmgrd.ControlPlaneAclManager.check_chassis_midplane_interface_exist = mock.MagicMock(return_value=False)
+        self.caclmgrd.ControlPlaneAclManager.get_chassis_midplane_interface_ip = mock.MagicMock(return_value='')
         caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
 
         iptables_rules_ret, _ = caclmgrd_daemon.get_acl_rules_and_translate_to_iptables_commands('')

--- a/src/sonic-host-services/tests/caclmgrd/caclmgrd_chassis_midplane_test.py
+++ b/src/sonic-host-services/tests/caclmgrd/caclmgrd_chassis_midplane_test.py
@@ -36,7 +36,9 @@ class TestCaclmgrdChassisMidplane(TestCase):
 
         self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ip = mock.MagicMock()
         self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock()
-        self.caclmgrd.ControlPlaneAclManager.check_chassis_midplane_interface_exist = mock.MagicMock(return_value=True)
+        self.caclmgrd.ControlPlaneAclManager.get_chassis_midplane_interface_ip = mock.MagicMock(return_value="1.0.0.33")
         caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
         ret = caclmgrd_daemon.generate_allow_internal_chasis_midplane_traffic('')
         self.assertListEqual(test_data["return"], ret)
+        ret = caclmgrd_daemon.generate_allow_internal_chasis_midplane_traffic('asic0')
+        self.assertListEqual([], ret)

--- a/src/sonic-host-services/tests/caclmgrd/test_chassis_midplane_vectors.py
+++ b/src/sonic-host-services/tests/caclmgrd/test_chassis_midplane_vectors.py
@@ -8,6 +8,7 @@ CACLMGRD_CHASSIS_MIDPLANE_TEST_VECTOR = [
         "Allow chassis midlane traffic",
         {
             "return": [
+                "iptables -A INPUT -s 1.0.0.33 -d 1.0.0.33 -j ACCEPT",
                 "iptables -A INPUT -i eth1-midplane -j ACCEPT"
             ]
         }


### PR DESCRIPTION
What/Why I did:

1. Allow traffic with source and destination as chassis eth1-midplane ip. Needed for Supervisor Redis-db connection (Redis packet has source and destination ip as eth1-midpane) after we load acl.json that has catch-all drop rule. Changes are generic and not specific to supervisor and applies on LC also.

2. Made multi_asic_ns_to_host_fwd as False for ACL service for External Client. This flag is needed for service SSH and SNMP where traffic can come in namespace over front-panel ports and we need to send the traffic in host where corresponding docker/service are running. There is no use-case of External client service for multi-asic as of now. Having flag as True creates failure when we try to load acl.json.

How I verify:
Manual Verification
UT updated accordingly.