### PR TITLE
Removed extra 'ip addr del' on the lo inteface

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -25,8 +25,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 {% endblock loopback %}
 {% block mgmt_interface %}
 

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces
@@ -9,8 +9,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt
@@ -9,8 +9,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp
@@ -9,8 +9,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband
@@ -9,8 +9,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband_ip
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband_ip
@@ -9,8 +9,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_ip
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_ip
@@ -9,8 +9,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
@@ -18,8 +18,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces_nomgmt
@@ -18,8 +18,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/two_mgmt_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/two_mgmt_interfaces
@@ -9,8 +9,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth1

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces
@@ -9,8 +9,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt
@@ -9,8 +9,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp
@@ -9,8 +9,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband
@@ -9,8 +9,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband_ip
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband_ip
@@ -9,8 +9,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_ip
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_ip
@@ -9,8 +9,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
@@ -18,8 +18,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces_nomgmt
@@ -18,8 +18,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/two_mgmt_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/two_mgmt_interfaces
@@ -9,8 +9,6 @@ iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
    scope host
-   post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0


### PR DESCRIPTION

#### Why I did it
The 'post-up ip addr del 127.0.0.1/8 dev lo' was thought to be required when the loopback interface subnet mask was narrowed from /8 to /16 (https://github.com/sonic-net/sonic-buildimage/pull/5353). After testing first reboot, subsequent reboots, config reloads, and systemctl restart networking on linecards and supevisors (DNX VOQ chassis), this cleanup command does not appear to be required. 

This change removes the delete command as well as reverts https://github.com/sonic-net/sonic-buildimage/pull/15080.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
Confirmed that ssh connections from supervisor to linecards can be established after first boot, subsequent reboots, config reload and systemctl restart networking tampers. 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

