### PR TITLE
[build][201811] Make the build to fail if raw image generation is not successful

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -60,7 +60,11 @@ elif [ "$IMAGE_TYPE" = "raw" ]; then
     ## Run the installer 
     ## The 'build' install mode of the installer is used to generate this dump.
     sudo chmod a+x $OUTPUT_ONIE_IMAGE
-    sudo ./$OUTPUT_ONIE_IMAGE
+    sudo ./$OUTPUT_ONIE_IMAGE || {
+        ## Failure during 'build' install mode of the installer results in an incomplete raw image.
+        ## Delete the incomplete raw image.
+        sudo rm -f $OUTPUT_RAW_IMAGE
+    }
 
     [ -r $OUTPUT_RAW_IMAGE ] || {
         echo "Error : $OUTPUT_RAW_IMAGE not generated!"


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To report a build failure if the raw image generation is not successful.

#### How I did it

If the 'build' install mode of the installer exits with an error, delete the incomplete raw image file generated.

#### How to verify it
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Modify the raw image disk size to an insufficient value and verify that the raw image build fails.

```
make target/sonic-broadcom.raw
+++ --- Making target/sonic-broadcom.raw --- +++
BLDENV=stretch make -f Makefile.work stretch
make[1]: Entering directory '/home/abalac/repos/201811/raw_image/sonic-buildimage'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 27736  100 27736    0     0  24654      0  0:00:01  0:00:01 --:--:-- 24676
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  9884  100  9884    0     0  11851      0 --:--:-- --:--:-- --:--:-- 11837
SONiC Build System

Build Configuration
"CONFIGURED_PLATFORM"             : "broadcom"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_BUILD_JOBS"                : "8"
"SONIC_CONFIG_MAKE_JOBS"          : "112"
"USERNAME"                        : "admin"
"PASSWORD"                        : "YourPaSsWoRd"
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"INSTALL_DEBUG_TOOLS"             : ""
"ROUTING_STACK"                   : "quagga"
"ENABLE_SYNCD_RPC"                : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"ENABLE_SYSTEM_TELEMETRY"         : ""
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : ""
"KERNEL_PROCURE_METHOD"           : "build"
"BUILD_TIMESTAMP"                 : "20230613.102621"
"VS_PREPARE_MEM"                  : "yes"

...
...
...

tar: ./overlay2/l/DXGPCC34DDWNMBT5TJXOKNXMPB: Cannot create symlink to '../bfc1f04feea0af6a0ac6e627b40d79b7dd960c989fc68aa7d0cab850982e1b2b/diff': No space left on device
tar: ./overlay2/l/JG57TK5DLEC4UODLLX54EJF2QO: Cannot create symlink to '../c08be3ee4dbcb94b014ced4fc8dd2f4c7f1323a05e1ddc6eec33a3fe8b4ca222/diff': No space left on device
tar: ./overlay2/l/EXDDVIVAWQ3SYSQ47DIMCCFMT5: Cannot create symlink to '../56ded1545f50a874764040462b8a79e8a1ecde0ae432d5e50a6356cbaddc45be/diff': No space left on device
tar: ./overlay2/56ded1545f50a874764040462b8a79e8a1ecde0ae432d5e50a6356cbaddc45be/diff/usr/lib/python2.6/dist-packages/scapy/arch/windows/__init__.py: Cannot create symlink to '../../../../../../share/pyshared/scapy/arch/windows/__init__.py': No space left on device
tar: ./overlay2/56ded1545f50a874764040462b8a79e8a1ecde0ae432d5e50a6356cbaddc45be/diff/usr/lib/python2.7/dist-packages/scapy/arch/windows/__init__.py: Cannot create symlink to '../../../../../../share/pyshared/scapy/arch/windows/__init__.py': No space left on device
tar: Exiting with failure status due to previous errors
umount: /tmp/tmp.8XolcS9H2T: target is busy
        (In some cases useful info about processes that
         use the device is found by lsof(8) or fuser(1).)
rm: cannot remove '/tmp/tmp.8XolcS9H2T/installer/build_raw_image_mnt': Device or resource busy
Error : target/sonic-broadcom.raw not generated!
[  FAIL LOG END  ] [ target/sonic-broadcom.raw ]
slave.mk:585: recipe for target 'target/sonic-broadcom.raw' failed
make: *** [target/sonic-broadcom.raw] Error 1
make[1]: *** [Makefile.work:142: target/sonic-broadcom.raw] Error 2
make[1]: Leaving directory '/home/abalac/repos/201811/raw_image/sonic-buildimage'
make: *** [Makefile:8: target/sonic-broadcom.raw] Error 2
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->
[build][201811] Make the build to fail if raw image generation is not successful

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

