### PR TITLE
Multiprocessing Manager resources (Queue) to be freed up during task stop (CherryPick PR#15212 to 202205)

### DIFF
--- a/src/system-health/health_checker/sysmonitor.py
+++ b/src/system-health/health_checker/sysmonitor.py
@@ -11,6 +11,7 @@ from sonic_py_common.logger import Logger
 from . import utils
 from sonic_py_common.task_base import ProcessTaskBase
 from .config import Config
+import signal
 
 SYSLOG_IDENTIFIER = "system#monitor"
 REDIS_TIMEOUT_MS = 0
@@ -117,6 +118,8 @@ class Sysmonitor(ProcessTaskBase):
         self.state_db = None
         self.config_db = None
         self.config = Config()
+        self.mpmgr = multiprocessing.Manager()
+        self.myQ = self.mpmgr.Queue()
 
     #Sets system ready status to state db
     def post_system_status(self, state):
@@ -422,13 +425,11 @@ class Sysmonitor(ProcessTaskBase):
             self.state_db = swsscommon.SonicV2Connector(use_unix_socket_path=True)
             self.state_db.connect(self.state_db.STATE_DB)
         
-        mpmgr = multiprocessing.Manager()
-        myQ = mpmgr.Queue()
         try:
-            monitor_system_bus = MonitorSystemBusTask(myQ)
+            monitor_system_bus = MonitorSystemBusTask(self.myQ)
             monitor_system_bus.task_run()
             
-            monitor_statedb_table = MonitorStateDbTask(myQ)
+            monitor_statedb_table = MonitorStateDbTask(self.myQ)
             monitor_statedb_table.task_run()
             
         except Exception as e:
@@ -442,7 +443,7 @@ class Sysmonitor(ProcessTaskBase):
         # Queue to receive the STATEDB and Systemd state change event
         while not self.task_stopping_event.is_set():
             try:
-                msg = myQ.get(timeout=QUEUE_TIMEOUT)
+                msg = self.myQ.get(timeout=QUEUE_TIMEOUT)
                 event = msg["unit"]
                 event_src = msg["evt_src"]
                 event_time = msg["time"]
@@ -466,5 +467,24 @@ class Sysmonitor(ProcessTaskBase):
             return
         self.system_service()
 
+    def task_stop(self):
+        # Signal the process to stop
+        self.task_stopping_event.set()
+        #Clear the resources of mpmgr- Queue
+        self.mpmgr.shutdown()
+
+        # Wait for the process to exit
+        self._task_process.join(self._stop_timeout_secs)
+
+        # If the process didn't exit, attempt to kill it
+        if self._task_process.is_alive():
+            logger.log_notice("Attempting to kill sysmon main process with pid {}".format(self._task_process.pid))
+            os.kill(self._task_process.pid, signal.SIGKILL)
+
+        if self._task_process.is_alive():
+            logger.log_error("Sysmon main process with pid {} could not be killed".format(self._task_process.pid))
+            return False
+
+        return True
 
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix for issue https://github.com/sonic-net/sonic-buildimage/issues/14964

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Free up Multiprocessing Manager resource at task stop request
[self.mpmgr.shutdown() in task_stop]

#### How to verify it
time systemctl stop system-health.service

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

