### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202205.2.2.1
+ref=202205.2.2.2


### PR DESCRIPTION
Why I did it
Release Notes for Cisco 8101-32FH-O:
·  Enable CMIS
·  Enable Subport for Static Breakout

How I did it
Update platform version to 202205.2.2.2 (equivalent to 202205-v0.16)

How to verify it

Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211



