### PR TITLE
[WIP] Make snmpd no response to OID rfc1657 BGP4-MIB

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.conf.j2
@@ -12,7 +12,6 @@
 !
 {% include "common/daemons.common.conf.j2" %}
 !
-agentx
 !
 {% if DEVICE_METADATA['localhost']['type'] == "SpineChassisFrontendRouter" %}
 {%  include "bgpd.spine_chassis_frontend_router.conf.j2" %}

--- a/dockers/docker-fpm-frr/frr/frr.conf.j2
+++ b/dockers/docker-fpm-frr/frr/frr.conf.j2
@@ -9,7 +9,6 @@
 {% include "common/daemons.common.conf.j2" %}
 {% from "common/functions.conf.j2" import get_ipv4_loopback_address, get_ipv6_loopback_address %}
 !
-agentx
 !
 {% include "zebra/zebra.interfaces.conf.j2" %}
 !

--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -30,7 +30,7 @@ stderr_logfile=syslog
 dependent_startup=true
 
 [program:zebra]
-command=/usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M dplane_fpm_nl -M snmp --asic-offload=notify_on_offload
+command=/usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M dplane_fpm_nl --asic-offload=notify_on_offload
 priority=4
 autostart=false
 autorestart=false
@@ -71,13 +71,13 @@ autostart=false
 autorestart=false
 startsecs=0
 stdout_logfile=syslog
-stderr_logfile=syslog
+stderr_logfile=syslogS
 dependent_startup=true
 dependent_startup_wait_for=zebra:running
 {% endif %}
 
 [program:bgpd]
-command=/usr/lib/frr/bgpd -A 127.0.0.1 -M snmp
+command=/usr/lib/frr/bgpd -A 127.0.0.1
 priority=5
 stopsignal=KILL
 autostart=false

--- a/dockers/docker-fpm-frr/snmp.conf
+++ b/dockers/docker-fpm-frr/snmp.conf
@@ -4,4 +4,4 @@
 # To verify this works you need to have a valid bgp daemon running and configured
 # Check that a snmpwalk to 1.3.6.1.2.1.15 gives an output
 # Further verification: 1.3.6.1.2.1.15.2.0 = INTEGER: 65000 the returned value should be the confiugred ASN
-agentXSocket    tcp:localhost:3161
+#agentXSocket    tcp:localhost:3161

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -192,7 +192,7 @@ master          agentx
 # to verify the SNMP docker side look for the following string in the log file:
 # INFO snmp-subagent [ax_interface] INFO: Using agentx socket type tcp with path tcp:localhost:3161
 # INFO supervisord snmp-subagent INFO:ax_interface:Using agentx socket type tcp with path tcp:localhost:3161
-agentxsocket    tcp:localhost:3161
+#agentxsocket    tcp:localhost:3161
 
 #
 #  SysDescription pass-through

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
@@ -15,7 +15,6 @@ log syslog informational
 log facility local4
 !
 ! end of template: common/daemons.common.conf.j2!
-agentx
 !
 ! template: bgpd/bgpd.main.conf.j2
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
@@ -13,7 +13,6 @@ log syslog informational
 log facility local4
 !
 ! end of template: common/daemons.common.conf.j2!
-agentx
 !
 ! Enable nht through default route
 ip nht resolve-via-default

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
@@ -17,7 +17,6 @@ log syslog informational
 log facility local4
 !
 ! end of template: common/daemons.common.conf.j2!
-agentx
 !
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
@@ -17,7 +17,6 @@ log syslog informational
 log facility local4
 !
 ! end of template: common/daemons.common.conf.j2!
-agentx
 !
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_dualtor.conf
@@ -17,7 +17,6 @@ log syslog informational
 log facility local4
 !
 ! end of template: common/daemons.common.conf.j2!
-agentx
 !
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
@@ -17,7 +17,6 @@ log syslog informational
 log facility local4
 !
 ! end of template: common/daemons.common.conf.j2!
-agentx
 !
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/frr.conf
@@ -14,7 +14,6 @@ log syslog informational
 log facility local4
 !
 ! end of template: common/daemons.common.conf.j2!
-agentx
 !
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
@@ -17,7 +17,6 @@ log syslog informational
 log facility local4
 !
 ! end of template: common/daemons.common.conf.j2!
-agentx
 !
 !
 ! Vnet BGP instance

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
@@ -17,7 +17,6 @@ log syslog informational
 log facility local4
 !
 ! end of template: common/daemons.common.conf.j2!
-agentx
 !
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
@@ -17,7 +17,6 @@ log syslog informational
 log facility local4
 !
 ! end of template: common/daemons.common.conf.j2!
-agentx
 !
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_dualtor.conf
@@ -17,7 +17,6 @@ log syslog informational
 log facility local4
 !
 ! end of template: common/daemons.common.conf.j2!
-agentx
 !
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
@@ -17,7 +17,6 @@ log syslog informational
 log facility local4
 !
 ! end of template: common/daemons.common.conf.j2!
-agentx
 !
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/frr.conf
@@ -14,7 +14,6 @@ log syslog informational
 log facility local4
 !
 ! end of template: common/daemons.common.conf.j2!
-agentx
 !
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
@@ -17,7 +17,6 @@ log syslog informational
 log facility local4
 !
 ! end of template: common/daemons.common.conf.j2!
-agentx
 !
 !
 ! Vnet BGP instance


### PR DESCRIPTION
Make snmpd no response to OID rfc1657 BGP4-MIB

#### Why I did it
The SNMP rfc1657 BGP4-MIB will trigger memory management issue and cause snmpd crash.

##### Work item tracking
- Microsoft ADO **(number only)**: 23925111

#### How I did it
Disable rfc1657 BGP4-MIB in config file.

#### How to verify it
Manually test to make sure the SNMP OID beend disabled.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [X] 202012
- [X] 202106
- [X] 202111
- [X] 202205
- [X] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Make snmpd no response to OID rfc1657 BGP4-MIB.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

