### PR TITLE
[yang] Change asn to start from 0 for bgp monitor

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1597,7 +1597,7 @@
         "BGP_MONITORS": {
             "5.6.7.8": {
                 "admin_status": "up",
-                "asn": "65000",
+                "asn": "0",
                 "holdtime": "180",
                 "keepalive": "60",
                 "local_addr": "10.0.0.11",

--- a/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
@@ -534,7 +534,7 @@ module sonic-bgp-common {
     grouping sonic-bgp-cmn-neigh {
         leaf asn {
             type uint32 {
-                range "1..4294967295";
+                range "0..4294967295";
             }
             description "Peer AS number";
         }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
@@ -534,7 +534,7 @@ module sonic-bgp-common {
     grouping sonic-bgp-cmn-neigh {
         leaf asn {
             type uint32 {
-                range "0..4294967295";
+                range "1..4294967295";
             }
             description "Peer AS number";
         }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-internal-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-internal-neighbor.yang
@@ -43,6 +43,9 @@ module sonic-bgp-internal-neighbor {
                         must "(current() = /dm:sonic-device_metadata/dm:DEVICE_METADATA/dm:localhost/dm:bgp_asn)" {
                             error-message "Internal iBGP neighbors should have same ASN as defined in device metadata";
                         }
+                        must ". >= 1" {
+                            error-message "ASN must be greater than 0";
+                        }
                     }
                     refine local_addr {
                         mandatory true;

--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -61,7 +61,13 @@ module sonic-bgp-neighbor {
                     description "BGP Neighbor address";
                 }
 
-                uses bgpcmn:sonic-bgp-cmn-neigh;
+                uses bgpcmn:sonic-bgp-cmn-neigh {
+                    refine asn {
+                        must ". >= 1" {
+                            error-message "ASN must be greater than 0";
+                        }
+                    }
+                }
             }
 
             list BGP_NEIGHBOR_LIST {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-voq-chassis-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-voq-chassis-neighbor.yang
@@ -45,6 +45,9 @@ module sonic-bgp-voq-chassis-neighbor {
                         must "(current() = /dm:sonic-device_metadata/dm:DEVICE_METADATA/dm:localhost/dm:bgp_asn)" {
                             error-message "Voq chassis BGP neighbors should have same ASN as defined in device metadata";
                         }
+                        must ". >= 1" {
+                            error-message "ASN must be greater than 0";
+                        }
                     }
                     refine local_addr {
                         mandatory true;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The asn 0 in BGP_MONITOR is invalid by YANG definition. However, the asn 0 in BGP_MONITOR is found in many devices. 
It was introduced by minigraph where its value is set to 0.
To unblock Config Updater test, the short term fix is to accept the asn 0 in BGP_MONITOR. 
We can revert this after NGS team make all the ASN change in minigraph.
##### Work item tracking
- Microsoft ADO **(24186140)**:

#### How I did it
Change the range
#### How to verify it
Unit test.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

