### PR TITLE
[arp_update]: Fix IPv6 neighbor race condition

### DIFF
--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -101,22 +101,17 @@ while /bin/true; do
         # 1. for every FAILED or INCOMPLETE neighbor in the kernel, check if there is a corresponding zero MAC neighbor in APPL_DB
         # 2. if no zero MAC neighbor entry exists, flush the kernel neighbor entry
         #     - generates the command 'ip neigh flush <neighbor IPv6>' for all such neighbors
-        #ip_neigh_flush_cmd="echo \"$unresolved_kernel_neighbors\" | cut -d ' ' -f 1 | xargs -I{} bash -c \"if [[ -z \\\"\\\$(sonic-db-cli APPL_DB hget NEIGH_TABLE:$vlan:{} neigh)\\\" ]]; then echo 'ip neigh flush {};'; fi\""
         unsync_neighbors=$(echo "$unresolved_kernel_neighbors" | cut -d ' ' -f 1 | xargs -I{} bash -c "if [[ -z \"\$(sonic-db-cli APPL_DB hget NEIGH_TABLE:$vlan:{} neigh)\" ]]; then echo '{}'; fi")
-
         if [[ ! -z "$unsync_neighbors" ]]; then
             ip_neigh_flush_cmd="echo \"$unsync_neighbors\" | sed -e 's/^/ip neigh flush /' -e 's/$/;/'"
-            echo `eval "$ip_neigh_flush_cmd"`
             eval `eval "$ip_neigh_flush_cmd"`
         fi
 
         # generates the following command for each FAILED or INCOMPLETE IPv6 neighbor
         # timeout 0.2 ping <neighbor IPv6> -n -q -i 0 -c 1 -W 1 -I <VLAN name> >/dev/null
-
         if [[ ! -z "$unresolved_kernel_neighbors" ]]; then
             ping6_template="sed -e 's/^/timeout 0.2 ping /' -e 's/,/ -n -q -i 0 -c 1 -W 1 -I /' -e 's/$/ >\/dev\/null;/'"
             failed_ip6_neigh_cmd="echo \"$unresolved_kernel_neighbors\" | cut -d ' ' -f 1,3 --output-delimiter=',' | $ping6_template"
-            echo `eval "$failed_ip6_neigh_cmd"`
             eval `eval "$failed_ip6_neigh_cmd"`
         fi
 
@@ -127,20 +122,11 @@ while /bin/true; do
         # 1. unsyncronized neighbors that were flushed, then pinged
         # 2. existing FAILED neighbors which will be set to transient INCOMPLETE by the above ping
         wait_neighbors="$unsync_neighbors"$'\n'"$failed_kernel_neighbors"
-        echo "wait neighbors: $wait_neighbors"
         if [[ ! -z "$wait_neighbors" ]]; then
             trans_incomplete_check=$(echo "$wait_neighbors" | sed  -e 's/^/ip neigh show /' -e 's/$/ | grep -q 'INCOMPLETE' \&\&/')
             trans_incomplete_check=$(echo $trans_incomplete_check | sed -e 's/\&\&$//')
-            echo "$trans_incomplete_check"
             timeout 10 bash -c "while eval \"$trans_incomplete_check\"; do echo 'waiting'; sleep 1; done"
         fi
-
-        # some pings may create transient INCOMPLETE neighbor entries in the kernel
-        # wait for these to transition to FAILED befor setting them to permanently INCOMPLETE
-        # mcast_solicit=$(cat /proc/sys/net/ipv6/neigh/$vlan/mcast_solicit)
-        # retrans_time_ms=$(cat /proc/sys/net/ipv6/neigh/$vlan/retrans_time_ms)
-        # (( transition_delay=(((mcast_solicit * retrans_time_ms) + 999) / 1000) + 1 )) # equivalent to ceiling(mcast_solicit * retrans_time_ms / 1000) + 1
-        # sleep $transition_delay
 
         # manually set any remaining FAILED entries to permanently INCOMPLETE
         # once these entries are INCOMPLETE, any subsequent neighbor advertisement messages are able to resolve the entry
@@ -149,11 +135,9 @@ while /bin/true; do
         # generates the following command for each FAILED IPv6 neighbor
         # ip neigh replace <neighbor IPv6> dev <VLAN name> nud incomplete
         failed_kernel_neighbors=$(ip -6 neigh show | grep -v fe80 | grep $vlan | grep -E 'FAILED')
