### PR TITLE
[chassis][voq] change voq_inband_interface to ip interface

### DIFF
--- a/src/sonic-config-engine/tests/sample-voq-graph.xml
+++ b/src/sonic-config-engine/tests/sample-voq-graph.xml
@@ -48,14 +48,13 @@
       <Hostname>linecard-1</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
-      <IPInterfaces/>
-      <VoqInbandInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-        <a:VoqInbandInterface>
-          <Name>Ethernet-IB0</Name>
-          <Type>port</Type>
-          <a:PrefixStr>2.2.2.2/32</a:PrefixStr>
-        </a:VoqInbandInterface>
-      </VoqInbandInterfaces>
+      <IPInterfaces>
+        <IPInterface>
+          <Name>VoqInband</Name>
+          <AttachTo>Ethernet-IB0</AttachTo>
+          <Prefix>2.2.2.2/32</Prefix>
+        </IPInterface>
+      </IPInterfaces>
       <DataAcls/>
       <AclInterfaces/>
       <DownstreamSummaries/>


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In the current minigraph for chassis the `voqInband` interfaces are defined as special interface.
This PR is making the changes to add them as regular IP interfaces with names as `voqInband` and `v6voqInband` respectively

##### Work item tracking
- Microsoft ADO **(24231821)**:

#### How I did it
update the minigraph parser and the sample minigraph file

#### How to verify it
UT and on voq chassis

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

