### PR TITLE
[Build] Fix the http proxy not used when building the base debian ima…

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -78,7 +78,7 @@ popd
 
 ## Build the host debian base system
 echo '[INFO] Build host debian base system...'
-TARGET_PATH=$TARGET_PATH scripts/build_debian_base_system.sh $CONFIGURED_ARCH $IMAGE_DISTRO $FILESYSTEM_ROOT
+TARGET_PATH=$TARGET_PATH scripts/build_debian_base_system.sh $CONFIGURED_ARCH $IMAGE_DISTRO $FILESYSTEM_ROOT $http_proxy
 
 # Prepare buildinfo
 sudo SONIC_VERSION_CACHE=${SONIC_VERSION_CACHE} \

--- a/scripts/build_debian_base_system.sh
+++ b/scripts/build_debian_base_system.sh
@@ -100,7 +100,7 @@ do
         exit 1
     fi
     filename=$(basename "$url")
-    SKIP_BUILD_HOOK=y wget $url -O $ARCHIEVES/$filename
+    SKIP_BUILD_HOOK=y http_proxy=$HTTP_PROXY wget $url -O $ARCHIEVES/$filename
     echo $packagename >> $DEBOOTSTRAP_REQUIRED
     echo "$packagename /var/cache/apt/archives/$filename" >> $DEBPATHS
 done


### PR DESCRIPTION
…ge issue

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the build proxy issue
```
Followed your suggestion to add “SONIC_VERSION_CONTROL_COMPONENTS=all” and “MIRROR_SNAPSHOT=y” in the build cmd, we get past the original build failure at “makedumpfile”. However we hit the failure at generating the final .bin image:

+ echo '[INFO] Build host debian base system...'
[INFO] Build host debian base system...
+ TARGET_PATH=target
+ scripts/build_debian_base_system.sh amd64 buster ./fsroot
--2023-05-30 21:17:58--  [http://packages.trafficmanager.net/snapshot/debian/20230509T000212Z/pool/main/a/adduser/adduser_3.118_all.deb](https://nam06.safelinks.protection.outlook.com/?url=http%3A%2F%2Fpackages.trafficmanager.net%2Fsnapshot%2Fdebian%2F20230509T000212Z%2Fpool%2Fmain%2Fa%2Fadduser%2Fadduser_3.118_all.deb&data=05%7C01%7Cxumia%40microsoft.com%7Cfc6a8b25b8104974ec3408db6161ea6e%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638210846400565307%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=RMbSpE%2B5J5R40%2BHeAgN0SmBf%2FpFpRC1pcfgoU1KLFpM%3D&reserved=0)
Resolving packages.trafficmanager.net (packages.trafficmanager.net)... 13.107.238.69, 13.107.237.69, 2620:1ec:bdf::69, ...
Connecting to packages.trafficmanager.net (packages.trafficmanager.net)|13.107.238.69|:80... failed: Connection timed out.
Connecting to packages.trafficmanager.net (packages.trafficmanager.net)|13.107.237.69|:80... failed: Connection timed out.
Connecting to packages.trafficmanager.net (packages.trafficmanager.net)|2620:1ec:bdf::69|:80... failed: Cannot assign requested address.
Connecting to packages.trafficmanager.net (packages.trafficmanager.net)|2620:1ec:46::69|:80... failed: Cannot assign requested address.
Retrying.
```

##### Work item tracking
- Microsoft ADO **(number only)**: 24131853

#### How I did it
Add the http proxy environment variable when wget.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

