### PR TITLE
[Mellanox] Use Debian reboot in Nvidia platform reboot when it is invoked from kdump capture boot

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
@@ -28,6 +28,17 @@ function SafePwrCycle() {
 
 ParseArguments "$@"
 
+# Reboot immediately if the kdump capture kernel is running
+VMCORE_FILE=/proc/vmcore
+if [ -e $VMCORE_FILE -a -s $VMCORE_FILE ]; then
+    sync ; sync
+    umount -fa > /dev/null 2&>1
+
+    # Run Debian reboot because the platform reboot isn't available
+    /sbin/reboot
+fi
+
+
 ${FW_UPGRADE_SCRIPT} --upgrade --verbose
 EXIT_CODE="$?"
 if [[ "${EXIT_CODE}" != "${EXIT_SUCCESS}" ]]; then

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
@@ -30,7 +30,7 @@ ParseArguments "$@"
 
 # Reboot immediately if the kdump capture kernel is running
 VMCORE_FILE=/proc/vmcore
-if [ $VMCORE_FILE -a -s $VMCORE_FILE ]; then
+if [ -s $VMCORE_FILE ]; then
     sync; sync
     umount -fa > /dev/null 2>&1
 

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
@@ -21,8 +21,8 @@ function ParseArguments() {
 }
 
 function SafePwrCycle() {
-    sync ; sync
-    umount -fa > /dev/null 2&>1
+    sync; sync
+    umount -fa > /dev/null 2>&1
     echo 1 > $SYSFS_PWR_CYCLE
 }
 
@@ -30,9 +30,9 @@ ParseArguments "$@"
 
 # Reboot immediately if the kdump capture kernel is running
 VMCORE_FILE=/proc/vmcore
-if [ -e $VMCORE_FILE -a -s $VMCORE_FILE ]; then
-    sync ; sync
-    umount -fa > /dev/null 2&>1
+if [ $VMCORE_FILE -a -s $VMCORE_FILE ]; then
+    sync; sync
+    umount -fa > /dev/null 2>&1
 
     # Run Debian reboot because the platform reboot isn't available
     /sbin/reboot


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When a kernel crash occurs, the system will reboot to the kdump capture kernel if kdump is enabled (`config kdump enable`). In the kdump capture boot, it only stores the crash information, and then reboot the system to a normal boot.
In this boot, no SONiC service is started but it invokes `reboot` which is actually the SONiC reboot that depends on SONiC services. There is a logic to skip all SONiC stuff and invoke platform reboot in SONiC reboot to avoid issues.
However, on Nvidia platforms, the platform reboot still depends on SONiC services, which can cause issues.
So, the Debian reboot is called directly in platform reboot if it is invoked from the kdump capture boot.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Manual test

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

