### PR TITLE
[202012][mlnx-ffb.sh] Update issu-version location 

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -823,7 +823,8 @@ for fw_file_name in ${!FW_FILE_MAP[@]}; do
     # Link old FW location to not break existing automation/scripts
     sudo ln -s /host/image-$SONIC_IMAGE_VERSION/$PLATFORM_DIR/fw/asic/${FW_FILE_MAP[$fw_file_name]} $FILESYSTEM_ROOT/etc/mlnx/${FW_FILE_MAP[$fw_file_name]}
 done
-sudo cp $files_path/$ISSU_VERSION_FILE $FILESYSTEM_ROOT/etc/mlnx/issu-version
+sudo cp $files_path/$ISSU_VERSION_FILE $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/asic/issu-version
+sudo ln -s /host/image-$SONIC_IMAGE_VERSION/$PLATFORM_DIR/fw/asic/issu-version /etc/mlnx/issu-version
 sudo cp $files_path/$MLNX_FFB_SCRIPT $FILESYSTEM_ROOT/usr/bin/mlnx-ffb.sh
 sudo cp $files_path/$MLNX_ONIE_FW_UPDATE $FILESYSTEM_ROOT/usr/bin/$MLNX_ONIE_FW_UPDATE
 sudo cp $files_path/$MLNX_SSD_FW_UPDATE $FILESYSTEM_ROOT/usr/bin/$MLNX_SSD_FW_UPDATE

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -824,7 +824,7 @@ for fw_file_name in ${!FW_FILE_MAP[@]}; do
     sudo ln -s /host/image-$SONIC_IMAGE_VERSION/$PLATFORM_DIR/fw/asic/${FW_FILE_MAP[$fw_file_name]} $FILESYSTEM_ROOT/etc/mlnx/${FW_FILE_MAP[$fw_file_name]}
 done
 sudo cp $files_path/$ISSU_VERSION_FILE $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/asic/issu-version
-sudo ln -s /host/image-$SONIC_IMAGE_VERSION/$PLATFORM_DIR/fw/asic/issu-version /etc/mlnx/issu-version
+sudo ln -s /host/image-$SONIC_IMAGE_VERSION/$PLATFORM_DIR/fw/asic/issu-version $FILESYSTEM_ROOT/etc/mlnx/issu-version
 sudo cp $files_path/$MLNX_FFB_SCRIPT $FILESYSTEM_ROOT/usr/bin/mlnx-ffb.sh
 sudo cp $files_path/$MLNX_ONIE_FW_UPDATE $FILESYSTEM_ROOT/usr/bin/$MLNX_ONIE_FW_UPDATE
 sudo cp $files_path/$MLNX_SSD_FW_UPDATE $FILESYSTEM_ROOT/usr/bin/$MLNX_SSD_FW_UPDATE

--- a/platform/mellanox/mlnx-ffb.sh
+++ b/platform/mellanox/mlnx-ffb.sh
@@ -33,41 +33,47 @@ check_sdk_upgrade()
         return "${FFB_SUCCESS}"
     fi
 
-    while :; do
-        mkdir -p "${FS_MOUNTPOINT}"
-        mount -t squashfs "${FS_PATH}" "${FS_MOUNTPOINT}" || {
-            >&2 echo "Failed to mount next SONiC image"
+    ISSU_VERSION_FILE_PATH="/etc/mlnx/issu-version"
+    CURRENT_ISSU_VERSION="$(cat ${ISSU_VERSION_FILE_PATH})"
+    NEXT_ISSU_VERSION="Unknown"
+
+    # /host/image-<version>/platform/fw/asic/issu-version is now the new location for ISSU version.
+    NEXT_IMAGE_ISSU_VERSION_FILE_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}/platform/fw/asic/issu-version"
+
+    if [ -f "${NEXT_IMAGE_ISSU_VERSION_FILE_PATH}" ]; then
+        NEXT_ISSU_VERSION="$(cat ${NEXT_IMAGE_ISSU_VERSION_FILE_PATH})"
+    else
+        while :; do
+            mkdir -p "${FS_MOUNTPOINT}"
+            mount -t squashfs "${FS_PATH}" "${FS_MOUNTPOINT}" || {
+                >&2 echo "Failed to mount next SONiC image"
+                break
+            }
+
+            [ -f "${ISSU_VERSION_FILE_PATH}" ] || {
+                >&2 echo "No ISSU version file found ${ISSU_VERSION_FILE_PATH}"
+                break
+            }
+
+            [ -f "${FS_MOUNTPOINT}/${ISSU_VERSION_FILE_PATH}" ] || {
+                >&2 echo "No ISSU version file found ${ISSU_VERSION_FILE_PATH} in ${NEXT_SONIC_IMAGE}"
+                break
+            }
+            NEXT_ISSU_VERSION="$(cat ${FS_MOUNTPOINT}/${ISSU_VERSION_FILE_PATH})"
             break
-        }
+        done
 
-        ISSU_VERSION_FILE_PATH="/etc/mlnx/issu-version"
+        umount -rf "${FS_MOUNTPOINT}" 2> /dev/null || true
+        rm -rf "${FS_MOUNTPOINT}" 2> /dev/null || true
+    fi
 
-        [ -f "${ISSU_VERSION_FILE_PATH}" ] || {
-            >&2 echo "No ISSU version file found ${ISSU_VERSION_FILE_PATH}"
-            break
-        }
-
-        [ -f "${FS_MOUNTPOINT}/${ISSU_VERSION_FILE_PATH}" ] || {
-            >&2 echo "No ISSU version file found ${ISSU_VERSION_FILE_PATH} in ${NEXT_SONIC_IMAGE}"
-            break
-        }
-
-        CURRENT_ISSU_VERSION="$(cat ${ISSU_VERSION_FILE_PATH})"
-        NEXT_ISSU_VERSION="$(cat ${FS_MOUNTPOINT}/${ISSU_VERSION_FILE_PATH})"
-
-        if [[ "${CURRENT_ISSU_VERSION}" == "${NEXT_ISSU_VERSION}" ]]; then
-            CHECK_RESULT="${FFB_SUCCESS}"
-        else
-            >&2 echo "Current and next ISSU version do not match:"
-            >&2 echo "Current ISSU version: ${CURRENT_ISSU_VERSION}"
-            >&2 echo "Next ISSU version: ${NEXT_ISSU_VERSION}"
-        fi
-
-        break
-    done
-
-    umount -rf "${FS_MOUNTPOINT}" 2> /dev/null || true
-    rm -rf "${FS_MOUNTPOINT}" 2> /dev/null || true
+    if [[ "${CURRENT_ISSU_VERSION}" == "${NEXT_ISSU_VERSION}" ]]; then
+        CHECK_RESULT="${FFB_SUCCESS}"
+    else
+        >&2 echo "Current and next ISSU version do not match:"
+        >&2 echo "Current ISSU version: ${CURRENT_ISSU_VERSION}"
+        >&2 echo "Next ISSU version: ${NEXT_ISSU_VERSION}"
+    fi
 
     return "${CHECK_RESULT}"
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

BACKPORT OF https://github.com/sonic-net/sonic-buildimage/pull/14925

#### Why I did it

ISSU version check fails due to inability to mount squashfs from 202211 on 201911

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Put ISSU version file under platform directory

#### How to verify it

202012 (with [202012][mlnx-ffb.sh] Update issu-version location  #14927) to master

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

