### PR TITLE
[DX010] fix possible cpld race read issue

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/component.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/component.py
@@ -54,7 +54,7 @@ class Component(ComponentBase):
 
     def get_register_value(self, register):
         # Retrieves the cpld register value
-        cmd = "echo {1} > {0}; cat {0}".format(GETREG_PATH, register)
+        cmd = "flock {0} -c 'echo {1} > {0}; cat {0}'".format(GETREG_PATH, register)
         p = subprocess.Popen(
             cmd, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         raw_data, err = p.communicate()

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/helper.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/helper.py
@@ -77,7 +77,7 @@ class APIHelper():
         return True
 
     def get_cpld_reg_value(self, getreg_path, register):
-        cmd = "echo {1} > {0}; cat {0}".format(getreg_path, register)
+        cmd = "flock {0} -c 'echo {1} > {0}; cat {0}'".format(getreg_path, register)
         status, result = self.run_command(cmd)
         return result if status else None
 


### PR DESCRIPTION
#### Why I did it
fix possible cpld race read issue between watchdog and reboot cause process

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Use flock to limit parallel access to cpld sys file

#### How to verify it
It can be simulate and verified with following python script

```python3
import signal
import subprocess
import threading

exit_flag = False

def run_command(cmd):
    status = True
    result = ""
    try:
        p = subprocess.Popen(
            cmd, shell=True, universal_newlines=True,
stdout=subprocess.PIPE, stderr=subprocess.PIPE)
        raw_data, err = p.communicate()
        if err == '':
            result = raw_data.strip()
    except:
        status = False
    return status, result

def get_cpld_reg_value(getreg_path, register):
    #cmd = "echo {1} > {0}; cat {0}".format(getreg_path, register)
    cmd = "flock {0} -c 'echo {1} > {0}; cat {0}'".format(getreg_path,
register)
    status, result = run_command(cmd)
    return result if status else None

def cpld_read(thread_num, cpld_reg):
    while not exit_flag:
        val
= get_cpld_reg_value("/sys/devices/platform/dx010_cpld/getreg",
cpld_reg)
        print(f"Thread {thread_num}: get cpld reg {cpld_reg}, value
{val}")

def signal_handler(sig, frame):
    global exit_flag
    print("Ctrl+C detected. Quitting...")
    exit_flag = True

if __name__ == '__main__':
    # Register the signal handler for Ctrl+C
    signal.signal(signal.SIGINT, signal_handler)

    t1 = threading.Thread(target=cpld_read, args=(1, '0x103',))
    t2 = threading.Thread(target=cpld_read, args=(2, '0x141',))
    t1.start()
    t2.start()
    t1.join()
    t2.join()
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

