### PR TITLE
[202205] Create default Vxlan and Vnet configs (#13409)

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1255,6 +1255,28 @@ def parse_spine_chassis_fe(results, vni, lo_intfs, phyport_intfs, pc_intfs, pc_m
             # Enslave the port channel interface to a Vnet
             pc_intfs[pc_intf] = {'vnet_name': chassis_vnet}        
 
+def parse_default_vxlan_decap(results, vni, lo_intfs):
+    vnet ='Vnet-default'
+    vxlan_tunnel = 'tunnel_v4'
+
+    # Vxlan tunnel information
+    lo_addr = '0.0.0.0'
+    for lo in lo_intfs:
+        lo_network = ipaddress.ip_network(UNICODE_TYPE(lo[1]), False)
+        if lo_network.version == 4:
+            lo_addr = str(lo_network.network_address)
+            break
+    results['VXLAN_TUNNEL'] = {vxlan_tunnel: {
+        'src_ip': lo_addr
+    }}
+
+    # Vnet information
+    results['VNET'] = {vnet: {
+        'vxlan_tunnel': vxlan_tunnel,
+        'scope': "default",
+        'vni': vni
+    }}
+
 ###############################################################################
 #
 # Post-processing functions
@@ -1605,9 +1627,10 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         for key in voq_inband_intfs:
            results['VOQ_INBAND_INTERFACE'][key] = voq_inband_intfs[key]
 
-
     if resource_type is not None:
         results['DEVICE_METADATA']['localhost']['resource_type'] = resource_type
+        if 'Appliance' in resource_type:
+            parse_default_vxlan_decap(results, vni_default, lo_intfs)
 
     if downstream_subrole is not None:
         results['DEVICE_METADATA']['localhost']['downstream_subrole'] = downstream_subrole

--- a/src/sonic-config-engine/tests/t0-sample-deployment-id.xml
+++ b/src/sonic-config-engine/tests/t0-sample-deployment-id.xml
@@ -731,6 +731,11 @@
             <a:Reference i:nil="true"/>
             <a:Value>2.2.2.2</a:Value>
           </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>ResourceType</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>HaAppliance</a:Value>
+          </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
     </Devices>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -494,6 +494,22 @@ class TestCfgGen(TestCase):
             utils.to_dict("{'lanes': '101,102,103,104', 'fec': 'rs', 'pfc_asym': 'off', 'mtu': '9100', 'tpid': '0x8100', 'alias': 'fortyGigE0/124', 'admin_status': 'up', 'speed': '100000', 'description': 'ARISTA04T1:Ethernet1/1'}")
         )
 
+    def test_minigraph_default_vxlan(self):
+        argument = '-m "' + self.sample_graph_deployment_id + '" -p "' + self.port_config + '" -v "VXLAN_TUNNEL"'
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            utils.to_dict("{'tunnel_v4': {'src_ip': '10.1.0.32'}}")
+        )
+
+    def test_minigraph_default_vnet(self):
+        argument = '-m "' + self.sample_graph_deployment_id + '" -p "' + self.port_config + '" -v "VNET"'
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            utils.to_dict("{'Vnet-default': {'vxlan_tunnel': 'tunnel_v4', 'scope': 'default', 'vni': 8000}}")
+        )
+
     def test_minigraph_bgp(self):
         argument = '-m "' + self.sample_graph_bgp_speaker + '" -p "' + self.port_config + '" -v "BGP_NEIGHBOR[\'10.0.0.59\']"'
         output = self.run_script(argument)


### PR DESCRIPTION


#### Why I did it

Cherry-pick #13409 

##### Work item tracking
- Microsoft ADO **24263117**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

