### PR TITLE
Fixed config load_minigraph logic to load FEC "rs" in the case when speed is 100G and more

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1785,7 +1785,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         # Note: FECDisabled only be effective on 100G port right now
         if linkmetas.get(alias, {}).get('FECDisabled', '').lower() == 'true':
             port['fec'] = 'none'
-        elif not port.get('fec') and port.get('speed') == '100000':
+        elif not port.get('fec') and port.get('speed') in ['100000', '200000', '400000', '800000']:
             port['fec'] = 'rs'
 
         # If AutoNegotiation is available in the minigraph, we override any value we may have received from port_config.ini


### PR DESCRIPTION
#### Why I did it
Because after load minigraph with interfaces which have speed 100G and more by command:  "config load_minigraph -y" in the output of "show interfaces status" FEC was "N/A" for those interfaces. Now for interfaces with speeds 100G and more - FEC will be "rs" in "show interfaces status" output.

Before change:
```
    Ethernet8            8,9,10,11,12,13,14,15     200G   9100    N/A     etp2           trunk      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
```

After change:
```
    Ethernet8            8,9,10,11,12,13,14,15     200G   9100    rs     etp2           trunk      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
See code

#### How to verify it
Replaced original file in SONiC and did command "config load_minigraph -y" - after it checked "show interfaces status" output

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Tested branch (Please provide the tested image version)
- [x] SONiC.202205.269491-b8d44e6fb

#### Description for the changelog
Fixed config load_minigraph logic to load FEC "rs" in the case when speed is 100G and more.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

