### PR TITLE
[Build][201911] Fix the stretch/jessie mirror removed issue

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -81,9 +81,9 @@ if [[ $CONFIGURED_ARCH == armhf || $CONFIGURED_ARCH == arm64 ]]; then
     # qemu arm bin executable for cross-building
     sudo mkdir -p $FILESYSTEM_ROOT/usr/bin
     sudo cp /usr/bin/qemu*static $FILESYSTEM_ROOT/usr/bin || true
-    sudo http_proxy=$http_proxy debootstrap --variant=minbase --arch $CONFIGURED_ARCH stretch $FILESYSTEM_ROOT http://deb.debian.org/debian
+    sudo http_proxy=$http_proxy debootstrap --variant=minbase --arch $CONFIGURED_ARCH stretch $FILESYSTEM_ROOT http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z
 else
-    sudo http_proxy=$http_proxy debootstrap --variant=minbase --arch $CONFIGURED_ARCH stretch $FILESYSTEM_ROOT http://debian-archive.trafficmanager.net/debian
+    sudo http_proxy=$http_proxy debootstrap --variant=minbase --arch $CONFIGURED_ARCH stretch $FILESYSTEM_ROOT http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z
 fi
 
 ## Config hostname and hosts, otherwise 'sudo ...' will complain 'sudo: unable to resolve host ...'

--- a/dockers/docker-base-stretch/sources.list
+++ b/dockers/docker-base-stretch/sources.list
@@ -1,8 +1,8 @@
 ## Debian mirror on Microsoft Azure
 ## Ref: http://debian-archive.trafficmanager.net/
 
