### PR TITLE
[Build][201811] Fix the stretch mirror removed issue

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -70,7 +70,7 @@ popd
 
 ## Build a basic Debian system by debootstrap
 echo '[INFO] Debootstrap...'
-sudo http_proxy=$http_proxy debootstrap --variant=minbase --arch amd64 stretch $FILESYSTEM_ROOT http://debian-archive.trafficmanager.net/debian
+sudo http_proxy=$http_proxy debootstrap --variant=minbase --arch amd64 stretch $FILESYSTEM_ROOT http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z
 
 ## Config hostname and hosts, otherwise 'sudo ...' will complain 'sudo: unable to resolve host ...'
 sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "echo '$HOSTNAME' > /etc/hostname"

--- a/files/apt/sources.list
+++ b/files/apt/sources.list
@@ -1,8 +1,8 @@
 ## Debian mirror on Microsoft Azure
 ## Ref: http://debian-archive.trafficmanager.net/
 
-deb http://debian-archive.trafficmanager.net/debian/ stretch main contrib non-free
-deb-src http://debian-archive.trafficmanager.net/debian/ stretch main contrib non-free
-deb http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free
-deb-src http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free
-deb http://debian-archive.trafficmanager.net/debian/ stretch-backports main contrib non-free
+deb http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb-src http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free
+deb-src http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free
+deb http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-backports main contrib non-free

--- a/files/image_config/apt/sources.list.d/debian_archive_trafficmanager_net_debian.list
+++ b/files/image_config/apt/sources.list.d/debian_archive_trafficmanager_net_debian.list
@@ -1,3 +1,3 @@
-deb http://debian-archive.trafficmanager.net/debian/ stretch main contrib non-free
-deb http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free
-deb http://debian-archive.trafficmanager.net/debian/ stretch-backports main contrib non-free
+deb http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free
+deb http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-backports main contrib non-free

--- a/sonic-slave-stretch/Dockerfile
+++ b/sonic-slave-stretch/Dockerfile
@@ -4,11 +4,11 @@ MAINTAINER gulv@microsoft.com
 
 COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
 
-RUN echo "deb http://debian-archive.trafficmanager.net/debian/ stretch main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb-src http://debian-archive.trafficmanager.net/debian/ stretch main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb-src http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb http://debian-archive.trafficmanager.net/debian stretch-backports main" >> /etc/apt/sources.list
+RUN echo "deb http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb-src http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb-src http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-backports main" >> /etc/apt/sources.list
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/sonic-slave-stretch/Dockerfile
+++ b/sonic-slave-stretch/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER gulv@microsoft.com
 
 COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
 
-RUN echo "deb http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" >> /etc/apt/sources.list && \
+RUN echo "deb http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" > /etc/apt/sources.list && \
         echo "deb-src http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb-src http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free" >> /etc/apt/sources.list && \

--- a/src/hiredis/Makefile
+++ b/src/hiredis/Makefile
@@ -8,9 +8,9 @@ DERIVED_TARGETS = libhiredis-dbg_$(HIREDIS_VERSION_FULL)_amd64.deb libhiredis-de
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf hiredis-$(HIREDIS_VERSION)
 
-	wget -O hiredis_$(HIREDIS_VERSION).orig.tar.gz http://http.debian.net/debian/pool/main/h/hiredis/hiredis_$(HIREDIS_VERSION).orig.tar.gz
-	wget -O hiredis_$(HIREDIS_VERSION_FULL).debian.tar.xz http://http.debian.net/debian/pool/main/h/hiredis/hiredis_$(HIREDIS_VERSION_FULL).debian.tar.xz
-	wget -O hiredis_$(HIREDIS_VERSION_FULL).dsc http://http.debian.net/debian/pool/main/h/hiredis/hiredis_$(HIREDIS_VERSION_FULL).dsc
+	wget -O hiredis_$(HIREDIS_VERSION).orig.tar.gz http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/h/hiredis/hiredis_$(HIREDIS_VERSION).orig.tar.gz
+	wget -O hiredis_$(HIREDIS_VERSION_FULL).debian.tar.xz http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/h/hiredis/hiredis_$(HIREDIS_VERSION_FULL).debian.tar.xz
+	wget -O hiredis_$(HIREDIS_VERSION_FULL).dsc http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/h/hiredis/hiredis_$(HIREDIS_VERSION_FULL).dsc
 
 	dpkg-source -x hiredis_$(HIREDIS_VERSION_FULL).dsc
 	pushd hiredis-$(HIREDIS_VERSION)

--- a/src/mpdecimal/Makefile
+++ b/src/mpdecimal/Makefile
@@ -8,9 +8,9 @@ DERIVED_TARGETS = libmpdec-dev_$(MPDECIMAL_VERSION_FULL)_amd64.deb
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf mpdecimal-$(MPDECIMAL_VERSION)
 
-	wget -N -O mpdecimal_$(MPDECIMAL_VERSION).orig.tar.gz http://http.debian.net/debian/pool/main/m/mpdecimal/mpdecimal_$(MPDECIMAL_VERSION).orig.tar.gz
-	wget -N -O mpdecimal_$(MPDECIMAL_VERSION_FULL).debian.tar.xz http://http.debian.net/debian/pool/main/m/mpdecimal/mpdecimal_$(MPDECIMAL_VERSION_FULL).debian.tar.xz
-	wget -N -O mpdecimal_$(MPDECIMAL_VERSION_FULL).dsc http://http.debian.net/debian/pool/main/m/mpdecimal/mpdecimal_$(MPDECIMAL_VERSION_FULL).dsc
+	wget -N -O mpdecimal_$(MPDECIMAL_VERSION).orig.tar.gz http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/m/mpdecimal/mpdecimal_$(MPDECIMAL_VERSION).orig.tar.gz
+	wget -N -O mpdecimal_$(MPDECIMAL_VERSION_FULL).debian.tar.xz http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/m/mpdecimal/mpdecimal_$(MPDECIMAL_VERSION_FULL).debian.tar.xz
+	wget -N -O mpdecimal_$(MPDECIMAL_VERSION_FULL).dsc http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/m/mpdecimal/mpdecimal_$(MPDECIMAL_VERSION_FULL).dsc
 
 	dpkg-source -x mpdecimal_$(MPDECIMAL_VERSION_FULL).dsc
 	pushd mpdecimal-$(MPDECIMAL_VERSION)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
[Build] Fix the stretch mirror removed issue.

##### Work item tracking
- Microsoft ADO **(number only)**:  22627384

#### How I did it
Change to use the snapshot mirror http://packages.trafficmanager.net/snapshot.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