-
         if [[ ! -z "$failed_kernel_neighbors" ]]; then
             neigh_replace_template="sed -e 's/^/ip neigh replace /' -e 's/,/ dev /' -e 's/$/ nud incomplete;/'" 
             ip_neigh_replace_cmd="echo \"$failed_kernel_neighbors\" | cut -d ' ' -f 1,3 --output-delimiter=',' | $neigh_replace_template"
-            echo `eval "$ip_neigh_replace_cmd"`
             eval `eval "$ip_neigh_replace_cmd"`
         fi
       fi

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -105,6 +105,7 @@ while /bin/true; do
         if [[ ! -z "$unsync_neighbors" ]]; then
             ip_neigh_flush_cmd="echo \"$unsync_neighbors\" | sed -e 's/^/ip neigh flush /' -e 's/$/;/'"
             eval `eval "$ip_neigh_flush_cmd"`
+            sleep 2
         fi
 
         # generates the following command for each FAILED or INCOMPLETE IPv6 neighbor
@@ -113,19 +114,8 @@ while /bin/true; do
             ping6_template="sed -e 's/^/timeout 0.2 ping /' -e 's/,/ -n -q -i 0 -c 1 -W 1 -I /' -e 's/$/ >\/dev\/null;/'"
             failed_ip6_neigh_cmd="echo \"$unresolved_kernel_neighbors\" | cut -d ' ' -f 1,3 --output-delimiter=',' | $ping6_template"
             eval `eval "$failed_ip6_neigh_cmd"`
-        fi
-
-        # wait for any transient INCOMPLETE neighbors to transition to FAILED
-        # once these transition to FAILED, we can guarantee that the kernel has generated a netlink message for the neighbor
-        # and proceed setting it to permanent INCOMPLETE
-        # this is necessary for:
-        # 1. unsyncronized neighbors that were flushed, then pinged
-        # 2. existing FAILED neighbors which will be set to transient INCOMPLETE by the above ping
-        wait_neighbors="$unsync_neighbors"$'\n'"$failed_kernel_neighbors"
-        if [[ ! -z "$wait_neighbors" ]]; then
-            trans_incomplete_check=$(echo "$wait_neighbors" | sed  -e 's/^/ip neigh show /' -e 's/$/ | grep -q 'INCOMPLETE' \&\&/')
-            trans_incomplete_check=$(echo $trans_incomplete_check | sed -e 's/\&\&$//')
-            timeout 10 bash -c "while eval \"$trans_incomplete_check\"; do echo 'waiting'; sleep 1; done"
+            # allow some time for any transient INCOMPLETE neighbors to transition to FAILED
+            sleep 5
         fi
 
         # manually set any remaining FAILED entries to permanently INCOMPLETE

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -89,32 +89,73 @@ while /bin/true; do
       eval `eval $ip6cmd`
  
       if [[ $SUBTYPE == "dualtor" ]]; then
-        # manually set any remaining FAILED/INCOMPLETE entries to permanently INCOMPLETE
-        # this prevents any remaining INCOMPLETE entries from automatically transitioning to FAILED
-        # once these entries are incomplete, any subsequent neighbor advertisement messages
-        # are able to resolve the entry
+        # capture all current failed/incomplete IPv6 neighbors in the kernel to avoid situations where new neighbors are learned
+        # in the middle of the below sequence of commands
+        unresolved_kernel_neighbors=$(ip -6 neigh show | grep -v fe80 | grep $vlan | grep -E 'FAILED|INCOMPLETE')
+        failed_kernel_neighbors=$(echo "$unresolved_kernel_neighbors" | grep FAILED | cut -d ' ' -f 1)
 
