### PR TITLE
Fix for fast/cold-boot: call db_migrator only after old config is loaded

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -257,10 +257,18 @@ function postStartAction()
             $SONIC_DB_CLI CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
         fi
 
-        if [[ -x /usr/local/bin/db_migrator.py ]]; then
-            # Migrate the DB to the latest schema version if needed
-            if [ -z "$DEV" ]; then
-                /usr/local/bin/db_migrator.py -o migrate
+        if [ -e /tmp/pending_config_migration ]; then
+            # this is first boot to a new image, config-setup execution is pending.
+            # For fast/cold reboot case, DB contains nothing at this point
+            # Call db_migrator after config-setup loads the config (from old config or minigraph)
+            echo "Delaying db_migrator until config migration is over"
+        else
+            # this is not a first time boot to a new image. Datbase container starts w/ old pre-existing config
+            if [[ -x /usr/local/bin/db_migrator.py ]]; then
+                # Migrate the DB to the latest schema version if needed
+                if [ -z "$DEV" ]; then
+                    /usr/local/bin/db_migrator.py -o migrate
+                fi
             fi
         fi
         # Add redis UDS to the redis group and give read/write access to the group

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -300,6 +300,16 @@ check_all_config_db_present()
     return 0   
 }
 
+# DB schema is subject to change between two images
+# Perform DB schema migration after loading backup config from previous image
+do_db_migration()
+{
+    if [[ -x /usr/local/bin/db_migrator.py ]]; then
+        # Migrate the DB to the latest schema version if needed
+        /usr/local/bin/db_migrator.py -o migrate
+    fi
+}
+
 # Perform configuration migration from backup copy.
 #  - This step is performed when a new image is installed and SONiC switch boots into it
 do_config_migration()
@@ -322,16 +332,19 @@ do_config_migration()
     if [ x"${WARM_BOOT}" == x"true" ]; then
         echo "Warm reboot detected..."
         disable_updategraph
+        do_db_migration
         rm -f /tmp/pending_config_migration
         exit 0
     elif check_all_config_db_present; then
         echo "Use config_db.json from old system..."
         reload_configdb
+        do_db_migration
         # Disable updategraph
         disable_updategraph
     elif [ -r ${MINGRAPH_FILE} ]; then
         echo "Use minigraph.xml from old system..."
         reload_minigraph
+        do_db_migration
         # Disable updategraph
         disable_updategraph
     else


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix the issue where db_migrator is called before DB is loaded w/ config. This leads to db_migrator:

1. Not finding anything, and resumes to incorrectly migrate every missing config
   This is not expected. migration should happen after the old config is loaded and only new schema changes need migration.
2. Since DB does not have anything when migrator is called, db_migrator fails when some APIs return None.

The reason for incorrect call is that:
1. database service starts db_migrator as part of startup sequence.
2. config-setup service loads data from old-config/minigraph. However, since it has `Requires=database.service`. 
3. Hence, config-setup starts only when database service is started. And database service is started when db_migrator is completed.

Fixed by:
1. Check if this is first time boot by checking `pending_config_migration` flag.
2. If `pending_config_migration` is enabled, then do not call db_migrator as part of database service startup.
3. Let database service start which triggers config-setup service to start. 
4. Now call db_migrator after when config-setup service loads old-config/minigraph


Error that's being fixed:
```
May  2 20:35:04 sonic database.sh[649]: Creating new database container
May  2 20:35:04 sonic database.sh[663]: 99e8edba01ed0c7581f0d61dd2fa78374fa4f23e636a957004dd03a6f68eea86
May  2 20:35:04 sonic root: Starting database service...
May  2 20:35:06 sonic database.sh[690]: database
May  2 20:35:10 sonic database.sh[926]: True

May  2 20:35:10 sonic database.sh[928]:   File "/usr/local/bin/db_migrator.py", line 714, in common_migration_ops
May  2 20:35:10 sonic database.sh[928]:   File "/usr/local/bin/db_migrator.py", line 741, in migrate
May  2 20:35:10 sonic database.sh[928]:   File "/usr/local/bin/db_migrator.py", line 782, in main
May  2 20:35:10 sonic database.sh[928]: Traceback (most recent call last):
May  2 20:35:10 sonic database.sh[928]: TypeError: argument of type 'NoneType' is not iterable
May  2 20:35:10 sonic database.sh[928]: argument of type 'NoneType' is not iterable
May  2 20:35:10 sonic database.sh[928]: optional arguments:
May  2 20:35:10 sonic database.sh[928]: usage: db_migrator.py [-h] [-o operation migrate, set_version, get_version]
May  2 20:35:10 sonic db_migrator: :- operator(): DB '{APPL_DB}' is empty with pattern 'COPP_TABLE:*'!
May  2 20:35:10 sonic db_migrator: :- operator(): DB '{APPL_DB}' is empty with pattern 'INTF_TABLE:*'!
May  2 20:35:10 sonic db_migrator: :- operator(): Key 'BUFFER_MAX_PARAM_TABLE|global' field 'mmu_size' unavailable in database 'STATE_DB'
May  2 20:35:10 sonic db_migrator: :- operator(): Key 'WARM_RESTART_ENABLE_TABLE|system' field 'enable' unavailable in database 'STATE_DB'
May  2 20:35:10 sonic db_migrator: Caught exception: argument of type 'NoneType' is not iterable

May  2 20:35:11 sonic config-setup[935]: Copying SONiC configuration minigraph.xml ...
May  2 20:35:11 sonic config-setup[935]: Reloading minigraph...
May  2 20:35:11 sonic config-setup[935]: Use minigraph.xml from old system...

May  2 20:35:11 sonic root: Started database service...
```
##### Work item tracking
- Microsoft ADO **(number only)**: 17972494

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

