### PR TITLE
[action] Fix auto merge workflow commit message.

### DIFF
--- a/.github/workflows/automerge_scan.yml
+++ b/.github/workflows/automerge_scan.yml
@@ -26,6 +26,7 @@ jobs:
         for ((i=0;i<$count;i++))
         do
           url=$(cat prs.log | jq -r ".[$i].url")
+          body=$(cat prs.log | jq -r ".[$i].body")
           created_at=$(cat prs.log | jq -r ".[$i].createdAt")
           echo PR: $(($i+1))/$count, URL: $url, createdAt: $created_at, now: $(date -u +"%FT%TZ")
           [[ "$url" == "" ]] && continue
@@ -68,6 +69,6 @@ jobs:
           done
           # merge the PR
           echo ========Merging  PR========
-          gh pr merge --rebase --admin -R sonic-net/sonic-buildimage $url || true
+          gh pr merge --squash --admin -R sonic-net/sonic-buildimage $url -b "$body" || true
           echo ========Finished PR========
         done

--- a/.github/workflows/automerge_scan.yml
+++ b/.github/workflows/automerge_scan.yml
@@ -1,12 +1,12 @@
 name: AutoMergeScan
 on:
   schedule:
-    - cron: '21 * * * *'
+    - cron: '31 */2 * * *'
   workflow_dispatch:
 
 jobs:
   automerge_scan:
-#    if: github.repository_owner == 'sonic-net'
+    if: github.repository_owner == 'sonic-net'
     runs-on: ubuntu-latest
     steps:
     - name: Debug

--- a/.github/workflows/automerge_scan.yml
+++ b/.github/workflows/automerge_scan.yml
@@ -1,12 +1,12 @@
 name: AutoMergeScan
 on:
   schedule:
-    - cron: '31 */2 * * *'
+    - cron: '21 * * * *'
   workflow_dispatch:
 
 jobs:
   automerge_scan:
-    if: github.repository_owner == 'sonic-net'
+#    if: github.repository_owner == 'sonic-net'
     runs-on: ubuntu-latest
     steps:
     - name: Debug
@@ -27,6 +27,7 @@ jobs:
         do
           url=$(cat prs.log | jq -r ".[$i].url")
           body=$(cat prs.log | jq -r ".[$i].body")
+          title=$(cat prs.log | jq -r ".[$i].title")
           created_at=$(cat prs.log | jq -r ".[$i].createdAt")
           echo PR: $(($i+1))/$count, URL: $url, createdAt: $created_at, now: $(date -u +"%FT%TZ")
           [[ "$url" == "" ]] && continue
@@ -69,6 +70,10 @@ jobs:
           done
           # merge the PR
           echo ========Merging  PR========
-          gh pr merge --squash --admin -R sonic-net/sonic-buildimage $url -b "$body" || true
+          if echo $title | grep "^\[submodule\]";then
+            gh pr merge --squash --admin -R sonic-net/sonic-buildimage $url -b "$body" || true
+          else
+            gh pr merge --rebase --admin -R sonic-net/sonic-buildimage $url || true
+          fi
           echo ========Finished PR========
         done


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Refine submodule update commit message.
##### Work item tracking
- Microsoft ADO **(number only)**:  24253804

#### How I did it
After refine:
```
commit 4098a90b90a19edb55123b45ba28f88699210b95 (azure/202211)
Author: mssonicbld <79238446+mssonicbld@users.noreply.github.com>
Date:   Tue Jun 13 14:56:44 2023 +0800

    [submodule] Update submodule sonic-swss to the latest HEAD automatically (#15441)

    #### Why I did it
    src/sonic-swss
    ```
    * bccb1cc - (HEAD -> 202211, origin/202211) [202211] [sflowmgrd] Infer sampling rate dynamically based on oper speed (#2805) (4 hours ago) [Vivek]
    ```
    #### How I did it
    #### How to verify it
    #### Description for the changelog

diff --git a/src/sonic-swss b/src/sonic-swss
index 1e8eaa721c..bccb1cca85 160000
--- a/src/sonic-swss
+++ b/src/sonic-swss
@@ -1 +1 @@
-Subproject commit 1e8eaa721c174ea162e22ddb1826e3f854829009
+Subproject commit bccb1cca85b86a2f009c7218ae124ad1f1fa7a8b
```
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