-        # generates the following command for each failed or incomplete IPv6 neighbor
-        # ip neigh replace <neighbor IPv6> dev <VLAN name> nud incomplete
-        neigh_replace_template="sed -e 's/^/ip neigh replace /' -e 's/,/ dev /' -e 's/$/ nud incomplete;/'" 
-        ip_neigh_replace_cmd="ip -6 neigh show | grep -v fe80 | grep $vlan | grep -E 'FAILED|INCOMPLETE' | cut -d ' ' -f 1,3 --output-delimiter=',' | $neigh_replace_template"
-        eval `eval $ip_neigh_replace_cmd`
+        # it's possible for kernel neighbors to fall out of sync with the hardware
+        # this can result in failed neighbors entries that don't have corresponding zero MAC neighbor entries
+        # and therefore don't have tunnel routes installed in the hardware
+        # flush these neighbors from the kernel to force relearning and resync them to the hardware:
+        # 1. for every FAILED or INCOMPLETE neighbor in the kernel, check if there is a corresponding zero MAC neighbor in APPL_DB
+        # 2. if no zero MAC neighbor entry exists, flush the kernel neighbor entry
+        #     - generates the command 'ip neigh flush <neighbor IPv6>' for all such neighbors
+        #ip_neigh_flush_cmd="echo \"$unresolved_kernel_neighbors\" | cut -d ' ' -f 1 | xargs -I{} bash -c \"if [[ -z \\\"\\\$(sonic-db-cli APPL_DB hget NEIGH_TABLE:$vlan:{} neigh)\\\" ]]; then echo 'ip neigh flush {};'; fi\""
+        unsync_neighbors=$(echo "$unresolved_kernel_neighbors" | cut -d ' ' -f 1 | xargs -I{} bash -c "if [[ -z \"\$(sonic-db-cli APPL_DB hget NEIGH_TABLE:$vlan:{} neigh)\" ]]; then echo '{}'; fi")
 
-        # on dual ToR devices, try to resolve failed neighbor entries since
-        # these entries will have tunnel routes installed, preventing normal 
-        # neighbor resolution (SWSS PR #2137)
+        if [[ ! -z "$unsync_neighbors" ]]; then
+            ip_neigh_flush_cmd="echo \"$unsync_neighbors\" | sed -e 's/^/ip neigh flush /' -e 's/$/;/'"
+            echo `eval "$ip_neigh_flush_cmd"`
+            eval `eval "$ip_neigh_flush_cmd"`
+        fi
 
-        # since ndisc6 is a userland process, the above ndisc6 commands are 
-        # insufficient to update the kernel neighbor table for failed entries
-
-        # we don't need to do this for ipv4 neighbors since arping is able to
-        # update the kernel neighbor table
-
-        # generates the following command for each failed or incomplete IPv6 neighbor
+        # generates the following command for each FAILED or INCOMPLETE IPv6 neighbor
         # timeout 0.2 ping <neighbor IPv6> -n -q -i 0 -c 1 -W 1 -I <VLAN name> >/dev/null
-        ping6_template="sed -e 's/^/timeout 0.2 ping /' -e 's/,/ -n -q -i 0 -c 1 -W 1 -I /' -e 's/$/ >\/dev\/null;/'"
-        failed_ip6_neigh_cmd="ip -6 neigh show | grep -v fe80 | grep $vlan | grep -E 'FAILED|INCOMPLETE' | cut -d ' ' -f 1,3 --output-delimiter=',' | $ping6_template"
-        eval `eval $failed_ip6_neigh_cmd`
+
+        if [[ ! -z "$unresolved_kernel_neighbors" ]]; then
+            ping6_template="sed -e 's/^/timeout 0.2 ping /' -e 's/,/ -n -q -i 0 -c 1 -W 1 -I /' -e 's/$/ >\/dev\/null;/'"
+            failed_ip6_neigh_cmd="echo \"$unresolved_kernel_neighbors\" | cut -d ' ' -f 1,3 --output-delimiter=',' | $ping6_template"
+            echo `eval "$failed_ip6_neigh_cmd"`
+            eval `eval "$failed_ip6_neigh_cmd"`
+        fi
+
+        # wait for any transient INCOMPLETE neighbors to transition to FAILED
+        # once these transition to FAILED, we can guarantee that the kernel has generated a netlink message for the neighbor
+        # and proceed setting it to permanent INCOMPLETE
+        # this is necessary for:
+        # 1. unsyncronized neighbors that were flushed, then pinged
+        # 2. existing FAILED neighbors which will be set to transient INCOMPLETE by the above ping
+        wait_neighbors="$unsync_neighbors"$'\n'"$failed_kernel_neighbors"
+        echo "wait neighbors: $wait_neighbors"
+        if [[ ! -z "$wait_neighbors" ]]; then
+            trans_incomplete_check=$(echo "$wait_neighbors" | sed  -e 's/^/ip neigh show /' -e 's/$/ | grep -q 'INCOMPLETE' \&\&/')
+            trans_incomplete_check=$(echo $trans_incomplete_check | sed -e 's/\&\&$//')
+            echo "$trans_incomplete_check"
+            timeout 10 bash -c "while eval \"$trans_incomplete_check\"; do echo 'waiting'; sleep 1; done"
+        fi
+
+        # some pings may create transient INCOMPLETE neighbor entries in the kernel
+        # wait for these to transition to FAILED befor setting them to permanently INCOMPLETE
+        # mcast_solicit=$(cat /proc/sys/net/ipv6/neigh/$vlan/mcast_solicit)
+        # retrans_time_ms=$(cat /proc/sys/net/ipv6/neigh/$vlan/retrans_time_ms)
+        # (( transition_delay=(((mcast_solicit * retrans_time_ms) + 999) / 1000) + 1 )) # equivalent to ceiling(mcast_solicit * retrans_time_ms / 1000) + 1
+        # sleep $transition_delay
+
+        # manually set any remaining FAILED entries to permanently INCOMPLETE
+        # once these entries are INCOMPLETE, any subsequent neighbor advertisement messages are able to resolve the entry
+        # ignore INCOMPLETE neighbors since if they are transiently incomplete (i.e. new kernel neighbors that we are attempting to resolve for the first time),
+        # setting them to permanently incomplete here means the kernel will never generate a netlink message for that neighbor
+        # generates the following command for each FAILED IPv6 neighbor
+        # ip neigh replace <neighbor IPv6> dev <VLAN name> nud incomplete
+        failed_kernel_neighbors=$(ip -6 neigh show | grep -v fe80 | grep $vlan | grep -E 'FAILED')
+
+        if [[ ! -z "$failed_kernel_neighbors" ]]; then
+            neigh_replace_template="sed -e 's/^/ip neigh replace /' -e 's/,/ dev /' -e 's/$/ nud incomplete;/'" 
+            ip_neigh_replace_cmd="echo \"$failed_kernel_neighbors\" | cut -d ' ' -f 1,3 --output-delimiter=',' | $neigh_replace_template"
+            echo `eval "$ip_neigh_replace_cmd"`
+            eval `eval "$ip_neigh_replace_cmd"`
+        fi
       fi
   done
   


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

