### PR TITLE
[Nokia-IXR7250E][Devicedata] update the device data for Nokia IXR7250E platform

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/jr2cp-nokia-18x100g-4x25g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/jr2cp-nokia-18x100g-4x25g-config.bcm
@@ -2093,3 +2093,4 @@ xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
 cmic_dma_abort_in_cold_boot=0
 sai_pfc_dlr_init_capability=0
 sai_disable_srcmacqedstmac_ctrl=1
+trunk_group_max_members=16

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/jr2cp-nokia-18x100g-4x25g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/jr2cp-nokia-18x100g-4x25g-config.bcm
@@ -2094,3 +2094,4 @@ xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
 cmic_dma_abort_in_cold_boot=0
 sai_pfc_dlr_init_capability=0
 sai_disable_srcmacqedstmac_ctrl=1
+trunk_group_max_members=16

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
@@ -2095,3 +2095,4 @@ xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
 cmic_dma_abort_in_cold_boot=0
 sai_pfc_dlr_init_capability=0
 sai_disable_srcmacqedstmac_ctrl=1
+trunk_group_max_members=16

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
@@ -2097,3 +2097,4 @@ xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
 cmic_dma_abort_in_cold_boot=0
 sai_pfc_dlr_init_capability=0
 sai_disable_srcmacqedstmac_ctrl=1
+trunk_group_max_members=16

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/chassisdb.conf
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/chassisdb.conf
@@ -1,4 +1,4 @@
 start_chassis_db=1
 chassis_db_address=10.6.0.100
 lag_id_start=1
-lag_id_end=512
+lag_id_end=1024


### PR DESCRIPTION
#### Why I did it
(cherry picked from commit 478ba478f5aaea347d36bc22021e0c5ab7e7e39b)
Update the device data files to support 1024 LAGs for Nokia IXR7250E platform

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

