### PR TITLE
[FRR][CVE] Add FRR patches to fix CVEs: CVE-2022-43681 CVE-2022-40318…

### DIFF
--- a/src/sonic-frr/patch/0027-bgpd-Ensure-FRR-has-enough-data-to-read-in-peek_for_as4_capability-and-bgp_open_option_parse.patch
+++ b/src/sonic-frr/patch/0027-bgpd-Ensure-FRR-has-enough-data-to-read-in-peek_for_as4_capability-and-bgp_open_option_parse.patch
@@ -1,0 +1,130 @@
+From 3e46b43e3788f0f87bae56a86b54d412b4710286 Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Fri, 30 Sep 2022 08:51:45 -0400
+Subject: [PATCH 1/2] bgpd: Ensure FRR has enough data to read 2 bytes in
+ peek_for_as4_capability
+
+In peek_for_as4_capability the code is checking that the
+stream has at least 2 bytes to read ( the opt_type and the
+opt_length ).  However if BGP_OPEN_EXT_OPT_PARAMS_CAPABLE(peer)
+is configured then FRR is reading 3 bytes.  Which is not good
+since the packet could be badly formated.  Ensure that
+FRR has the appropriate data length to read the data.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+---
+ bgpd/bgp_open.c | 27 +++++++++++++++++++++------
+ 1 file changed, 21 insertions(+), 6 deletions(-)
+
+diff --git a/bgpd/bgp_open.c b/bgpd/bgp_open.c
+index 7248f034a5a..a760a7ca013 100644
+--- a/bgpd/bgp_open.c
++++ b/bgpd/bgp_open.c
+@@ -1185,15 +1185,30 @@ as_t peek_for_as4_capability(struct peer *peer, uint16_t length)
+ 		uint8_t opt_type;
+ 		uint16_t opt_length;
+ 
+-		/* Check the length. */
+-		if (stream_get_getp(s) + 2 > end)
++		/* Ensure we can read the option type */
++		if (stream_get_getp(s) + 1 > end)
+ 			goto end;
+ 
+-		/* Fetch option type and length. */
++		/* Fetch the option type */
+ 		opt_type = stream_getc(s);
+-		opt_length = BGP_OPEN_EXT_OPT_PARAMS_CAPABLE(peer)
+-				     ? stream_getw(s)
+-				     : stream_getc(s);
++
++		/*
++		 * Check the length and fetch the opt_length
++		 * If the peer is BGP_OPEN_EXT_OPT_PARAMS_CAPABLE(peer)
++		 * then we do a getw which is 2 bytes.  So we need to
++		 * ensure that we can read that as well
++		 */
++		if (BGP_OPEN_EXT_OPT_PARAMS_CAPABLE(peer)) {
++			if (stream_get_getp(s) + 2 > end)
++				goto end;
++
++			opt_length = stream_getw(s);
++		} else {
++			if (stream_get_getp(s) + 1 > end)
++				goto end;
++
++			opt_length = stream_getc(s);
++		}
+ 
+ 		/* Option length check. */
+ 		if (stream_get_getp(s) + opt_length > end)
+
+From 1117baca3c592877a4d8a13ed6a1d9bd83977487 Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Fri, 30 Sep 2022 08:57:43 -0400
+Subject: [PATCH 2/2] bgpd: Ensure FRR has enough data to read 2 bytes in
+ bgp_open_option_parse
+
+In bgp_open_option_parse the code is checking that the
+stream has at least 2 bytes to read ( the opt_type and
+the opt_length).  However if BGP_OPEN_EXT_OPT_PARAMS_CAPABLE(peer)
+is configured then FRR is reading 3 bytes.  Which is not good
+since the packet could be badly formateed.  Ensure that
+FRR has the appropriate data length to read the data.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+---
+ bgpd/bgp_open.c | 35 ++++++++++++++++++++++++++++-------
+ 1 file changed, 28 insertions(+), 7 deletions(-)
+
+diff --git a/bgpd/bgp_open.c b/bgpd/bgp_open.c
+index a760a7ca013..d1667fac261 100644
+--- a/bgpd/bgp_open.c
++++ b/bgpd/bgp_open.c
+@@ -1278,19 +1278,40 @@ int bgp_open_option_parse(struct peer *peer, uint16_t length,
+ 		uint8_t opt_type;
+ 		uint16_t opt_length;
+ 
+-		/* Must have at least an OPEN option header */
+-		if (STREAM_READABLE(s) < 2) {
++		/*
++		 * Check that we can read the opt_type and fetch it
++		 */
++		if (STREAM_READABLE(s) < 1) {
+ 			zlog_info("%s Option length error", peer->host);
+ 			bgp_notify_send(peer, BGP_NOTIFY_OPEN_ERR,
+ 					BGP_NOTIFY_OPEN_MALFORMED_ATTR);
+ 			return -1;
+ 		}
+-
+-		/* Fetch option type and length. */
+ 		opt_type = stream_getc(s);
+-		opt_length = BGP_OPEN_EXT_OPT_PARAMS_CAPABLE(peer)
+-				     ? stream_getw(s)
+-				     : stream_getc(s);
++
++		/*
++		 * Check the length of the stream to ensure that
++		 * FRR can properly read the opt_length. Then read it
++		 */
++		if (BGP_OPEN_EXT_OPT_PARAMS_CAPABLE(peer)) {
++			if (STREAM_READABLE(s) < 2) {
++				zlog_info("%s Option length error", peer->host);
++				bgp_notify_send(peer, BGP_NOTIFY_OPEN_ERR,
++						BGP_NOTIFY_OPEN_MALFORMED_ATTR);
++				return -1;
++			}
++
++			opt_length = stream_getw(s);
++		} else {
++			if (STREAM_READABLE(s) < 1) {
++				zlog_info("%s Option length error", peer->host);
++				bgp_notify_send(peer, BGP_NOTIFY_OPEN_ERR,
++						BGP_NOTIFY_OPEN_MALFORMED_ATTR);
++				return -1;
++			}
++
++			opt_length = stream_getc(s);
++		}
+ 
+ 		/* Option length check. */
+ 		if (STREAM_READABLE(s) < opt_length) {

--- a/src/sonic-frr/patch/0028-bgpd-Ensure-that-bgp-open-message-stream-has-enough-data-to-read.patch
+++ b/src/sonic-frr/patch/0028-bgpd-Ensure-that-bgp-open-message-stream-has-enough-data-to-read.patch
@@ -1,0 +1,47 @@
+From 766eec1b7accffe2c04a5c9ebb14e9f487bb9f78 Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Wed, 2 Nov 2022 13:24:48 -0400
+Subject: [PATCH] bgpd: Ensure that bgp open message stream has enough data to
+ read
+
+If a operator receives an invalid packet that is of insufficient size
+then it is possible for BGP to assert during reading of the packet
+instead of gracefully resetting the connection with the peer.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+---
+ bgpd/bgp_packet.c | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/bgpd/bgp_packet.c b/bgpd/bgp_packet.c
+index 769f9613da8..72d6a923175 100644
+--- a/bgpd/bgp_packet.c
++++ b/bgpd/bgp_packet.c
+@@ -1386,8 +1386,27 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
+ 	    || CHECK_FLAG(peer->flags, PEER_FLAG_EXTENDED_OPT_PARAMS)) {
+ 		uint8_t opttype;
+ 
++		if (STREAM_READABLE(peer->curr) < 1) {
++			flog_err(
++				EC_BGP_PKT_OPEN,
++				"%s: stream does not have enough bytes for extended optional parameters",
++				peer->host);
++			bgp_notify_send(peer, BGP_NOTIFY_OPEN_ERR,
++					BGP_NOTIFY_OPEN_MALFORMED_ATTR);
++			return BGP_Stop;
++		}
++
+ 		opttype = stream_getc(peer->curr);
+ 		if (opttype == BGP_OPEN_NON_EXT_OPT_TYPE_EXTENDED_LENGTH) {
++			if (STREAM_READABLE(peer->curr) < 2) {
++				flog_err(
++					EC_BGP_PKT_OPEN,
++					"%s: stream does not have enough bytes to read the extended optional parameters optlen",
++					peer->host);
++				bgp_notify_send(peer, BGP_NOTIFY_OPEN_ERR,
++						BGP_NOTIFY_OPEN_MALFORMED_ATTR);
++				return BGP_Stop;
++			}
+ 			optlen = stream_getw(peer->curr);
+ 			SET_FLAG(peer->sflags,
+ 				 PEER_STATUS_EXT_OPT_PARAMS_LENGTH);

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -25,4 +25,6 @@ cross-compile-changes.patch
 0024-zebra-continue-fpm-read-when-we-decide-a-netlink-message-is-not-needed.patch
 0025-zebra-Send-nht-resolved-entry-up-to-concerned-protoc.patch
 0026-bgpd-Ensure-suppress-fib-pending-works-with-network-.patch
+0027-bgpd-Ensure-FRR-has-enough-data-to-read-in-peek_for_as4_capability-and-bgp_open_option_parse.patch
+0028-bgpd-Ensure-that-bgp-open-message-stream-has-enough-data-to-read.patch
 


### PR DESCRIPTION
… CVE-2022-40302

Add patches from PRs
https://github.com/FRRouting/frr/pull/12043
https://github.com/FRRouting/frr/pull/12247

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix CVEs found in FRR 8.2

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Take commit from  the FRR repo and created a patch from them

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