A race condition exists which makes it possible for the kernel to resolve a trapped packet's destination IP at the same time that arp_update is running the `ip neigh replace` command for that neighbor IP. When this occurs, the kernel's neighbor entry for this IP is in the INCOMPLETE state, and the `ip neigh replace` command sets it to permanently incomplete. This means no netlink message will be generated for this neighbor, since the kernel doesn't generate netlink messages for INCOMPLETE neighbors (it would only generate a message once the neighbor transitions to FAILED, which doesn't happen due to the `ip neigh replace` command). As a result, no APPL_DB neighbor table entry is ever created and no tunnel route for the IP is ever installed, leading to dropped traffic.

##### Work item tracking
- Microsoft ADO **(number only)**: 24152065

#### How I did it

- Check each FAILED or INCOMPLETE neighbor to see if a corresponding APPL_DB neighbor table entry exists. If no entry exists, flush the neighbor from the kernel
- After `ping`ing the neighbor IPs, wait for any neighbor entries which might be transiently INCOMPLETE to transition to FAILED (so that the subsequent `ip neigh replace` command can set them to permanently incomplete)
- Exclude any INCOMPLETE neighbors from the `ip neigh replace` command in case they are new neighbors for which no netlink message has been generated yet

#### How to verify it
- Run `arp_update` with no FAILED or INCOMPLETE neighbor entries, verify no changes are made to the kernel neighbor table
- Run `arp_update` with a FAILED neighbor entry with corresponding APPL_DB entry, verify the neighbor IP is pinged and set to INCOMPLETE permanently
- Run `arp_update` with an INCOMPLETE neighbor entry with corresponding APPL_DB entry, verify the neighbor IP is pinged and set to INCOMPLETE permanently
- Run `arp_update` with a FAILED neighbor entry without corresponding APPL_DB entry, verify the neighbor is flushed, pinged, and set to INCOMPLETE permanently
- Run `arp_update` with an INCOMPLETE neighbor entry without corresponding APPL_DB entry, verify the neighbor is flushed, pinged, and set to INCOMPLETE permanently
- Run `arp_update` with various combinations of above scenarios - verify that only neighbors missing APPL_DB entries are flushed from the kernel; verify that all FAILED/INCOMPLETE neighbors are pinged and set to permanently INCOMPLETE

- 
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

