### PR TITLE
[Arista] fix platform.json for a few devices

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32/platform.json
+++ b/device/arista/x86_64-arista_7050_qx32/platform.json
@@ -53,37 +53,43 @@
         "psus": [
             {
                 "name": "psu1",
-                "fans": []
+                "fans": [
+                    {
+                        "name": "psu1/1",
+                        "speed": {
+                            "controllable": false
+                        }
+                    }
+                ]
             },
             {
                 "name": "psu2",
-                "fans": []
+                "fans": [
+                    {
+                        "name": "psu2/1",
+                        "speed": {
+                            "controllable": false
+                        }
+                    }
+                ]
             }
         ],
         "thermals": [
             {
-                "name": "Cpu temp sensor"
+                "name": "Cpu temp sensor",
+                "controllable": false
             },
             {
-                "name": "Board sensor"
+                "name": "Board sensor",
+                "controllable": false
             },
             {
-                "name": "Front-panel temp sensor"
+                "name": "Front-panel temp sensor",
+                "controllable": false
             },
             {
-                "name": "Rear temp sensor"
-            },
-            {
-                "name": "Power supply 1 inlet temp sensor"
-            },
-            {
-                "name": "Power supply 1 internal sensor"
-            },
-            {
-                "name": "Power supply 2 inlet temp sensor"
-            },
-            {
-                "name": "Power supply 2 internal sensor"
+                "name": "Rear temp sensor",
+                "controllable": false
             }
         ],
         "sfps": [

--- a/device/arista/x86_64-arista_7050_qx32s/platform.json
+++ b/device/arista/x86_64-arista_7050_qx32s/platform.json
@@ -40,46 +40,47 @@
         "psus": [
             {
                 "name": "psu1",
-                "fans": []
+                "fans": [
+                    {
+                        "name": "psu1/1",
+                        "speed": {
+                            "controllable": false
+                        }
+                    }
+                ]
             },
             {
                 "name": "psu2",
-                "fans": []
+                "fans": [
+                    {
+                        "name": "psu2/1",
+                        "speed": {
+                            "controllable": false
+                        }
+                    }
+                ]
             }
         ],
         "thermals": [
             {
-                "name": "Cpu temp sensor"
+                "name": "Cpu temp sensor",
+                "controllable": false
             },
             {
-                "name": "Cpu board temp sensor"
+                "name": "Cpu board temp sensor",
+                "controllable": false
             },
             {
-                "name": "Back-panel temp sensor"
+                "name": "Back-panel temp sensor",
+                "controllable": false
             },
             {
-                "name": "Board Sensor"
+                "name": "Board Sensor",
+                "controllable": false
             },
             {
-                "name": "Front-panel temp sensor"
-            },
-            {
-                "name": "Power supply 1 hotspot sensor"
-            },
-            {
-                "name": "Power supply 1 inlet temp sensor"
-            },
-            {
-                "name": "Power supply 1 exhaust temp sensor"
-            },
-            {
-                "name": "Power supply 2 hotspot sensor"
-            },
-            {
-                "name": "Power supply 2 inlet temp sensor"
-            },
-            {
-                "name": "Power supply 2 exhaust temp sensor"
+                "name": "Front-panel temp sensor",
+                "controllable": false
             }
         ],
         "sfps": [

--- a/device/arista/x86_64-arista_7060_cx32s/platform_components.json
+++ b/device/arista/x86_64-arista_7060_cx32s/platform_components.json
@@ -1,6 +1,6 @@
 {
     "chassis": {
-        "DCS-7050CX3-32S": {
+        "DCS-7060CX-32S": {
             "component": {
                 "Aboot()": {},
                 "Scd(addr=0000:02:00.0)": {},


### PR DESCRIPTION
#### Why I did it

sonic-mgmt is failing tests due to invalid test data in `platform.json`
Fwutil is upset the chassis name in the `platform_component.json` of the 7060CX-32S

#### How I did it

Fixed the aforementioned issues

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog

fix platform.json for a few Arista devices
