### PR TITLE
Adding S3IP supported attribute for LEDs in PDDF

### DIFF
--- a/platform/pddf/i2c/modules/include/pddf_led_defs.h
+++ b/platform/pddf/i2c/modules/include/pddf_led_defs.h
@@ -35,32 +35,32 @@ struct kobject *cur_state_kobj=NULL;
 #define NAME_SIZE 32
 #define VALUE_SIZE 5
 typedef enum {
-    STATUS_LED_COLOR_GREEN,
-    STATUS_LED_COLOR_GREEN_BLINK,
-    STATUS_LED_COLOR_RED,
-    STATUS_LED_COLOR_RED_BLINK,
+    STATUS_LED_COLOR_OFF=0,
+    STATUS_LED_COLOR_GREEN=1,
+    STATUS_LED_COLOR_YELLOW=2,
+    STATUS_LED_COLOR_RED=3,
+    STATUS_LED_COLOR_BLUE=4,
+    STATUS_LED_COLOR_GREEN_BLINK=5,
+    STATUS_LED_COLOR_YELLOW_BLINK=6,
+    STATUS_LED_COLOR_RED_BLINK=7,
+    STATUS_LED_COLOR_BLUE_BLINK=8,
     STATUS_LED_COLOR_AMBER,
     STATUS_LED_COLOR_AMBER_BLINK,
-    STATUS_LED_COLOR_BLUE,
-    STATUS_LED_COLOR_BLUE_BLINK,
-    STATUS_LED_COLOR_YELLOW,
-    STATUS_LED_COLOR_YELLOW_BLINK,
-    STATUS_LED_COLOR_OFF,
     MAX_LED_STATUS
 }LED_STATUS;
 
 char*  LED_STATUS_STR[] = {
+    "off",
     "green",
-    "green_blink",
-    "red",
-    "red_blink",
-    "amber",
-    "amber_blink",
-    "blue",
-    "blue_blink",
     "yellow",
+    "red",
+    "blue",
+    "green_blink",
     "yellow_blink",
-    "off"
+    "red_blink",
+    "blue_blink",
+    "amber",
+    "amber_blink"
 };
 
 
@@ -86,6 +86,22 @@ typedef struct
 {
     int state;
     char color[NAME_SIZE]; 
+/* S3IP System LED RW sysfs */
+    int sys_led;
+    int bmc_led;
+    int fan_led;
+    int psu_led;
+    int loc_led;
+/* S3IP Power LED  RO sysfs */
+    int psu1_led;
+    int psu2_led;
+/* S3IP Fantray LED RO sysfs */
+    int fantray1_led;
+    int fantray2_led;
+    int fantray3_led;
+    int fantray4_led;
+    int fantray5_led;
+    int fantray6_led;
 } CUR_STATE_DATA;
 
 typedef struct
@@ -107,6 +123,7 @@ typedef enum{
 	LED_FANTRAY,
 	LED_DIAG,
 	LED_LOC,
+    LED_BMC,
 	LED_TYPE_MAX
 } LED_TYPE;
 char* LED_TYPE_STR[LED_TYPE_MAX] = 
@@ -117,6 +134,7 @@ char* LED_TYPE_STR[LED_TYPE_MAX] =
 	"LED_FANTRAY",
 	"LED_DIAG",
 	"LED_LOC",
