### PR TITLE
[E1031] fix pca9548 initializes failed occasionally

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.init
@@ -53,6 +53,7 @@ start)
         [ $found -eq 0 ] && echo "cannot find iSMT" && exit 1
 
         i2cset -y ${devnum} 0x73 0x10 0x00 0x01 i
+        sleep 0.5
 
         # Attach PCA9548 0x73 Channel Extender for CPU Board
         echo pca9548 0x73 > /sys/bus/i2c/devices/i2c-${devnum}/new_device


### PR DESCRIPTION
ADO: 24524572

#### Why I did it
[E1031] fix pca9548 initializes failed occasionally in stress test. When failure happened, ismt i2c bus hang up and need power cycle to recover it.

#### How I did it
Add 0.5s delay between setuping and configuring pca9548 i2c mux.

#### How to verify it
Reboot stress test at least 100 times without failure.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

