### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202205.2.2.4
+ref=202205.2.2.5


### PR DESCRIPTION
Why I did it

Release Notes for Cisco 8101-32FH-O:
• Fixed a FEC lane related error message
• Implemented 'show platform npu mac-state -i ' CLI for NPU MAC information and save-state dump.
• Fixed a Mac Port SerDes credit mismatch error message
• Configurable drop counter support for SAI_DEBUG_COUNTER_ATTR_TYPE (MIGSMSFT-197)
• Removed eth1-midplane creation rule that is not needed for this platform.
• Fix to move control packets from queue 0 to queue 7

How I did it

Update platform version to 202205.2.2.5

#### A picture of a cute animal (not mandatory but encouraged)

