### PR TITLE
Fix docker-sonic-mgmt build by specific version install of pyaml and azure-cli by apt-get

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y apt-transport-https \
                                          apt-utils \
+                                         azure-cli \
                                          build-essential \
                                          ca-certificates \
                                          cmake \
@@ -75,6 +76,7 @@ RUN pip install allure-pytest==2.8.22 \
                 pexpect \
                 prettytable \
                 psutil \
+                pyaml==21.10.1 \
                 pyasn1==0.1.9 \
                 pycryptodome==3.9.8 \
                 pyfiglet \
@@ -129,9 +131,6 @@ RUN apt-get update                  \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"    \
     && apt-get update                                                                                              \
     && apt-get install -y docker-ce-cli
-
-# Install Azure CLI
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
 ## Copy and install sonic-mgmt docker dependencies
 COPY \


### PR DESCRIPTION
#### Why I did it
Current docker-sonic-mgmt build is broken. So below are two fixes which can help in mitigating the same.

1. PYAML - Download a specific version in python2 as after https://pypi.org/project/pyaml/23.5.5/ there was support only for python3. This update happened on May 5th. And consequently all daily builds after this changes https://dev.azure.com/mssonic/build/_build/results?buildId=266733&view=results (starting build to break) kept failing
2. Azure-CLI - this can be downloaded by apt-get repository. So modify as an improvement.

##### Work item tracking
- Microsoft ADO **(number only)**: #15567

#### How I did it
By manually checking the release notes of pyaml and install azure-cli in newly installed docker container using apt-get

#### How to verify it
You can run below commands to validate:

make configure PLATFORM=generic
make target/docker-sonic-mgmt.gz

Second line would fail without the commit.
