### PR TITLE
[mgmt-framework] Fix rest-server startup script

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/rest-server.sh
+++ b/dockers/docker-sonic-mgmt-framework/rest-server.sh
@@ -16,13 +16,13 @@ MGMT_VARS=${MGMT_VARS//[\']/\"}
 REST_SERVER=$(echo $MGMT_VARS | jq -r '.rest_server')
 
 if [ -n "$REST_SERVER" ]; then
-    SERVER_PORT=$(echo $REST_SERVER | jq -r '.port')
-    CLIENT_AUTH=$(echo $REST_SERVER | jq -r '.client_auth')
-    LOG_LEVEL=$(echo $REST_SERVER | jq -r '.log_level')
+    SERVER_PORT=$(echo $REST_SERVER | jq -r '.port // empty')
+    CLIENT_AUTH=$(echo $REST_SERVER | jq -r '.client_auth // empty')
+    LOG_LEVEL=$(echo $REST_SERVER | jq -r '.log_level // empty')
 
-    SERVER_CRT=$(echo $REST_SERVER | jq -r '.server_crt')
-    SERVER_KEY=$(echo $REST_SERVER | jq -r '.server_key')
-    CA_CRT=$(echo $REST_SERVER | jq -r '.ca_crt')
+    SERVER_CRT=$(echo $REST_SERVER | jq -r '.server_crt // empty')
+    SERVER_KEY=$(echo $REST_SERVER | jq -r '.server_key // empty')
+    CA_CRT=$(echo $REST_SERVER | jq -r '.ca_crt // empty')
 fi
 
 if [[ -z $SERVER_CRT ]] && [[ -z $SERVER_KEY ]] && [[ -z $CA_CRT ]]; then
@@ -31,9 +31,9 @@ fi
 
 # Read certificate file paths from DEVICE_METADATA|x509 entry.
 if [ -n "$X509" ]; then
-    SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
-    SERVER_KEY=$(echo $X509 | jq -r '.server_key')
-    CA_CRT=$(echo $X509 | jq -r '.ca_crt')
+    SERVER_CRT=$(echo $X509 | jq -r '.server_crt // empty')
+    SERVER_KEY=$(echo $X509 | jq -r '.server_key // empty')
+    CA_CRT=$(echo $X509 | jq -r '.ca_crt // empty')
 fi
 
 # Create temporary server certificate if they not configured in ConfigDB


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Mgmt-framework REST server startup script is using "null" as default value for all optional fields of REST_SERVER table -- due to incorrect use of `jq -r` command. Server was not coming up when REST_SERVER entry exists but some fields were not given (which is a valid configuration).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Fixed the jq query expression to return empty string for non existing fields.

#### How to verify it

Verify REST server startup with following configurations:

- No REST_SERVER and x509 table entries
- With client_auth config in REST_SERVER entry
- With log_level config in REST_SERVER entry
- With certificate configs in REST_SERVER entry
- WIth all configs in REST_SERVER entry
- With certificate configs in x509 entry
- With client_auth config in REST_SERVER entry and certificate configs in x509 entry
- With certificate configs in both REST_SERVER and x509 entries

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x ] SONiC.master.243527-3d1733bc4
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

