### PR TITLE
[Arista] Update hwsku.json for Arista-7050QX-32S-S4Q31

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/hwsku.json
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/hwsku.json
@@ -1,7 +1,7 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "4x10G[1G]",
+            "default_brkout_mode": "3x10G(3)+1x1G(1)",
             "port_type": "RJ45"
         },
         "Ethernet4": {

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/hwsku.json
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/hwsku.json
@@ -1,143 +1,131 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "1x10G",
-            "port_type": "RJ45"
-        },
-        "Ethernet1": {
-            "default_brkout_mode": "1x10G",
-            "port_type": "RJ45"
-        },
-        "Ethernet2": {
-            "default_brkout_mode": "1x10G",
-            "port_type": "RJ45"
-        },
-        "Ethernet3": {
-            "default_brkout_mode": "1x1G",
+            "default_brkout_mode": "4x10G[1G]",
             "port_type": "RJ45"
         },
         "Ethernet4": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet8": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet12": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet16": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet20": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet24": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet28": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet32": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet36": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet40": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet44": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet48": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet52": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet56": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet60": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet64": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet68": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet72": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet76": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet80": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet84": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet88": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet92": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet96": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet100": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet104": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet108": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet112": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet116": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet120": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         },
         "Ethernet124": {
-            "default_brkout_mode": "1x40G",
+            "default_brkout_mode": "1x40G[10G]",
             "port_type": "QSFP+"
         }
     }

--- a/device/arista/x86_64-arista_7050_qx32s/platform.json
+++ b/device/arista/x86_64-arista_7050_qx32s/platform.json
@@ -201,6 +201,12 @@
                 "1x40G[10G]": [
                     "Ethernet5/1"
                 ],
+                "4x10G[1G]": [
+                    "Ethernet1",
+                    "Ethernet2",
+                    "Ethernet3",
+                    "Ethernet4"
+                ],
                 "2x20G[10G]": [
                     "Ethernet5/1",
                     "Ethernet5/3"

--- a/device/arista/x86_64-arista_7050_qx32s/platform.json
+++ b/device/arista/x86_64-arista_7050_qx32s/platform.json
@@ -201,7 +201,7 @@
                 "1x40G[10G]": [
                     "Ethernet5/1"
                 ],
-                "4x10G[1G]": [
+                "3x10G(3)+1x1G(1)": [
                     "Ethernet1",
                     "Ethernet2",
                     "Ethernet3",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is to fix some issues of hwsku.json for Arista-7050QX-32S-S4Q31:
 - default_brkout_mode in hwsku.json should be available in platform.json
 - interface in hwsku.json should be available in platform.json
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Change platform.json add a new breakout mode 4x10G[1G] for SONiC SFP ports Ethernet0, Ethernet1, Ethernet2 and Ethernet3.
Change hwsku.json to update the default_brkout_mode for all ports and remove Ethernet1, Ethernet2 and Ethernet3.

#### How to verify it
Sanitize a dut and check that the result in 'show int status' as below matches the port_config.ini
 root@ck331:/home/admin# show int st
  Interface            Lanes    Speed    MTU    FEC         Alias    Vlan    Oper    Admin                                      Type    Asym PFC
-----------  ---------------  -------  -----  -----  ------------  ------  ------  -------  ----------------------------------------  ----------
  Ethernet0                9      10G   9100    N/A     Ethernet1  routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
  Ethernet1               10      10G   9100    N/A     Ethernet2  routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
  Ethernet2               11      10G   9100    N/A     Ethernet3  routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
  Ethernet3               12      10G   9100    N/A     Ethernet4  routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
  Ethernet4      13,14,15,16      40G   9100    N/A   Ethernet6/1  routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
  Ethernet8      17,18,19,20      40G   9100    N/A   Ethernet7/1  routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
... ...

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

