### PR TITLE
[202205][yang] Extend device_metadata yang model with rack_mgmt_map

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -822,7 +822,8 @@ instance is supported in SONiC.
         "bgp_asn": "65100",
         "deployment_id": "1",
         "type": "ToRRouter",
-        "buffer_model": "traditional"
+        "buffer_model": "traditional",
+        "rack_mgmt_map": "dummy_value"
     }
   }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -315,7 +315,8 @@
                 "switch_type": "voq",
                 "max_cores": "8",
                 "sub_role": "FrontEnd",
-                "dhcp_server": "disabled"
+                "dhcp_server": "disabled",
+                "rack_mgmt_map": "dummy_value"
             }
         },
         "VLAN": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -113,6 +113,13 @@
     "DEVICE_METADATA_INVALID_DHCP_SERVER": {
         "desc": "Verifying invalid dhcp_server configuration.",
         "eStrKey": "InvalidValue"
+    },
+    "DEVICE_METADATA_VALID_RACK_MGMT_MAP": {
+        "desc": "Verifying rack_mgmt_map configuration."
+    },
+    "DEVICE_METADATA_INVALID_RACK_MGMT_MAP": {
+        "desc": "Verifying invalid rack_mgmt_map configuration.",
+        "eStr": "Invalid length for the rack mgmt map."
     }
 
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -311,5 +311,23 @@
                 }
             }
         }
+    },
+    "DEVICE_METADATA_VALID_RACK_MGMT_MAP": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "rack_mgmt_map": "dummy_value"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_INVALID_RACK_MGMT_MAP": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "rack_mgmt_map": "dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value-dummy_value"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -193,6 +193,15 @@ module sonic-device_metadata {
                     type stypes:admin_mode;
                     description "Indicate whether enable the embedded DHCP server.";
                 }
+
+                leaf rack_mgmt_map {
+                    type string {
+                        length 0..128 {
+                            error-message "Invalid length for the rack mgmt map.";
+                        }
+                    }
+                    description "Information of rack mgmt map.";
+                }
             }
             /* end of container localhost */
         }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Manually cherry-pick and resolve conflicts of this PR: https://github.com/sonic-net/sonic-buildimage/pull/15109
Extend device_metadata yang model.

##### Work item tracking
- Microsoft ADO **(number only)**: 22912178

#### How I did it
Add rack_mgmt_map field in yang model.

#### How to verify it
Build image.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

