### PR TITLE
[frrcfgd] Add support for v6only option for unnumbered BGP peers

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1799,6 +1799,7 @@ class BGPConfigDaemon:
                    ('conn_retry',                           '{no:no-prefix}neighbor {} timers connect {}'),
                    ('min_adv_interval',                     '{no:no-prefix}neighbor {} advertisement-interval {}'),
                    ('passive_mode',                         '{no:no-prefix}neighbor {} passive', ['true', 'false']),
+                   ('v6only',                               '{no:no-prefix}neighbor {} interface v6only', ['true', 'false']),
                    ('capability_ext_nexthop',               '{no:no-prefix}neighbor {} capability extended-nexthop', ['true', 'false']),
                    ('disable_ebgp_connected_route_check',   '{no:no-prefix}neighbor {} disable-connected-check', ['true', 'false']),
                    ('enforce_first_as',                     '{no:no-prefix}neighbor {} enforce-first-as', ['true', 'false']),

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_or_peer.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_or_peer.j2
@@ -24,6 +24,9 @@
 {% if 'peer_group_name' in nbr_or_peer %}
  neighbor {{name_or_ip}} {{ns_intf.intf_arg}}peer-group {{nbr_or_peer['peer_group_name']}}
 {% endif %}
+{% if 'v6only' in nbr_or_peer and nbr_or_peer['v6only'] == 'true' %}
+ neighbor {{name_or_ip}} {{ns_intf.intf_arg}}v6only
+{% endif %}
 {% if 'local_asn' in nbr_or_peer %}
  neighbor {{name_or_ip}} local-as {{nbr_or_peer['local_asn']}}
 {% endif %}

--- a/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
@@ -331,6 +331,11 @@ module sonic-bgp-common {
             type boolean;
             description "Do not prepend local-as to updates from ibgp peers";
         }
+
+        leaf v6only {
+            type boolean;
+            description "Always use IPv6 unnumbered BGP peering";
+        }
     }
 
 


### PR DESCRIPTION
#### Why I did it
This option is useful to force FRR to use unnumbered BGP peering despite an IPv4 address being configured on the interface.

#### How I did it
Added the option to the Jinja2 template and frrcfgd.

#### How to verify it
- Configure unnumbered BGP peering on an interface
- Observe that the peering is successful
- Add an IPv4 address to the interface (e.g. `192.0.2.1/31`)
- Observe that FRR no longer tries to connect to the LLA IPv6 of the peer, but only to the peer IP it computes from the local IP (e.g. `192.0.2.0`)
- Enable `v6only` option for this peer
- Observe that FRR uses unnumbered peering again

#### Which release branch to backport (provide reason below if selected)
None (it's a feature)

#### Tested branch (Please provide the tested image version)
- [x] 202111
- [x] 202205

#### Description for the changelog
Add support for v6only option for unnumbered BGP peers

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

