### PR TITLE
[YANG][SNMP]: Add YANG model for SNMP_AGENT_ADDRESS_CONFIG table

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
@@ -117,6 +117,9 @@
     "SNMP_AGENT_ADDRESS_CONFIG": {
         "desc": "Load SNMP agent address config"
     },
+    "SNMP_AGENT_ADDRESS_CONFIG_IPV6": {
+        "desc": "Load SNMP agent address config"
+    },
     "SNMP_AGENT_ADDRESS_CONFIG_MGMT_VRF": {
         "desc": "Load SNMP agent address config with mgmt vrf"
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
@@ -113,5 +113,34 @@
     "SNMP_USER_PRIV_LONG_ENCRYPT_PASS_NEG_TEST": {
         "desc": "Load SNMP user with user type Priv with long encryption password",
         "eStrKey": "Range"
+    },
+    "SNMP_AGENT_ADDRESS_CONFIG": {
+        "desc": "Load SNMP agent address config"
+    },
+    "SNMP_AGENT_ADDRESS_CONFIG_MGMT_VRF": {
+        "desc": "Load SNMP agent address config with mgmt vrf"
+    },
+    "SNMP_AGENT_ADDRESS_CONFIG_NO_VRF": {
+        "desc": "Load SNMP agent address config with no vrf",
+	"eStr": ["Missing required element"]
+    },
+    "SNMP_AGENT_ADDRESS_CONFIG_INVALID_PORT": {
+        "desc": "Load SNMP agent address config with invalid port",
+        "eStrKey": "InvalidValue"
+    },
+    "SNMP_AGENT_ADDRESS_CONFIG_DUPLICATE_IP_PORT": {
+        "desc": "Load two SNMP agent address config same ip and port",
+	"eStr": ["Unique data leaf(s)"]
+    },
+    "SNMP_AGENT_ADDRESS_CONFIG_INVALID_IPV4_ADDRESS": {
+        "desc": "Load SNMP agent address config with invalid IPv4 address",
+        "eStrKey": "InvalidValue",
+        "eStr": ["ip"]
+    },
+    "SNMP_AGENT_ADDRESS_CONFIG_INVALID_IPV6_ADDRESS": {
+        "desc": "Load SNMP agent address config with invalid IPV6 address",
+        "eStrKey": "InvalidValue",
+        "eStr": ["ip"]
     }
 }
+

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
@@ -120,6 +120,9 @@
     "SNMP_AGENT_ADDRESS_CONFIG_IPV6": {
         "desc": "Load SNMP agent address config"
     },
+    "SNMP_AGENT_ADDRESS_CONFIG_EMPTY_PORT_NUMBER": {
+        "desc": "Load SNMP agent address config with empty port number"
+    },
     "SNMP_AGENT_ADDRESS_CONFIG_MGMT_VRF": {
         "desc": "Load SNMP agent address config with mgmt vrf"
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
@@ -529,6 +529,19 @@
             }
          }
     },
+    "SNMP_AGENT_ADDRESS_CONFIG_EMPTY_PORT_NUMBER": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
+                "SNMP_AGENT_ADDRESS_LIST": [
+                    {
+                       "agent_ip": "10.0.0.1",
+                       "port": "",
+                       "vrf_name": "mgmt"
+                    }
+                ]
+            }
+         }
+    },
     "SNMP_AGENT_ADDRESS_CONFIG_MGMT_VRF": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
@@ -502,5 +502,100 @@
                 ]
             }
          }
