### PR TITLE
Add override_config to load_minigraph in config-setup service

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -118,7 +118,8 @@ clean_flash() {
            [ $f != "minigraph.xml" ] &&
            [ $f != "snmp.yml" ] &&
            [ $f != "acl.json" ] &&
-           [ $f != "port_config.json" ]
+           [ $f != "port_config.json" ] &&
+           [ $f != "golden_config_db.json" ]
         then
             rm -rf "$target_path/$f"
         fi

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -109,7 +109,7 @@ run_hookdir() {
 reload_minigraph()
 {
     echo "Reloading minigraph..."
-    config load_minigraph -y -n --override_config
+    config load_minigraph -y -n --override_config --golden_config_path '/etc/sonic/golden_config_db.json'
     config save -y
 }
 

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -109,7 +109,11 @@ run_hookdir() {
 reload_minigraph()
 {
     echo "Reloading minigraph..."
-    config load_minigraph -y -n --override_config --golden_config_path '/etc/sonic/golden_config_db.json'
+    if [ -f /etc/sonic/golden_config_db.json ]; then
+        config load_minigraph -y -n --override_config --golden_config_path '/etc/sonic/golden_config_db.json'
+    else
+        config load_minigraph -y -n
+    fi
     config save -y
 }
 

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -109,7 +109,7 @@ run_hookdir() {
 reload_minigraph()
 {
     echo "Reloading minigraph..."
-    config load_minigraph -y -n
+    config load_minigraph -y -n --override_config
     config save -y
 }
 
@@ -305,7 +305,7 @@ check_all_config_db_present()
 do_config_migration()
 {
     # Identify list of files to migrate
-    copy_list="minigraph.xml snmp.yml acl.json port_config.json frr telemetry"
+    copy_list="minigraph.xml snmp.yml acl.json port_config.json frr telemetry golden_config_db.json"
 
     # Migrate all configuration files from old to new
     copy_config_files_and_directories $copy_list

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -126,6 +126,7 @@ migrate_nos_configuration()
         PORT_CONFIG_GZFILE=$NOS_DIR/port_config.json.gz.base64.txt
         PORT_CONFIG_FILE=$NOS_DIR/port_config.json
         SNMP_FILE=$NOS_DIR/snmp.yml
+        GOLDEN_CONFIG_DB_GZFILE=$NOS_DIR/golden_config_db.json.gz.base64.txt
         GOLDEN_CONFIG_DB_FILE=$NOS_DIR/golden_config_db.json
         mkdir -p $NOS_DIR
 
@@ -138,6 +139,7 @@ migrate_nos_configuration()
             [ -f $MG_GZFILE ] && /usr/bin/base64 -d $MG_GZFILE | /bin/gunzip > $MG_FILE
             [ -f $ACL_GZFILE ] && /usr/bin/base64 -d $ACL_GZFILE | /bin/gunzip > $ACL_FILE
             [ -f $PORT_CONFIG_GZFILE ] && /usr/bin/base64 -d $PORT_CONFIG_GZFILE | /bin/gunzip > $PORT_CONFIG_FILE
+            [ -f $GOLDEN_CONFIG_DB_GZFILE] && /usr/bin/base64 -d $GOLDEN_CONFIG_DB_GZFILE| /bin/gunzip > $GOLDEN_CONFIG_DB_FILE
 
             # Copy relevant files
             nos_migration_import $NOS_DIR/mgmt_interface.cfg /host/migration

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -126,6 +126,7 @@ migrate_nos_configuration()
         PORT_CONFIG_GZFILE=$NOS_DIR/port_config.json.gz.base64.txt
         PORT_CONFIG_FILE=$NOS_DIR/port_config.json
         SNMP_FILE=$NOS_DIR/snmp.yml
+        GOLDEN_CONFIG_DB_FILE=$NOS_DIR/golden_config_db.json
         mkdir -p $NOS_DIR
 
         mount $nos_dev $NOS_DIR
@@ -144,6 +145,7 @@ migrate_nos_configuration()
             nos_migration_import $ACL_FILE /host/migration
             nos_migration_import $PORT_CONFIG_FILE /host/migration
             nos_migration_import $SNMP_FILE /host/migration
+            nos_migration_import $GOLDEN_CONFIG_DB_FILE /host/migration
 
             if [ "$sonic_fast_reboot" == true ]; then
                 mkdir -p /host/fast-reboot
@@ -261,6 +263,7 @@ if [ -f $FIRST_BOOT_FILE ]; then
         [ -f /host/acl.json ] && mv /host/acl.json /etc/sonic/old_config/
         [ -f /host/port_config.json ] && mv /host/port_config.json /etc/sonic/old_config/
         [ -f /host/snmp.yml ] && mv /host/snmp.yml /etc/sonic/old_config/
+        [ -f /host/golden_config_db.json ] && mv /host/golden_config_db.json /etc/sonic/old_config/
         touch /tmp/pending_config_migration
     elif [ -n "$migration" ] && [ -f /host/migration/minigraph.xml ];  then
         mkdir -p /etc/sonic/old_config
@@ -268,6 +271,7 @@ if [ -f $FIRST_BOOT_FILE ]; then
         [ -f /host/migration/acl.json ] && mv /host/migration/acl.json /etc/sonic/old_config/
         [ -f /host/migration/port_config.json ] && mv /host/migration/port_config.json /etc/sonic/old_config/
         [ -f /host/migration/snmp.yml ] && mv /host/migration/snmp.yml /etc/sonic/old_config/
+        [ -f /host/migration/golden_config_db.json ] && mv /host/migration/golden_config_db.json /etc/sonic/old_config/
         touch /tmp/pending_config_migration
         [ -f /etc/sonic/updategraph.conf ] && sed -i -e "s/enabled=false/enabled=true/g" /etc/sonic/updategraph.conf
     else

--- a/files/image_config/secureboot/allowlist_paths.conf
+++ b/files/image_config/secureboot/allowlist_paths.conf
@@ -36,3 +36,4 @@ etc/subuid
 etc/tacplus_nss.conf
 etc/tacplus_user
 lib/systemd/system/serial-getty@.service
+etc/sonic/golden_config_db.json


### PR DESCRIPTION
#### Why I did it
This PR is to handle the override minigraph config by golden_config_db.json file if it is present in the backup location.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

