### PR TITLE
[system-health] When disabling a feature the SYSTEM_READY|SYSTEM_STAT…

### DIFF
--- a/src/system-health/health_checker/sysmonitor.py
+++ b/src/system-health/health_checker/sysmonitor.py
@@ -406,6 +406,12 @@ class Sysmonitor(ProcessTaskBase):
             if event in self.dnsrvs_name:
                 self.dnsrvs_name.remove(event)
 
+            if len(self.dnsrvs_name) == 0:
+                astate = "UP"
+            else:
+                astate = "DOWN"
+            self.publish_system_status(astate)
+
             srv_name,last = event.split('.')
             # stop on service maybe propagated to timers and in that case,
             # the state_db entry for the service should not be deleted

--- a/src/system-health/tests/mock_connector.py
+++ b/src/system-health/tests/mock_connector.py
@@ -23,6 +23,9 @@ class MockConnector(object):
     def get_all(self, db_id, key):
         return MockConnector.data[key]
 
+    def exists(self, db_id, key):
+        return key in MockConnector.data
+
     def set(self, db_id, key, field, value):
         self.data[key] = {}
         self.data[key][field] = value

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -674,20 +674,19 @@ def test_check_unit_status():
 @patch('health_checker.sysmonitor.Sysmonitor.run_systemctl_show', MagicMock(return_value=mock_srv_props['mock_bgp.service']))
 @patch('health_checker.sysmonitor.Sysmonitor.get_app_ready_status', MagicMock(return_value=('Down','-','-')))
 @patch('health_checker.sysmonitor.Sysmonitor.post_unit_status', MagicMock())
-def test_check_unit_status2():
+@patch('health_checker.sysmonitor.Sysmonitor.print_console_message', MagicMock())
+def test_system_status_up_after_service_removed():
     sysmon = Sysmonitor()
     sysmon.publish_system_status('UP')
 
     sysmon.check_unit_status('mock_bgp.service')
     assert 'mock_bgp.service' in sysmon.dnsrvs_name
-    print(sysmon.dnsrvs_name)
     result = swsscommon.SonicV2Connector.get(MockConnector, 0, "SYSTEM_READY|SYSTEM_STATE", 'Status')
     print("system status result before service was removed from system: {}".format(result))
     assert result == "DOWN"
 
     sysmon.check_unit_status('mock_bgp.service')
     assert 'mock_bgp.service' not in sysmon.dnsrvs_name
-    print(sysmon.dnsrvs_name)
     result = swsscommon.SonicV2Connector.get(MockConnector, 0, "SYSTEM_READY|SYSTEM_STATE", 'Status')
     print("system status result after service was removed from system: {}".format(result))
     assert result == "UP"


### PR DESCRIPTION
…E was not updated
Fix issue https://github.com/sonic-net/sonic-buildimage/issues/14916
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
If you enable feature and then disable it, System Ready status change to Not Ready
```

root@qa-eth-vt01-2-3700v:/home/admin# config feature state dhcp_relay enabled 
root@qa-eth-vt01-2-3700v:/home/admin# show system-health sysready-status 
System is ready

Service-Name            Service-Status    App-Ready-Status    Down-Reason
----------------------  ----------------  ------------------  -------------
containerd              OK                OK                  -
dhcp_relay              OK                OK                  -
docker                  OK                OK                  -
...


root@qa-eth-vt01-2-3700v:/home/admin# config feature state dhcp_relay disabled 
root@qa-eth-vt01-2-3700v:/home/admin# show system-health sysready-status 
System is not ready - one or more services are not up

Service-Name            Service-Status    App-Ready-Status    Down-Reason
----------------------  ----------------  ------------------  -------------
containerd              OK                OK                  -
docker                  OK                OK                  -
...

```
A disabled feature should not affect the system ready status.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
During the disable flow of dhcp_relay, it entered the dnsrvs_name list, which caused the SYSTEM_STATE key to be set to DOWN. Right after that, the dhcp_relay service was removed from the full service list, however, but, when it was removed from the dnsrvs_name, there was no flow to reset the system state back to UP even though there was no more services in down state.


#### How to verify it
```
root@qa-eth-vt01-2-3700v:/home/admin# config feature state dhcp_relay enabled 
root@qa-eth-vt01-2-3700v:/home/admin# show system-health sysready-status 

root@qa-eth-vt01-2-3700v:/home/admin# config feature state dhcp_relay disabled
root@qa-eth-vt01-2-3700v:/home/admin# show system-health sysready-status 

```
Should see
`System is ready 
`
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

