### PR TITLE
[build][201811] Increase raw image disk size to 1216MB

### DIFF
--- a/onie-image.conf
+++ b/onie-image.conf
@@ -34,7 +34,7 @@ OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin
 OUTPUT_RAW_IMAGE=target/sonic-$TARGET_MACHINE.raw
 
 ## Raw image size in MB
-RAW_IMAGE_DISK_SIZE=1024
+RAW_IMAGE_DISK_SIZE=1216
 
 ## Output file name for kvm image
 OUTPUT_KVM_IMAGE=target/sonic-$TARGET_MACHINE.img


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

1GB disk size is not sufficient for latest 201811 broadcom raw image.

##### Work item tracking

#### How I did it

Increase raw image disk size from 1024MB to 1216MB

#### How to verify it
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Initiate build for 'target/sonic-broadcom.raw' and verify that the build is successful.
```
Creating SONiC raw partition : target/sonic-broadcom.raw of size 1216 MB
Verifying image checksum ... OK.
Preparing image archive ... OK.
Installing SONiC in BUILD
ONIE Installer: platform: x86_64-broadcom-r0
onie_platform:
mke2fs 1.42.12 (29-Aug-2014)
Discarding device blocks:   4096/311296^H^H^H^H^H^H^H^H^H^H^H^H^H             ^H^H^H^H^H^H^H^H^H^H^H^H^Hdone
Creating filesystem with 311296 4k blocks and 77920 inodes
Filesystem UUID: 5c0c892f-5cef-4776-a5a3-c88dfff94c4b
Superblock backups stored on blocks:
        32768, 98304, 163840, 229376, 294912

Allocating group tables:  0/10^H^H^H^H^H     ^H^H^H^H^Hdone
Writing inode tables:  0/10^H^H^H^H^H     ^H^H^H^H^Hdone
Creating journal (8192 blocks): done
Writing superblocks and filesystem accounting information:  0/10^H^H^H^H^H     ^H^H^H^H^Hdone

Mounting /sonic/target/sonic-broadcom.raw on build_raw_image_mnt...
Installing SONiC to build_raw_image_mnt/image-201811.0-dirty-20230519.134841
Archive:  fs.zip
   creating: build_raw_image_mnt/image-201811.0-dirty-20230519.134841/boot/
  inflating: build_raw_image_mnt/image-201811.0-dirty-20230519.134841/boot/initrd.img-4.9.0-14-amd64
  inflating: build_raw_image_mnt/image-201811.0-dirty-20230519.134841/boot/vmlinuz-4.9.0-14-amd64
  inflating: build_raw_image_mnt/image-201811.0-dirty-20230519.134841/boot/System.map-4.9.0-14-amd64
  inflating: build_raw_image_mnt/image-201811.0-dirty-20230519.134841/boot/config-4.9.0-14-amd64
...
...
...
  inflating: build_raw_image_mnt/image-201811.0-dirty-20230519.134841/fs.squashfs
Installed SONiC base image SONiC-OS successfully
The compressed raw image is in target/sonic-broadcom.raw
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

[build][201811] Increase raw image disk size to 1216MB

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

