### PR TITLE
[202205] Update SOC properties for DLR_INIT based pfcwd recovery

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/config.bcm.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/config.bcm.j2
@@ -1,16 +1,23 @@
 {# Construct config.bcm to include additional soc properties per specific device metadata requirement #}
 {%- set map_prio = '' -%}
+{%- set pfcwd_sock = '' -%}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['subtype'] is defined -%}
 {%-     set switch_subtype = DEVICE_METADATA['localhost']['subtype'] -%}
 {%-     if 'dualtor' in switch_subtype.lower() %}
 {%-         set map_prio = 'sai_remap_prio_on_tnl_egress=1' -%}
 {%-     endif %}
 {%- endif %}
+{%- if SYSTEM_DEFAULTS is defined and 'tunnel_qos_remap' in SYSTEM_DEFAULTS and SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled' -%}
+{%-     set pfcwd_sock = 'hybrid_pfc_deadlock_enable=1
+                          pfc_deadlock_seq_control=1
+                          sai_pfc_dlr_init_capability=1' -%}
+{%- endif %}
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_premium_issu/b870.6.4.1/
 l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
 sai_verify_incoming_chksum=0
 {{ map_prio }}
+{{ pfcwd_sock }}
 host_as_route_disable=1
 use_all_splithorizon_groups=1
 riot_enable=1

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/config.bcm.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/config.bcm.j2
@@ -1,16 +1,23 @@
 {# Construct config.bcm to include additional soc properties per specific device metadata requirement #}
 {%- set map_prio = '' -%}
+{%- set pfcwd_sock = '' -%}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['subtype'] is defined -%}
 {%-     set switch_subtype = DEVICE_METADATA['localhost']['subtype'] -%}
 {%-     if 'dualtor' in switch_subtype.lower() %}
 {%-         set map_prio = 'sai_remap_prio_on_tnl_egress=1' -%}
 {%-     endif %}
 {%- endif %}
+{%- if SYSTEM_DEFAULTS is defined and 'tunnel_qos_remap' in SYSTEM_DEFAULTS and SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled' -%}
+{%-     set pfcwd_sock = 'hybrid_pfc_deadlock_enable=1
+                          pfc_deadlock_seq_control=1
+                          sai_pfc_dlr_init_capability=1' -%}
+{%- endif %}
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_premium_issu/b870.6.4.1/
 l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
 sai_verify_incoming_chksum=0
 {{ map_prio }}
+{{ pfcwd_sock }}
 host_as_route_disable=1
 use_all_splithorizon_groups=1
 riot_enable=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
@@ -2,6 +2,7 @@
 {%- set mmu_sock = 'mmu_init_config="MSFT-TH2-Tier1"' -%}
 {%- set IPinIP_sock = '' -%}
 {%- set map_prio = '' -%}
+{%- set pfcwd_sock = '' -%}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined -%}
 {%-     if DEVICE_METADATA['localhost']['type'] is defined -%}
 {%-         set switch_role = DEVICE_METADATA['localhost']['type'] -%}
@@ -20,11 +21,17 @@
 {%-         endif %}
 {%-     endif %}
 {%- endif %}
+{%- if SYSTEM_DEFAULTS is defined and 'tunnel_qos_remap' in SYSTEM_DEFAULTS and SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled' -%}
+{%-     set pfcwd_sock = 'hybrid_pfc_deadlock_enable=1
+                          pfc_deadlock_seq_control=1
+                          sai_pfc_dlr_init_capability=1' -%}
+{%- endif %}
 {# The following is the common soc properties that used to be named "th2-a7260cx3-64-64x100G-t1.config.bcm" #}
 
 l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
 {{ map_prio }}
+{{ pfcwd_sock }}
 PHY_AN_ALLOW_PLL_CHANGE=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C10/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C10/config.bcm.j2
@@ -1,6 +1,7 @@
 {# Construct config.bcm to include additional soc properties per specific device metadata requirement #}
 {%- set IPinIP_sock = '' -%}
 {%- set map_prio = '' -%}
+{%- set pfcwd_sock = '' -%}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['subtype'] is defined -%}
 {%-     set switch_subtype = DEVICE_METADATA['localhost']['subtype'] -%}
 {%-     if 'dualtor' in switch_subtype.lower() %}
@@ -11,10 +12,16 @@
 {%-         set map_prio = 'sai_remap_prio_on_tnl_egress=1' -%}
 {%-     endif %}
 {%- endif %}
+{%- if SYSTEM_DEFAULTS is defined and 'tunnel_qos_remap' in SYSTEM_DEFAULTS and SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled' -%}
+{%-     set pfcwd_sock = 'hybrid_pfc_deadlock_enable=1
+                          pfc_deadlock_seq_control=1
+                          sai_pfc_dlr_init_capability=1' -%}
+{%- endif %}
 {# The following is the common soc properties that used to be named "th2-a7260cx3-64-112x50G+8x100G.config.bcm" #}
 l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
 {{ map_prio }}
+{{ pfcwd_sock }}
 PHY_AN_ALLOW_PLL_CHANGE=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
@@ -1,6 +1,7 @@
 {# Construct config.bcm to include additional soc properties per specific device metadata requirement #}
 {%- set IPinIP_sock = '' -%}
 {%- set map_prio = '' -%}
+{%- set pfcwd_sock = '' -%}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['subtype'] is defined -%}
 {%-     set switch_subtype = DEVICE_METADATA['localhost']['subtype'] -%}
 {%-     if 'dualtor' in switch_subtype.lower() %}
@@ -11,10 +12,16 @@
 {%-         set map_prio = 'sai_remap_prio_on_tnl_egress=1' -%}
 {%-     endif %}
 {%- endif %}
+{%- if SYSTEM_DEFAULTS is defined and 'tunnel_qos_remap' in SYSTEM_DEFAULTS and SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled' -%}
+{%-     set pfcwd_sock = 'hybrid_pfc_deadlock_enable=1
+                          pfc_deadlock_seq_control=1
+                          sai_pfc_dlr_init_capability=1' -%}
+{%- endif %}
 {# The following is the common soc properties that used to be named "th2-a7260cx3-64-112x50G+8x100G.config.bcm" #}
 l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
 {{ map_prio }}
+{{ pfcwd_sock }}
 PHY_AN_ALLOW_PLL_CHANGE=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
@@ -2,6 +2,7 @@
 {%- set mmu_sock = 'mmu_init_config="MSFT-TH2-Tier1"' -%}
 {%- set IPinIP_sock = '' -%}
 {%- set map_prio = '' -%}
+{%- set pfcwd_sock = '' -%}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined -%}
 {%-     if DEVICE_METADATA['localhost']['type'] is defined -%}
 {%-         set switch_role = DEVICE_METADATA['localhost']['type'] -%}
@@ -20,10 +21,16 @@
 {%-         endif %}
 {%-     endif %}
 {%- endif %}
+{%- if SYSTEM_DEFAULTS is defined and 'tunnel_qos_remap' in SYSTEM_DEFAULTS and SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled' -%}
+{%-     set pfcwd_sock = 'hybrid_pfc_deadlock_enable=1
+                          pfc_deadlock_seq_control=1
+                          sai_pfc_dlr_init_capability=1' -%}
+{%- endif %}
 {# The following is the common soc properties that used to be named "th2-a7260cx3-64-64x40G.config.bcm" #}
 l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
 {{ map_prio }}
+{{ pfcwd_sock }}
 PHY_AN_ALLOW_PLL_CHANGE=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/src/sonic-config-engine/tests/data/j2_template/config.bcm.j2
+++ b/src/sonic-config-engine/tests/data/j2_template/config.bcm.j2
@@ -2,6 +2,7 @@
 {%- set mmu_sock = 'mmu_init_config="MSFT-TH2-Tier1"' -%}
 {%- set IPinIP_sock = '' -%}
 {%- set map_prio = '' -%}
+{%- set pfcwd_sock = '' -%}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined -%}
 {%-     if DEVICE_METADATA['localhost']['type'] is defined -%}
 {%-         set switch_role = DEVICE_METADATA['localhost']['type'] -%}
@@ -20,9 +21,15 @@
 {%-         endif %}
 {%-     endif %}
 {%- endif %}
+{%- if SYSTEM_DEFAULTS is defined and 'tunnel_qos_remap' in SYSTEM_DEFAULTS and SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled' -%}
+{%-     set pfcwd_sock = 'hybrid_pfc_deadlock_enable=1
+                          pfc_deadlock_seq_control=1
+                          sai_pfc_dlr_init_capability=1' -%}
+{%- endif %}
 {# The following is the common soc properties that used to be named "th2-a7260cx3-64-64x100G-t1.config.bcm" #}
 
 l3_alpm_hit_skip=1
 {{ map_prio }}
 {{ mmu_sock }}
 {{ IPinIP_sock }}
+{{ pfcwd_sock }}

--- a/src/sonic-config-engine/tests/sample_output/py3/arista7050cx3-dualtor.config.bcm
+++ b/src/sonic-config-engine/tests/sample_output/py3/arista7050cx3-dualtor.config.bcm
@@ -6,3 +6,6 @@ sai_tunnel_support=1
                                    sai_tunnel_underlay_route_mode=1
                                    host_as_route_disable=1
                                    l3_ecmp_levels=2
+hybrid_pfc_deadlock_enable=1
+                          pfc_deadlock_seq_control=1
+                          sai_pfc_dlr_init_capability=1

--- a/src/sonic-config-engine/tests/sample_output/py3/arista7260-dualtor.config.bcm
+++ b/src/sonic-config-engine/tests/sample_output/py3/arista7260-dualtor.config.bcm
@@ -6,3 +6,6 @@ sai_tunnel_support=1
                                    sai_tunnel_underlay_route_mode=1
                                    host_as_route_disable=1
                                    l3_ecmp_levels=2
+hybrid_pfc_deadlock_enable=1
+                          pfc_deadlock_seq_control=1
+                          sai_pfc_dlr_init_capability=1

--- a/src/sonic-config-engine/tests/sample_output/py3/arista7260-t1.config.bcm
+++ b/src/sonic-config-engine/tests/sample_output/py3/arista7260-t1.config.bcm
@@ -3,3 +3,6 @@ l3_alpm_hit_skip=1
 
 mmu_init_config="MSFT-TH2-Tier1"
 
+hybrid_pfc_deadlock_enable=1
+                          pfc_deadlock_seq_control=1
+                          sai_pfc_dlr_init_capability=1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Update soc properties for certain roles that need to use pfcwd dlr init based recovery mechanism

#### How to verify it
Updated the templates on a 7050cx3 dual tor and 7260 T1 which satisfies these conditions and validated pfcwd recovery which uses DLR_INIT based mechanism. Also validated that this mechanism is not used on 7050cx3 single tor with the updated templates

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 20220531.27 image with the updated bcm templates and custom swss deb

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

