### PR TITLE
SONiC Yang model support for IPv6 link local (#14757)

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -27,7 +27,8 @@ Table of Contents
          * [Device neighbor metada](#device-neighbor-metada)
          * [DHCP_RELAY](#dhcp_relay)
          * [DSCP_TO_TC_MAP](#dscp_to_tc_map)  
-         * [FLEX_COUNTER_TABLE](#flex_counter_table)  
+         * [FLEX_COUNTER_TABLE](#flex_counter_table) 
+         * [IPv6 Link-local] (#ipv6-link-local)  
          * [KDUMP](#kdump)  
          * [L2 Neighbors](#l2-neighbors)  
          * [Loopback Interface](#loopback-interface)  
@@ -936,6 +937,27 @@ instance is supported in SONiC.
 	}
 }
 
+```
+
+### IPv6 Link-local
+```
+{
+    "INTERFACE": {
+        "Ethernet8": {
+            "ipv6_use_link_local_only": "disable"
+        }
+    },
+    "PORTCHANNEL_INTERFACE": {
+        "PortChannel01": {
+            "ipv6_use_link_local_only": "enable"
+        }
+    },
+    "VLAN_INTERFACE": {
+        "Vlan1000": {
+            "ipv6_use_link_local_only": "enable"
+        }
+    }
+}
 ```
 
 ### KDUMP

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -106,7 +106,8 @@
         "PORTCHANNEL_INTERFACE": {
                 "PortChannel0003": {
                     "nat_zone": "1",
-                    "loopback_action": "drop"
+                    "loopback_action": "drop",
+                    "ipv6_use_link_local_only": "enable"
                 },
                 "PortChannel0004": {"vrf_name": "Vrf_blue"},
                 "PortChannel42|10.1.0.1/31": {},
@@ -122,7 +123,8 @@
         "VLAN_INTERFACE": {
             "Vlan111": {
                 "nat_zone": "0",
-                "loopback_action": "forward"
+                "loopback_action": "forward",
+                "ipv6_use_link_local_only": "disable"
             },
             "Vlan777": {},
             "Vlan111|2a04:5555:45:6709::1/64": {
@@ -950,7 +952,8 @@
             "Ethernet16": {},
             "Ethernet18": {
                 "nat_zone": "1",
-                "loopback_action": "forward"
+                "loopback_action": "forward",
+                "ipv6_use_link_local_only": "enable"
             },
             "Ethernet112|2a04:5555:40:a709::2/126": {
                 "scope": "global",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/interface.json
@@ -22,5 +22,12 @@
         "desc": "INCORRECT LOOPBACK ACTION IN INTERFACE TABLE.",
         "eStrKey" : "Pattern",
         "eStr": ["drop|forward"]
+    },
+    "INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local."
+    },
+    "INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local as true.",
+        "eStr": "Invalid value \"true\" in \"ipv6_use_link_local_only\" element."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
@@ -68,5 +68,12 @@
         "desc": "INCORRECT LOOPBACK ACTION IN PORTCHANNEL_INTERFACE TABLE.",
         "eStrKey" : "Pattern",
         "eStr": ["drop|forward"]
+    },
+    "PORTCHANNEL_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local."
+    },
+    "PORTCHANNEL_INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local as true.",
+        "eStr": "Invalid value \"true\" in \"ipv6_use_link_local_only\" element."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
@@ -79,5 +79,12 @@
         "desc": "INCORRECT LOOPBACK ACTION IN VLAN_INTERFACE TABLE.",
         "eStrKey" : "Pattern",
         "eStr": ["drop|forward"]
+    },
+    "VLAN_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local."
+    },
+    "VLAN_INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local as true.",
+        "eStr": "Invalid value \"true\" in \"ipv6_use_link_local_only\" element."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/interface.json
@@ -209,5 +209,61 @@
                 ]
             }
         }
+    },
+    "INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "ipv6_use_link_local_only": "enable"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet8",
+                        "fec": "rs",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet8",
+                        "speed": 25000
+                    }
+                ]
+            }
+        }
+    },
+    "INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "ipv6_use_link_local_only": "true"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet8",
+                        "fec": "rs",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet8",
+                        "speed": 25000
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
@@ -412,5 +412,79 @@
                 ]
             }
         }
+    },
+    "PORTCHANNEL_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001"
+                    }
+                ]
+            },
+            "sonic-portchannel:PORTCHANNEL_INTERFACE": {
+                "PORTCHANNEL_INTERFACE_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "ipv6_use_link_local_only": "enable"
+                    }
+                ]
+            }
+        }
+    },
+    "PORTCHANNEL_INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001"
+                    }
+                ]
+            },
+            "sonic-portchannel:PORTCHANNEL_INTERFACE": {
+                "PORTCHANNEL_INTERFACE_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "ipv6_use_link_local_only": "true"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
@@ -626,5 +626,93 @@
                 ]
             }
         }
+    },
+    "VLAN_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "description": "vlan_nat",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_MEMBER": {
+                "VLAN_MEMBER_LIST": [
+                    {
+                        "port": "Ethernet0",
+                        "tagging_mode": "tagged",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "ipv6_use_link_local_only": "enable"
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "description": "vlan_nat",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_MEMBER": {
+                "VLAN_MEMBER_LIST": [
+                    {
+                        "port": "Ethernet0",
+                        "tagging_mode": "tagged",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "ipv6_use_link_local_only": "true"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-interface.yang
@@ -75,6 +75,12 @@ module sonic-interface {
 					}
 				}
 
+				leaf ipv6_use_link_local_only {
+					description "Enable/Disable IPv6 link local address on interface";
+					type stypes:mode-status;
+					default disable;
+				}
+
                 leaf loopback_action {
                     description "Packet action when a packet ingress and gets routed on the same IP interface";
                     type stypes:loopback_action;

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -177,6 +177,12 @@ module sonic-portchannel {
 				enum disable;
 			}
 		}
+
+		leaf ipv6_use_link_local_only {
+			description "Enable/Disable IPv6 link local address on portchannel interface";
+			type stypes:mode-status;
+			default disable;
+		}
             } /* end of list PORTCHANNEL_INTERFACE_LIST */
 
             list PORTCHANNEL_INTERFACE_IPPREFIX_LIST {

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -102,6 +102,12 @@ module sonic-vlan {
 					}
 				}
 
+				leaf ipv6_use_link_local_only {
+					description "Enable/Disable IPv6 link local address on vlan interface";
+					type stypes:mode-status;
+					default disable;
+				}
+
                 leaf loopback_action {
                     description "Packet action when a packet ingress and gets routed on the same IP interface";
                     type stypes:loopback_action;


### PR DESCRIPTION
This is backport of https://github.com/sonic-net/sonic-buildimage/pull/14757

SONiC Yang model support for IPv6 link local

What I did
Created SONiC Yang model for IPv6 link local

How I did it
Defined Yang models for IPv6 link local based on https://github.com/sonic-net/SONiC/blob/master/doc/ipv6/ipv6_link_local.md

How to verify it
Added enable test case.

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>