### PR TITLE
[arm64] Fix marvell-arm64 pipeline build

### DIFF
--- a/platform/marvell-arm64/prestera/debian/rules
+++ b/platform/marvell-arm64/prestera/debian/rules
@@ -21,7 +21,8 @@ clean:
 build:
 	# get sources
 	rm -rf mrvl-prestera || true
-	git clone -b ${MRVL_PRESTERA_SRC_TAG} ${MRVL_PRESTERA_SRC_URL}
+	git clone ${MRVL_PRESTERA_SRC_URL}
+	cd mrvl-prestera && git checkout ${MRVL_PRESTERA_SRC_TAG} && cd ..	
 	sed "s/KVERSION/${KVERSION}/g" /sonic/platform/marvell-arm64/prestera/debian/mrvlprestera.install.template > /sonic/platform/marvell-arm64/prestera/debian/mrvlprestera.install
 
 	make modules -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$(MODULE_DIR)/


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When git clone -b xxx command is used the versions-git will reset the HEAD of the git to the commit ID in the versions-git file. Which causes incorrect commit to be checked out causing build errors. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Split ‘git clone -b’ into two steps to avoid owerwrite
1.	Git clone
2.	cd mrvl-prestera; git checkout ; cd ..


#### How to verify it
Build marvell-arm64 target using below instructions
make init
make configure PLATFORM=marvell-arm64 PLATFORM_ARCH=arm64
make target/sonic-marvell-arm64.bin SONIC_BUILD_JOBS=2
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

