### PR TITLE
[202205][yang] add Yang model for MUX_LINKMGR|LINK_PROBER (#15384)

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1150,8 +1150,6 @@ The **MUX_CABLE** table is used for dualtor interface configuration. The `cable_
 }
 ```
 
-<<<<<<< HEAD
-=======
 ### MUX_LINKMGR
 The **MUX_LINKMGR** table is used for dualtor device configuration.
 ```
@@ -1171,33 +1169,6 @@ The **MUX_LINKMGR** table is used for dualtor device configuration.
 }
 ```
 
-### NEIGH
-
-The **NEIGH** table is used to keep track of resolved and static neighbors.
-
-Resolve case:
-```
-{
-    "NEIGH": {
-        "Vlan100|100.1.1.3": {
-            "family": "IPv4"
-        }
-    }
-}
-```
-Static Nbr:
-```
-{
-    "NEIGH": {
-        "Vlan100|100.1.1.5": {
-            "neigh": "00:02:02:03:04:05",
-            "family": "IPv4"
-        }
-    }
-}
-```
-
->>>>>>> 6ba5b84d9... [yang] add Yang model for `MUX_LINKMGR|LINK_PROBER` (#15384)
 ### NTP Global Configuration
 
 These configuration options are used to modify the way that

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -38,6 +38,7 @@ Table of Contents
          * [Management VRF](#management-vrf)  
          * [MAP_PFC_PRIORITY_TO_QUEUE](#map_pfc_priority_to_queue)  
          * [MUX_CABLE](#muxcable)  
+         * [MUX_LINKMGR](#mux_linkmgr)
          * [NTP Global Configuration](#ntp-global-configuration)  
          * [NTP and SYSLOG servers](#ntp-and-syslog-servers)  
          * [Peer Switch](#peer-switch)
@@ -1149,6 +1150,54 @@ The **MUX_CABLE** table is used for dualtor interface configuration. The `cable_
 }
 ```
 
+<<<<<<< HEAD
+=======
+### MUX_LINKMGR
+The **MUX_LINKMGR** table is used for dualtor device configuration.
+```
+{
+    "MUX_LINKMGR": {
+        "LINK_PROBER": {
+            "interval_v4": "100",
+            "interval_v6": "1000",
+            "positive_signal_count": "1",
+            "negative_signal_count": "3",
+            "suspend_timer": "500",
+            "use_well_known_mac": "enabled",
+            "src_mac": "ToRMac",
+            "interval_pck_loss_count_update": "3"
+        }
+    }
+}
+```
+
+### NEIGH
+
+The **NEIGH** table is used to keep track of resolved and static neighbors.
+
+Resolve case:
+```
+{
+    "NEIGH": {
+        "Vlan100|100.1.1.3": {
+            "family": "IPv4"
+        }
+    }
+}
+```
+Static Nbr:
+```
+{
+    "NEIGH": {
+        "Vlan100|100.1.1.5": {
+            "neigh": "00:02:02:03:04:05",
+            "family": "IPv4"
+        }
+    }
+}
+```
+
+>>>>>>> 6ba5b84d9... [yang] add Yang model for `MUX_LINKMGR|LINK_PROBER` (#15384)
 ### NTP Global Configuration
 
 These configuration options are used to modify the way that

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -118,6 +118,7 @@ setup(
                          './yang-models/sonic-mgmt_vrf.yang',
                          './yang-models/sonic-mirror-session.yang',
                          './yang-models/sonic-mux-cable.yang',
+                         './yang-models/sonic-mux-linkmgr.yang',
                          './yang-models/sonic-ntp.yang',
                          './yang-models/sonic-nat.yang',
                          './yang-models/sonic-nvgre-tunnel.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1827,6 +1827,19 @@
             }
         },
 
+        "MUX_LINKMGR": {
+            "LINK_PROBER": {
+                "interval_v4": "100",
+                "interval_v6": "1000",
+                "positive_signal_count": "1",
+                "negative_signal_count": "3",
+                "suspend_timer": "500",
+                "use_well_known_mac": "enabled",
+                "src_mac": "ToRMac",
+                "interval_pck_loss_count_update": "3"
+            }
+        },
+
 
         "POLICER": {
             "everflow_static_policer": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mux-linkmgr.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mux-linkmgr.json
@@ -1,0 +1,8 @@
+{
+    "MUX_LINKMGR_LINK_PROBER_INTERVAL_CHANGE": {
+        "desc": "Consume ICMP heartbeat interval and timeout config changes. "
+    },
+    "MUX_LINKMGR_LINK_PROBER_CHANGE_MAC_ADDR": {
+        "desc": "Use well-known mac and vlan mac as dst/src in linkmgrd link prober. "
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mux-linkmgr.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mux-linkmgr.json
@@ -1,0 +1,26 @@
+{
+    "MUX_LINKMGR_LINK_PROBER_INTERVAL_CHANGE": {
+        "sonic-mux-linkmgr:sonic-mux-linkmgr": {
+            "sonic-mux-linkmgr:MUX_LINKMGR": {
+                "sonic-mux-linkmgr:LINK_PROBER": 
+                    {
+                        "interval_v4": "1000",
+                        "interval_v6": "10000",
+                        "positive_signal_count": 3,
+                        "negative_signal_count": 9
+                    }
+            }
+        }
+    },
+    "MUX_LINKMGR_LINK_PROBER_CHANGE_MAC_ADDR": {
+        "sonic-mux-linkmgr:sonic-mux-linkmgr": {
+            "sonic-mux-linkmgr:MUX_LINKMGR": {
+                "sonic-mux-linkmgr:LINK_PROBER": 
+                    {
+                        "use_well_known_mac": "enabled",
+                        "src_mac": "VlanMac"
+                    }
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-mux-linkmgr.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mux-linkmgr.yang
@@ -1,0 +1,88 @@
+module sonic-mux-linkmgr {
+    namespace "http://github.com/sonic-net/sonic-mux-linkmgr";
+    prefix mux_linkmgr;
+    yang-version 1.1;
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "SONiC DualToR Linkmgrd configuration data";
+
+    revision 2023-06-07 {
+        description
+            "Initial revision";
+    }
+
+    container sonic-mux-linkmgr {
+
+        container MUX_LINKMGR {
+
+            container LINK_PROBER {
+
+                leaf interval_v4 {
+                    type uint32;
+                    default 100;
+                    units milliseconds;
+
+                    description "IPv4 ICMP heartbeat interval. ";
+                }
+
+                leaf interval_v6 {
+                    type uint32;
+                    default 1000;
+                    units milliseconds;
+
+                    description "IPv6 ICMP heartbeat interval. ";
+                }
+
+                leaf positive_signal_count {
+                    type uint32;
+                    default 1;
+
+                    description "Linkmgrd positive signal count. ";
+                }
+
+                leaf negative_signal_count {
+                    type uint32;
+                    default 3;
+
+                    description "Linkmgrd negative signal count. ";
+                }
+
+                leaf suspend_timer {
+                    type uint32;
+
+                    description "ICMP heartbeat suspending timer, currently not in use. ";
+                }
+
+                leaf use_well_known_mac {
+                    type enumeration {
+                        enum enabled;
+                        enum disabled;
+                    }
+
+                    description "ICMP heartbeat use well known mac as dst mac or not. ";
+                }
+
+                leaf src_mac {
+                    type enumeration {
+                        enum ToRMac;
+                        enum VlanMac;
+                    }
+
+                    description "ICMP heartbeat use what mac as src mac. ";
+                }
+
+                leaf interval_pck_loss_count_update {
+                    type uint32;
+                    
+                    description "The frequency of streaming ICMP heartbeat loss data to telemetry. ";
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Manually submitting PR for cherry-pick conflict.

sign-off: Jing Zhang zhangjing@microsoft.com 

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**: 24196914

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

