### PR TITLE
[Arista] Ensure the kernel-cmdline-append is initially empty

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -201,6 +201,9 @@ elif [ "$IMAGE_TYPE" = "aboot" ]; then
     generate_device_list ".platforms_asic"
     zip -g $OUTPUT_ABOOT_IMAGE .platforms_asic
 
+    # create kernel cmdline argument file, any argument added to this file must
+    # first be allowed in the boot0.j2 file
+    echo -n > kernel-cmdline-append
     if [ "$ENABLE_FIPS" = "y" ]; then
         echo "sonic_fips=1" >> kernel-cmdline-append
     else


### PR DESCRIPTION
#### Why I did it

The `kernel-cmdline-append` file is not being reset before being generated.
Multiple invocations of `build_image.sh` would lead to an ever growing file.

#### How I did it

Truncate the file at the beginning of build_image.sh

#### How to verify it

No duplicated content in `kernel-cmdline-append` after running `build_image.sh` twice.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
