### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202205.2.2.5
+ref=202205.2.2.6


### PR DESCRIPTION


Why I did it

Release content for Cisco 8808 platform:
• Includes a short-term fix for gbsyncd return SAI failure after rekey (MIGSMSFT-216)
• Enabled MACSec Engine for either direction (MIGSMSFT-213)
• Fix for log analyzer error, "SDK_LOG|-E-HLD-0- check_reset_allowed: CRIT mac port SerDes 3/1/2-3: has credit mismatch"
• XR Migration support

How I did it

Update platform version to 202205.2.2.6
