### PR TITLE
[Marvell] Fix get_system_mac for system without eeprom

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -713,19 +713,21 @@ def get_system_mac(namespace=None):
         machine_vars = get_machine_info()
         (mac, err) = run_command(syseeprom_cmd)
         hw_mac_entry_outputs.append((mac, err))
-        if not mac:
-            if machine_vars is not None and machine_key in machine_vars:
-                hwsku = machine_vars[machine_key]
-                profile_cmd0 = ['cat', HOST_DEVICE_PATH + '/' + platform + '/' + hwsku + '/profile.ini']
+        if machine_vars is not None and machine_key in machine_vars:
+            hwsku = machine_vars[machine_key]
+            profile_file = HOST_DEVICE_PATH + '/' + platform + '/' + hwsku + '/profile.ini'
+            if os.path.exists(profile_file):
+                profile_cmd0 = ['cat', profile_file]
                 profile_cmd1 = ['grep', 'switchMacAddress']
                 profile_cmd2 = ['cut', '-f2', '-d', '=']
                 (mac, err) = run_command_pipe(profile_cmd0, profile_cmd1, profile_cmd2)
-            else:
-                profile_cmd = ["false"]
-                (mac, err) = run_command(profile_cmd)
+                hw_mac_entry_outputs.append((mac, err))
+        else:
+            profile_cmd = ["false"]
+            (mac, err) = run_command(profile_cmd)
             hw_mac_entry_outputs.append((mac, err))
-            (mac, err) = run_command_pipe(iplink_cmd0, iplink_cmd1, iplink_cmd2)
-            hw_mac_entry_outputs.append((mac, err))
+        (mac, err) = run_command_pipe(iplink_cmd0, iplink_cmd1, iplink_cmd2)
+        hw_mac_entry_outputs.append((mac, err))
     elif (version_info['asic_type'] == 'cisco-8000'):
         # Try to get valid MAC from profile.ini first, else fetch it from syseeprom or eth0
         platform = get_platform()


### PR DESCRIPTION
Change-Id: Ifeb78f366d80e70043db1f9828f2f75a8a710f46

fixes #15375 

#### Why I did it
get_system_mac was returning 'None' mac for system without eeprom. 
get_system_mac for marvell platform checks for mac in eeprom, profile.ini(hwsku file) and eth0. Check for valid mac returned by syseeprom was incorrect. Which was resulting in bypassing mac get from profile.ini and eth0.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
get_system_mac already has a logic to get first valid mac.
Removed null check for mac returned by eeprom.
Corrected the check for profile.ini file by checking if file exist.

#### How to verify it
Executed sonic-cfggen to check valid mac address is getting configured in config_db.json with/without profile.ini.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

