### PR TITLE
Add function to retrieve docker0 ipv4 and ipv6 addresses

### DIFF
--- a/src/sonic-py-common/setup.py
+++ b/src/sonic-py-common/setup.py
@@ -10,6 +10,7 @@ sonic_dependencies = ['redis-dump-load']
 dependencies = [
     'natsort==6.2.1', # 6.2.1 is the last version which supports Python 2
     'pyyaml',
+    'netifaces>=0.10.7',
 ]
 
 dependencies += sonic_dependencies

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import subprocess
+import netifaces
 
 from natsort import natsorted
 from swsscommon import swsscommon
@@ -484,3 +485,26 @@ def get_asic_presence_list():
                     # asic is asid id: asic0, asic1.... asicN. Get the numeric value.
                     asics_list.append(int(get_asic_id_from_name(asic)))
     return asics_list
+
+def get_docker0_ip():
+    """
+    @summary: This function will return docker0 ipv4 and ipv6 addresses
+              for multi_asic platform.
+              This function will return None for single asic platform.
+    @return: tuple containing docker0 ipv4 and ipv6 address
+    """
+    docker0_v4 = None
+    docker0_v6 = None
+
+    # return (None, None) for single asic platform
+    if not is_multi_asic():
+        return (docker0_v4, docker0_v6)
+
+    interfaces = netifaces.interfaces()
+    if "docker0" in interfaces:
+       addresses = netifaces.ifaddresses("docker0")
+       if netifaces.AF_INET in addresses:
+           docker0_v4 = addresses[netifaces.AF_INET][0]['addr']
+       if netifaces.AF_INET6 in addresses:
+           docker0_v6 = addresses[netifaces.AF_INET6][0]['addr']
+    return (docker0_v4, docker0_v6)

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -486,7 +486,7 @@ def get_asic_presence_list():
                     asics_list.append(int(get_asic_id_from_name(asic)))
     return asics_list
 
-def get_docker0_ip():
+def get_docker0_ips():
     """
     @summary: This function will return docker0 ipv4 and ipv6 addresses
               for multi_asic platform.


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
https://github.com/sonic-net/sonic-buildimage/pull/15487 this PR modifies snmpd to listen on specific IPs.
By default, snmpd will listen on management and loopback0 ipv4 and ipv6 addresses for single asic platform.
snmpd will listen will listen on management and docker0 ip address for multi asic platforn.
This PR is to add function to retrieve docker0 ip addresses for multi-asic platform, which could be used generically.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add a new function get_docker0_ip() in sonic_py_common to get docker0 ipv4 and ipv6 address on multi-asic platform.

#### How to verify it
on multi-asic platform
```
>>> from sonic_py_common.multi_asic import get_docker0_ip
>>> get_docker0_ip()
('240.127.1.1', 'fd00::1')
>>> 
```
on single-asic platform
```
>>> from sonic_py_common.multi_asic import get_docker0_ip
>>> get_docker0_ip()
(None, None)
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

