### PR TITLE
Revert "Fix for fast/cold-boot: call db_migrator only after old config is loaded"

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -257,18 +257,10 @@ function postStartAction()
             $SONIC_DB_CLI CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
         fi
 
-        if [ -e /tmp/pending_config_migration ]; then
-            # this is first boot to a new image, config-setup execution is pending.
-            # For fast/cold reboot case, DB contains nothing at this point
-            # Call db_migrator after config-setup loads the config (from old config or minigraph)
-            echo "Delaying db_migrator until config migration is over"
-        else
-            # this is not a first time boot to a new image. Datbase container starts w/ old pre-existing config
-            if [[ -x /usr/local/bin/db_migrator.py ]]; then
-                # Migrate the DB to the latest schema version if needed
-                if [ -z "$DEV" ]; then
-                    /usr/local/bin/db_migrator.py -o migrate
-                fi
+        if [[ -x /usr/local/bin/db_migrator.py ]]; then
+            # Migrate the DB to the latest schema version if needed
+            if [ -z "$DEV" ]; then
+                /usr/local/bin/db_migrator.py -o migrate
             fi
         fi
         # Add redis UDS to the redis group and give read/write access to the group

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -304,16 +304,6 @@ check_all_config_db_present()
     return 0   
 }
 
-# DB schema is subject to change between two images
-# Perform DB schema migration after loading backup config from previous image
-do_db_migration()
-{
-    if [[ -x /usr/local/bin/db_migrator.py ]]; then
-        # Migrate the DB to the latest schema version if needed
-        /usr/local/bin/db_migrator.py -o migrate
-    fi
-}
-
 # Perform configuration migration from backup copy.
 #  - This step is performed when a new image is installed and SONiC switch boots into it
 do_config_migration()
@@ -336,19 +326,16 @@ do_config_migration()
     if [ x"${WARM_BOOT}" == x"true" ]; then
         echo "Warm reboot detected..."
         disable_updategraph
-        do_db_migration
         rm -f /tmp/pending_config_migration
         exit 0
     elif check_all_config_db_present; then
         echo "Use config_db.json from old system..."
         reload_configdb
-        do_db_migration
         # Disable updategraph
         disable_updategraph
     elif [ -r ${MINGRAPH_FILE} ]; then
         echo "Use minigraph.xml from old system..."
         reload_minigraph
-        do_db_migration
         # Disable updategraph
         disable_updategraph
     else


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#14933

The earlier commit caused a race condition that particularly broke cross branch warm upgrade.

Issue happens when db_migrator is still migrating the DB and finalizer is checking DB for list of components to reconcile.

If migration is not complete, finalizer get an empty list to wait for. Due to this, finalizer concludes warmboot (deletes system wide warmboot flag) and cause all the services to do cold restart.

ADO: 24274591