### PR TITLE
Enable 400G to 100G/40G speed change via minigraph for all platforms (#14736)

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1676,17 +1676,15 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         port_default_speed =  port_speeds_default.get(port_name, None)
         port_png_speed = port_speed_png[port_name]
 
-        # Add a check for for voq, T1
-        if results['DEVICE_METADATA']['localhost']['type'].lower() == 'leafrouter' or switch_type == 'voq':
-            # when the port speed is changes from 400g to 100g 
-            # update the port lanes, use the first 4 lanes of the 400G port to support 100G port
-            if port_default_speed == '400000' and port_png_speed == '100000':
-                port_lanes =  ports[port_name].get('lanes', '').split(',')
-                # check if the 400g port has only 8 lanes
-                if len(port_lanes) != 8:
-                    continue
-                updated_lanes = ",".join(port_lanes[:4])
-                ports[port_name]['lanes'] = updated_lanes
+        # when the port speed is changes from 400g to 100g/40g 
+        # update the port lanes, use the first 4 lanes of the 400G port to support 100G/40G port
+        if port_default_speed == '400000' and (port_png_speed == '100000' or port_png_speed == '40000'):
+            port_lanes =  ports[port_name].get('lanes', '').split(',')
+            # check if the 400g port has only 8 lanes
+            if len(port_lanes) != 8:
+                continue
+            updated_lanes = ",".join(port_lanes[:4])
+            ports[port_name]['lanes'] = updated_lanes
 
         ports.setdefault(port_name, {})['speed'] = port_speed_png[port_name]
 


### PR DESCRIPTION
    Signed-off-by: anamehra anamehra@cisco.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

**- Why I did it**
There are chassis-packet and Single asic platforms which support this 400G to 100G/40G speed change via config.
Enabling this feature for all platforms which can support this. Keeping it enabled for all does not affect the platforms
which do not support this feature yet.

##### Work item tracking
- Microsoft ADO **(number only)**:
17952356

**- How I did it**
Removed switch_type and role type check.

**- How to verify it**
Loaded router with default 400G config. Loaded minigraph to convert 400G to 100G speed.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

