### PR TITLE
[sonic-bgpcfgd] replace yaml.load() and exit()

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/utils.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/utils.py
@@ -26,7 +26,7 @@ def run_command(command, shell=False, hide_errors=False):
 def read_constants():
     """ Read file with constants values from /etc/sonic/constants.yml """
     with open('/etc/sonic/constants.yml') as fp:
-        content = yaml.load(fp) # FIXME: , Loader=yaml.FullLoader)
+        content = yaml.safe_load(fp) # FIXME: , Loader=yaml.FullLoader)
         if "constants" not in content:
             log_crit("/etc/sonic/constants.yml doesn't have 'constants' key")
             raise Exception("/etc/sonic/constants.yml doesn't have 'constants' key")

--- a/src/sonic-bgpcfgd/bgpcfgd/utils.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/utils.py
@@ -26,7 +26,7 @@ def run_command(command, shell=False, hide_errors=False):
 def read_constants():
     """ Read file with constants values from /etc/sonic/constants.yml """
     with open('/etc/sonic/constants.yml') as fp:
-        content = yaml.safe_load(fp) # FIXME: , Loader=yaml.FullLoader)
+        content = yaml.safe_load(fp)
         if "constants" not in content:
             log_crit("/etc/sonic/constants.yml doesn't have 'constants' key")
             raise Exception("/etc/sonic/constants.yml doesn't have 'constants' key")

--- a/src/sonic-bgpcfgd/bgpmon/bgpmon.py
+++ b/src/sonic-bgpcfgd/bgpmon/bgpmon.py
@@ -25,6 +25,7 @@ Description: bgpmon.py -- populating bgp related information in stateDB.
 """
 import json
 import os
+import sys
 import syslog
 from swsscommon import swsscommon
 import time
@@ -160,7 +161,7 @@ def main():
         bgp_state_get = BgpStateGet()
     except Exception as e:
         syslog.syslog(syslog.LOG_ERR, "{}: error exit 1, reason {}".format("THIS_MODULE", str(e)))
-        exit(1)
+        sys.exit(1)
 
     # periodically obtain the new neighbor information and update if necessary
     while True:

--- a/src/sonic-bgpcfgd/tests/util.py
+++ b/src/sonic-bgpcfgd/tests/util.py
@@ -15,6 +15,6 @@ def load_constants_dir_mappings():
 
 def load_constants(constants = CONSTANTS_PATH):
     with open(constants) as f:
-        data = yaml.load(f) # FIXME" , Loader=yaml.FullLoader)
+        data = yaml.safe_load(f) # FIXME" , Loader=yaml.FullLoader)
     assert "constants" in data, "'constants' key not found in constants.yml"
     return data

--- a/src/sonic-bgpcfgd/tests/util.py
+++ b/src/sonic-bgpcfgd/tests/util.py
@@ -15,6 +15,6 @@ def load_constants_dir_mappings():
 
 def load_constants(constants = CONSTANTS_PATH):
     with open(constants) as f:
-        data = yaml.safe_load(f) # FIXME" , Loader=yaml.FullLoader)
+        data = yaml.safe_load(f)
     assert "constants" in data, "'constants' key not found in constants.yml"
     return data


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
It is not safe to call yaml.load with any data received from an untrusted source.
sys.exit is better than exit, considered good to use in production code.
Ref:
https://stackoverflow.com/questions/6501121/difference-between-exit-and-sys-exit-in-python
https://stackoverflow.com/questions/19747371/python-exit-commands-why-so-many-and-when-should-each-be-used
##### Work item tracking
- Microsoft ADO **(number only)**: 15022050

#### How I did it
Replace yaml.load() with yaml.safe_load()
Replace exit() by sys.exit()
#### How to verify it
pass UT
test in DUT
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 --> internal.0-f06bc9dd7e
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

