### PR TITLE
Third Party Container Management Support in Sonic App Extension

### DIFF
--- a/files/build_templates/default_manifest
+++ b/files/build_templates/default_manifest
@@ -1,0 +1,60 @@
+{
+    "version": "1.0.0",
+    "package": {
+        "version": "1.0.0",
+        "name": "default_manifest",
+        "description": "",
+        "base-os": {},
+        "depends": [],
+        "breaks": [],
+        "init-cfg": {},
+        "changelog": {},
+        "debug-dump": ""
+    },
+    "service": {
+        "name": "default_manifest",
+        "requires": [],
+        "requisite": [],
+        "wanted-by": [],
+        "after": [],
+        "before": [],
+        "dependent": [],
+        "dependent-of": [],
+        "post-start-action": "",
+        "pre-shutdown-action": "",
+        "asic-service": false,
+        "host-service": true,
+        "delayed": false,
+        "check_up_status": false,
+        "warm-shutdown": {
+            "after": [],
+            "before": []
+        },
+        "fast-shutdown": {
+            "after": [],
+            "before": []
+        },
+        "syslog": {
+            "support-rate-limit": false
+        }
+    },
+    "container": {
+        "privileged": false,
+        "entrypoint": "",
+        "volumes": [],
+        "mounts": [],
+        "environment": {},
+        "tmpfs": []
+    },
+    "processes": [],
+    "cli": {
+        "mandatory": false,
+        "show": [],
+        "config": [],
+        "clear": [],
+        "auto-generate-show": false,
+        "auto-generate-config": false,
+        "auto-generate-show-source-yang-modules": [],
+        "auto-generate-config-source-yang-modules": []
+    }
+}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -845,6 +845,11 @@ if [ "${PIPESTATUS[0]}" != "0" ]; then
     exit 1
 fi
 
+#Copy the default manifest file to SONIC_PACKAGE_MANAGER_FOLDER directly
+sudo cp $BUILD_TEMPLATES/default_manifest $FILESYSTEM_ROOT/$SONIC_PACKAGE_MANAGER_FOLDER/default_manifest
+#Create a new manifests subdirectory under SONIC_PACKAGE_MANAGER_FOLDER for all the user created custom manifests
+sudo mkdir -p $FILESYSTEM_ROOT/$SONIC_PACKAGE_MANAGER_FOLDER/manifests
+
 # Copy docker_image_ctl.j2 for SONiC Package Manager
 sudo cp $BUILD_TEMPLATES/docker_image_ctl.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/docker_image_ctl.j2
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To support Third Party Container Management in Sonic App Extension Framework

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
The main changes for this feature are in sonic-utilities repo. 
Here in this sonic-buildimage repo, this change is to prepare the directory (subdirectory "manifests" under /var/lib/sonic-package-manager) and the default manifest at build time without the need to create it in runtime every time



#### How to verify it
Execute commands specified in sonic-utilities repo PR for TPCM.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

