### PR TITLE
Refine test job definition and assert logic

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -203,39 +203,6 @@ stages:
         MAX_WORKER: $(T0_2VLANS_INSTANCE_NUM)
         DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
 
-  - job:
-    pool:
-      vmImage: 'ubuntu-20.04'
-    displayName: "kvmtest-t0"
-    dependsOn:
-    - t0_part1
-    - t0_part2
-    - t0_testbedv2
-    - t0_2vlans_testbedv2
-    condition: always()
-    continueOnError: false
-    variables:
-      resultOfPart1: $[ dependencies.t0_part1.result ]
-      resultOfPart2: $[ dependencies.t0_part2.result ]
-      resultOfT0TestbedV2: $[ dependencies.t0_testbedv2.result ]
-      resultOfT02VlansTestbedV2: $[ dependencies.t0_2vlans_testbedv2.result ]
-
-    steps:
-    - script: |
-        if [ $(resultOfT0TestbedV2) == "Succeeded" ] && [ $(resultOfT02VlansTestbedV2) == "Succeeded" ]; then
-          echo "TestbedV2 t0 passed."
-          exit 0
-        fi
-
-        if [ $(resultOfPart1) == "Succeeded" ] && [ $(resultOfPart2) == "Succeeded" ]; then
-          echo "Classic t0 jobs(both part1 and part2) passed."
-          exit 0
-        fi
-
-        echo "Both classic and TestbedV2 t0 jobs failed! Please check the detailed information. (Any of them passed, t0 will be considered as passed)"
-        exit 1
-
-
   - job: t1_lag_classic
     pool: sonictest-t1-lag
     displayName: "kvmtest-t1-lag classic"
@@ -265,33 +232,11 @@ stages:
         MAX_WORKER: $(T1_LAG_INSTANCE_NUM)
 
   - job:
-    pool:
-      vmImage: 'ubuntu-20.04'
-    displayName: "kvmtest-t1-lag"
-    dependsOn:
-    - t1_lag_classic
-    - t1_lag_testbedv2
-    condition: always()
-    continueOnError: false
-    variables:
-      resultOfClassic: $[ dependencies.t1_lag_classic.result ]
-      resultOfTestbedV2: $[ dependencies.t1_lag_testbedv2.result ]
-    steps:
-    - script: |
-        if [ $(resultOfClassic) == "Succeeded" ] || [ $(resultOfTestbedV2) == "Succeeded" ]; then
-          echo "One or both of t1_lag_classic and t1_lag_testbedv2 passed."
-          exit 0
-        else
-          echo "Both t1_lag_classic and t1_lag_testbedv2 failed! Please check the detailed information."
-          exit 1
-        fi
-
-  - job:
     pool: sonictest-sonic-t0
     displayName: "kvmtest-t0-sonic"
     timeoutInMinutes: 360
     condition: and(succeeded(), eq(variables.BUILD_IMG_RUN_CLASSICAL_TEST, 'YES'))
-    continueOnError: true
+    continueOnError: false
     steps:
     - template: .azure-pipelines/run-test-template.yml
       parameters:
@@ -306,7 +251,7 @@ stages:
     displayName: "kvmtest-multi-asic-t1-lag"
     timeoutInMinutes: 240
     condition: and(succeeded(), eq(variables.BUILD_IMG_RUN_CLASSICAL_TEST, 'YES'))
-    continueOnError: true
+    continueOnError: false
     steps:
     - template: .azure-pipelines/run-test-template.yml
       parameters:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. Remove 'kvmtest-t0' and 'kvmtest-t1-lag' test jobs since all the test jobs are required (continueOnError: false) already, and will only enable one of classical and testbedV2 tests, no need to do an unnecessary 'or' compute test job.
2. Change classic multi-asic and t0-sonic test jobs as required (continueOnError: false) following current testbedV2's logic.
##### Work item tracking
- Microsoft ADO **(number only)**: 21199599

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

