### PR TITLE
Revert "[gearbox] use credo sai v0.9.0"

### DIFF
--- a/platform/components/docker-gbsyncd-credo.mk
+++ b/platform/components/docker-gbsyncd-credo.mk
@@ -1,9 +1,9 @@
 DOCKER_GBSYNCD_PLATFORM_CODE = credo
 
-LIBSAI_CREDO = libsaicredo_0.9.0_amd64.deb
-$(LIBSAI_CREDO)_URL = "https://sonicstorage.blob.core.windows.net/packages/credosai/libsaicredo_0.9.0_amd64.deb?sv=2021-04-10&st=2023-03-08T02%3A10%3A11Z&se=2100-03-09T02%3A10%3A00Z&sr=b&sp=r&sig=mxOWttgAuOXVjvDI3zF5KHcrTHBgg6mv%2FOpTOxlCoVM%3D"
-LIBSAI_CREDO_OWL = libsaicredo-owl_0.9.0_amd64.deb
-$(LIBSAI_CREDO_OWL)_URL = "https://sonicstorage.blob.core.windows.net/packages/credosai/libsaicredo-owl_0.9.0_amd64.deb?sv=2021-04-10&st=2023-03-08T02%3A12%3A02Z&se=2100-03-09T02%3A12%3A00Z&sr=b&sp=r&sig=n4mqMVnZxC3u14EWRehfl6bqqUAi1VP1uUdHGg3%2B7H4%3D"
+LIBSAI_CREDO = libsaicredo_0.8.2_amd64.deb
+$(LIBSAI_CREDO)_URL = "https://sonicstorage.blob.core.windows.net/packages/credosai/libsaicredo_0.8.2_amd64.deb?sv=2021-04-10&st=2023-01-31T04%3A24%3A23Z&se=2100-01-31T04%3A24%3A00Z&sr=b&sp=r&sig=RZPbmaIetvDRtwifrVT4s%2FaQxB%2FBTOyCqXtMtoNRjmY%3D"
+LIBSAI_CREDO_OWL = libsaicredo-owl_0.8.2_amd64.deb
+$(LIBSAI_CREDO_OWL)_URL = "https://sonicstorage.blob.core.windows.net/packages/credosai/libsaicredo-owl_0.8.2_amd64.deb?sv=2021-04-10&st=2023-01-31T04%3A25%3A43Z&se=2100-01-31T04%3A25%3A00Z&sr=b&sp=r&sig=%2BdSFujwy0gY%2FiH50Ffi%2FsqZOAHBOFPUcBdR06fHEZkI%3D"
 
 ifneq ($($(LIBSAI_CREDO)_URL),)
 include $(PLATFORM_PATH)/../template/docker-gbsyncd-base.mk


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#14149

This SAI `libsaicredo_0.9.0_amd64.deb` causing packet forwarding issues on Linecards https://github.com/aristanetworks/sonic/issues/92