### PR TITLE
[Yang model] Add Yang models for VNET table.

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2028,7 +2028,7 @@ channel name as object key, and tagging mode as attributes.
 
 ### VNET
 
-VNET member table has Vnet name as the object key, and vxlan_tunnel name, scope, vni, peer list, advertised prefix, src mac, and overlay dest mac as attributes.
+VNET table has Vnet name as the object key, and vxlan_tunnel name, scope, vni, peer list, advertised prefix, src mac, and overlay dest mac as attributes.
 The vxlan_tunnel name (mandatory) is the tunnel name from the VXLAN table. scope (optional) must "default", vni (mandatory) is the vxlan tunnel vni, peer_list (optional) is for Vnet
 peering, advertise_prefix (optional) is used to allow advertisement of this vnet's routes, overlay_dmac (optional) is the mac address which is used for VNET ping
 monitoring sessions for the vnet routes and is optional.

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2028,9 +2028,9 @@ channel name as object key, and tagging mode as attributes.
 
 ### VNET
 
-VLAN member table has Vnet name as the object key, and vxlan_tunnel name, scope, vni, peer list, advertised prefix, src mac, and overlay dest mac as attributes.
-The vxlan_tunnel name is the tunnel name from the VXLAN table. scope must "default", vni is the vxlan tunnel vni, peer_list is for Vnet
-peering or can be empty, advertise_prefix is used to allow advertisement of this vnet's routes, overlay_dmac is the mac address which is used for VNET ping
+VNET member table has Vnet name as the object key, and vxlan_tunnel name, scope, vni, peer list, advertised prefix, src mac, and overlay dest mac as attributes.
+The vxlan_tunnel name (mandatory) is the tunnel name from the VXLAN table. scope (optional) must "default", vni (mandatory) is the vxlan tunnel vni, peer_list (optional) is for Vnet
+peering, advertise_prefix (optional) is used to allow advertisement of this vnet's routes, overlay_dmac (optional) is the mac address which is used for VNET ping
 monitoring sessions for the vnet routes and is optional.
 
 ```

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -68,6 +68,7 @@ Table of Contents
          * [Versions](#versions)  
          * [VLAN](#vlan)   
          * [VLAN_MEMBER](#vlan_member)  
+         * [VNET](#vnet)
          * [VOQ Inband Interface](#voq-inband-interface)  
          * [VXLAN](#vxlan)  
          * [Virtual router](#virtual-router)  
@@ -2020,6 +2021,33 @@ channel name as object key, and tagging mode as attributes.
 	},
 	"Vlan2000|PortChannel47": {
 		"tagging_mode": "tagged"
+	}
+  }
+}
+```
+
+### VNET
+
+VLAN member table has Vnet name as the object key, and vxlan_tunnel name, scope, vni, peer list, advertised prefix, src mac, and overlay dest mac as attributes.
+The vxlan_tunnel name is the tunnel name from the VXLAN table. scope must "default", vni is the vxlan tunnel vni, peer_list is for Vnet
+peering or can be empty, advertise_prefix is used to allow advertisement of this vnet's routes, overlay_dmac is the mac address which is used for VNET ping
+monitoring sessions for the vnet routes and is optional.
+
+```
+{
+"VNET": {
+	"Vnet1-1": {
+	    "vxlan_tunnel": "vtep1",
+		"scope": "default",
+		"vni": "10011",
+		"peer_list": "",
+		"advertise_prefix": "true",
+		"overlay_dmac": "22:33:44:55:66:77"
+	},
+    "Vnetv4_v4-0": {
+	    "vxlan_tunnel": "vtep2",
+		"scope": "default",
+		"vni": "10011",
 	}
   }
 }

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -158,6 +158,7 @@ setup(
                          './yang-models/sonic-types.yang',
                          './yang-models/sonic-versions.yang',
                          './yang-models/sonic-vlan.yang',
+                         './yang-models/sonic-vnet.yang',
                          './yang-models/sonic-voq-inband-interface.yang',
                          './yang-models/sonic-vxlan.yang',
                          './yang-models/sonic-vrf.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2012,6 +2012,16 @@
                 "vlan": "Vlan100"
             }
         },
+        "VNET": {
+            "vnet1": {
+                "vxlan_tunnel": "vtep1",
+                "scope": "default",
+                "vni": "100",
+                "peer_list": "",
+                "advertise_prefix": "true",
+                "overlay_dmac": "22:33:44:55:66:77"
+            }
+        },
         "PORT_QOS_MAP": {
            "Ethernet0": {
               "dot1p_to_tc_map" : "Dot1p_to_tc_map1",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
@@ -1,0 +1,28 @@
+{
+    "VNET_VALID_TEST1": {
+        "desc": "Valid VNET Configuration."
+    },
+    "VNET_VALID_TEST2": {
+        "desc": "Valid VNET Configuration."
+    },
+    "VNET_INVALID_VALUE_TEST1": {
+        "desc": "Invalid values in parameters.",
+        "eStr": [ "Invalid VRF name" ]
+    },
+    "VNET_INVALID_VALUE_TEST2": {
+        "desc": "Invalid values in parameters.",
+        "eStr": [ "Invalid value" ]
+    },
+    "VNET_INVALID_VALUE_TEST3": {
+        "desc": "Invalid values in parameters.",
+        "eStr": [ "does not satisfy the constraint" ]
+    },
+    "VNET_INVALID_VALUE_TEST4": {
+        "desc": "Invalid values in parameters.",
+        "eStr": [ "does not satisfy the constraint" ]
+    },
+    "VNET_INVALID_VXLAN_VTEP": {
+        "desc": "Missing Vxlan_TUNNEL configuration",
+        "eStr" : [ "points to a non-existing leaf" ]
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
@@ -1,0 +1,182 @@
+{
+    "VNET_VALID_TEST1": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name" : "def",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10011"
+                    }
+               ]
+             }
+        }
+    },
+	"VNET_VALID_TEST2": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                       "name" : "abcd",
+                        "vxlan_tunnel": "vtep1",
+                        "scope": "default",
+                        "vni": "10011",
+                        "peer_list": "",
+                        "advertise_prefix": "true",
+                        "overlay_dmac": "22:33:44:55:66:77"
+                    }
+                ] 
+             }
+        }
+    },
+    "VNET_INVALID_VALUE_TEST1": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+
+                    {
+                        "name" : "abcd-1",
+                        "vxlan_tunnel": "vtep1",
+                        "scope": "Vrf_blue",
+                        "vni": "10011",
+                        "peer_list": "",
+                        "advertise_prefix": "true",
+                        "overlay_dmac": "22:33:44:55:66:77"
+                    }
+                ]
+            }
+        }
+    },
+	"VNET_INVALID_VALUE_TEST2": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name" : "abcdfg",
+                        "vxlan_tunnel": "vtep1",
+                        "scope": "default",
+                        "vni": "999999999999",
+                        "advertise_prefix": "unknown",
+                        "overlay_dmac": "22:33:44:55:66:77"
+                    }
+                ]
+            }
+        }
+    },
+	"VNET_INVALID_VALUE_TEST3": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name" : "abcd",
+                        "vxlan_tunnel": "vtep1",
+                        "scope": "default",
+                        "vni": "20100",
+                        "overlay_dmac": "22::"
+                    }
+                ]
+            }
+        }
+    },
+	"VNET_INVALID_VALUE_TEST4": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name" : "abcdfd",
+                        "scope": "default",
+                        "overlay_dmac": "22::"
+                    }
+
+                ]
+            }
+        }
+    },
+    "VNET_INVALID_VXLAN_VTEP": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name" : "abcd",
+                        "vxlan_tunnel": "vtepxyz",
+                        "scope": "default",
+                        "vni": "10011",
+                        "peer_list": "",
+                        "advertise_prefix": "true",
+                        "overlay_dmac": "22:33:44:55:66:77"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-vnet.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vnet.yang
@@ -43,11 +43,13 @@ module sonic-vnet {
                 key "name";
                 
                 leaf name {
+                    description "An alphanumaric string to represent the name of the unique vnet";
                     type string;
                 }
 
                 leaf vxlan_tunnel {
                     mandatory true;
+                    description "A valid and active vxlan tunnel to be used with this vnet for traffic encapsulation.";
                     type leafref {
                         path "/svxlan:sonic-vxlan/svxlan:VXLAN_TUNNEL/svxlan:VXLAN_TUNNEL_LIST/svxlan:name";
                     }
@@ -55,6 +57,7 @@ module sonic-vnet {
                 
                 leaf vni {
                     mandatory true;
+                    description "A valid and unique vni which will become part of the encapsulated traffic header.";
                     type stypes:vnid_type;
                 }
 
@@ -65,6 +68,7 @@ module sonic-vnet {
                 }
 
                 leaf guid {
+                    description "An optional guid.";
                     type string {
                         length 1..255;
                     }

--- a/src/sonic-yang-models/yang-models/sonic-vnet.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vnet.yang
@@ -1,0 +1,100 @@
+module sonic-vnet {
+    yang-version 1.1;
+    namespace "http://github.com/sonic-net/sonic-vnet";
+    prefix svnet;
+
+    import ietf-yang-types {
+        prefix yang;
+    }
+
+    import ietf-inet-types {
+        prefix inet;
+    }
+
+    import sonic-types {
+        prefix stypes;
+    }
+
+    import sonic-vxlan {
+        prefix svxlan;
+    }
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "VNET YANG Module for SONiC OS";
+
+    revision 2023-04-25 {
+        description
+            "First revision.";
+    }
+
+    container sonic-vnet {
+
+        container VNET {
+
+            description "config db VNET table";
+
+            list VNET_LIST {
+
+                key "name";
+                
+                leaf name {
+                    type string;
+                }
+
+                leaf vxlan_tunnel {
+                    mandatory true;
+                    type leafref {
+                        path "/svxlan:sonic-vxlan/svxlan:VXLAN_TUNNEL/svxlan:VXLAN_TUNNEL_LIST/svxlan:name";
+                    }
+                }
+                
+                leaf vni {
+                    mandatory true;
+                    type stypes:vnid_type;
+                }
+
+                leaf peer_list {
+                    description "Set of peers";
+                    /* Values in leaf list are UNIQUE */
+                    type string;
+                }
+
+                leaf guid {
+                    type string {
+                        length 1..255;
+                    }
+                }
+
+                leaf scope {
+                    description "can either be default or a valid VRF.";
+                    type string {
+                        pattern "default" {
+                            error-message "Invalid VRF name";
+                        }
+                    } 
+                }
+
+                leaf advertise_prefix {
+                    description "Flag to enable advertisement of route prefixes belonging to the Vnet.";
+                    type  boolean;
+                }
+
+                leaf overlay_dmac {
+                    description "Overlay Dest MAC address to be used by Vnet ping.";
+                    type yang:mac-address;
+                }
+
+                leaf src_mac {
+                    description "source mac address for the Vnet";
+                    type yang:mac-address;
+                }
+            }
+        }
+    }
+}
+

--- a/src/sonic-yang-models/yang-models/sonic-vnet.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vnet.yang
@@ -71,7 +71,7 @@ module sonic-vnet {
                 }
 
                 leaf scope {
-                    description "can either be default or a valid VRF.";
+                    description "can only be default.";
                     type string {
                         pattern "default" {
                             error-message "Invalid VRF name";


### PR DESCRIPTION
Created Yang Modle for VNET table.
https://github.com/sonic-net/sonic-buildimage/issues/14534

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:
18215579
#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

