### PR TITLE
[Mellanox] Added patchwork link to commit message

### DIFF
--- a/platform/mellanox/integration-scripts/helper.py
+++ b/platform/mellanox/integration-scripts/helper.py
@@ -199,6 +199,7 @@ def build_commit_description(changes):
         content = content + f"* {key} : {value}\n"
     return content
 
+
 def parse_id(id_):
     if id_ and id_ != "N/A":
         id_ = "https://github.com/torvalds/linux/commit/" + id_

--- a/platform/mellanox/integration-scripts/tests/data/Patch_Status_Table.txt
+++ b/platform/mellanox/integration-scripts/tests/data/Patch_Status_Table.txt
@@ -48,10 +48,10 @@ Kernel-5.10
 |0044-platform-mellanox-mlxreg-io-Fix-read-access-of-n-byt.patch  | 5fd56f11838d       | Bugfix upstream                          |  5.10.75   |                                                |
 |0045-i2c-mlxcpld-Fix-criteria-for-frequency-setting.patch        | 52f57396c75a       | Feature upstream                         |            |                                                |
 |0046-i2c-mlxcpld-Reduce-polling-time-for-performance-impr.patch  | 669b2e4aa1a8       | Feature upstream                         |            | (5.16)                                         |
-|0047-i2c-mlxcpld-Allow-flexible-polling-time-setting-for-.patch  | 712d6617d0a2       | Feature upstream                         |            | (5.16)                                         |
 |0048-hwmon-pmbus-mp2975-Add-missed-POUT-attribute-for-pag.patch  | 2292e2f685cd       | Bugfix upstream                          |  5.10.71   |                                                |
 |0049-leds-mlxreg-Provide-conversion-for-hardware-LED-colo.patch  |                    | Rejected; take[ALL]                      |            |Need to check patch apply. Can break patch apply|
 |0050-leds-mlxreg-Skip-setting-LED-color-during-initializa.patch  |                    | Downstream                               |            |                                                |
 |0051-leds-mlxreg-Allow-multi-instantiation-of-same-name-L.patch  |                    | Downstream                               |            | Modular SN4800                                 |
+|0188-i2c-mux-Add-register-map-based-mux-driver.patch             |                    | Feature pending                          |            | BF3-COME                                       |
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/platform/mellanox/integration-scripts/tests/data/expected_data/series
+++ b/platform/mellanox/integration-scripts/tests/data/expected_data/series
@@ -51,6 +51,7 @@
 0105-mlxsw-reg-Extend-MTBR-register-with-new-slot-number-.patch
 0106-mlxsw-reg-Extend-MCIA-register-with-new-slot-number-.patch
 0107-mlxsw-reg-Extend-MCION-register-with-new-slot-number.patch
+0188-i2c-mux-Add-register-map-based-mux-driver.patch
 ###-> mellanox_hw_mgmt-end
 
 # Cisco patches for 5.10 kernel

--- a/platform/mellanox/integration-scripts/tests/data/expected_data/series.patch
+++ b/platform/mellanox/integration-scripts/tests/data/expected_data/series.patch
@@ -8,6 +8,7 @@
 +0169-TMP-mlxsw-i2c-Prevent-transaction-execution-for-spec.patch
 +0172-DS-platform-mlx-platform-Add-SPI-path-for-rack-switc.patch
 +0174-DS-mlxsw-core_linecards-Skip-devlink-and-provisionin.patch
+ 0188-i2c-mux-Add-register-map-based-mux-driver.patch
  ###-> mellanox_hw_mgmt-end
  
  # Cisco patches for 5.10 kernel


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Add the patchwork link to the commit description for non-upstream patches if present

#### How I did it

Parse the `patchwork/<patch_name>.txt` file from hw-mgmt

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

