### PR TITLE
Fix ffi

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -213,6 +213,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install libffi-dev
 # Install Python module for bcrypt
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install bcrypt==3.2.2
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install cryptography==3.3.2
 
 # Install SONiC Utilities Python package
 SONIC_UTILITIES_PY3_WHEEL_NAME=$(basename {{sonic_utilities_py3_wheel_path}})

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -129,7 +129,7 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install psutil
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install ipaddr
 
 # Install Python module for bcrypt
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install bcrypt=3.2.2
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install bcrypt==3.2.2
 
 # Install Python module for grpcio and grpcio-toole
 if [[ $CONFIGURED_ARCH == amd64 ]]; then

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -128,6 +128,9 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install psutil
 # Install Python module for ipaddr
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install ipaddr
 
+# Install Python module for bcrypt
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install bcrypt=3.2.2
+
 # Install Python module for grpcio and grpcio-toole
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
     sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio==1.39.0"

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -128,8 +128,6 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install psutil
 # Install Python module for ipaddr
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install ipaddr
 
-# Install Python module for bcrypt
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install bcrypt==3.2.2
 
 # Install Python module for grpcio and grpcio-toole
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
@@ -210,9 +208,13 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 # Install prerequisites needed for using the Python m2crypto package, used by sonic-utilities
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install openssl
 
-# Install SONiC Utilities Python package
+
 # install libffi-dev to match utilities' dependency.
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install libffi-dev
+# Install Python module for bcrypt
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install bcrypt==3.2.2
+
+# Install SONiC Utilities Python package
 SONIC_UTILITIES_PY3_WHEEL_NAME=$(basename {{sonic_utilities_py3_wheel_path}})
 sudo cp {{sonic_utilities_py3_wheel_path}} $FILESYSTEM_ROOT/$SONIC_UTILITIES_PY3_WHEEL_NAME
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install $SONIC_UTILITIES_PY3_WHEEL_NAME

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -208,6 +208,8 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install openssl
 
 # Install SONiC Utilities Python package
+# install libffi-dev to match utilities' dependency.
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install libffi-dev
 SONIC_UTILITIES_PY3_WHEEL_NAME=$(basename {{sonic_utilities_py3_wheel_path}})
 sudo cp {{sonic_utilities_py3_wheel_path}} $FILESYSTEM_ROOT/$SONIC_UTILITIES_PY3_WHEEL_NAME
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install $SONIC_UTILITIES_PY3_WHEEL_NAME
@@ -446,7 +448,7 @@ sudo cp $IMAGE_CONFIGS/rasdaemon/rasdaemon.timer $FILESYSTEM_ROOT_USR_LIB_SYSTEM
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT systemctl disable rasdaemon.service
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT systemctl enable rasdaemon.timer
 
-sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install libffi-dev libssl-dev
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install libssl-dev
 
 {% if include_bootchart == 'y' %}
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install systemd-bootchart


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
#### Why I did it
src/sonic-utilities
```
* 71ef4f16 - (HEAD -> master, origin/master, origin/HEAD) [build] Fix base OS compilation issue caused by incompatibility with requests >= 2.29.0. (#2830) (10 hours ago) [Oleksandr Ivantsiv]
* 1097373b - [show] Added alias interface mode support for 'show interfaces counters ...' command (#2468) (3 days ago) [Julian Chang - TW]
* 589375fc - correctly parsing complete ipv6 vnet info (#2827) (4 days ago) [Keith Lu]
* 634ac77c - LAG keepalive script to reduce lacp session wait during warm-reboot (#2806) (4 days ago) [Vaibhav Hemant Dixit]
* 331c9de0 - [config]: Dynamically start and stop ndppd (#2814) (4 days ago) [Lawrence Lee]
* d1f307d0 - [GCU]Fix rdma check failure (#2824) (5 days ago) [jingwenxie]
* ce81a340 - Revert "[config]Support multi-asic  Golden Config override (#2738)" (#2823) (5 days ago) [jingwenxie]
* 61e0e810 - Added platform plugin support in load_minigraph (#2808) (5 days ago) [anamehra]
* d4355a96 - Change default CDB run mode to non-hitless (#2817) (6 days ago) [mihirpat1]
* 88ffb167 - [config]config reload should generate sysinfo if missing (#2778) (8 days ago) [jingwenxie]
* 7443b9e5 - [sonic-package-manager] support extension with multiple YANG modules (#2752) (8 days ago) [Stepan Blyshchak]
* 522c3a9e - [sonic-package-manager] add support for multiple CLI plugin files (#2753) (8 days ago) [Stepan Blyshchak]
* b38fcfd1 - [show][muxcable] fix `show mux hwmode muxdirection` RC (#2812) (10 days ago) [Jing Zhang]
* 7e24463f - [chassis]: remote cli commands infra for sonic chassis (#2701) (2 weeks ago) [Arvindsrinivasan Lakshmi Narasimhan]
* bee593e4 - [DPB]Fixing typo in config breakout output (#2802) (3 weeks ago) [Sudharsan Dhamal Gopalarathnam]
* ada603c5 - [config]Support multi-asic  Golden Config override (#2738) (3 weeks ago) [jingwenxie]
* 88a7daa8 - [show][barefoot] replace shell=True (#2699) (3 weeks ago) [Mai Bui]
* 5e99edb5 - [sonic_package_manager] replace shell=True (#2726) (3 weeks ago) [Mai Bui]
* b547bb45 - [acl-loader] Only add default deny rule when table is L3 or L3V6 (#2796) (3 weeks ago) [Zhijian Li]
```


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

