### PR TITLE
Migrate flush_unused_database from py-redis to sonic-swss-common

### DIFF
--- a/dockers/docker-database/flush_unused_database
+++ b/dockers/docker-database/flush_unused_database
@@ -32,7 +32,7 @@ for instname, v in instlists.items():
             if instsocket is not None:
                 # connect with Unix socket
                 connector =  swsscommon.DBConnector(dbid, instsocket, 0)
-            else
+            else:
                 # connect with TCP socket
                 port = swsscommon.SonicDBConfig.getDbPort(dbname);
                 connector =  swsscommon.DBConnector(dbid, insthost, port, 0)

--- a/dockers/docker-database/flush_unused_database
+++ b/dockers/docker-database/flush_unused_database
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 from swsscommon import swsscommon
-import redis
 import subprocess
 import time
 import syslog
@@ -26,7 +25,18 @@ for instname, v in instlists.items():
             continue
 
         try:
-            r = redis.Redis(host=insthost, unix_socket_path=instsocket, db=dbid)
-            r.flushdb()
-        except (redis.exceptions.ConnectionError):
+            # Migrate code from py-redis to swsscommon, original code:
+            #    r = redis.Redis(host=insthost, unix_socket_path=instsocket, db=dbid)
+            #    py-redis will use TCP connection when unix_socket_path is None
+            #    https://github.com/redis/redis-py/blob/d95d8a24ed2af3eae80b7b0f14cbccc9dbe86e96/redis/client.py#L1006
+            if instsocket is not None:
+                # connect with Unix socket
+                connector =  swsscommon.DBConnector(dbid, instsocket, 0)
+            else
+                # connect with TCP socket
+                port = swsscommon.SonicDBConfig.getDbPort(dbname);
+                connector =  swsscommon.DBConnector(dbid, insthost, port, 0)
+
+            connector.flushdb()
+        except RuntimeError:
            syslog.syslog(syslog.LOG_INFO,"flushdb:Redis Unix Socket connection error for path {} and dbaname {}".format(instsocket, dbname))

--- a/dockers/docker-database/flush_unused_database
+++ b/dockers/docker-database/flush_unused_database
@@ -31,11 +31,11 @@ for instname, v in instlists.items():
             #    https://github.com/redis/redis-py/blob/d95d8a24ed2af3eae80b7b0f14cbccc9dbe86e96/redis/client.py#L1006
             if instsocket is not None:
                 # connect with Unix socket
-                connector =  swsscommon.DBConnector(dbid, instsocket, 0)
+                connector = swsscommon.DBConnector(dbid, instsocket, 0)
             else:
                 # connect with TCP socket
                 port = swsscommon.SonicDBConfig.getDbPort(dbname);
-                connector =  swsscommon.DBConnector(dbid, insthost, port, 0)
+                connector = swsscommon.DBConnector(dbid, insthost, port, 0)
 
             connector.flushdb()
         except RuntimeError:


### PR DESCRIPTION
Migrate flush_unused_database from py-redis to sonic-swss-common

#### Why I did it
flush_unused_database using py-redis, but sonic-swss-common already support flushdb, so we need migrate to sonic-swss-common

##### Work item tracking
- Microsoft ADO **(number only)**: 24292565

#### How I did it
Migrate flush_unused_database from py-redis to sonic-swss-common

#### How to verify it
Pass all UT and E2E test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Migrate flush_unused_database from py-redis to sonic-swss-common


#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

