### PR TITLE
Switch to mirror 'archive.debian.org' for redis

### DIFF
--- a/src/redis/Makefile
+++ b/src/redis/Makefile
@@ -15,9 +15,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	mkdir redis_build
 	pushd redis_build
 
-	wget -O redis_$(REDIS_VERSION).orig.tar.gz -N "http://http.debian.net/debian/pool/main/r/redis/redis_$(REDIS_VERSION).orig.tar.gz"
-	wget -O redis_$(REDIS_VERSION_FULL).dsc -N "http://http.debian.net/debian/pool/main/r/redis/redis_$(REDIS_VERSION_FULL).dsc"
-	wget -O redis_$(REDIS_VERSION_FULL).debian.tar.xz -N "http://http.debian.net/debian/pool/main/r/redis/redis_$(REDIS_VERSION_FULL).debian.tar.xz"
+	wget -O redis_$(REDIS_VERSION).orig.tar.gz -N "https://archive.debian.org/debian/pool/main/r/redis/redis_$(REDIS_VERSION).orig.tar.gz"
+	wget -O redis_$(REDIS_VERSION_FULL).dsc -N "https://archive.debian.org/debian/pool/main/r/redis/redis_$(REDIS_VERSION_FULL).dsc"
+	wget -O redis_$(REDIS_VERSION_FULL).debian.tar.xz -N "https://archive.debian.org/debian/pool/main/r/redis/redis_$(REDIS_VERSION_FULL).debian.tar.xz"
 	dpkg-source -x redis_$(REDIS_VERSION_FULL).dsc
 
 	pushd redis-$(REDIS_VERSION)


### PR DESCRIPTION
#### Why I did it
Redis-5.0.3 source archive no longer exists in http://http.debian.net/debian/pool/main/r/redis/
It's archived in https://archive.debian.org/debian/pool/main/r/redis/
Thus, switching mirror for redis is necessary.

#### How I did it
Modify src/redis/Makefile.

#### How to verify it
Delete redis deb in DPKG cache folder then build branch 202111.
With this commit: it'll succeed
Without this commit: it'll fail