-deb [arch=amd64] http://debian-archive.trafficmanager.net/debian/ stretch main contrib non-free
-deb-src [arch=amd64] http://debian-archive.trafficmanager.net/debian/ stretch main contrib non-free
-deb [arch=amd64] http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free
-deb-src [arch=amd64] http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free
-deb [arch=amd64] http://debian-archive.trafficmanager.net/debian/ stretch-backports main contrib non-free
+deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb-src [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free
+deb-src [arch=amd64] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free
+deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-backports main contrib non-free

--- a/dockers/docker-base-stretch/sources.list.arm64
+++ b/dockers/docker-base-stretch/sources.list.arm64
@@ -1,7 +1,7 @@
 ## Debian mirror for ARM repo
 
 # ARM repo
-deb [arch=arm64] http://deb.debian.org/debian stretch main contrib non-free
-deb-src [arch=arm64] http://deb.debian.org/debian stretch main contrib non-free
+deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb-src [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
 deb [arch=arm64] http://security.debian.org stretch/updates main contrib non-free
 deb-src [arch=arm64] http://security.debian.org stretch/updates main contrib non-free

--- a/dockers/docker-base-stretch/sources.list.armhf
+++ b/dockers/docker-base-stretch/sources.list.armhf
@@ -1,7 +1,7 @@
 ## Debian mirror for ARM repo
 
 # ARM repo
-deb [arch=armhf] http://deb.debian.org/debian stretch main contrib non-free
-deb-src [arch=armhf] http://deb.debian.org/debian stretch main contrib non-free
+deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
 deb [arch=armhf] http://security.debian.org stretch/updates main contrib non-free
 deb-src [arch=armhf] http://security.debian.org stretch/updates main contrib non-free

--- a/dockers/docker-base/sources.list
+++ b/dockers/docker-base/sources.list
@@ -1,7 +1,7 @@
 ## Debian mirror on Microsoft Azure
 ## Ref: http://debian-archive.trafficmanager.net/
 
-deb [arch=amd64] http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free
-deb-src [arch=amd64] http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free
-deb [arch=amd64] http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free
-deb-src [arch=amd64] http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free
+deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ jessie main contrib non-free
+deb-src [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ jessie main contrib non-free
+deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z jessie/updates main contrib non-free
+deb-src [arch=amd64] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z jessie/updates main contrib non-free

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -9,6 +9,10 @@ FROM {{ prefix }}debian:stretch
 
 MAINTAINER Pavel Shirshov
 
+# Configure the debian mirrors
+COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]
+COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
+
 ## Remove retired jessie-updates repo
 RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
 

--- a/dockers/docker-ptf/no-check-valid-until
+++ b/dockers/docker-ptf/no-check-valid-until
@@ -1,0 +1,1 @@
+../docker-base-stretch/no-check-valid-until

--- a/dockers/docker-ptf/no-check-valid-until
+++ b/dockers/docker-ptf/no-check-valid-until
@@ -1,1 +1,4 @@
-../docker-base-stretch/no-check-valid-until
+# Instruct apt-get to NOT check the "Valid Until" date in Release files
+# Once the Debian team archives a repo, they stop updating this date
+
+Acquire::Check-Valid-Until "false";

--- a/dockers/docker-ptf/sources.list.amd64
+++ b/dockers/docker-ptf/sources.list.amd64
@@ -1,1 +1,8 @@
-../docker-base-stretch/sources.list
+## Debian mirror on Microsoft Azure
+## Ref: http://debian-archive.trafficmanager.net/
+
+deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb-src [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free
+deb-src [arch=amd64] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free
+deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-backports main contrib non-free

--- a/dockers/docker-ptf/sources.list.amd64
+++ b/dockers/docker-ptf/sources.list.amd64
@@ -1,0 +1,1 @@
+../docker-base-stretch/sources.list

--- a/dockers/docker-ptf/sources.list.arm64
+++ b/dockers/docker-ptf/sources.list.arm64
@@ -1,1 +1,7 @@
-../docker-base-stretch/sources.list.arm64
+## Debian mirror for ARM repo
+
+# ARM repo
+deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb-src [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb [arch=arm64] http://security.debian.org stretch/updates main contrib non-free
+deb-src [arch=arm64] http://security.debian.org stretch/updates main contrib non-free

--- a/dockers/docker-ptf/sources.list.arm64
+++ b/dockers/docker-ptf/sources.list.arm64
@@ -1,0 +1,1 @@
+../docker-base-stretch/sources.list.arm64

--- a/dockers/docker-ptf/sources.list.armhf
+++ b/dockers/docker-ptf/sources.list.armhf
@@ -1,0 +1,1 @@
+../docker-base-stretch/sources.list.armhf

--- a/dockers/docker-ptf/sources.list.armhf
+++ b/dockers/docker-ptf/sources.list.armhf
@@ -1,1 +1,7 @@
-../docker-base-stretch/sources.list.armhf
+## Debian mirror for ARM repo
+
+# ARM repo
+deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb [arch=armhf] http://security.debian.org stretch/updates main contrib non-free
+deb-src [arch=armhf] http://security.debian.org stretch/updates main contrib non-free

--- a/files/apt/sources.list.amd64
+++ b/files/apt/sources.list.amd64
@@ -1,8 +1,8 @@
 ## Debian mirror on Microsoft Azure
 ## Ref: http://debian-archive.trafficmanager.net/
 
-deb [arch=amd64] http://debian-archive.trafficmanager.net/debian/ stretch main contrib non-free
-deb-src [arch=amd64] http://debian-archive.trafficmanager.net/debian/ stretch main contrib non-free
-deb [arch=amd64] http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free
-deb-src [arch=amd64] http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free
-deb [arch=amd64] http://debian-archive.trafficmanager.net/debian/ stretch-backports main contrib non-free
+deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb-src [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free
+deb-src [arch=amd64] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free
+deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-backports main contrib non-free

--- a/files/apt/sources.list.arm64
+++ b/files/apt/sources.list.arm64
@@ -5,4 +5,4 @@ deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000
 deb-src [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
 deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free
 deb-src [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free
-deb [arch=arm64] http://ftp.debian.org/debian stretch-backports main
+deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-backports main

--- a/files/apt/sources.list.arm64
+++ b/files/apt/sources.list.arm64
@@ -1,8 +1,8 @@
 ## Debian mirror for ARM
 ## Not the repo mirror site can change in future, and needs to be updated to be in sync
 
-deb [arch=arm64] http://deb.debian.org/debian stretch main contrib non-free
-deb-src [arch=arm64] http://deb.debian.org/debian stretch main contrib non-free
-deb [arch=arm64] http://deb.debian.org/debian stretch-updates main contrib non-free
-deb-src [arch=arm64] http://deb.debian.org/debian stretch-updates main contrib non-free
+deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb-src [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free
+deb-src [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free
 deb [arch=arm64] http://ftp.debian.org/debian stretch-backports main

--- a/files/apt/sources.list.armhf
+++ b/files/apt/sources.list.armhf
@@ -5,4 +5,4 @@ deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000
 deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
 deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free
 deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free
-deb [arch=armhf] http://ftp.debian.org/debian stretch-backports main
+deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-backports main

--- a/files/apt/sources.list.armhf
+++ b/files/apt/sources.list.armhf
@@ -1,8 +1,8 @@
 ## Debian mirror for ARM
 ## Not the repo mirror site can change in future, and needs to be updated to be in sync
 
-deb [arch=armhf] http://deb.debian.org/debian stretch main contrib non-free
-deb-src [arch=armhf] http://deb.debian.org/debian stretch main contrib non-free
-deb [arch=armhf] http://deb.debian.org/debian stretch-updates main contrib non-free
-deb-src [arch=armhf] http://deb.debian.org/debian stretch-updates main contrib non-free
+deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free
+deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free
 deb [arch=armhf] http://ftp.debian.org/debian stretch-backports main

--- a/files/image_config/apt/sources.list.d/amd64/debian_archive_trafficmanager_net_debian.list
+++ b/files/image_config/apt/sources.list.d/amd64/debian_archive_trafficmanager_net_debian.list
@@ -1,3 +1,3 @@
-deb [arch=amd64] http://debian-archive.trafficmanager.net/debian/ stretch main contrib non-free
-deb [arch=amd64] http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free
-deb [arch=amd64] http://debian-archive.trafficmanager.net/debian/ stretch-backports main contrib non-free
+deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free
+deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-backports main contrib non-free

--- a/files/image_config/apt/sources.list.d/arm64/debian_mirror_arm64.list
+++ b/files/image_config/apt/sources.list.d/arm64/debian_mirror_arm64.list
@@ -5,5 +5,5 @@ deb-src [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101
 deb [arch=arm64] http://security.debian.org stretch/updates main contrib non-free
 deb-src [arch=arm64] http://security.debian.org stretch/updates main contrib non-free
 deb [arch=arm64] https://download.docker.com/linux/debian stretch stable
-deb [arch=arm64] http://ftp.debian.org/debian stretch-backports main
+deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-backports main
 

--- a/files/image_config/apt/sources.list.d/arm64/debian_mirror_arm64.list
+++ b/files/image_config/apt/sources.list.d/arm64/debian_mirror_arm64.list
@@ -1,7 +1,7 @@
-deb [arch=arm64] http://deb.debian.org/debian stretch main contrib non-free
-deb-src [arch=arm64] http://deb.debian.org/debian stretch main contrib non-free
-deb [arch=arm64] http://deb.debian.org/debian stretch-updates main contrib non-free
-deb-src [arch=arm64] http://deb.debian.org/debian stretch-updates main contrib non-free
+deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb-src [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free
+deb-src [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free
 deb [arch=arm64] http://security.debian.org stretch/updates main contrib non-free
 deb-src [arch=arm64] http://security.debian.org stretch/updates main contrib non-free
 deb [arch=arm64] https://download.docker.com/linux/debian stretch stable

--- a/files/image_config/apt/sources.list.d/armhf/debian_mirror_armhf.list
+++ b/files/image_config/apt/sources.list.d/armhf/debian_mirror_armhf.list
@@ -1,7 +1,7 @@
-deb [arch=armhf] http://deb.debian.org/debian stretch main contrib non-free
-deb-src [arch=armhf] http://deb.debian.org/debian stretch main contrib non-free
-deb [arch=armhf] http://deb.debian.org/debian stretch-updates main contrib non-free
-deb-src [arch=armhf] http://deb.debian.org/debian stretch-updates main contrib non-free
+deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free
+deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free
+deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free
 deb [arch=armhf] http://security.debian.org stretch/updates main contrib non-free
 deb-src [arch=armhf] http://security.debian.org stretch/updates main contrib non-free
 deb [arch=armhf] https://download.docker.com/linux/debian stretch stable

--- a/files/image_config/apt/sources.list.d/armhf/debian_mirror_armhf.list
+++ b/files/image_config/apt/sources.list.d/armhf/debian_mirror_armhf.list
@@ -5,5 +5,5 @@ deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101
 deb [arch=armhf] http://security.debian.org stretch/updates main contrib non-free
 deb-src [arch=armhf] http://security.debian.org stretch/updates main contrib non-free
 deb [arch=armhf] https://download.docker.com/linux/debian stretch stable
-deb [arch=armhf] http://ftp.debian.org/debian stretch-backports main
+deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-backports main
 

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -11,7 +11,7 @@ MAINTAINER gulv@microsoft.com
 
 COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
 
-RUN echo "deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" >> /etc/apt/sources.list && \
+RUN echo "deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" > /etc/apt/sources.list && \
         echo "deb-src [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb-src [arch=amd64] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free" >> /etc/apt/sources.list && \

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -24,7 +24,7 @@ RUN echo "deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20
         echo "deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb [arch=armhf] http://security.debian.org stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb-src [arch=armhf] http://security.debian.org stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo 'deb [arch=armhf] http://ftp.debian.org/debian stretch-backports main' >> /etc/apt/sources.list
+        echo 'deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-backports main' >> /etc/apt/sources.list
 {%- elif CONFIGURED_ARCH == "arm64" %}
 RUN echo "deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" > /etc/apt/sources.list && \
         echo "deb-src [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" >> /etc/apt/sources.list && \
@@ -32,7 +32,7 @@ RUN echo "deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20
         echo "deb-src [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb [arch=arm64] http://security.debian.org stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb-src [arch=arm64] http://security.debian.org stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo 'deb [arch=arm64] http://ftp.debian.org/debian stretch-backports main' >> /etc/apt/sources.list
+        echo 'deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-backports main' >> /etc/apt/sources.list
 {%- endif %}
 
 ## Make apt-get non-interactive

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -11,25 +11,25 @@ MAINTAINER gulv@microsoft.com
 
 COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
 
-RUN echo "deb [arch=amd64] http://debian-archive.trafficmanager.net/debian/ stretch main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb-src [arch=amd64] http://debian-archive.trafficmanager.net/debian/ stretch main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb [arch=amd64] http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb-src [arch=amd64] http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb [arch=amd64] http://debian-archive.trafficmanager.net/debian stretch-backports main" >> /etc/apt/sources.list
+RUN echo "deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb-src [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb-src [arch=amd64] http://packages.trafficmanager.net/snapshot/debian-security/20230101T000243Z stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb [arch=amd64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-backports main" >> /etc/apt/sources.list
 
 {%- if CONFIGURED_ARCH == "armhf" %}
-RUN echo "deb [arch=armhf] http://deb.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list && \
-        echo "deb-src [arch=armhf] http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb [arch=armhf] http://deb.debian.org/debian stretch-updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb-src [arch=armhf] http://deb.debian.org/debian stretch-updates main contrib non-free" >> /etc/apt/sources.list && \
+RUN echo "deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" > /etc/apt/sources.list && \
+        echo "deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb-src [arch=armhf] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb [arch=armhf] http://security.debian.org stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb-src [arch=armhf] http://security.debian.org stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
         echo 'deb [arch=armhf] http://ftp.debian.org/debian stretch-backports main' >> /etc/apt/sources.list
 {%- elif CONFIGURED_ARCH == "arm64" %}
-RUN echo "deb [arch=arm64] http://deb.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list && \
-        echo "deb-src [arch=arm64] http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb [arch=arm64] http://deb.debian.org/debian stretch-updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb-src [arch=arm64] http://deb.debian.org/debian stretch-updates main contrib non-free" >> /etc/apt/sources.list && \
+RUN echo "deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" > /etc/apt/sources.list && \
+        echo "deb-src [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free" >> /etc/apt/sources.list && \
+        echo "deb-src [arch=arm64] http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/ stretch-updates main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb [arch=arm64] http://security.debian.org stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb-src [arch=arm64] http://security.debian.org stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
         echo 'deb [arch=arm64] http://ftp.debian.org/debian stretch-backports main' >> /etc/apt/sources.list

--- a/src/hiredis/Makefile
+++ b/src/hiredis/Makefile
@@ -8,9 +8,9 @@ DERIVED_TARGETS = libhiredis0.14-dbgsym_$(HIREDIS_VERSION_FULL)_$(CONFIGURED_ARC
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf hiredis-$(HIREDIS_VERSION)
 
-	wget -O hiredis_$(HIREDIS_VERSION).orig.tar.gz http://http.debian.net/debian/pool/main/h/hiredis/hiredis_$(HIREDIS_VERSION).orig.tar.gz
-	wget -O hiredis_$(HIREDIS_VERSION_FULL).debian.tar.xz http://http.debian.net/debian/pool/main/h/hiredis/hiredis_$(HIREDIS_VERSION_FULL).debian.tar.xz
-	wget -O hiredis_$(HIREDIS_VERSION_FULL).dsc http://http.debian.net/debian/pool/main/h/hiredis/hiredis_$(HIREDIS_VERSION_FULL).dsc
+	wget -O hiredis_$(HIREDIS_VERSION).orig.tar.gz http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/h/hiredis/hiredis_$(HIREDIS_VERSION).orig.tar.gz
+	wget -O hiredis_$(HIREDIS_VERSION_FULL).debian.tar.xz http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/h/hiredis/hiredis_$(HIREDIS_VERSION_FULL).debian.tar.xz
+	wget -O hiredis_$(HIREDIS_VERSION_FULL).dsc http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/h/hiredis/hiredis_$(HIREDIS_VERSION_FULL).dsc
 
 	dpkg-source -x hiredis_$(HIREDIS_VERSION_FULL).dsc
 	pushd hiredis-$(HIREDIS_VERSION)

--- a/src/iptables/Makefile
+++ b/src/iptables/Makefile
@@ -8,7 +8,7 @@ DERIVED_TARGETS = libip4tc0_$(IPTABLES_VERSION_FULL)_amd64.deb \
 		  libiptc0_$(IPTABLES_VERSION_FULL)_amd64.deb \
 		  libxtables12_$(IPTABLES_VERSION_FULL)_amd64.deb
 
-IPTABLES_URL = http://deb.debian.org/debian/pool/main/i/iptables
+IPTABLES_URL = http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/i/iptables
 
 DSC_FILE = iptables_$(IPTABLES_VERSION_FULL).dsc
 ORIG_FILE = iptables_$(IPTABLES_VERSION).orig.tar.bz2

--- a/src/kdump-tools/Makefile
+++ b/src/kdump-tools/Makefile
@@ -10,8 +10,8 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf ./makedumpfile-$(KDUMP_TOOLS_VERSION_BASE)
 
 	# Get makedumpfile release
-	wget http://deb.debian.org/debian/pool/main/m/makedumpfile/makedumpfile_$(KDUMP_TOOLS_VERSION_BASE).orig.tar.gz
-	wget http://deb.debian.org/debian/pool/main/m/makedumpfile/makedumpfile_$(KDUMP_TOOLS_VERSION).debian.tar.xz
+	wget http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/m/makedumpfile/makedumpfile_$(KDUMP_TOOLS_VERSION_BASE).orig.tar.gz
+	wget http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/m/makedumpfile/makedumpfile_$(KDUMP_TOOLS_VERSION).debian.tar.xz
 	tar -f makedumpfile_$(KDUMP_TOOLS_VERSION_BASE).orig.tar.gz -x
 	pushd ./makedumpfile-$(KDUMP_TOOLS_VERSION_BASE)
 	tar -f ../makedumpfile_$(KDUMP_TOOLS_VERSION).debian.tar.xz -x

--- a/src/lldpd/Makefile
+++ b/src/lldpd/Makefile
@@ -5,7 +5,7 @@ SHELL = /bin/bash
 MAIN_TARGET = $(LLDPD)
 DERIVED_TARGETS = $(LIBLLDPCTL) $(LLDPD_DBG)
 
-LLDP_URL = http://ftp.debian.org/debian/pool/main/l/lldpd
+LLDP_URL = http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/l/lldpd
 
 DSC_FILE = lldpd_$(LLDPD_VERSION_FULL).dsc
 ORIG_FILE = lldpd_$(LLDPD_VERSION).orig.tar.gz

--- a/src/lm-sensors/Makefile
+++ b/src/lm-sensors/Makefile
@@ -13,7 +13,7 @@ DERIVED_TARGETS = fancontrol_$(LM_SENSORS_VERSION_FULL)_all.deb \
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf lm-sensors-$(LM_SENSORS_VERSION)
-	dget -u http://deb.debian.org/debian/pool/main/l/lm-sensors/lm-sensors_$(LM_SENSORS_VERSION_FULL).dsc
+	dget -u http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/l/lm-sensors/lm-sensors_$(LM_SENSORS_VERSION_FULL).dsc
 	git apply *.patch
 	pushd lm-sensors-$(LM_SENSORS_VERSION)
 	DEB_BUILD_OPTIONS=nocheck PROG_EXTRA=sensord dpkg-buildpackage -us -uc -b -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)

--- a/src/mpdecimal/Makefile
+++ b/src/mpdecimal/Makefile
@@ -8,9 +8,9 @@ DERIVED_TARGETS = libmpdec-dev_$(MPDECIMAL_VERSION_FULL)_$(CONFIGURED_ARCH).deb
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf mpdecimal-$(MPDECIMAL_VERSION)
 
-	wget -N -O mpdecimal_$(MPDECIMAL_VERSION).orig.tar.gz http://http.debian.net/debian/pool/main/m/mpdecimal/mpdecimal_$(MPDECIMAL_VERSION).orig.tar.gz
-	wget -N -O mpdecimal_$(MPDECIMAL_VERSION_FULL).debian.tar.xz http://http.debian.net/debian/pool/main/m/mpdecimal/mpdecimal_$(MPDECIMAL_VERSION_FULL).debian.tar.xz
-	wget -N -O mpdecimal_$(MPDECIMAL_VERSION_FULL).dsc http://http.debian.net/debian/pool/main/m/mpdecimal/mpdecimal_$(MPDECIMAL_VERSION_FULL).dsc
+	wget -N -O mpdecimal_$(MPDECIMAL_VERSION).orig.tar.gz http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/m/mpdecimal/mpdecimal_$(MPDECIMAL_VERSION).orig.tar.gz
+	wget -N -O mpdecimal_$(MPDECIMAL_VERSION_FULL).debian.tar.xz http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/m/mpdecimal/mpdecimal_$(MPDECIMAL_VERSION_FULL).debian.tar.xz
+	wget -N -O mpdecimal_$(MPDECIMAL_VERSION_FULL).dsc http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/m/mpdecimal/mpdecimal_$(MPDECIMAL_VERSION_FULL).dsc
 
 	dpkg-source -x mpdecimal_$(MPDECIMAL_VERSION_FULL).dsc
 	pushd mpdecimal-$(MPDECIMAL_VERSION)

--- a/src/redis/Makefile
+++ b/src/redis/Makefile
@@ -15,9 +15,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	mkdir redis_build
 	pushd redis_build
 
-	wget -O redis_$(REDIS_VERSION).orig.tar.gz -N "http://http.debian.net/debian/pool/main/r/redis/redis_$(REDIS_VERSION).orig.tar.gz"
-	wget -O redis_$(REDIS_VERSION_FULL).dsc -N "http://http.debian.net/debian/pool/main/r/redis/redis_$(REDIS_VERSION_FULL).dsc"
-	wget -O redis_$(REDIS_VERSION_FULL).debian.tar.xz -N "http://http.debian.net/debian/pool/main/r/redis/redis_$(REDIS_VERSION_FULL).debian.tar.xz"
+	wget -O redis_$(REDIS_VERSION).orig.tar.gz -N "http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/r/redis/redis_$(REDIS_VERSION).orig.tar.gz"
+	wget -O redis_$(REDIS_VERSION_FULL).dsc -N "http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/r/redis/redis_$(REDIS_VERSION_FULL).dsc"
+	wget -O redis_$(REDIS_VERSION_FULL).debian.tar.xz -N "http://packages.trafficmanager.net/snapshot/debian/20230101T000234Z/pool/main/r/redis/redis_$(REDIS_VERSION_FULL).debian.tar.xz"
 	dpkg-source -x redis_$(REDIS_VERSION_FULL).dsc
 
 	pushd redis-$(REDIS_VERSION)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
[Build] Fix the stretch/jessie mirror removed issue.

##### Work item tracking
- Microsoft ADO **(number only)**:  22627384

#### How I did it
Change to use the snapshot mirror http://packages.trafficmanager.net/snapshot.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

