### PR TITLE
Delete PROC_INFO table in APPL_DB using DEL command during non warm-reboot scenario

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -167,7 +167,8 @@ start() {
 
     # Don't flush DB during warm boot
     if [[ x"$WARM_BOOT" != x"true" ]]; then
-        debug "Flushing APP, ASIC, COUNTER, CONFIG, and partial STATE databases ..."
+        debug "Flushing APP, ASIC, COUNTER, CONFIG, and partial APPL and STATE databases ..."
+        clean_up_tables APPL_DB "'PROC_INFO*'"
         $SONIC_DB_CLI APPL_DB FLUSHDB
         $SONIC_DB_CLI ASIC_DB FLUSHDB
         $SONIC_DB_CLI COUNTERS_DB FLUSHDB


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
This fix is needed for sonic-net/sonic-platform-daemons/pull/377 to work in scenarios requiring OA to restart

#### Why I did it
It seems that currently, APPL_DB is deleted using FLUSH command during OA crash, config reload handling. This causes the subscriber XCVRD process to not receive any notification when any entry from the APPL_DB is removed.

This task is to ensure that SWSS deleted the PROC_INFO table by invoking "DEL" command so that xcvrd takes the relevant action upon receiving this event during OA crash/restart scenarios.

##### Work item tracking
- Microsoft ADO **(number only)**:
24264739

#### How I did it
Calling clean_up_tables to delete PROC_INFO table. Deleting remaining entries in APPL_DB using the existing FLUSH command.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

