### PR TITLE
[202205][YANG] add model for `MUX_CABLE` and `PEER_SWITCH`

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -40,6 +40,7 @@ Table of Contents
          * [MUX_CABLE](#muxcable)  
          * [NTP Global Configuration](#ntp-global-configuration)  
          * [NTP and SYSLOG servers](#ntp-and-syslog-servers)  
+         * [Peer Switch](#peer-switch)
          * [Policer](#policer)   
          * [Port](#port)   
          * [Port Channel](#port-channel)  

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -37,6 +37,7 @@ Table of Contents
          * [Management port](#management-port)  
          * [Management VRF](#management-vrf)  
          * [MAP_PFC_PRIORITY_TO_QUEUE](#map_pfc_priority_to_queue)  
+         * [MUX_CABLE](#muxcable)  
          * [NTP Global Configuration](#ntp-global-configuration)  
          * [NTP and SYSLOG servers](#ntp-and-syslog-servers)  
          * [Policer](#policer)   
@@ -1129,6 +1130,24 @@ instead of data network.
   }
 }
 ```
+### MUX_CABLE
+
+The **MUX_CABLE** table is used for dualtor interface configuration. The `cable_type` and `soc_ipv4` objects are optional. 
+
+```
+{
+    "MUX_CABLE": {
+        "Ethernet4": {
+            "cable_type": "active-active",
+            "server_ipv4": "192.168.0.2/32",
+            "server_ipv6": "fc02:1000::30/128",
+            "soc_ipv4": "192.168.0.3/32",
+            "state": "auto"
+        }
+    }
+}
+```
+
 ### NTP Global Configuration
 
 These configuration options are used to modify the way that

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -156,6 +156,7 @@ setup(
                          './yang-models/sonic-storm-control.yang',
                          './yang-models/sonic-tc-priority-group-map.yang',
                          './yang-models/sonic-tc-queue-map.yang',
+                         './yang-models/sonic-peer-switch.yang',
                          './yang-models/sonic-pfc-priority-queue-map.yang',
                          './yang-models/sonic-pfc-priority-priority-group-map.yang',
                          './yang-models/sonic-port-qos-map.yang',

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -117,6 +117,7 @@ setup(
                          './yang-models/sonic-mgmt_port.yang',
                          './yang-models/sonic-mgmt_vrf.yang',
                          './yang-models/sonic-mirror-session.yang',
+                         './yang-models/sonic-mux-cable.yang',
                          './yang-models/sonic-ntp.yang',
                          './yang-models/sonic-nat.yang',
                          './yang-models/sonic-nvgre-tunnel.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1807,6 +1807,22 @@
         },
 
 
+        "MUX_CABLE": {
+            "Ethernet4": {
+                "cable_type": "active-active",
+                "server_ipv4": "192.168.0.2/32",
+                "server_ipv6": "fc02:1000::30/128",
+                "soc_ipv4": "192.168.0.3/32",
+                "state": "auto"
+            }, 
+            "Ethernet0": {
+                "server_ipv4": "192.168.0.2/32",
+                "server_ipv6": "fc02:1000::30/128",
+                "state": "auto"
+            }
+        },
+
+
         "POLICER": {
             "everflow_static_policer": {
                 "meter_type": "bytes",

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1806,6 +1806,11 @@
             }
         },
 
+        "PEER_SWITCH": {
+            "vlab-05": {
+                "address_ipv4":  "10.1.0.33"
+            }
+        },
 
         "MUX_CABLE": {
             "Ethernet4": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mux_cable.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mux_cable.json
@@ -1,0 +1,16 @@
+{
+    "MUX_CABLE_ACTIVE_STANDBY_INTERFACE": {
+        "desc": "Load MUX_CABLE for active-standby interface."
+    },
+    "MUX_CABLE_ACTIVE_ACTIVE_INTERFACE": {
+        "desc":"Load MUX_CABLE for active-active interface."
+    },
+    "MUX_CABLE_INVALID_STATE": {
+        "desc": "Load MUX_CABLE with invalid state.",
+        "eStrKey": "InvalidValue"
+    },
+    "MUX_CABLE_INVALID_IP": {
+        "desc": "Load MUX_CABLE with invalid server ip address.",
+        "eStrKey": "Pattern"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/peer-switch.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/peer-switch.json
@@ -1,0 +1,13 @@
+{
+    "PEER_SWITCH_LOAD_NORMAL": {
+        "desc": "Load PEER_SWITCH for dualtor device."
+    },
+    "PEER_SWITCH_MISSING_DEVICE__NAME": {
+        "desc": "Load PEER_SWITCH missing PEER Device name.",
+        "eStrKey": "Mandatory"
+    },
+    "PEER_SWITCH_INVALID_IP_ADDRESS": {
+        "desc": "Load PEER_SWITCH with invalid IPv4 Address.",
+        "eStrKey": "Pattern"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mux_cable.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mux_cable.json
@@ -1,0 +1,93 @@
+{
+    "MUX_CABLE_ACTIVE_STANDBY_INTERFACE": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet0",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet0",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
+        "sonic-mux-cable:sonic-mux-cable": {
+            "sonic-mux-cable:MUX_CABLE": {
+                "MUX_CABLE_LIST": [
+                    {
+                        "ifname": "Ethernet0",
+                        "server_ipv4": "192.168.0.2/32",
+                        "server_ipv6": "fc02:1000::30/128",
+                        "state": "auto"
+                    }
+                ]
+
+            }
+        }
+    },
+
+    "MUX_CABLE_ACTIVE_ACTIVE_INTERFACE": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet4",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet4",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
+        "sonic-mux-cable:sonic-mux-cable": {
+            "sonic-mux-cable:MUX_CABLE": {
+                "MUX_CABLE_LIST": [
+                    {
+                        "ifname": "Ethernet4",
+                        "cable_type": "active-active",
+                        "server_ipv4": "192.168.0.2/32",
+                        "server_ipv6": "fc02:1000::30/128",
+                        "soc_ipv4": "192.168.0.3/32",
+                        "state": "auto"
+                    }
+                ]
+
+            }
+        }
+    },
+
+    "MUX_CABLE_INVALID_STATE": {
+        "sonic-mux-cable:sonic-mux-cable": {
+            "sonic-mux-cable:MUX_CABLE": {
+                "MUX_CABLE_LIST": [
+                    {
+                        "state": "Standby"
+                    }
+                ]
+
+            }
+        }
+    },
+    
+    "MUX_CABLE_INVALID_IP": {
+        "sonic-mux-cable:sonic-mux-cable": {
+            "sonic-mux-cable:MUX_CABLE": {
+                "MUX_CABLE_LIST": [
+                    {
+                        "server_ipv4": "999.999.999.999/32"
+                    }
+                ]
+
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/peer-switch.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/peer-switch.json
@@ -1,0 +1,39 @@
+{
+    "PEER_SWITCH_LOAD_NORMAL": {
+        "sonic-peer-switch:sonic-peer-switch": {
+            "sonic-peer-switch:PEER_SWITCH": {
+                "PEER_SWITCH_LIST": [
+                    {
+                        "peer_switch": "vlab-05",
+                        "address_ipv4":  "10.1.0.33"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PEER_SWITCH_MISSING_DEVICE__NAME": {
+        "sonic-peer-switch:sonic-peer-switch": {
+            "sonic-peer-switch:PEER_SWITCH": {
+                "PEER_SWITCH_LIST": [
+                    {
+                        "address_ipv4":  "10.1.0.33"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PEER_SWITCH_INVALID_IP_ADDRESS": {
+        "sonic-peer-switch:sonic-peer-switch": {
+            "sonic-peer-switch:PEER_SWITCH": {
+                "PEER_SWITCH_LIST": [
+                    {
+                        "peer_switch": "vlab-05",
+                        "address_ipv4":  "10.1.0.33/32"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-mux-cable.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mux-cable.yang
@@ -1,0 +1,92 @@
+module sonic-mux-cable {
+    namespace "http://github.com/Azure/sonic-mux-cable";
+    prefix mux_cable;
+    yang-version 1.1;
+
+    import ietf-inet-types {
+        prefix inet;
+    }
+
+    import sonic-port {
+        prefix prt;
+    }
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "SONiC DualToR MUX CABLE confifuration data";
+
+    revision 2022-08-19 {
+        description
+            "Initial revision";
+    }
+
+    container sonic-mux-cable {
+        
+        container MUX_CABLE {
+            
+            list MUX_CABLE_LIST {
+                
+                key "ifname";
+
+                leaf ifname {
+                    type leafref {
+                        path "/prt:sonic-port/prt:PORT/prt:PORT_LIST/prt:name";
+                    }
+                    description
+                        "Reference of port on which MUX cable to be configured.";
+                }
+
+                leaf cable_type {
+                    type enumeration {
+                        enum active-active;
+                        enum active-standby;
+                    }
+                    default active-standby;
+                    description "SONiC DualToR interface cable type.";
+                }
+
+                leaf server_ipv4 {
+                    type inet:ipv4-prefix;
+
+                    description "Server IPv4 Address.";
+                }
+
+                leaf server_ipv6 {
+                    type inet:ipv6-prefix;
+
+                    description "Server IPv6 Address.";
+                }
+
+                leaf soc_ipv4 {
+                    type inet:ipv4-prefix;
+
+                    description "SoC IPv4 address. Optional and for active-active ports only. ";
+                }
+
+                leaf soc_ipv6 {
+                    type inet:ipv6-prefix;
+
+                    description "SoC IPv6 address. Optional and for active-active ports only. ";
+                }
+
+                leaf state {
+                    type enumeration {
+                        enum auto;
+                        enum manual;
+                        enum detach;
+                        enum active;
+                        enum standby;
+                    }
+
+                    default auto;
+                    description "MUX mode determining if auto failover is enabled. ";
+                }
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-peer-switch.yang
+++ b/src/sonic-yang-models/yang-models/sonic-peer-switch.yang
@@ -1,0 +1,49 @@
+module sonic-peer-switch {
+    yang-version 1.1;
+    namespace "http://github.com/Azure/sonic-peer-switch";
+    prefix peer_switch;
+
+    import ietf-inet-types {
+        prefix inet;
+    }
+    
+    import sonic-types {
+        prefix stypes;
+    }
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "SONiC DualToR peer switch data";
+
+    revision 2022-08-23 {
+        description
+            "Initial revision";
+    }
+
+    container sonic-peer-switch {
+        container PEER_SWITCH {
+            list PEER_SWITCH_LIST {
+                max-elements 1;
+
+                key "peer_switch";
+                
+                leaf peer_switch {
+                    type stypes:hostname;
+
+                    description "SONiC DualToR peer host name.";
+                }
+
+                leaf address_ipv4 {
+                    type inet:ipv4-address;
+
+                    description "SONiC DualToR peer's IPv4 address.";
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Cherry-pick conflicts: 
0cdef2ebc       Jing Zhang      Thu Aug 25 08:46:45 2022 -0700  [YANG] add peer switch model (#11828)
fdd9130ec       Jing Zhang      Thu Sep 1 11:52:02 2022 -0700   [YANG] Add MUX_CABLE yang model  (#11797)

sign-off: Jing Zhang zhangjing@microsoft.com 

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

