### PR TITLE
[Mellanox] Update SN5600 sensors.conf and pcie.yaml files

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5600-r0/pcie.yaml
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/pcie.yaml
@@ -144,3 +144,8 @@
   id: 15bb
   name: 'Ethernet controller: Intel Corporation Ethernet Connection (7) I219-LM (rev
     10)'
+- bus: '01'
+  dev: '00'
+  fn: '0'
+  id: cf80
+  name: 'Ethernet controller: Mellanox Technologies Spectrum-4'

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/pcie.yaml
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/pcie.yaml
@@ -82,12 +82,6 @@
     f0)'
 - bus: '00'
   dev: 1b
-  fn: '2'
-  id: a342
-  name: 'PCI bridge: Intel Corporation Cannon Lake PCH PCI Express Root Port #19 (rev
-    f0)'
-- bus: '00'
-  dev: 1b
   fn: '4'
   id: a32c
   name: 'PCI bridge: Intel Corporation Cannon Lake PCH PCI Express Root Port #21 (rev

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/sensors.conf
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/sensors.conf
@@ -160,7 +160,7 @@ chip "mp2975-i2c-*-6a"
     ignore curr4
     ignore curr5
     ignore curr6
-chip "mp2975-i2c-*-6b"
+chip "mp2975-i2c-*-6c"
     label in1      "PMIC-10 PSU 13V5 Rail (in1)"
     label in2      "PMIC-10 HVDD_T03 1V2 Rail (out1)"
     label in3      "PMIC-10 HVDD_T47 1V2 Rail (out2)"
@@ -198,7 +198,7 @@ chip "mp2975-i2c-*-6e"
 
 # Power supplies
 
-chip "dps460-i2c-*-5a"
+chip "dps460-i2c-*-59"
     label in1 "PSU-1(L) 220V Rail (in)"
     ignore in2
     label in3 "PSU-1(L) 12V Rail (out)"
@@ -210,7 +210,8 @@ chip "dps460-i2c-*-5a"
     label power2 "PSU-1(L) 12V Rail Pwr (out)"
     label curr1 "PSU-1(L) 220V Rail Curr (in)"
     label curr2 "PSU-1(L) 12V Rail Curr (out)"
-chip "dps460-i2c-*-59"
+    set power2_cap 0
+chip "dps460-i2c-*-5a"
     label in1 "PSU-2(R) 220V Rail (in)"
     ignore in2
     label in3 "PSU-2(R) 12V Rail (out)"
@@ -229,8 +230,8 @@ chip "pmbus-i2c-*-10"
     ignore in2
     ignore in3
     label temp1    	"IBC-1 Temp 1"
-    label curr1 	"IBC-1 13V5 Rail Curr (out)"
-    ignore curr2
+    ignore curr1
+    label curr2 	"IBC-1 13V5 Rail Curr (out)"
 chip "pmbus-i2c-*-11"
     label in1      	"IBC-2 PWR CONV 54V Rail (in1)"
     ignore in2


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Update the sensors.conf and pcie.yaml according to the real hardware.

##### Work item tracking


#### How I did it

Update the sensors.conf and pcie.yaml 

#### How to verify it

run relevant sonic-mgmt test cases.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

