### PR TITLE
[DX010] fix possible cpld race access issue

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/component.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/component.py
@@ -51,21 +51,13 @@ class Component(ComponentBase):
         except Exception as e:
             return None
 
-    def get_register_value(self, register):
-        # Retrieves the cpld register value
-        with open(GETREG_PATH, 'w') as file:
-            file.write(register + '\n')
-        with open(GETREG_PATH, 'r') as file:
-            raw_data = file.readline()
-        return raw_data.strip()
-
     def __get_cpld_version(self):
         # Retrieves the CPLD firmware version
         cpld_version = dict()
         for cpld_name in CPLD_ADDR_MAPPING:
             try:
                 cpld_addr = CPLD_ADDR_MAPPING[cpld_name]
-                cpld_version_raw = self.get_register_value(cpld_addr)
+                cpld_version_raw = self._api_helper.get_cpld_reg_value(GETREG_PATH, cpld_addr)
                 cpld_version_str = "{}.{}".format(int(cpld_version_raw[2], 16), int(
                     cpld_version_raw[3], 16)) if cpld_version_raw is not None else 'None'
                 cpld_version[cpld_name] = cpld_version_str

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/helper.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/helper.py
@@ -1,3 +1,4 @@
+import fcntl
 import os
 import struct
 import subprocess
@@ -74,9 +75,23 @@ class APIHelper():
         return True
 
     def get_cpld_reg_value(self, getreg_path, register):
-        with open(getreg_path, 'w') as file:
+        file = open(getreg_path, 'w+')
+        # Acquire an exclusive lock on the file
+        fcntl.flock(file, fcntl.LOCK_EX)
+
+        try:
             file.write(register + '\n')
-        with open(getreg_path, 'r') as file:
-            result = file.readline()
+            file.flush()
+
+            # Seek to the beginning of the file
+            file.seek(0)
+
+            # Read the content of the file
+            result = file.readline().strip()
+        finally:
+            # Release the lock and close the file
+            fcntl.flock(file, fcntl.LOCK_UN)
+            file.close()
+
         return result
 


### PR DESCRIPTION
#### Why I did it
fix possible cpld race read issue between watchdog and reboot cause process

#### How I did it
Use fcntl.flock to limit parallel access to cpld sys file

#### How to verify it
It can be simulated and verified with following python script

``` python3
import fcntl
import signal
import threading

exit_flag = False

def get_cpld_reg_value(getreg_path, register):
    file = open(getreg_path, 'w+')
    # Acquire an exclusive lock on the file
    fcntl.flock(file, fcntl.LOCK_EX)

    try:
        file.write(register + '\n')
        file.flush()

        # Seek to the beginning of the file
        file.seek(0)

        # Read the content of the file
        result = file.readline().strip()
    finally:
        # Release the lock and close the file
        fcntl.flock(file, fcntl.LOCK_UN)
        file.close()

    return result

def cpld_read(thread_num, cpld_reg, expect_val):
    while not exit_flag:
        val
= get_cpld_reg_value("/sys/devices/platform/dx010_cpld/getreg",
cpld_reg)
        #print(f"Thread {thread_num}: get cpld reg {cpld_reg}, value
{val}")
        if val != expect_val:
            print(f"Thread {thread_num}: get cpld reg {cpld_reg}, value
{val}, expect_val {expect_val}")

def signal_handler(sig, frame):
    global exit_flag
    print("Ctrl+C detected. Quitting...")
    exit_flag = True

if __name__ == '__main__':
    # Register the signal handler for Ctrl+C
    signal.signal(signal.SIGINT, signal_handler)

    t1 = threading.Thread(target=cpld_read, args=(1, '0x103', '0x11',))
    t2 = threading.Thread(target=cpld_read, args=(2, '0x141', '0x00',))
    t1.start()
    t2.start()
    t1.join()
    t2.join()
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