+    "LED_BMC"
 };
 
 /*****************************************


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The S3IP (Simplified Switch System INtegration Program) sysfs specification defines a unified interface to access peripheral hardware on devices from different vendors, making it easier for SONiC to support different devices and platforms.

PDDF is a framework to simplify the driver and SONiC platform APIs development for new platforms. This effort is first step in combining the two frameworks.

This specific PR adds the S3IP supported sysfs attributes in PDDF common LED driver.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
S3IP exposes many more attributes than any SONiC platform APIs require. Hence S3IP sysfs from PDDF point of view are categorised as below, 

   * Static info: These are static attributes which are written directly into the files of the S3IP /sys_switch file system
   * Dynamic Info: For such information, we created softlinks to PDDF attributes. If PDDF doesnt support this any particular attribute then support is provided (depending upon the platform support for such attribute) in PDDF. 
   * Some of the devices are not supported via PDDF common drivers, such as current sensor, voltage sensor etc. For such devices there platform vendor needs to provide a driver and make it S3IP compatible and provide the S3IP sysfs.



#### How to verify it
For adding support for S3IP on a platform which is already using PDDF for bringup, steps are mentioned in the HLD in detail. Below is the short description,

- Add "enable_s3ip": "yes" into the pddf-device.json file for that platform
- Create a softlink for the 'pddf-s3ip-init.service' inside service folder for that platform.

Once built, the pddf-s3ip-init.service starts after the pddf-platform-init.service and creates the S3IP sysfs. 

**_LOGS:_**
```
root@sonic:/home/admin# show ver

SONiC Software Version: SONiC.master.0-dirty-20230503.022004
Distribution: Debian 11.7
Kernel: 5.10.0-18-2-amd64
Build commit: f3052c617
Build date: Wed May  3 10:46:08 UTC 2023
Built by: fk410167@sonic-lvn-csg-005

Platform: x86_64-accton_as7326_56x-r0
HwSKU: Accton-AS7326-56X
ASIC: broadcom
ASIC Count: 1
Serial Number: 732656X1818022
Model Number: FP4ZZ7656005A
Hardware Revision: N/A
Uptime: 08:53:48 up 3 days,  4:40,  1 user,  load average: 1.36, 1.26, 1.22
Date: Mon 08 May 2023 08:53:48

Docker images:
REPOSITORY                    TAG                              IMAGE ID       SIZE
docker-orchagent              latest                           f5aa1a40e97e   341MB
docker-orchagent              master.0-dirty-20230503.022004   f5aa1a40e97e   341MB
docker-fpm-frr                latest                           217d8158591a   359MB
docker-fpm-frr                master.0-dirty-20230503.022004   217d8158591a   359MB
docker-nat                    latest                           6dfd1e7c940c   332MB
docker-nat                    master.0-dirty-20230503.022004   6dfd1e7c940c   332MB
docker-sflow                  latest                           6718dccae068   331MB
docker-sflow                  master.0-dirty-20230503.022004   6718dccae068   331MB
docker-teamd                  latest                           6475a2b8557e   330MB
docker-teamd                  master.0-dirty-20230503.022004   6475a2b8557e   330MB
docker-platform-monitor       latest                           946cdb8457d3   434MB
docker-platform-monitor       master.0-dirty-20230503.022004   946cdb8457d3   434MB
docker-snmp                   latest                           9828293f032a   352MB
docker-snmp                   master.0-dirty-20230503.022004   9828293f032a   352MB
docker-sonic-telemetry        latest                           4a93c1680a3c   611MB
docker-sonic-telemetry        master.0-dirty-20230503.022004   4a93c1680a3c   611MB
docker-syncd-brcm             latest                           a68ebc819c38   685MB
docker-syncd-brcm             master.0-dirty-20230503.022004   a68ebc819c38   685MB
docker-gbsyncd-broncos        latest                           b53169b18a8c   361MB
docker-gbsyncd-broncos        master.0-dirty-20230503.022004   b53169b18a8c   361MB
docker-lldp                   latest                           baf60ae928c1   355MB
docker-lldp                   master.0-dirty-20230503.022004   baf60ae928c1   355MB
docker-sonic-p4rt             latest                           269271f12e48   883MB
docker-sonic-p4rt             master.0-dirty-20230503.022004   269271f12e48   883MB
docker-gbsyncd-credo          latest                           d2059486f5ba   334MB
docker-gbsyncd-credo          master.0-dirty-20230503.022004   d2059486f5ba   334MB
docker-database               latest                           0c9d45fbb9cd   313MB
docker-database               master.0-dirty-20230503.022004   0c9d45fbb9cd   313MB
docker-router-advertiser      latest                           8def9b326c67   313MB
docker-router-advertiser      master.0-dirty-20230503.022004   8def9b326c67   313MB
docker-eventd                 latest                           46c53ce69f51   312MB
docker-eventd                 master.0-dirty-20230503.022004   46c53ce69f51   312MB
docker-mux                    latest                           1feb3e9d9c41   361MB
docker-mux                    master.0-dirty-20230503.022004   1feb3e9d9c41   361MB
docker-sonic-mgmt-framework   latest                           563f818eacd4   416MB
docker-sonic-mgmt-framework   master.0-dirty-20230503.022004   563f818eacd4   416MB
docker-dhcp-relay             latest                           9f213d0a8a7b   308MB
docker-macsec                 latest                           d1ac0f90c76a   318MB

root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# systemctl status pddf-platform-init.service
● pddf-platform-init.service - PDDF module and device initialization service
     Loaded: loaded (/lib/systemd/system/pddf-platform-init.service; enabled; v>
     Active: active (exited) since Fri 2023-05-05 04:13:28 UTC; 3 days ago
   Main PID: 355 (code=exited, status=0/SUCCESS)
      Tasks: 0 (limit: 19043)
     Memory: 0B
     CGroup: /system.slice/pddf-platform-init.service

Warning: journal has been rotated since unit was started, output may be incompl>
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# systemctl status pddf-s3ip-init.service
● pddf-s3ip-init.service - S3IP sysfs creation in PDDF based platforms
     Loaded: loaded (/lib/systemd/system/pddf-s3ip-init.service; enabled; vendo>
     Active: active (exited) since Fri 2023-05-05 04:13:39 UTC; 3 days ago
   Main PID: 4736 (code=exited, status=0/SUCCESS)
      Tasks: 0 (limit: 19043)
     Memory: 0B
     CGroup: /system.slice/pddf-s3ip-init.service

Warning: journal has been rotated since unit was started, output may be incompl>
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# tree -psv /sys_switch/fan/
/sys_switch/fan/
├── [drwxrwxrwx        4096]  fan1
│   ├── [lrwxrwxrwx          62]  direction -> /sys/bus/i2c/devices/i2c-0/i2c-1/i2c-11/11-0066/fan1_direction
│   ├── [-rw-r--r--           3]  hardware_version
│   ├── [-rw-r--r--           3]  led_status
│   ├── [-rw-r--r--           3]  model_name
│   ├── [drwxrwxrwx        4096]  motor1
│   │   └── [lrwxrwxrwx          58]  speed -> /sys/bus/i2c/devices/i2c-0/i2c-1/i2c-11/11-0066/fan1_input
│   ├── [drwxrwxrwx        4096]  motor2
│   │   └── [lrwxrwxrwx          58]  speed -> /sys/bus/i2c/devices/i2c-0/i2c-1/i2c-11/11-0066/fan2_input
│   ├── [-rw-r--r--           2]  motor_number
..
..
root@sonic:/home/admin# 
root@sonic:/home/admin# 
root@sonic:/home/admin# find /sys_switch/psu/ -type f,l |xargs ls -l
-rw-r--r-- 1 root root  2 May  5 04:19 /sys_switch/psu/number
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu1/fan_ratio
lrwxrwxrwx 1 root root 66 May  5 04:19 /sys_switch/psu/psu1/fan_speed -> /sys/bus/i2c/devices/i2c-0/i2c-1/i2c-17/17-0059/psu_fan1_speed_rpm
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu1/hardware_version
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu1/in_curr
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu1/in_power
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu1/in_status
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu1/in_vol
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu1/led_status
lrwxrwxrwx 1 root root 62 May  5 04:19 /sys_switch/psu/psu1/model_name -> /sys/bus/i2c/devices/i2c-0/i2c-1/i2c-17/17-0051/psu_model_name
-rw-r--r-- 1 root root  2 May  5 04:19 /sys_switch/psu/psu1/num_power_sensors
-rw-r--r-- 1 root root  2 May  5 04:19 /sys_switch/psu/psu1/num_temp_sensors
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu1/out_curr
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu1/out_max_power
lrwxrwxrwx 1 root root 62 May  5 04:19 /sys_switch/psu/psu1/out_status -> /sys/bus/i2c/devices/i2c-0/i2c-1/i2c-17/17-0059/psu_power_good
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu1/out_vol
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu1/part_number
lrwxrwxrwx 1 root root 59 May  5 04:19 /sys_switch/psu/psu1/present -> /sys/bus/i2c/devices/i2c-0/i2c-1/i2c-17/17-0059/psu_present
lrwxrwxrwx 1 root root 62 May  5 04:19 /sys_switch/psu/psu1/serial_number -> /sys/bus/i2c/devices/i2c-0/i2c-1/i2c-17/17-0051/psu_serial_num
-rw-r--r-- 1 root root  2 May  5 04:19 /sys_switch/psu/psu1/type
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu2/fan_ratio
lrwxrwxrwx 1 root root 66 May  5 04:19 /sys_switch/psu/psu2/fan_speed -> /sys/bus/i2c/devices/i2c-0/i2c-1/i2c-13/13-005b/psu_fan1_speed_rpm
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu2/hardware_version
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu2/in_curr
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu2/in_power
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu2/in_status
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu2/in_vol
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu2/led_status
lrwxrwxrwx 1 root root 62 May  5 04:19 /sys_switch/psu/psu2/model_name -> /sys/bus/i2c/devices/i2c-0/i2c-1/i2c-13/13-0053/psu_model_name
-rw-r--r-- 1 root root  2 May  5 04:19 /sys_switch/psu/psu2/num_power_sensors
-rw-r--r-- 1 root root  2 May  5 04:19 /sys_switch/psu/psu2/num_temp_sensors
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu2/out_curr
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu2/out_max_power
lrwxrwxrwx 1 root root 62 May  5 04:19 /sys_switch/psu/psu2/out_status -> /sys/bus/i2c/devices/i2c-0/i2c-1/i2c-13/13-005b/psu_power_good
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu2/out_vol
-rw-r--r-- 1 root root  3 May  5 04:19 /sys_switch/psu/psu2/part_number
lrwxrwxrwx 1 root root 59 May  5 04:19 /sys_switch/psu/psu2/present -> /sys/bus/i2c/devices/i2c-0/i2c-1/i2c-13/13-005b/psu_present
lrwxrwxrwx 1 root root 62 May  5 04:19 /sys_switch/psu/psu2/serial_number -> /sys/bus/i2c/devices/i2c-0/i2c-1/i2c-13/13-0053/psu_serial_num
-rw-r--r-- 1 root root  2 May  5 04:19 /sys_switch/psu/psu2/type
root@sonic:/home/admin#
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

