### PR TITLE
Re-add 127.0.0.1/8 when bringing down the interfaces

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -26,6 +26,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 {% endblock loopback %}
 {% block mgmt_interface %}
 

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces
@@ -10,6 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt
@@ -10,6 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp
@@ -10,6 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband
@@ -10,6 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband_ip
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband_ip
@@ -10,6 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_ip
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_ip
@@ -10,6 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
@@ -19,6 +19,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces_nomgmt
@@ -19,6 +19,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/two_mgmt_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/two_mgmt_interfaces
@@ -10,6 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth1

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces
@@ -10,6 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt
@@ -10,6 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp
@@ -10,6 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband
@@ -10,6 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband_ip
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband_ip
@@ -10,6 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_ip
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_ip
@@ -10,6 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
@@ -19,6 +19,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces_nomgmt
@@ -19,6 +19,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/two_mgmt_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/two_mgmt_interfaces
@@ -10,6 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
+   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

With #5353, 127.0.0.1/16 was added to the lo interface, and then 127.0.0.1/8 was removed. However, when bringing down the lo interface, like during a config reload, 127.0.0.1/16 gets removed, but 127.0.0.1/8 isn't added back to the interface. This means that there's a period of time where 127.0.0.1 is not available at all, and services that need to connect to 127.0.0.1 (such as for redis DB) will fail.

Fixes #15117.
Fixes #14880.

##### Work item tracking
- Microsoft ADO **(number only)**: 18637195

#### How I did it

To fix this, when going down, add 127.0.0.1/8. Add this address before the existing configuration gets removed, so that 127.0.0.1 is available at all times.

Note that running `ifdown lo` doesn't actually bring down the loopback interface; the interface always stays "physically" up.

#### How to verify it

On a virtual switch, `config reload` was run for 8 times, and the `docker-wait-any` process for the `swss` container correctly monitored both `syncd` and `teamd`. On my setup, prior to this change, there was at least a 50% chance where during `swss` startup, `sonic-db-cli` would fail, and `teamd` would not get monitored by `docker-wait-any`:

```
admin@vlab-02:~$ ps -ef | grep docker-wait
root      484870  483774  0 22:59 ?        00:00:00 python3 /usr/bin/docker-wait-any -s swss -d syncd teamd
admin     486833   11367  0 23:02 pts/0    00:00:00 grep docker-wait
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

