### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202205.2.2.3
+ref=202205.2.2.4


### PR DESCRIPTION
Why I did it
    Release Notes for Cisco 8102-64H-O:
         T0 / DualTor - Pre-GA

How I did it
    Update platform version to 202205.2.2.4