+    },
+    "SNMP_AGENT_ADDRESS_CONFIG": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
+                "SNMP_AGENT_ADDRESS_LIST": [
+                    {
+                       "agent_ip": "10.0.0.1",
+                       "port": "161",
+                       "vrf_name": ""
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_AGENT_ADDRESS_CONFIG_MGMT_VRF": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
+                "SNMP_AGENT_ADDRESS_LIST": [
+                    {
+                       "agent_ip": "10.0.0.1",
+                       "port": "161",
+                       "vrf_name": "mgmt"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_AGENT_ADDRESS_CONFIG_NO_VRF": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
+                "SNMP_AGENT_ADDRESS_LIST": [
+                    {
+                       "agent_ip": "10.0.0.1",
+                       "port": "161"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_AGENT_ADDRESS_CONFIG_INVALID_PORT": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
+                "SNMP_AGENT_ADDRESS_LIST": [
+                    {
+                       "agent_ip": "10.0.0.1",
+		       "port": "65536",
+                       "vrf_name": "mgmt"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_AGENT_ADDRESS_CONFIG_DUPLICATE_IP_PORT": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
+                "SNMP_AGENT_ADDRESS_LIST": [
+                    {
+                       "agent_ip": "10.0.0.1",
+                       "port": "161",
+                       "vrf_name": "mgmt"
+                    },
+                    {
+                       "agent_ip": "10.0.0.1",
+                       "port": "161",
+                       "vrf_name": ""
+                    } 
+                ]
+            }
+         }
+    },
+    "SNMP_AGENT_ADDRESS_CONFIG_INVALID_IPV4_ADDRESS": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
+                "SNMP_AGENT_ADDRESS_LIST": [
+                    {
+                       "agent_ip": "340.1.1.10",
+                       "port": "161",
+                       "vrf_name": ""
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_AGENT_ADDRESS_CONFIG_INVALID_IPV6_ADDRESS": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
+                "SNMP_AGENT_ADDRESS_LIST": [
+                    {
+                       "agent_ip": "2001:aa:aa:aa",
+                       "port": "161",
+                       "vrf_name": ""
+                    }
+                ]
+            }
+         }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
@@ -516,6 +516,19 @@
             }
          }
     },
+    "SNMP_AGENT_ADDRESS_CONFIG_IPV6": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
+                "SNMP_AGENT_ADDRESS_LIST": [
+                    {
+                       "agent_ip": "fd00::1",
+                       "port": "161",
+                       "vrf_name": ""
+                    }
+                ]
+            }
+         }
+    },
     "SNMP_AGENT_ADDRESS_CONFIG_MGMT_VRF": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -3,6 +3,12 @@ module sonic-snmp {
   prefix ssnmp;
   yang-version 1.1;
 
+  import ietf-inet-types {
+      prefix inet;
+  }
+  import sonic-vrf {
+    prefix vrf;
+  }
 
   organization
     "SONiC";
@@ -153,6 +159,36 @@ module sonic-snmp {
                 (current()/../SNMP_USER_TYPE = 'Priv' and string-length(current()) >= 8)";
           description
             "Encryption password for the user.";
+        }
+      }
+    }
+    container SNMP_AGENT_ADDRESS_CONFIG {
+      list SNMP_AGENT_ADDRESS_LIST {
+        key "agent_ip port vrf_name";
+        unique "agent_ip port";
+        description "List of SNMP agent listening IP Addresses and ports.";
+
+        leaf agent_ip {
+          type inet:ip-address;
+          description "SNMP agent listening IP";
+        }
+        leaf port {
+          type inet:port-number;
+          description "SNMP agent listening port number";
+        }
+        leaf vrf_name {
+          type union {
+            type string {
+              pattern '';
+            }
+            type string {
+              pattern 'mgmt';
+            }
+            type string {
+              pattern "Vrf[a-zA-Z0-9_-]+";
+            }
+          }
+          description "VRF name";
         }
       }
     }

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -179,6 +179,7 @@ module sonic-snmp {
             }
             type inet:port-number;
           }
+          default "";
           description "SNMP agent listening port number";
         }
         leaf vrf_name {
@@ -193,6 +194,7 @@ module sonic-snmp {
               pattern "Vrf[a-zA-Z0-9_-]+";
             }
           }
+          default "";
           description "VRF name";
         }
       }

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -173,7 +173,12 @@ module sonic-snmp {
           description "SNMP agent listening IP";
         }
         leaf port {
-          type inet:port-number;
+          type union {
+            type string {
+              pattern '';
+            }
+            type inet:port-number;
+          }
           description "SNMP agent listening port number";
         }
         leaf vrf_name {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
https://github.com/sonic-net/sonic-utilities/pull/472 Added SNMP_AGENT_ADDRESS_CONFIG table in config db.
This PR is to add corresponding YANG model for that table.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added YANG modesl for SNMP_AGENT_ADDRESS_CONFIG.

keys: agent_ip, port number, vrf.
CLI implementaion checks if agent_ip, port number already exists in CONFIG_DB table, if it does, then new entry is not added.
So added another condition to ensure combination of agent_ip and port is unique.
Below is an example of how data looks like in DB:
```
127.0.0.1:6379[4]> HGETALL  "SNMP_AGENT_ADDRESS_CONFIG|10.1.1.1|161|foo"
1) "NULL"
2) "NULL"
127.0.0.1:6379[4]> HGETALL "SNMP_AGENT_ADDRESS_CONFIG|10.1.0.32|161|"
1) "NULL"
2) "NULL"
```
#### How to verify it
Added unit-test for various combinations and ensures that it passes.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

