### PR TITLE
[202012] [TACACS+] Add Config DB schema and HostCfg Enforcer plugin to support TACACS+ per-command authorization&accounting.(#9029)

### DIFF
--- a/src/sonic-host-services/pytest.ini
+++ b/src/sonic-host-services/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --cov=scripts --cov-report html --cov-report term --cov-report xml --ignore=tests/hostcfgd/test_vectors.py --ignore=tests/caclmgrd/test_dhcp_vectors.py
+addopts = --cov=scripts --cov-report html --cov-report term --cov-report xml --ignore=tests/hostcfgd/test*_vectors.py  --ignore=tests/caclmgrd/test_dhcp_vectors.py

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -161,15 +161,23 @@ class Iptables(object):
 
 class AaaCfg(object):
     def __init__(self):
-        self.auth_default = {
+        self.authentication_default = {
             'login': 'local',
+        }
+        self.authorization_default = {
+            'login': 'local',
+        }
+        self.accounting_default = {
+            'login': 'disable',
         }
         self.tacplus_global_default = {
             'auth_type': TACPLUS_SERVER_AUTH_TYPE_DEFAULT,
             'timeout': TACPLUS_SERVER_TIMEOUT_DEFAULT,
             'passkey': TACPLUS_SERVER_PASSKEY_DEFAULT
         }
-        self.auth = {}
+        self.authentication = {}
+        self.authorization = {}
+        self.accounting = {}
         self.tacplus_global = {}
         self.tacplus_servers = {}
         self.debug = False
@@ -186,11 +194,15 @@ class AaaCfg(object):
 
     def aaa_update(self, key, data, modify_conf=True):
         if key == 'authentication':
-            self.auth = data
+            self.authentication = data
             if 'failthrough' in data:
-                self.auth['failthrough'] = is_true(data['failthrough'])
+                self.authentication['failthrough'] = is_true(data['failthrough'])
             if 'debug' in data:
                 self.debug = is_true(data['debug'])
+        if key == 'authorization':
+            self.authorization = data
+        if key == 'accounting':
+            self.accounting = data
         if modify_conf:
             self.modify_conf_file()
 
@@ -231,8 +243,12 @@ class AaaCfg(object):
         self.check_file_not_empty(filename)
 
     def modify_conf_file(self):
-        auth = self.auth_default.copy()
-        auth.update(self.auth)
+        authentication = self.authentication_default.copy()
+        authentication.update(self.authentication)
+        authorization = self.authorization_default.copy()
+        authorization.update(self.authorization)
+        accounting = self.accounting_default.copy()
+        accounting.update(self.accounting)
         tacplus_global = self.tacplus_global_default.copy()
         tacplus_global.update(self.tacplus_global)
         if 'src_ip' in tacplus_global:
@@ -253,7 +269,7 @@ class AaaCfg(object):
         env = jinja2.Environment(loader=jinja2.FileSystemLoader('/'), trim_blocks=True)
         env.filters['sub'] = sub
         template = env.get_template(template_file)
-        pam_conf = template.render(auth=auth, src_ip=src_ip, servers=servers_conf)
+        pam_conf = template.render(auth=authentication, src_ip=src_ip, servers=servers_conf)
         with open(PAM_AUTH_CONF, 'w') as f:
             f.write(pam_conf)
 
@@ -266,17 +282,40 @@ class AaaCfg(object):
             self.modify_single_file('/etc/pam.d/login', [ "'/^@include/s/common-auth-sonic$/common-auth/'" ])
 
         # Add tacplus in nsswitch.conf if TACACS+ enable
-        if 'tacacs+' in auth['login']:
+        if 'tacacs+' in authentication['login']:
             if os.path.isfile(NSS_CONF):
                 self.modify_single_file(NSS_CONF, [ "'/tacplus/b'", "'/^passwd/s/compat/tacplus &/'", "'/^passwd/s/files/tacplus &/'" ])
         else:
             if os.path.isfile(NSS_CONF):
                 self.modify_single_file(NSS_CONF, [ "'/^passwd/s/tacplus //g'" ])
 
+        # Add tacplus authorization configration in nsswitch.conf
+        tacacs_authorization_conf = None
+        local_authorization_conf = None
+        if 'tacacs+' in authorization['login']:
+            tacacs_authorization_conf = "on"
+        if 'local' in authorization['login']:
+            local_authorization_conf = "on"
+
+        # Add tacplus accounting configration in nsswitch.conf
+        tacacs_accounting_conf = None
+        local_accounting_conf = None
+        if 'tacacs+' in accounting['login']:
+            tacacs_accounting_conf = "on"
+        if 'local' in accounting['login']:
+            local_accounting_conf = "on"
+
         # Set tacacs+ server in nss-tacplus conf
         template_file = os.path.abspath(NSS_TACPLUS_CONF_TEMPLATE)
         template = env.get_template(template_file)
-        nss_tacplus_conf = template.render(debug=self.debug, src_ip=src_ip, servers=servers_conf)
+        nss_tacplus_conf = template.render(
+                                        debug=self.debug,
+                                        src_ip=src_ip,
+                                        servers=servers_conf,
+                                        local_accounting=local_accounting_conf,
+                                        tacacs_accounting=tacacs_accounting_conf,
+                                        local_authorization=local_authorization_conf,
+                                        tacacs_authorization=tacacs_authorization_conf)
         with open(NSS_TACPLUS_CONF, 'w') as f:
             f.write(nss_tacplus_conf)
 

--- a/src/sonic-host-services/tests/hostcfgd/hostcfgd_tacacs_test.py
+++ b/src/sonic-host-services/tests/hostcfgd/hostcfgd_tacacs_test.py
@@ -1,0 +1,118 @@
+import importlib.machinery
+import importlib.util
+import filecmp
+import shutil
+import os
+import sys
+import subprocess
+from swsscommon import swsscommon
+
+from parameterized import parameterized
+from unittest import TestCase, mock
+from tests.hostcfgd.test_tacacs_vectors import HOSTCFGD_TEST_TACACS_VECTOR
+from tests.common.mock_configdb import MockConfigDb, MockSubscriberStateTable
+from tests.common.mock_configdb import MockSelect, MockDBConnector
+
+test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+modules_path = os.path.dirname(test_path)
+scripts_path = os.path.join(modules_path, "scripts")
+src_path = os.path.dirname(modules_path)
+templates_path = os.path.join(src_path, "sonic-host-services-data/templates")
+output_path = os.path.join(test_path, "hostcfgd/output")
+sample_output_path = os.path.join(test_path, "hostcfgd/sample_output")
+sys.path.insert(0, modules_path)
+
+# Load the file under test
+hostcfgd_path = os.path.join(scripts_path, 'hostcfgd')
+loader = importlib.machinery.SourceFileLoader('hostcfgd', hostcfgd_path)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+hostcfgd = importlib.util.module_from_spec(spec)
+loader.exec_module(hostcfgd)
+sys.modules['hostcfgd'] = hostcfgd
+
+# Mock swsscommon classes
+hostcfgd.ConfigDBConnector = MockConfigDb
+hostcfgd.SubscriberStateTable = MockSubscriberStateTable
+hostcfgd.Select = MockSelect
+hostcfgd.DBConnector = MockDBConnector
+
+class TestHostcfgdTACACS(TestCase):
+    """
+        Test hostcfd daemon - TACACS
+    """
+    def run_diff(self, file1, file2):
+        return subprocess.check_output('diff -uR {} {} || true'.format(file1, file2), shell=True)
+
+    """
+        Check different config 
+    """
+    def check_config(self, test_name, test_data, config_name):
+        t_path = templates_path
+        op_path = output_path + "/" + test_name + "_" + config_name
+        sop_path = sample_output_path + "/" +  test_name + "_" + config_name
+
+        hostcfgd.PAM_AUTH_CONF_TEMPLATE = t_path + "/common-auth-sonic.j2"
+        hostcfgd.NSS_TACPLUS_CONF_TEMPLATE = t_path + "/tacplus_nss.conf.j2"
+        hostcfgd.NSS_RADIUS_CONF_TEMPLATE = t_path + "/radius_nss.conf.j2"
+        hostcfgd.PAM_RADIUS_AUTH_CONF_TEMPLATE = t_path + "/pam_radius_auth.conf.j2"
+        hostcfgd.PAM_AUTH_CONF = op_path + "/common-auth-sonic"
+        hostcfgd.NSS_TACPLUS_CONF = op_path + "/tacplus_nss.conf"
+        hostcfgd.NSS_RADIUS_CONF = op_path + "/radius_nss.conf"
+        hostcfgd.NSS_CONF = op_path + "/nsswitch.conf"
+        hostcfgd.ETC_PAMD_SSHD = op_path + "/sshd"
+        hostcfgd.ETC_PAMD_LOGIN = op_path + "/login"
+        hostcfgd.RADIUS_PAM_AUTH_CONF_DIR = op_path + "/"
+
+        shutil.rmtree( op_path, ignore_errors=True)
+        os.mkdir( op_path)
+
+        shutil.copyfile( sop_path + "/sshd.old", op_path + "/sshd")
+        shutil.copyfile( sop_path + "/login.old", op_path + "/login")
+
+        MockConfigDb.set_config_db(test_data[config_name])
+        host_config_daemon = hostcfgd.HostConfigDaemon()
+
+        aaa = host_config_daemon.config_db.get_table('AAA')
+
+        try:
+            tacacs_global = host_config_daemon.config_db.get_table('TACPLUS')
+        except:
+            tacacs_global = []
+        try:
+            tacacs_server = \
+                host_config_daemon.config_db.get_table('TACPLUS_SERVER')
+        except:
+            tacacs_server = []
+
+        host_config_daemon.aaacfg.load(aaa,tacacs_global,tacacs_server,[],[])
+        dcmp = filecmp.dircmp(sop_path, op_path)
+        diff_output = ""
+        for name in dcmp.diff_files:
+            diff_output += \
+                "Diff: file: {} expected: {} output: {}\n".format(\
+                    name, dcmp.left, dcmp.right)
+            diff_output += self.run_diff( dcmp.left + "/" + name,\
+                dcmp.right + "/" + name)
+        self.assertTrue(len(diff_output) == 0, diff_output)
+
+
+    @parameterized.expand(HOSTCFGD_TEST_TACACS_VECTOR)
+    def test_hostcfgd_tacacs(self, test_name, test_data):
+        """
+            Test TACACS hostcfd daemon initialization
+
+            Args:
+                test_name(str): test name
+                test_data(dict): test data which contains initial Config Db tables, and expected results
+
+            Returns:
+                None
+        """
+        # test local config
+        self.check_config(test_name, test_data, "config_db_local")
+        # test remote config
+        self.check_config(test_name, test_data, "config_db_tacacs")
+        # test local + tacacs config
+        self.check_config(test_name, test_data, "config_db_local_and_tacacs")
+        # test disable accounting
+        self.check_config(test_name, test_data, "config_db_disable_accounting")

--- a/src/sonic-host-services/tests/hostcfgd/hostcfgd_tacacs_test.py
+++ b/src/sonic-host-services/tests/hostcfgd/hostcfgd_tacacs_test.py
@@ -99,6 +99,7 @@ class TestHostcfgdTACACS(TestCase):
             Returns:
                 None
         """
+        os.mkdir(output_path)
         # test local config
         self.check_config(test_name, test_data, "config_db_local")
         # test remote config

--- a/src/sonic-host-services/tests/hostcfgd/hostcfgd_tacacs_test.py
+++ b/src/sonic-host-services/tests/hostcfgd/hostcfgd_tacacs_test.py
@@ -53,21 +53,12 @@ class TestHostcfgdTACACS(TestCase):
 
         hostcfgd.PAM_AUTH_CONF_TEMPLATE = t_path + "/common-auth-sonic.j2"
         hostcfgd.NSS_TACPLUS_CONF_TEMPLATE = t_path + "/tacplus_nss.conf.j2"
-        hostcfgd.NSS_RADIUS_CONF_TEMPLATE = t_path + "/radius_nss.conf.j2"
-        hostcfgd.PAM_RADIUS_AUTH_CONF_TEMPLATE = t_path + "/pam_radius_auth.conf.j2"
         hostcfgd.PAM_AUTH_CONF = op_path + "/common-auth-sonic"
         hostcfgd.NSS_TACPLUS_CONF = op_path + "/tacplus_nss.conf"
-        hostcfgd.NSS_RADIUS_CONF = op_path + "/radius_nss.conf"
         hostcfgd.NSS_CONF = op_path + "/nsswitch.conf"
-        hostcfgd.ETC_PAMD_SSHD = op_path + "/sshd"
-        hostcfgd.ETC_PAMD_LOGIN = op_path + "/login"
-        hostcfgd.RADIUS_PAM_AUTH_CONF_DIR = op_path + "/"
 
         shutil.rmtree( op_path, ignore_errors=True)
         os.mkdir( op_path)
-
-        shutil.copyfile( sop_path + "/sshd.old", op_path + "/sshd")
-        shutil.copyfile( sop_path + "/login.old", op_path + "/login")
 
         MockConfigDb.set_config_db(test_data[config_name])
         host_config_daemon = hostcfgd.HostConfigDaemon()
@@ -84,7 +75,7 @@ class TestHostcfgdTACACS(TestCase):
         except:
             tacacs_server = []
 
-        host_config_daemon.aaacfg.load(aaa,tacacs_global,tacacs_server,[],[])
+        host_config_daemon.aaacfg.load(aaa,tacacs_global,tacacs_server)
         dcmp = filecmp.dircmp(sop_path, op_path)
         diff_output = ""
         for name in dcmp.diff_files:

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/LOCAL/tacplus_nss.conf
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/LOCAL/tacplus_nss.conf
@@ -3,51 +3,32 @@
 # debug - If you want to open debug log, set it on
 # Default: off
 # debug=on
-{% if debug %}
 debug=on
-{% endif %}
 
 # local_accounting - If you want to local accounting, set it
 # Default: None
 # local_accounting
-{% if local_accounting %}
-local_accounting
-{% endif %}
 
 # tacacs_accounting - If you want to tacacs+ accounting, set it
 # Default: None
 # tacacs_accounting
-{% if tacacs_accounting %}
-tacacs_accounting
-{% endif %}
 
 # local_authorization - If you want to local authorization, set it
 # Default: None
 # local_authorization
-{% if local_authorization %}
 local_authorization
-{% endif %}
 
 # tacacs_authorization - If you want to tacacs+ authorization, set it
 # Default: None
 # tacacs_authorization
-{% if tacacs_authorization %}
-tacacs_authorization
-{% endif %}
 
 # src_ip - set source address of TACACS+ protocol packets
 # Default: None (auto source ip address)
 # src_ip=2.2.2.2
-{% if src_ip %}
-src_ip={{ src_ip }}
-{% endif %}
 
 # server - set ip address, tcp port, secret string and timeout for TACACS+ servers
 # Default: None (no TACACS+ server)
 # server=1.1.1.1:49,secret=test,timeout=3
-{% for server in servers %}
-server={{ server.ip }}:{{ server.tcp_port }},secret={{ server.passkey }},timeout={{ server.timeout }}{% if server.vrf %},vrf={{ server.vrf }}{% endif %}{{''}}
-{% endfor %}
 
 # user_priv - set the map between TACACS+ user privilege and local user's passwd
 # Default:
@@ -57,4 +38,3 @@ server={{ server.ip }}:{{ server.tcp_port }},secret={{ server.passkey }},timeout
 # many_to_one - create one local user for many TACACS+ users which has the same privilege
 # Default: many_to_one=n
 # many_to_one=y
-

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/RADIUS/tacplus_nss.conf
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/RADIUS/tacplus_nss.conf
@@ -3,51 +3,32 @@
 # debug - If you want to open debug log, set it on
 # Default: off
 # debug=on
-{% if debug %}
 debug=on
-{% endif %}
 
 # local_accounting - If you want to local accounting, set it
 # Default: None
 # local_accounting
-{% if local_accounting %}
-local_accounting
-{% endif %}
 
 # tacacs_accounting - If you want to tacacs+ accounting, set it
 # Default: None
 # tacacs_accounting
-{% if tacacs_accounting %}
-tacacs_accounting
-{% endif %}
 
 # local_authorization - If you want to local authorization, set it
 # Default: None
 # local_authorization
-{% if local_authorization %}
 local_authorization
-{% endif %}
 
 # tacacs_authorization - If you want to tacacs+ authorization, set it
 # Default: None
 # tacacs_authorization
-{% if tacacs_authorization %}
-tacacs_authorization
-{% endif %}
 
 # src_ip - set source address of TACACS+ protocol packets
 # Default: None (auto source ip address)
 # src_ip=2.2.2.2
-{% if src_ip %}
-src_ip={{ src_ip }}
-{% endif %}
 
 # server - set ip address, tcp port, secret string and timeout for TACACS+ servers
 # Default: None (no TACACS+ server)
 # server=1.1.1.1:49,secret=test,timeout=3
-{% for server in servers %}
-server={{ server.ip }}:{{ server.tcp_port }},secret={{ server.passkey }},timeout={{ server.timeout }}{% if server.vrf %},vrf={{ server.vrf }}{% endif %}{{''}}
-{% endfor %}
 
 # user_priv - set the map between TACACS+ user privilege and local user's passwd
 # Default:
@@ -57,4 +38,3 @@ server={{ server.ip }}:{{ server.tcp_port }},secret={{ server.passkey }},timeout
 # many_to_one - create one local user for many TACACS+ users which has the same privilege
 # Default: many_to_one=n
 # many_to_one=y
-

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_disable_accounting/common-auth-sonic
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_disable_accounting/common-auth-sonic
@@ -1,0 +1,21 @@
+#THIS IS AN AUTO-GENERATED FILE
+#
+# /etc/pam.d/common-auth- authentication settings common to all services
+# This file is included from other service-specific PAM config files,
+# and should contain a list of the authentication modules that define
+# the central authentication scheme for use on the system
+# (e.g., /etc/shadow, LDAP, Kerberos, etc.). The default is to use the
+# traditional Unix authentication mechanisms.
+#
+# here are the per-package modules (the "Primary" block)
+
+auth	[success=1 default=ignore]	pam_unix.so nullok try_first_pass
+
+#
+# here's the fallback if no module succeeds
+auth    requisite                       pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+auth    required                        pam_permit.so
+# and here are more per-package modules (the "Additional" block)

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_disable_accounting/login
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_disable_accounting/login
@@ -1,0 +1,116 @@
+#
+# The PAM configuration file for the Shadow `login' service
+#
+
+# Enforce a minimal delay in case of failure (in microseconds).
+# (Replaces the `FAIL_DELAY' setting from login.defs)
+# Note that other modules may require another minimal delay. (for example,
+# to disable any delay, you should add the nodelay option to pam_unix)
+auth       optional   pam_faildelay.so  delay=3000000
+
+# Outputs an issue file prior to each login prompt (Replaces the
+# ISSUE_FILE option from login.defs). Uncomment for use
+# auth       required   pam_issue.so issue=/etc/issue
+
+# Disallows root logins except on tty's listed in /etc/securetty
+# (Replaces the `CONSOLE' setting from login.defs)
+#
+# With the default control of this module:
+#   [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die]
+# root will not be prompted for a password on insecure lines.
+# if an invalid username is entered, a password is prompted (but login
+# will eventually be rejected)
+#
+# You can change it to a "requisite" module if you think root may mis-type
+# her login and should not be prompted for a password in that case. But
+# this will leave the system as vulnerable to user enumeration attacks.
+#
+# You can change it to a "required" module if you think it permits to
+# guess valid user names of your system (invalid user names are considered
+# as possibly being root on insecure lines), but root passwords may be
+# communicated over insecure lines.
+auth [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die] pam_securetty.so
+
+# Disallows other than root logins when /etc/nologin exists
+# (Replaces the `NOLOGINS_FILE' option from login.defs)
+auth       requisite  pam_nologin.so
+
+# SELinux needs to be the first session rule. This ensures that any
+# lingering context has been cleared. Without this it is possible
+# that a module could execute code in the wrong domain.
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
+
+# Sets the loginuid process attribute
+session    required     pam_loginuid.so
+
+# SELinux needs to intervene at login time to ensure that the process
+# starts in the proper default security context. Only sessions which are
+# intended to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+
+# This module parses environment configuration file(s)
+# and also allows you to use an extended config
+# file /etc/security/pam_env.conf.
+# 
+# parsing /etc/environment needs "readenv=1"
+session       required   pam_env.so readenv=1
+# locale variables are also kept into /etc/default/locale in etch
+# reading this file *in addition to /etc/environment* does not hurt
+session       required   pam_env.so readenv=1 envfile=/etc/default/locale
+
+# Standard Un*x authentication.
+@include common-auth-sonic
+
+# This allows certain extra groups to be granted to a user
+# based on things like time of day, tty, service, and user.
+# Please edit /etc/security/group.conf to fit your needs
+# (Replaces the `CONSOLE_GROUPS' option in login.defs)
+auth       optional   pam_group.so
+
+# Uncomment and edit /etc/security/time.conf if you need to set
+# time restraint on logins.
+# (Replaces the `PORTTIME_CHECKS_ENAB' option from login.defs
+# as well as /etc/porttime)
+# account    requisite  pam_time.so
+
+# Uncomment and edit /etc/security/access.conf if you need to
+# set access limits.
+# (Replaces /etc/login.access file)
+# account  required       pam_access.so
+
+# Sets up user limits according to /etc/security/limits.conf
+# (Replaces the use of /etc/limits in old login)
+session    required   pam_limits.so
+
+# Prints the last login info upon successful login
+# (Replaces the `LASTLOG_ENAB' option from login.defs)
+session    optional   pam_lastlog.so
+
+# Prints the message of the day upon successful login.
+# (Replaces the `MOTD_FILE' option in login.defs)
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional   pam_motd.so motd=/run/motd.dynamic
+session    optional   pam_motd.so noupdate
+
+# Prints the status of the user's mailbox upon successful login
+# (Replaces the `MAIL_CHECK_ENAB' option from login.defs). 
+#
+# This also defines the MAIL environment variable
+# However, userdel also needs MAIL_DIR and MAIL_FILE variables
+# in /etc/login.defs to make sure that removing a user 
+# also removes the user's mail spool file.
+# See comments in /etc/login.defs
+session    optional   pam_mail.so standard
+
+# Create a new session keyring.
+session    optional   pam_keyinit.so force revoke
+
+# Standard Un*x account and session
+@include common-account
+@include common-session
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_disable_accounting/login.old
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_disable_accounting/login.old
@@ -1,0 +1,116 @@
+#
+# The PAM configuration file for the Shadow `login' service
+#
+
+# Enforce a minimal delay in case of failure (in microseconds).
+# (Replaces the `FAIL_DELAY' setting from login.defs)
+# Note that other modules may require another minimal delay. (for example,
+# to disable any delay, you should add the nodelay option to pam_unix)
+auth       optional   pam_faildelay.so  delay=3000000
+
+# Outputs an issue file prior to each login prompt (Replaces the
+# ISSUE_FILE option from login.defs). Uncomment for use
+# auth       required   pam_issue.so issue=/etc/issue
+
+# Disallows root logins except on tty's listed in /etc/securetty
+# (Replaces the `CONSOLE' setting from login.defs)
+#
+# With the default control of this module:
+#   [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die]
+# root will not be prompted for a password on insecure lines.
+# if an invalid username is entered, a password is prompted (but login
+# will eventually be rejected)
+#
+# You can change it to a "requisite" module if you think root may mis-type
+# her login and should not be prompted for a password in that case. But
+# this will leave the system as vulnerable to user enumeration attacks.
+#
+# You can change it to a "required" module if you think it permits to
+# guess valid user names of your system (invalid user names are considered
+# as possibly being root on insecure lines), but root passwords may be
+# communicated over insecure lines.
+auth [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die] pam_securetty.so
+
+# Disallows other than root logins when /etc/nologin exists
+# (Replaces the `NOLOGINS_FILE' option from login.defs)
+auth       requisite  pam_nologin.so
+
+# SELinux needs to be the first session rule. This ensures that any
+# lingering context has been cleared. Without this it is possible
+# that a module could execute code in the wrong domain.
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
+
+# Sets the loginuid process attribute
+session    required     pam_loginuid.so
+
+# SELinux needs to intervene at login time to ensure that the process
+# starts in the proper default security context. Only sessions which are
+# intended to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+
+# This module parses environment configuration file(s)
+# and also allows you to use an extended config
+# file /etc/security/pam_env.conf.
+# 
+# parsing /etc/environment needs "readenv=1"
+session       required   pam_env.so readenv=1
+# locale variables are also kept into /etc/default/locale in etch
+# reading this file *in addition to /etc/environment* does not hurt
+session       required   pam_env.so readenv=1 envfile=/etc/default/locale
+
+# Standard Un*x authentication.
+@include common-auth
+
+# This allows certain extra groups to be granted to a user
+# based on things like time of day, tty, service, and user.
+# Please edit /etc/security/group.conf to fit your needs
+# (Replaces the `CONSOLE_GROUPS' option in login.defs)
+auth       optional   pam_group.so
+
+# Uncomment and edit /etc/security/time.conf if you need to set
+# time restraint on logins.
+# (Replaces the `PORTTIME_CHECKS_ENAB' option from login.defs
+# as well as /etc/porttime)
+# account    requisite  pam_time.so
+
+# Uncomment and edit /etc/security/access.conf if you need to
+# set access limits.
+# (Replaces /etc/login.access file)
+# account  required       pam_access.so
+
+# Sets up user limits according to /etc/security/limits.conf
+# (Replaces the use of /etc/limits in old login)
+session    required   pam_limits.so
+
+# Prints the last login info upon successful login
+# (Replaces the `LASTLOG_ENAB' option from login.defs)
+session    optional   pam_lastlog.so
+
+# Prints the message of the day upon successful login.
+# (Replaces the `MOTD_FILE' option in login.defs)
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional   pam_motd.so motd=/run/motd.dynamic
+session    optional   pam_motd.so noupdate
+
+# Prints the status of the user's mailbox upon successful login
+# (Replaces the `MAIL_CHECK_ENAB' option from login.defs). 
+#
+# This also defines the MAIL environment variable
+# However, userdel also needs MAIL_DIR and MAIL_FILE variables
+# in /etc/login.defs to make sure that removing a user 
+# also removes the user's mail spool file.
+# See comments in /etc/login.defs
+session    optional   pam_mail.so standard
+
+# Create a new session keyring.
+session    optional   pam_keyinit.so force revoke
+
+# Standard Un*x account and session
+@include common-account
+@include common-session
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_disable_accounting/radius_nss.conf
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_disable_accounting/radius_nss.conf
@@ -1,0 +1,55 @@
+#THIS IS AN AUTO-GENERATED FILE
+# Generated from: /usr/share/sonic/templates/radius_nss.conf.j2
+# RADIUS NSS Configuration File
+#
+# Debug: on|off|trace
+# Default: off
+#
+# debug=on
+
+#
+# User Privilege:
+# Default:
+# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=1;pw_info=remote_user;gid=999;group=docker;shell=/usr/bin/sonic-launch-shell
+
+# Eg:
+# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=7;pw_info=netops;gid=999;group=docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=1;pw_info=operator;gid=100;group=docker;shell=/usr/bin/sonic-launch-shell
+#
+
+# many_to_one:
+#   y: Map RADIUS users to one local user per privilege.
+#   n: Create local user account on first successful authentication.
+# Default: n
+#
+
+# Eg:
+# many_to_one=y
+#
+
+# unconfirmed_disallow:
+#   y: Do not allow unconfirmed users (users created before authentication)
+#   n: Allow unconfirmed users.
+# Default: n
+
+# Eg:
+# unconfirmed_disallow=y
+#
+
+# unconfirmed_ageout:
+#   <seconds>: Wait time before purging unconfirmed users
+# Default: 600
+#
+
+# Eg:
+# unconfirmed_ageout=900
+#
+
+# unconfirmed_regexp:
+#   <regexp>: The RE to match the command line of processes for which the
+#             creation of unconfirmed users are to be allowed.
+# Default: (.*: <user> \[priv\])|(.*: \[accepted\])
+#   where: <user> is the unconfirmed user.
+#

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_disable_accounting/sshd
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_disable_accounting/sshd
@@ -1,0 +1,55 @@
+# PAM configuration for the Secure Shell service
+
+# Standard Un*x authentication.
+@include common-auth-sonic
+
+# Disallow non-root logins when /etc/nologin exists.
+account    required     pam_nologin.so
+
+# Uncomment and edit /etc/security/access.conf if you need to set complex
+# access limits that are hard to express in sshd_config.
+# account  required     pam_access.so
+
+# Standard Un*x authorization.
+@include common-account
+
+# SELinux needs to be the first session rule.  This ensures that any
+# lingering context has been cleared.  Without this it is possible that a
+# module could execute code in the wrong domain.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
+
+# Set the loginuid process attribute.
+session    required     pam_loginuid.so
+
+# Create a new session keyring.
+session    optional     pam_keyinit.so force revoke
+
+# Standard Un*x session setup and teardown.
+@include common-session
+
+# Print the message of the day upon successful login.
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional     pam_motd.so  motd=/run/motd.dynamic
+session    optional     pam_motd.so noupdate
+
+# Print the status of the user's mailbox upon successful login.
+session    optional     pam_mail.so standard noenv # [1]
+
+# Set up user limits from /etc/security/limits.conf.
+session    required     pam_limits.so
+
+# Read environment variables from /etc/environment and
+# /etc/security/pam_env.conf.
+session    required     pam_env.so # [1]
+# In Debian 4.0 (etch), locale-related environment variables were moved to
+# /etc/default/locale, so read that as well.
+session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
+
+# SELinux needs to intervene at login time to ensure that the process starts
+# in the proper default security context.  Only sessions which are intended
+# to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
+
+# Standard Un*x password updating.
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_disable_accounting/sshd.old
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_disable_accounting/sshd.old
@@ -1,0 +1,55 @@
+# PAM configuration for the Secure Shell service
+
+# Standard Un*x authentication.
+@include common-auth
+
+# Disallow non-root logins when /etc/nologin exists.
+account    required     pam_nologin.so
+
+# Uncomment and edit /etc/security/access.conf if you need to set complex
+# access limits that are hard to express in sshd_config.
+# account  required     pam_access.so
+
+# Standard Un*x authorization.
+@include common-account
+
+# SELinux needs to be the first session rule.  This ensures that any
+# lingering context has been cleared.  Without this it is possible that a
+# module could execute code in the wrong domain.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
+
+# Set the loginuid process attribute.
+session    required     pam_loginuid.so
+
+# Create a new session keyring.
+session    optional     pam_keyinit.so force revoke
+
+# Standard Un*x session setup and teardown.
+@include common-session
+
+# Print the message of the day upon successful login.
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional     pam_motd.so  motd=/run/motd.dynamic
+session    optional     pam_motd.so noupdate
+
+# Print the status of the user's mailbox upon successful login.
+session    optional     pam_mail.so standard noenv # [1]
+
+# Set up user limits from /etc/security/limits.conf.
+session    required     pam_limits.so
+
+# Read environment variables from /etc/environment and
+# /etc/security/pam_env.conf.
+session    required     pam_env.so # [1]
+# In Debian 4.0 (etch), locale-related environment variables were moved to
+# /etc/default/locale, so read that as well.
+session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
+
+# SELinux needs to intervene at login time to ensure that the process starts
+# in the proper default security context.  Only sessions which are intended
+# to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
+
+# Standard Un*x password updating.
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_disable_accounting/tacplus_nss.conf
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_disable_accounting/tacplus_nss.conf
@@ -3,51 +3,33 @@
 # debug - If you want to open debug log, set it on
 # Default: off
 # debug=on
-{% if debug %}
-debug=on
-{% endif %}
 
 # local_accounting - If you want to local accounting, set it
 # Default: None
 # local_accounting
-{% if local_accounting %}
-local_accounting
-{% endif %}
 
 # tacacs_accounting - If you want to tacacs+ accounting, set it
 # Default: None
 # tacacs_accounting
-{% if tacacs_accounting %}
-tacacs_accounting
-{% endif %}
 
 # local_authorization - If you want to local authorization, set it
 # Default: None
 # local_authorization
-{% if local_authorization %}
 local_authorization
-{% endif %}
 
 # tacacs_authorization - If you want to tacacs+ authorization, set it
 # Default: None
 # tacacs_authorization
-{% if tacacs_authorization %}
-tacacs_authorization
-{% endif %}
 
 # src_ip - set source address of TACACS+ protocol packets
 # Default: None (auto source ip address)
 # src_ip=2.2.2.2
-{% if src_ip %}
-src_ip={{ src_ip }}
-{% endif %}
 
 # server - set ip address, tcp port, secret string and timeout for TACACS+ servers
 # Default: None (no TACACS+ server)
 # server=1.1.1.1:49,secret=test,timeout=3
-{% for server in servers %}
-server={{ server.ip }}:{{ server.tcp_port }},secret={{ server.passkey }},timeout={{ server.timeout }}{% if server.vrf %},vrf={{ server.vrf }}{% endif %}{{''}}
-{% endfor %}
+server=192.168.1.1:50,secret=dellsonic,timeout=10,vrf=default
+server=192.168.1.2:51,secret=dellsonic1,timeout=15,vrf=mgmt
 
 # user_priv - set the map between TACACS+ user privilege and local user's passwd
 # Default:
@@ -57,4 +39,3 @@ server={{ server.ip }}:{{ server.tcp_port }},secret={{ server.passkey }},timeout
 # many_to_one - create one local user for many TACACS+ users which has the same privilege
 # Default: many_to_one=n
 # many_to_one=y
-

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local/common-auth-sonic
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local/common-auth-sonic
@@ -1,0 +1,21 @@
+#THIS IS AN AUTO-GENERATED FILE
+#
+# /etc/pam.d/common-auth- authentication settings common to all services
+# This file is included from other service-specific PAM config files,
+# and should contain a list of the authentication modules that define
+# the central authentication scheme for use on the system
+# (e.g., /etc/shadow, LDAP, Kerberos, etc.). The default is to use the
+# traditional Unix authentication mechanisms.
+#
+# here are the per-package modules (the "Primary" block)
+
+auth	[success=1 default=ignore]	pam_unix.so nullok try_first_pass
+
+#
+# here's the fallback if no module succeeds
+auth    requisite                       pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+auth    required                        pam_permit.so
+# and here are more per-package modules (the "Additional" block)

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local/login
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local/login
@@ -1,0 +1,116 @@
+#
+# The PAM configuration file for the Shadow `login' service
+#
+
+# Enforce a minimal delay in case of failure (in microseconds).
+# (Replaces the `FAIL_DELAY' setting from login.defs)
+# Note that other modules may require another minimal delay. (for example,
+# to disable any delay, you should add the nodelay option to pam_unix)
+auth       optional   pam_faildelay.so  delay=3000000
+
+# Outputs an issue file prior to each login prompt (Replaces the
+# ISSUE_FILE option from login.defs). Uncomment for use
+# auth       required   pam_issue.so issue=/etc/issue
+
+# Disallows root logins except on tty's listed in /etc/securetty
+# (Replaces the `CONSOLE' setting from login.defs)
+#
+# With the default control of this module:
+#   [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die]
+# root will not be prompted for a password on insecure lines.
+# if an invalid username is entered, a password is prompted (but login
+# will eventually be rejected)
+#
+# You can change it to a "requisite" module if you think root may mis-type
+# her login and should not be prompted for a password in that case. But
+# this will leave the system as vulnerable to user enumeration attacks.
+#
+# You can change it to a "required" module if you think it permits to
+# guess valid user names of your system (invalid user names are considered
+# as possibly being root on insecure lines), but root passwords may be
+# communicated over insecure lines.
+auth [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die] pam_securetty.so
+
+# Disallows other than root logins when /etc/nologin exists
+# (Replaces the `NOLOGINS_FILE' option from login.defs)
+auth       requisite  pam_nologin.so
+
+# SELinux needs to be the first session rule. This ensures that any
+# lingering context has been cleared. Without this it is possible
+# that a module could execute code in the wrong domain.
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
+
+# Sets the loginuid process attribute
+session    required     pam_loginuid.so
+
+# SELinux needs to intervene at login time to ensure that the process
+# starts in the proper default security context. Only sessions which are
+# intended to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+
+# This module parses environment configuration file(s)
+# and also allows you to use an extended config
+# file /etc/security/pam_env.conf.
+# 
+# parsing /etc/environment needs "readenv=1"
+session       required   pam_env.so readenv=1
+# locale variables are also kept into /etc/default/locale in etch
+# reading this file *in addition to /etc/environment* does not hurt
+session       required   pam_env.so readenv=1 envfile=/etc/default/locale
+
+# Standard Un*x authentication.
+@include common-auth-sonic
+
+# This allows certain extra groups to be granted to a user
+# based on things like time of day, tty, service, and user.
+# Please edit /etc/security/group.conf to fit your needs
+# (Replaces the `CONSOLE_GROUPS' option in login.defs)
+auth       optional   pam_group.so
+
+# Uncomment and edit /etc/security/time.conf if you need to set
+# time restraint on logins.
+# (Replaces the `PORTTIME_CHECKS_ENAB' option from login.defs
+# as well as /etc/porttime)
+# account    requisite  pam_time.so
+
+# Uncomment and edit /etc/security/access.conf if you need to
+# set access limits.
+# (Replaces /etc/login.access file)
+# account  required       pam_access.so
+
+# Sets up user limits according to /etc/security/limits.conf
+# (Replaces the use of /etc/limits in old login)
+session    required   pam_limits.so
+
+# Prints the last login info upon successful login
+# (Replaces the `LASTLOG_ENAB' option from login.defs)
+session    optional   pam_lastlog.so
+
+# Prints the message of the day upon successful login.
+# (Replaces the `MOTD_FILE' option in login.defs)
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional   pam_motd.so motd=/run/motd.dynamic
+session    optional   pam_motd.so noupdate
+
+# Prints the status of the user's mailbox upon successful login
+# (Replaces the `MAIL_CHECK_ENAB' option from login.defs). 
+#
+# This also defines the MAIL environment variable
+# However, userdel also needs MAIL_DIR and MAIL_FILE variables
+# in /etc/login.defs to make sure that removing a user 
+# also removes the user's mail spool file.
+# See comments in /etc/login.defs
+session    optional   pam_mail.so standard
+
+# Create a new session keyring.
+session    optional   pam_keyinit.so force revoke
+
+# Standard Un*x account and session
+@include common-account
+@include common-session
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local/login.old
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local/login.old
@@ -1,0 +1,116 @@
+#
+# The PAM configuration file for the Shadow `login' service
+#
+
+# Enforce a minimal delay in case of failure (in microseconds).
+# (Replaces the `FAIL_DELAY' setting from login.defs)
+# Note that other modules may require another minimal delay. (for example,
+# to disable any delay, you should add the nodelay option to pam_unix)
+auth       optional   pam_faildelay.so  delay=3000000
+
+# Outputs an issue file prior to each login prompt (Replaces the
+# ISSUE_FILE option from login.defs). Uncomment for use
+# auth       required   pam_issue.so issue=/etc/issue
+
+# Disallows root logins except on tty's listed in /etc/securetty
+# (Replaces the `CONSOLE' setting from login.defs)
+#
+# With the default control of this module:
+#   [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die]
+# root will not be prompted for a password on insecure lines.
+# if an invalid username is entered, a password is prompted (but login
+# will eventually be rejected)
+#
+# You can change it to a "requisite" module if you think root may mis-type
+# her login and should not be prompted for a password in that case. But
+# this will leave the system as vulnerable to user enumeration attacks.
+#
+# You can change it to a "required" module if you think it permits to
+# guess valid user names of your system (invalid user names are considered
+# as possibly being root on insecure lines), but root passwords may be
+# communicated over insecure lines.
+auth [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die] pam_securetty.so
+
+# Disallows other than root logins when /etc/nologin exists
+# (Replaces the `NOLOGINS_FILE' option from login.defs)
+auth       requisite  pam_nologin.so
+
+# SELinux needs to be the first session rule. This ensures that any
+# lingering context has been cleared. Without this it is possible
+# that a module could execute code in the wrong domain.
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
+
+# Sets the loginuid process attribute
+session    required     pam_loginuid.so
+
+# SELinux needs to intervene at login time to ensure that the process
+# starts in the proper default security context. Only sessions which are
+# intended to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+
+# This module parses environment configuration file(s)
+# and also allows you to use an extended config
+# file /etc/security/pam_env.conf.
+# 
+# parsing /etc/environment needs "readenv=1"
+session       required   pam_env.so readenv=1
+# locale variables are also kept into /etc/default/locale in etch
+# reading this file *in addition to /etc/environment* does not hurt
+session       required   pam_env.so readenv=1 envfile=/etc/default/locale
+
+# Standard Un*x authentication.
+@include common-auth
+
+# This allows certain extra groups to be granted to a user
+# based on things like time of day, tty, service, and user.
+# Please edit /etc/security/group.conf to fit your needs
+# (Replaces the `CONSOLE_GROUPS' option in login.defs)
+auth       optional   pam_group.so
+
+# Uncomment and edit /etc/security/time.conf if you need to set
+# time restraint on logins.
+# (Replaces the `PORTTIME_CHECKS_ENAB' option from login.defs
+# as well as /etc/porttime)
+# account    requisite  pam_time.so
+
+# Uncomment and edit /etc/security/access.conf if you need to
+# set access limits.
+# (Replaces /etc/login.access file)
+# account  required       pam_access.so
+
+# Sets up user limits according to /etc/security/limits.conf
+# (Replaces the use of /etc/limits in old login)
+session    required   pam_limits.so
+
+# Prints the last login info upon successful login
+# (Replaces the `LASTLOG_ENAB' option from login.defs)
+session    optional   pam_lastlog.so
+
+# Prints the message of the day upon successful login.
+# (Replaces the `MOTD_FILE' option in login.defs)
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional   pam_motd.so motd=/run/motd.dynamic
+session    optional   pam_motd.so noupdate
+
+# Prints the status of the user's mailbox upon successful login
+# (Replaces the `MAIL_CHECK_ENAB' option from login.defs). 
+#
+# This also defines the MAIL environment variable
+# However, userdel also needs MAIL_DIR and MAIL_FILE variables
+# in /etc/login.defs to make sure that removing a user 
+# also removes the user's mail spool file.
+# See comments in /etc/login.defs
+session    optional   pam_mail.so standard
+
+# Create a new session keyring.
+session    optional   pam_keyinit.so force revoke
+
+# Standard Un*x account and session
+@include common-account
+@include common-session
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local/radius_nss.conf
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local/radius_nss.conf
@@ -1,0 +1,55 @@
+#THIS IS AN AUTO-GENERATED FILE
+# Generated from: /usr/share/sonic/templates/radius_nss.conf.j2
+# RADIUS NSS Configuration File
+#
+# Debug: on|off|trace
+# Default: off
+#
+# debug=on
+
+#
+# User Privilege:
+# Default:
+# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=1;pw_info=remote_user;gid=999;group=docker;shell=/usr/bin/sonic-launch-shell
+
+# Eg:
+# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=7;pw_info=netops;gid=999;group=docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=1;pw_info=operator;gid=100;group=docker;shell=/usr/bin/sonic-launch-shell
+#
+
+# many_to_one:
+#   y: Map RADIUS users to one local user per privilege.
+#   n: Create local user account on first successful authentication.
+# Default: n
+#
+
+# Eg:
+# many_to_one=y
+#
+
+# unconfirmed_disallow:
+#   y: Do not allow unconfirmed users (users created before authentication)
+#   n: Allow unconfirmed users.
+# Default: n
+
+# Eg:
+# unconfirmed_disallow=y
+#
+
+# unconfirmed_ageout:
+#   <seconds>: Wait time before purging unconfirmed users
+# Default: 600
+#
+
+# Eg:
+# unconfirmed_ageout=900
+#
+
+# unconfirmed_regexp:
+#   <regexp>: The RE to match the command line of processes for which the
+#             creation of unconfirmed users are to be allowed.
+# Default: (.*: <user> \[priv\])|(.*: \[accepted\])
+#   where: <user> is the unconfirmed user.
+#

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local/sshd
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local/sshd
@@ -1,0 +1,55 @@
+# PAM configuration for the Secure Shell service
+
+# Standard Un*x authentication.
+@include common-auth-sonic
+
+# Disallow non-root logins when /etc/nologin exists.
+account    required     pam_nologin.so
+
+# Uncomment and edit /etc/security/access.conf if you need to set complex
+# access limits that are hard to express in sshd_config.
+# account  required     pam_access.so
+
+# Standard Un*x authorization.
+@include common-account
+
+# SELinux needs to be the first session rule.  This ensures that any
+# lingering context has been cleared.  Without this it is possible that a
+# module could execute code in the wrong domain.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
+
+# Set the loginuid process attribute.
+session    required     pam_loginuid.so
+
+# Create a new session keyring.
+session    optional     pam_keyinit.so force revoke
+
+# Standard Un*x session setup and teardown.
+@include common-session
+
+# Print the message of the day upon successful login.
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional     pam_motd.so  motd=/run/motd.dynamic
+session    optional     pam_motd.so noupdate
+
+# Print the status of the user's mailbox upon successful login.
+session    optional     pam_mail.so standard noenv # [1]
+
+# Set up user limits from /etc/security/limits.conf.
+session    required     pam_limits.so
+
+# Read environment variables from /etc/environment and
+# /etc/security/pam_env.conf.
+session    required     pam_env.so # [1]
+# In Debian 4.0 (etch), locale-related environment variables were moved to
+# /etc/default/locale, so read that as well.
+session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
+
+# SELinux needs to intervene at login time to ensure that the process starts
+# in the proper default security context.  Only sessions which are intended
+# to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
+
+# Standard Un*x password updating.
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local/sshd.old
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local/sshd.old
@@ -1,0 +1,55 @@
+# PAM configuration for the Secure Shell service
+
+# Standard Un*x authentication.
+@include common-auth
+
+# Disallow non-root logins when /etc/nologin exists.
+account    required     pam_nologin.so
+
+# Uncomment and edit /etc/security/access.conf if you need to set complex
+# access limits that are hard to express in sshd_config.
+# account  required     pam_access.so
+
+# Standard Un*x authorization.
+@include common-account
+
+# SELinux needs to be the first session rule.  This ensures that any
+# lingering context has been cleared.  Without this it is possible that a
+# module could execute code in the wrong domain.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
+
+# Set the loginuid process attribute.
+session    required     pam_loginuid.so
+
+# Create a new session keyring.
+session    optional     pam_keyinit.so force revoke
+
+# Standard Un*x session setup and teardown.
+@include common-session
+
+# Print the message of the day upon successful login.
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional     pam_motd.so  motd=/run/motd.dynamic
+session    optional     pam_motd.so noupdate
+
+# Print the status of the user's mailbox upon successful login.
+session    optional     pam_mail.so standard noenv # [1]
+
+# Set up user limits from /etc/security/limits.conf.
+session    required     pam_limits.so
+
+# Read environment variables from /etc/environment and
+# /etc/security/pam_env.conf.
+session    required     pam_env.so # [1]
+# In Debian 4.0 (etch), locale-related environment variables were moved to
+# /etc/default/locale, so read that as well.
+session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
+
+# SELinux needs to intervene at login time to ensure that the process starts
+# in the proper default security context.  Only sessions which are intended
+# to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
+
+# Standard Un*x password updating.
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local/tacplus_nss.conf
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local/tacplus_nss.conf
@@ -3,51 +3,34 @@
 # debug - If you want to open debug log, set it on
 # Default: off
 # debug=on
-{% if debug %}
-debug=on
-{% endif %}
 
 # local_accounting - If you want to local accounting, set it
 # Default: None
 # local_accounting
-{% if local_accounting %}
 local_accounting
-{% endif %}
 
 # tacacs_accounting - If you want to tacacs+ accounting, set it
 # Default: None
 # tacacs_accounting
-{% if tacacs_accounting %}
-tacacs_accounting
-{% endif %}
 
 # local_authorization - If you want to local authorization, set it
 # Default: None
 # local_authorization
-{% if local_authorization %}
 local_authorization
-{% endif %}
 
 # tacacs_authorization - If you want to tacacs+ authorization, set it
 # Default: None
 # tacacs_authorization
-{% if tacacs_authorization %}
-tacacs_authorization
-{% endif %}
 
 # src_ip - set source address of TACACS+ protocol packets
 # Default: None (auto source ip address)
 # src_ip=2.2.2.2
-{% if src_ip %}
-src_ip={{ src_ip }}
-{% endif %}
 
 # server - set ip address, tcp port, secret string and timeout for TACACS+ servers
 # Default: None (no TACACS+ server)
 # server=1.1.1.1:49,secret=test,timeout=3
-{% for server in servers %}
-server={{ server.ip }}:{{ server.tcp_port }},secret={{ server.passkey }},timeout={{ server.timeout }}{% if server.vrf %},vrf={{ server.vrf }}{% endif %}{{''}}
-{% endfor %}
+server=192.168.1.1:50,secret=dellsonic,timeout=10,vrf=default
+server=192.168.1.2:51,secret=dellsonic1,timeout=15,vrf=mgmt
 
 # user_priv - set the map between TACACS+ user privilege and local user's passwd
 # Default:
@@ -57,4 +40,3 @@ server={{ server.ip }}:{{ server.tcp_port }},secret={{ server.passkey }},timeout
 # many_to_one - create one local user for many TACACS+ users which has the same privilege
 # Default: many_to_one=n
 # many_to_one=y
-

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local_and_tacacs/common-auth-sonic
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local_and_tacacs/common-auth-sonic
@@ -1,0 +1,21 @@
+#THIS IS AN AUTO-GENERATED FILE
+#
+# /etc/pam.d/common-auth- authentication settings common to all services
+# This file is included from other service-specific PAM config files,
+# and should contain a list of the authentication modules that define
+# the central authentication scheme for use on the system
+# (e.g., /etc/shadow, LDAP, Kerberos, etc.). The default is to use the
+# traditional Unix authentication mechanisms.
+#
+# here are the per-package modules (the "Primary" block)
+
+auth	[success=1 default=ignore]	pam_unix.so nullok try_first_pass
+
+#
+# here's the fallback if no module succeeds
+auth    requisite                       pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+auth    required                        pam_permit.so
+# and here are more per-package modules (the "Additional" block)

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local_and_tacacs/login
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local_and_tacacs/login
@@ -1,0 +1,116 @@
+#
+# The PAM configuration file for the Shadow `login' service
+#
+
+# Enforce a minimal delay in case of failure (in microseconds).
+# (Replaces the `FAIL_DELAY' setting from login.defs)
+# Note that other modules may require another minimal delay. (for example,
+# to disable any delay, you should add the nodelay option to pam_unix)
+auth       optional   pam_faildelay.so  delay=3000000
+
+# Outputs an issue file prior to each login prompt (Replaces the
+# ISSUE_FILE option from login.defs). Uncomment for use
+# auth       required   pam_issue.so issue=/etc/issue
+
+# Disallows root logins except on tty's listed in /etc/securetty
+# (Replaces the `CONSOLE' setting from login.defs)
+#
+# With the default control of this module:
+#   [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die]
+# root will not be prompted for a password on insecure lines.
+# if an invalid username is entered, a password is prompted (but login
+# will eventually be rejected)
+#
+# You can change it to a "requisite" module if you think root may mis-type
+# her login and should not be prompted for a password in that case. But
+# this will leave the system as vulnerable to user enumeration attacks.
+#
+# You can change it to a "required" module if you think it permits to
+# guess valid user names of your system (invalid user names are considered
+# as possibly being root on insecure lines), but root passwords may be
+# communicated over insecure lines.
+auth [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die] pam_securetty.so
+
+# Disallows other than root logins when /etc/nologin exists
+# (Replaces the `NOLOGINS_FILE' option from login.defs)
+auth       requisite  pam_nologin.so
+
+# SELinux needs to be the first session rule. This ensures that any
+# lingering context has been cleared. Without this it is possible
+# that a module could execute code in the wrong domain.
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
+
+# Sets the loginuid process attribute
+session    required     pam_loginuid.so
+
+# SELinux needs to intervene at login time to ensure that the process
+# starts in the proper default security context. Only sessions which are
+# intended to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+
+# This module parses environment configuration file(s)
+# and also allows you to use an extended config
+# file /etc/security/pam_env.conf.
+# 
+# parsing /etc/environment needs "readenv=1"
+session       required   pam_env.so readenv=1
+# locale variables are also kept into /etc/default/locale in etch
+# reading this file *in addition to /etc/environment* does not hurt
+session       required   pam_env.so readenv=1 envfile=/etc/default/locale
+
+# Standard Un*x authentication.
+@include common-auth-sonic
+
+# This allows certain extra groups to be granted to a user
+# based on things like time of day, tty, service, and user.
+# Please edit /etc/security/group.conf to fit your needs
+# (Replaces the `CONSOLE_GROUPS' option in login.defs)
+auth       optional   pam_group.so
+
+# Uncomment and edit /etc/security/time.conf if you need to set
+# time restraint on logins.
+# (Replaces the `PORTTIME_CHECKS_ENAB' option from login.defs
+# as well as /etc/porttime)
+# account    requisite  pam_time.so
+
+# Uncomment and edit /etc/security/access.conf if you need to
+# set access limits.
+# (Replaces /etc/login.access file)
+# account  required       pam_access.so
+
+# Sets up user limits according to /etc/security/limits.conf
+# (Replaces the use of /etc/limits in old login)
+session    required   pam_limits.so
+
+# Prints the last login info upon successful login
+# (Replaces the `LASTLOG_ENAB' option from login.defs)
+session    optional   pam_lastlog.so
+
+# Prints the message of the day upon successful login.
+# (Replaces the `MOTD_FILE' option in login.defs)
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional   pam_motd.so motd=/run/motd.dynamic
+session    optional   pam_motd.so noupdate
+
+# Prints the status of the user's mailbox upon successful login
+# (Replaces the `MAIL_CHECK_ENAB' option from login.defs). 
+#
+# This also defines the MAIL environment variable
+# However, userdel also needs MAIL_DIR and MAIL_FILE variables
+# in /etc/login.defs to make sure that removing a user 
+# also removes the user's mail spool file.
+# See comments in /etc/login.defs
+session    optional   pam_mail.so standard
+
+# Create a new session keyring.
+session    optional   pam_keyinit.so force revoke
+
+# Standard Un*x account and session
+@include common-account
+@include common-session
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local_and_tacacs/login.old
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local_and_tacacs/login.old
@@ -1,0 +1,116 @@
+#
+# The PAM configuration file for the Shadow `login' service
+#
+
+# Enforce a minimal delay in case of failure (in microseconds).
+# (Replaces the `FAIL_DELAY' setting from login.defs)
+# Note that other modules may require another minimal delay. (for example,
+# to disable any delay, you should add the nodelay option to pam_unix)
+auth       optional   pam_faildelay.so  delay=3000000
+
+# Outputs an issue file prior to each login prompt (Replaces the
+# ISSUE_FILE option from login.defs). Uncomment for use
+# auth       required   pam_issue.so issue=/etc/issue
+
+# Disallows root logins except on tty's listed in /etc/securetty
+# (Replaces the `CONSOLE' setting from login.defs)
+#
+# With the default control of this module:
+#   [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die]
+# root will not be prompted for a password on insecure lines.
+# if an invalid username is entered, a password is prompted (but login
+# will eventually be rejected)
+#
+# You can change it to a "requisite" module if you think root may mis-type
+# her login and should not be prompted for a password in that case. But
+# this will leave the system as vulnerable to user enumeration attacks.
+#
+# You can change it to a "required" module if you think it permits to
+# guess valid user names of your system (invalid user names are considered
+# as possibly being root on insecure lines), but root passwords may be
+# communicated over insecure lines.
+auth [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die] pam_securetty.so
+
+# Disallows other than root logins when /etc/nologin exists
+# (Replaces the `NOLOGINS_FILE' option from login.defs)
+auth       requisite  pam_nologin.so
+
+# SELinux needs to be the first session rule. This ensures that any
+# lingering context has been cleared. Without this it is possible
+# that a module could execute code in the wrong domain.
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
+
+# Sets the loginuid process attribute
+session    required     pam_loginuid.so
+
+# SELinux needs to intervene at login time to ensure that the process
+# starts in the proper default security context. Only sessions which are
+# intended to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+
+# This module parses environment configuration file(s)
+# and also allows you to use an extended config
+# file /etc/security/pam_env.conf.
+# 
+# parsing /etc/environment needs "readenv=1"
+session       required   pam_env.so readenv=1
+# locale variables are also kept into /etc/default/locale in etch
+# reading this file *in addition to /etc/environment* does not hurt
+session       required   pam_env.so readenv=1 envfile=/etc/default/locale
+
+# Standard Un*x authentication.
+@include common-auth
+
+# This allows certain extra groups to be granted to a user
+# based on things like time of day, tty, service, and user.
+# Please edit /etc/security/group.conf to fit your needs
+# (Replaces the `CONSOLE_GROUPS' option in login.defs)
+auth       optional   pam_group.so
+
+# Uncomment and edit /etc/security/time.conf if you need to set
+# time restraint on logins.
+# (Replaces the `PORTTIME_CHECKS_ENAB' option from login.defs
+# as well as /etc/porttime)
+# account    requisite  pam_time.so
+
+# Uncomment and edit /etc/security/access.conf if you need to
+# set access limits.
+# (Replaces /etc/login.access file)
+# account  required       pam_access.so
+
+# Sets up user limits according to /etc/security/limits.conf
+# (Replaces the use of /etc/limits in old login)
+session    required   pam_limits.so
+
+# Prints the last login info upon successful login
+# (Replaces the `LASTLOG_ENAB' option from login.defs)
+session    optional   pam_lastlog.so
+
+# Prints the message of the day upon successful login.
+# (Replaces the `MOTD_FILE' option in login.defs)
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional   pam_motd.so motd=/run/motd.dynamic
+session    optional   pam_motd.so noupdate
+
+# Prints the status of the user's mailbox upon successful login
+# (Replaces the `MAIL_CHECK_ENAB' option from login.defs). 
+#
+# This also defines the MAIL environment variable
+# However, userdel also needs MAIL_DIR and MAIL_FILE variables
+# in /etc/login.defs to make sure that removing a user 
+# also removes the user's mail spool file.
+# See comments in /etc/login.defs
+session    optional   pam_mail.so standard
+
+# Create a new session keyring.
+session    optional   pam_keyinit.so force revoke
+
+# Standard Un*x account and session
+@include common-account
+@include common-session
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local_and_tacacs/radius_nss.conf
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local_and_tacacs/radius_nss.conf
@@ -1,0 +1,55 @@
+#THIS IS AN AUTO-GENERATED FILE
+# Generated from: /usr/share/sonic/templates/radius_nss.conf.j2
+# RADIUS NSS Configuration File
+#
+# Debug: on|off|trace
+# Default: off
+#
+# debug=on
+
+#
+# User Privilege:
+# Default:
+# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=1;pw_info=remote_user;gid=999;group=docker;shell=/usr/bin/sonic-launch-shell
+
+# Eg:
+# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=7;pw_info=netops;gid=999;group=docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=1;pw_info=operator;gid=100;group=docker;shell=/usr/bin/sonic-launch-shell
+#
+
+# many_to_one:
+#   y: Map RADIUS users to one local user per privilege.
+#   n: Create local user account on first successful authentication.
+# Default: n
+#
+
+# Eg:
+# many_to_one=y
+#
+
+# unconfirmed_disallow:
+#   y: Do not allow unconfirmed users (users created before authentication)
+#   n: Allow unconfirmed users.
+# Default: n
+
+# Eg:
+# unconfirmed_disallow=y
+#
+
+# unconfirmed_ageout:
+#   <seconds>: Wait time before purging unconfirmed users
+# Default: 600
+#
+
+# Eg:
+# unconfirmed_ageout=900
+#
+
+# unconfirmed_regexp:
+#   <regexp>: The RE to match the command line of processes for which the
+#             creation of unconfirmed users are to be allowed.
+# Default: (.*: <user> \[priv\])|(.*: \[accepted\])
+#   where: <user> is the unconfirmed user.
+#

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local_and_tacacs/sshd
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local_and_tacacs/sshd
@@ -1,0 +1,55 @@
+# PAM configuration for the Secure Shell service
+
+# Standard Un*x authentication.
+@include common-auth-sonic
+
+# Disallow non-root logins when /etc/nologin exists.
+account    required     pam_nologin.so
+
+# Uncomment and edit /etc/security/access.conf if you need to set complex
+# access limits that are hard to express in sshd_config.
+# account  required     pam_access.so
+
+# Standard Un*x authorization.
+@include common-account
+
+# SELinux needs to be the first session rule.  This ensures that any
+# lingering context has been cleared.  Without this it is possible that a
+# module could execute code in the wrong domain.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
+
+# Set the loginuid process attribute.
+session    required     pam_loginuid.so
+
+# Create a new session keyring.
+session    optional     pam_keyinit.so force revoke
+
+# Standard Un*x session setup and teardown.
+@include common-session
+
+# Print the message of the day upon successful login.
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional     pam_motd.so  motd=/run/motd.dynamic
+session    optional     pam_motd.so noupdate
+
+# Print the status of the user's mailbox upon successful login.
+session    optional     pam_mail.so standard noenv # [1]
+
+# Set up user limits from /etc/security/limits.conf.
+session    required     pam_limits.so
+
+# Read environment variables from /etc/environment and
+# /etc/security/pam_env.conf.
+session    required     pam_env.so # [1]
+# In Debian 4.0 (etch), locale-related environment variables were moved to
+# /etc/default/locale, so read that as well.
+session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
+
+# SELinux needs to intervene at login time to ensure that the process starts
+# in the proper default security context.  Only sessions which are intended
+# to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
+
+# Standard Un*x password updating.
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local_and_tacacs/sshd.old
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local_and_tacacs/sshd.old
@@ -1,0 +1,55 @@
+# PAM configuration for the Secure Shell service
+
+# Standard Un*x authentication.
+@include common-auth
+
+# Disallow non-root logins when /etc/nologin exists.
+account    required     pam_nologin.so
+
+# Uncomment and edit /etc/security/access.conf if you need to set complex
+# access limits that are hard to express in sshd_config.
+# account  required     pam_access.so
+
+# Standard Un*x authorization.
+@include common-account
+
+# SELinux needs to be the first session rule.  This ensures that any
+# lingering context has been cleared.  Without this it is possible that a
+# module could execute code in the wrong domain.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
+
+# Set the loginuid process attribute.
+session    required     pam_loginuid.so
+
+# Create a new session keyring.
+session    optional     pam_keyinit.so force revoke
+
+# Standard Un*x session setup and teardown.
+@include common-session
+
+# Print the message of the day upon successful login.
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional     pam_motd.so  motd=/run/motd.dynamic
+session    optional     pam_motd.so noupdate
+
+# Print the status of the user's mailbox upon successful login.
+session    optional     pam_mail.so standard noenv # [1]
+
+# Set up user limits from /etc/security/limits.conf.
+session    required     pam_limits.so
+
+# Read environment variables from /etc/environment and
+# /etc/security/pam_env.conf.
+session    required     pam_env.so # [1]
+# In Debian 4.0 (etch), locale-related environment variables were moved to
+# /etc/default/locale, so read that as well.
+session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
+
+# SELinux needs to intervene at login time to ensure that the process starts
+# in the proper default security context.  Only sessions which are intended
+# to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
+
+# Standard Un*x password updating.
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local_and_tacacs/tacplus_nss.conf
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_local_and_tacacs/tacplus_nss.conf
@@ -3,51 +3,36 @@
 # debug - If you want to open debug log, set it on
 # Default: off
 # debug=on
-{% if debug %}
-debug=on
-{% endif %}
 
 # local_accounting - If you want to local accounting, set it
 # Default: None
 # local_accounting
-{% if local_accounting %}
 local_accounting
-{% endif %}
 
 # tacacs_accounting - If you want to tacacs+ accounting, set it
 # Default: None
 # tacacs_accounting
-{% if tacacs_accounting %}
 tacacs_accounting
-{% endif %}
 
 # local_authorization - If you want to local authorization, set it
 # Default: None
 # local_authorization
-{% if local_authorization %}
 local_authorization
-{% endif %}
 
 # tacacs_authorization - If you want to tacacs+ authorization, set it
 # Default: None
 # tacacs_authorization
-{% if tacacs_authorization %}
 tacacs_authorization
-{% endif %}
 
 # src_ip - set source address of TACACS+ protocol packets
 # Default: None (auto source ip address)
 # src_ip=2.2.2.2
-{% if src_ip %}
-src_ip={{ src_ip }}
-{% endif %}
 
 # server - set ip address, tcp port, secret string and timeout for TACACS+ servers
 # Default: None (no TACACS+ server)
 # server=1.1.1.1:49,secret=test,timeout=3
-{% for server in servers %}
-server={{ server.ip }}:{{ server.tcp_port }},secret={{ server.passkey }},timeout={{ server.timeout }}{% if server.vrf %},vrf={{ server.vrf }}{% endif %}{{''}}
-{% endfor %}
+server=192.168.1.1:50,secret=dellsonic,timeout=10,vrf=default
+server=192.168.1.2:51,secret=dellsonic1,timeout=15,vrf=mgmt
 
 # user_priv - set the map between TACACS+ user privilege and local user's passwd
 # Default:
@@ -57,4 +42,3 @@ server={{ server.ip }}:{{ server.tcp_port }},secret={{ server.passkey }},timeout
 # many_to_one - create one local user for many TACACS+ users which has the same privilege
 # Default: many_to_one=n
 # many_to_one=y
-

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_tacacs/common-auth-sonic
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_tacacs/common-auth-sonic
@@ -1,0 +1,21 @@
+#THIS IS AN AUTO-GENERATED FILE
+#
+# /etc/pam.d/common-auth- authentication settings common to all services
+# This file is included from other service-specific PAM config files,
+# and should contain a list of the authentication modules that define
+# the central authentication scheme for use on the system
+# (e.g., /etc/shadow, LDAP, Kerberos, etc.). The default is to use the
+# traditional Unix authentication mechanisms.
+#
+# here are the per-package modules (the "Primary" block)
+
+auth	[success=1 default=ignore]	pam_unix.so nullok try_first_pass
+
+#
+# here's the fallback if no module succeeds
+auth    requisite                       pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+auth    required                        pam_permit.so
+# and here are more per-package modules (the "Additional" block)

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_tacacs/login
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_tacacs/login
@@ -1,0 +1,116 @@
+#
+# The PAM configuration file for the Shadow `login' service
+#
+
+# Enforce a minimal delay in case of failure (in microseconds).
+# (Replaces the `FAIL_DELAY' setting from login.defs)
+# Note that other modules may require another minimal delay. (for example,
+# to disable any delay, you should add the nodelay option to pam_unix)
+auth       optional   pam_faildelay.so  delay=3000000
+
+# Outputs an issue file prior to each login prompt (Replaces the
+# ISSUE_FILE option from login.defs). Uncomment for use
+# auth       required   pam_issue.so issue=/etc/issue
+
+# Disallows root logins except on tty's listed in /etc/securetty
+# (Replaces the `CONSOLE' setting from login.defs)
+#
+# With the default control of this module:
+#   [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die]
+# root will not be prompted for a password on insecure lines.
+# if an invalid username is entered, a password is prompted (but login
+# will eventually be rejected)
+#
+# You can change it to a "requisite" module if you think root may mis-type
+# her login and should not be prompted for a password in that case. But
+# this will leave the system as vulnerable to user enumeration attacks.
+#
+# You can change it to a "required" module if you think it permits to
+# guess valid user names of your system (invalid user names are considered
+# as possibly being root on insecure lines), but root passwords may be
+# communicated over insecure lines.
+auth [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die] pam_securetty.so
+
+# Disallows other than root logins when /etc/nologin exists
+# (Replaces the `NOLOGINS_FILE' option from login.defs)
+auth       requisite  pam_nologin.so
+
+# SELinux needs to be the first session rule. This ensures that any
+# lingering context has been cleared. Without this it is possible
+# that a module could execute code in the wrong domain.
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
+
+# Sets the loginuid process attribute
+session    required     pam_loginuid.so
+
+# SELinux needs to intervene at login time to ensure that the process
+# starts in the proper default security context. Only sessions which are
+# intended to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+
+# This module parses environment configuration file(s)
+# and also allows you to use an extended config
+# file /etc/security/pam_env.conf.
+# 
+# parsing /etc/environment needs "readenv=1"
+session       required   pam_env.so readenv=1
+# locale variables are also kept into /etc/default/locale in etch
+# reading this file *in addition to /etc/environment* does not hurt
+session       required   pam_env.so readenv=1 envfile=/etc/default/locale
+
+# Standard Un*x authentication.
+@include common-auth-sonic
+
+# This allows certain extra groups to be granted to a user
+# based on things like time of day, tty, service, and user.
+# Please edit /etc/security/group.conf to fit your needs
+# (Replaces the `CONSOLE_GROUPS' option in login.defs)
+auth       optional   pam_group.so
+
+# Uncomment and edit /etc/security/time.conf if you need to set
+# time restraint on logins.
+# (Replaces the `PORTTIME_CHECKS_ENAB' option from login.defs
+# as well as /etc/porttime)
+# account    requisite  pam_time.so
+
+# Uncomment and edit /etc/security/access.conf if you need to
+# set access limits.
+# (Replaces /etc/login.access file)
+# account  required       pam_access.so
+
+# Sets up user limits according to /etc/security/limits.conf
+# (Replaces the use of /etc/limits in old login)
+session    required   pam_limits.so
+
+# Prints the last login info upon successful login
+# (Replaces the `LASTLOG_ENAB' option from login.defs)
+session    optional   pam_lastlog.so
+
+# Prints the message of the day upon successful login.
+# (Replaces the `MOTD_FILE' option in login.defs)
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional   pam_motd.so motd=/run/motd.dynamic
+session    optional   pam_motd.so noupdate
+
+# Prints the status of the user's mailbox upon successful login
+# (Replaces the `MAIL_CHECK_ENAB' option from login.defs). 
+#
+# This also defines the MAIL environment variable
+# However, userdel also needs MAIL_DIR and MAIL_FILE variables
+# in /etc/login.defs to make sure that removing a user 
+# also removes the user's mail spool file.
+# See comments in /etc/login.defs
+session    optional   pam_mail.so standard
+
+# Create a new session keyring.
+session    optional   pam_keyinit.so force revoke
+
+# Standard Un*x account and session
+@include common-account
+@include common-session
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_tacacs/login.old
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_tacacs/login.old
@@ -1,0 +1,116 @@
+#
+# The PAM configuration file for the Shadow `login' service
+#
+
+# Enforce a minimal delay in case of failure (in microseconds).
+# (Replaces the `FAIL_DELAY' setting from login.defs)
+# Note that other modules may require another minimal delay. (for example,
+# to disable any delay, you should add the nodelay option to pam_unix)
+auth       optional   pam_faildelay.so  delay=3000000
+
+# Outputs an issue file prior to each login prompt (Replaces the
+# ISSUE_FILE option from login.defs). Uncomment for use
+# auth       required   pam_issue.so issue=/etc/issue
+
+# Disallows root logins except on tty's listed in /etc/securetty
+# (Replaces the `CONSOLE' setting from login.defs)
+#
+# With the default control of this module:
+#   [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die]
+# root will not be prompted for a password on insecure lines.
+# if an invalid username is entered, a password is prompted (but login
+# will eventually be rejected)
+#
+# You can change it to a "requisite" module if you think root may mis-type
+# her login and should not be prompted for a password in that case. But
+# this will leave the system as vulnerable to user enumeration attacks.
+#
+# You can change it to a "required" module if you think it permits to
+# guess valid user names of your system (invalid user names are considered
+# as possibly being root on insecure lines), but root passwords may be
+# communicated over insecure lines.
+auth [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die] pam_securetty.so
+
+# Disallows other than root logins when /etc/nologin exists
+# (Replaces the `NOLOGINS_FILE' option from login.defs)
+auth       requisite  pam_nologin.so
+
+# SELinux needs to be the first session rule. This ensures that any
+# lingering context has been cleared. Without this it is possible
+# that a module could execute code in the wrong domain.
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
+
+# Sets the loginuid process attribute
+session    required     pam_loginuid.so
+
+# SELinux needs to intervene at login time to ensure that the process
+# starts in the proper default security context. Only sessions which are
+# intended to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
+# When the module is present, "required" would be sufficient (When SELinux
+# is disabled, this returns success.)
+
+# This module parses environment configuration file(s)
+# and also allows you to use an extended config
+# file /etc/security/pam_env.conf.
+# 
+# parsing /etc/environment needs "readenv=1"
+session       required   pam_env.so readenv=1
+# locale variables are also kept into /etc/default/locale in etch
+# reading this file *in addition to /etc/environment* does not hurt
+session       required   pam_env.so readenv=1 envfile=/etc/default/locale
+
+# Standard Un*x authentication.
+@include common-auth
+
+# This allows certain extra groups to be granted to a user
+# based on things like time of day, tty, service, and user.
+# Please edit /etc/security/group.conf to fit your needs
+# (Replaces the `CONSOLE_GROUPS' option in login.defs)
+auth       optional   pam_group.so
+
+# Uncomment and edit /etc/security/time.conf if you need to set
+# time restraint on logins.
+# (Replaces the `PORTTIME_CHECKS_ENAB' option from login.defs
+# as well as /etc/porttime)
+# account    requisite  pam_time.so
+
+# Uncomment and edit /etc/security/access.conf if you need to
+# set access limits.
+# (Replaces /etc/login.access file)
+# account  required       pam_access.so
+
+# Sets up user limits according to /etc/security/limits.conf
+# (Replaces the use of /etc/limits in old login)
+session    required   pam_limits.so
+
+# Prints the last login info upon successful login
+# (Replaces the `LASTLOG_ENAB' option from login.defs)
+session    optional   pam_lastlog.so
+
+# Prints the message of the day upon successful login.
+# (Replaces the `MOTD_FILE' option in login.defs)
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional   pam_motd.so motd=/run/motd.dynamic
+session    optional   pam_motd.so noupdate
+
+# Prints the status of the user's mailbox upon successful login
+# (Replaces the `MAIL_CHECK_ENAB' option from login.defs). 
+#
+# This also defines the MAIL environment variable
+# However, userdel also needs MAIL_DIR and MAIL_FILE variables
+# in /etc/login.defs to make sure that removing a user 
+# also removes the user's mail spool file.
+# See comments in /etc/login.defs
+session    optional   pam_mail.so standard
+
+# Create a new session keyring.
+session    optional   pam_keyinit.so force revoke
+
+# Standard Un*x account and session
+@include common-account
+@include common-session
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_tacacs/radius_nss.conf
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_tacacs/radius_nss.conf
@@ -1,0 +1,55 @@
+#THIS IS AN AUTO-GENERATED FILE
+# Generated from: /usr/share/sonic/templates/radius_nss.conf.j2
+# RADIUS NSS Configuration File
+#
+# Debug: on|off|trace
+# Default: off
+#
+# debug=on
+
+#
+# User Privilege:
+# Default:
+# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=1;pw_info=remote_user;gid=999;group=docker;shell=/usr/bin/sonic-launch-shell
+
+# Eg:
+# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=7;pw_info=netops;gid=999;group=docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=1;pw_info=operator;gid=100;group=docker;shell=/usr/bin/sonic-launch-shell
+#
+
+# many_to_one:
+#   y: Map RADIUS users to one local user per privilege.
+#   n: Create local user account on first successful authentication.
+# Default: n
+#
+
+# Eg:
+# many_to_one=y
+#
+
+# unconfirmed_disallow:
+#   y: Do not allow unconfirmed users (users created before authentication)
+#   n: Allow unconfirmed users.
+# Default: n
+
+# Eg:
+# unconfirmed_disallow=y
+#
+
+# unconfirmed_ageout:
+#   <seconds>: Wait time before purging unconfirmed users
+# Default: 600
+#
+
+# Eg:
+# unconfirmed_ageout=900
+#
+
+# unconfirmed_regexp:
+#   <regexp>: The RE to match the command line of processes for which the
+#             creation of unconfirmed users are to be allowed.
+# Default: (.*: <user> \[priv\])|(.*: \[accepted\])
+#   where: <user> is the unconfirmed user.
+#

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_tacacs/sshd
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_tacacs/sshd
@@ -1,0 +1,55 @@
+# PAM configuration for the Secure Shell service
+
+# Standard Un*x authentication.
+@include common-auth-sonic
+
+# Disallow non-root logins when /etc/nologin exists.
+account    required     pam_nologin.so
+
+# Uncomment and edit /etc/security/access.conf if you need to set complex
+# access limits that are hard to express in sshd_config.
+# account  required     pam_access.so
+
+# Standard Un*x authorization.
+@include common-account
+
+# SELinux needs to be the first session rule.  This ensures that any
+# lingering context has been cleared.  Without this it is possible that a
+# module could execute code in the wrong domain.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
+
+# Set the loginuid process attribute.
+session    required     pam_loginuid.so
+
+# Create a new session keyring.
+session    optional     pam_keyinit.so force revoke
+
+# Standard Un*x session setup and teardown.
+@include common-session
+
+# Print the message of the day upon successful login.
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional     pam_motd.so  motd=/run/motd.dynamic
+session    optional     pam_motd.so noupdate
+
+# Print the status of the user's mailbox upon successful login.
+session    optional     pam_mail.so standard noenv # [1]
+
+# Set up user limits from /etc/security/limits.conf.
+session    required     pam_limits.so
+
+# Read environment variables from /etc/environment and
+# /etc/security/pam_env.conf.
+session    required     pam_env.so # [1]
+# In Debian 4.0 (etch), locale-related environment variables were moved to
+# /etc/default/locale, so read that as well.
+session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
+
+# SELinux needs to intervene at login time to ensure that the process starts
+# in the proper default security context.  Only sessions which are intended
+# to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
+
+# Standard Un*x password updating.
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_tacacs/sshd.old
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_tacacs/sshd.old
@@ -1,0 +1,55 @@
+# PAM configuration for the Secure Shell service
+
+# Standard Un*x authentication.
+@include common-auth
+
+# Disallow non-root logins when /etc/nologin exists.
+account    required     pam_nologin.so
+
+# Uncomment and edit /etc/security/access.conf if you need to set complex
+# access limits that are hard to express in sshd_config.
+# account  required     pam_access.so
+
+# Standard Un*x authorization.
+@include common-account
+
+# SELinux needs to be the first session rule.  This ensures that any
+# lingering context has been cleared.  Without this it is possible that a
+# module could execute code in the wrong domain.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
+
+# Set the loginuid process attribute.
+session    required     pam_loginuid.so
+
+# Create a new session keyring.
+session    optional     pam_keyinit.so force revoke
+
+# Standard Un*x session setup and teardown.
+@include common-session
+
+# Print the message of the day upon successful login.
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional     pam_motd.so  motd=/run/motd.dynamic
+session    optional     pam_motd.so noupdate
+
+# Print the status of the user's mailbox upon successful login.
+session    optional     pam_mail.so standard noenv # [1]
+
+# Set up user limits from /etc/security/limits.conf.
+session    required     pam_limits.so
+
+# Read environment variables from /etc/environment and
+# /etc/security/pam_env.conf.
+session    required     pam_env.so # [1]
+# In Debian 4.0 (etch), locale-related environment variables were moved to
+# /etc/default/locale, so read that as well.
+session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
+
+# SELinux needs to intervene at login time to ensure that the process starts
+# in the proper default security context.  Only sessions which are intended
+# to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
+
+# Standard Un*x password updating.
+@include common-password

--- a/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_tacacs/tacplus_nss.conf
+++ b/src/sonic-host-services/tests/hostcfgd/sample_output/TACACS_config_db_tacacs/tacplus_nss.conf
@@ -3,51 +3,34 @@
 # debug - If you want to open debug log, set it on
 # Default: off
 # debug=on
-{% if debug %}
-debug=on
-{% endif %}
 
 # local_accounting - If you want to local accounting, set it
 # Default: None
 # local_accounting
-{% if local_accounting %}
-local_accounting
-{% endif %}
 
 # tacacs_accounting - If you want to tacacs+ accounting, set it
 # Default: None
 # tacacs_accounting
-{% if tacacs_accounting %}
 tacacs_accounting
-{% endif %}
 
 # local_authorization - If you want to local authorization, set it
 # Default: None
 # local_authorization
-{% if local_authorization %}
-local_authorization
-{% endif %}
 
 # tacacs_authorization - If you want to tacacs+ authorization, set it
 # Default: None
 # tacacs_authorization
-{% if tacacs_authorization %}
 tacacs_authorization
-{% endif %}
 
 # src_ip - set source address of TACACS+ protocol packets
 # Default: None (auto source ip address)
 # src_ip=2.2.2.2
-{% if src_ip %}
-src_ip={{ src_ip }}
-{% endif %}
 
 # server - set ip address, tcp port, secret string and timeout for TACACS+ servers
 # Default: None (no TACACS+ server)
 # server=1.1.1.1:49,secret=test,timeout=3
-{% for server in servers %}
-server={{ server.ip }}:{{ server.tcp_port }},secret={{ server.passkey }},timeout={{ server.timeout }}{% if server.vrf %},vrf={{ server.vrf }}{% endif %}{{''}}
-{% endfor %}
+server=192.168.1.1:50,secret=dellsonic,timeout=10,vrf=default
+server=192.168.1.2:51,secret=dellsonic1,timeout=15,vrf=mgmt
 
 # user_priv - set the map between TACACS+ user privilege and local user's passwd
 # Default:
@@ -57,4 +40,3 @@ server={{ server.ip }}:{{ server.tcp_port }},secret={{ server.passkey }},timeout
 # many_to_one - create one local user for many TACACS+ users which has the same privilege
 # Default: many_to_one=n
 # many_to_one=y
-

--- a/src/sonic-host-services/tests/hostcfgd/test_tacacs_vectors.py
+++ b/src/sonic-host-services/tests/hostcfgd/test_tacacs_vectors.py
@@ -1,0 +1,260 @@
+from unittest.mock import call
+
+"""
+    hostcfgd test tacacs vector
+"""
+HOSTCFGD_TEST_TACACS_VECTOR = [
+    [
+        "TACACS",
+        {
+            "config_db_local": {
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "hostname": "radius",
+                    }
+                },
+                "FEATURE": {
+                    "dhcp_relay": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "kube",
+                        "state": "enabled"
+                    },
+                },
+                "KDUMP": {
+                    "config": {
+                        "enabled": "false",
+                        "num_dumps": "3",
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                        }
+                },
+                "AAA": {
+                    "authentication": {
+                        "login": "local"
+                    },
+                    "authorization": {
+                        "login": "local" 
+                    },
+                    "accounting": {
+                        "login": "local" 
+                    }
+                },
+                "TACPLUS": {
+                    "global": {
+                            "auth_type": "chap",
+                            "timeout": 5,
+                            "passkey": "dellsonic",
+                            "src_intf": "Ethernet0"
+                    }
+                },
+                "TACPLUS_SERVER": {
+                    "192.168.1.1" : {
+                            "priority": 5,
+                            "tcp_port": 50,
+                            "timeout": 10,
+                            "auth_type": "chap",
+                            "passkey": "dellsonic",
+                            "vrf": "default"
+                    },
+                    "192.168.1.2" : {
+                            "priority": 2,
+                            "tcp_port": 51,
+                            "timeout": 15,
+                            "auth_type": "pap",
+                            "passkey": "dellsonic1",
+                            "vrf": "mgmt"
+                    }
+                },
+            },
+            "config_db_tacacs": {
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "hostname": "radius",
+                    }
+                },
+                "FEATURE": {
+                    "dhcp_relay": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "kube",
+                        "state": "enabled"
+                    },
+                },
+                "KDUMP": {
+                    "config": {
+                        "enabled": "false",
+                        "num_dumps": "3",
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                        }
+                },
+                "AAA": {
+                    "authentication": {
+                        "login": "local"
+                    },
+                    "authorization": {
+                        "login": "tacacs+" 
+                    },
+                    "accounting": {
+                        "login": "tacacs+" 
+                    }
+                },
+                "TACPLUS": {
+                    "global": {
+                            "auth_type": "chap",
+                            "timeout": 5,
+                            "passkey": "dellsonic",
+                            "src_intf": "Ethernet0"
+                    }
+                },
+                "TACPLUS_SERVER": {
+                    "192.168.1.1" : {
+                            "priority": 5,
+                            "tcp_port": 50,
+                            "timeout": 10,
+                            "auth_type": "chap",
+                            "passkey": "dellsonic",
+                            "vrf": "default"
+                    },
+                    "192.168.1.2" : {
+                            "priority": 2,
+                            "tcp_port": 51,
+                            "timeout": 15,
+                            "auth_type": "pap",
+                            "passkey": "dellsonic1",
+                            "vrf": "mgmt"
+                    }
+                },
+            },
+            "config_db_local_and_tacacs": {
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "hostname": "radius",
+                    }
+                },
+                "FEATURE": {
+                    "dhcp_relay": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "kube",
+                        "state": "enabled"
+                    },
+                },
+                "KDUMP": {
+                    "config": {
+                        "enabled": "false",
+                        "num_dumps": "3",
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                        }
+                },
+                "AAA": {
+                    "authentication": {
+                        "login": "local"
+                    },
+                    "authorization": {
+                        "login": "tacacs+ local" 
+                    },
+                    "accounting": {
+                        "login": "tacacs+ local" 
+                    }
+                },
+                "TACPLUS": {
+                    "global": {
+                            "auth_type": "chap",
+                            "timeout": 5,
+                            "passkey": "dellsonic",
+                            "src_intf": "Ethernet0"
+                    }
+                },
+                "TACPLUS_SERVER": {
+                    "192.168.1.1" : {
+                            "priority": 5,
+                            "tcp_port": 50,
+                            "timeout": 10,
+                            "auth_type": "chap",
+                            "passkey": "dellsonic",
+                            "vrf": "default"
+                    },
+                    "192.168.1.2" : {
+                            "priority": 2,
+                            "tcp_port": 51,
+                            "timeout": 15,
+                            "auth_type": "pap",
+                            "passkey": "dellsonic1",
+                            "vrf": "mgmt"
+                    }
+                },
+            },
+            "config_db_disable_accounting": {
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "hostname": "radius",
+                    }
+                },
+                "FEATURE": {
+                    "dhcp_relay": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "kube",
+                        "state": "enabled"
+                    },
+                },
+                "KDUMP": {
+                    "config": {
+                        "enabled": "false",
+                        "num_dumps": "3",
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                        }
+                },
+                "AAA": {
+                    "authentication": {
+                        "login": "local"
+                    },
+                    "authorization": {
+                        "login": "local" 
+                    },
+                    "accounting": {
+                        "login": "disable" 
+                    }
+                },
+                "TACPLUS": {
+                    "global": {
+                            "auth_type": "chap",
+                            "timeout": 5,
+                            "passkey": "dellsonic",
+                            "src_intf": "Ethernet0"
+                    }
+                },
+                "TACPLUS_SERVER": {
+                    "192.168.1.1" : {
+                            "priority": 5,
+                            "tcp_port": 50,
+                            "timeout": 10,
+                            "auth_type": "chap",
+                            "passkey": "dellsonic",
+                            "vrf": "default"
+                    },
+                    "192.168.1.2" : {
+                            "priority": 2,
+                            "tcp_port": 51,
+                            "timeout": 15,
+                            "auth_type": "pap",
+                            "passkey": "dellsonic1",
+                            "vrf": "mgmt"
+                    }
+                },
+            }
+        }
+    ]
+]

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1,0 +1,1311 @@
+{
+    "SAMPLE_CONFIG_DB_JSON": {
+        "VRF": {
+                "Vrf_blue": {
+                }
+        },
+        "PORTCHANNEL": {
+            "PortChannel0003": {
+                "admin_status": "up",
+                "min_links": "1",
+                "members": [
+                    "Ethernet1"
+                ],
+                "tpid": "0x8100",
+                "mtu": "9100",
+                "lacp_key": "auto"
+            },
+            "PortChannel0004": {
+                "admin_status": "up",
+                "min_links": "1",
+                "members": [
+                    "Ethernet2"
+                ],
+                "tpid": "0x9200",
+                "mtu": "9100",
+                "lacp_key": "auto"
+            }
+        },
+        "PORTCHANNEL_INTERFACE": {
+                "PortChannel0003": {
+                    "nat_zone": "1"
+                },
+                "PortChannel0004": {"vrf_name": "Vrf_blue"}
+        },
+        "PORTCHANNEL_MEMBER": {
+            "PortChannel0003|Ethernet1": {},
+            "PortChannel0004|Ethernet2": {}
+        },
+        "VLAN_INTERFACE": {
+            "Vlan111": {
+                "nat_zone": "0"
+            },
+            "Vlan777": {},
+            "Vlan111|2a04:5555:45:6709::1/64": {
+                "scope": "global",
+                "family": "IPv6"
+            },
+            "Vlan111|10.222.10.65/26": {
+                "scope": "global",
+                "family": "IPv4"
+            },
+            "Vlan111|fe80::1/10": {
+                "scope": "local",
+                "family": "IPv6"
+            },
+            "Vlan777|2a04:5555:41:4e9::1/64": {
+                "scope": "global",
+                "family": "IPv6"
+            },
+            "Vlan777|10.111.58.65/26": {
+                "scope": "global",
+                "family": "IPv4"
+            },
+            "Vlan777|fe80::1/10": {
+                "scope": "local",
+                "family": "IPv6"
+            }
+        },
+        "ACL_RULE": {
+            "V4-ACL-TABLE|DEFAULT_DENY": {
+                "PACKET_ACTION": "DROP",
+                "IP_TYPE": "IPv4ANY",
+                "PRIORITY": "0"
+            },
+            "V4-ACL-TABLE|Rule_20": {
+                "PACKET_ACTION": "FORWARD",
+                "DST_IP": "10.222.72.0/26",
+                "SRC_IP": "10.222.0.0/15",
+                "PRIORITY": "777780",
+                "IP_TYPE": "IPv4ANY"
+            },
+            "V4-ACL-TABLE|Rule_40": {
+                "PACKET_ACTION": "FORWARD",
+                "DST_IP": "10.222.72.64/26",
+                "SRC_IP": "10.222.0.0/15",
+                "PRIORITY": "777760",
+                "IP_TYPE": "IPv4ANY"
+            },
+            "V4-ACL-TABLE|Rule_60": {
+                "PACKET_ACTION": "FORWARD",
+                "DST_IP": "10.222.80.0/26",
+                "SRC_IP": "10.222.0.0/15",
+                "PRIORITY": "777740",
+                "IP_TYPE": "IPv4ANY"
+            },
+            "V4-ACL-TABLE|Rule_80": {
+                "PACKET_ACTION": "FORWARD",
+                "DST_IP": "10.222.80.64/26",
+                "SRC_IP": "10.222.0.0/15",
+                "PRIORITY": "777720",
+                "IP_TYPE": "IPv4ANY"
+            },
+            "V4-ACL-TABLE|Rule_111": {
+                "PACKET_ACTION": "FORWARD",
+                "DST_IP": "10.152.17.52/32",
+                "SRC_IP": "10.222.0.0/15",
+                "PRIORITY": "777700",
+                "IP_TYPE": "IPv4ANY"
+            },
+            "V4-ACL-TABLE|Rule_120": {
+                "PACKET_ACTION": "FORWARD",
+                "DST_IP": "10.252.208.41/32",
+                "SRC_IP": "10.222.0.0/15",
+                "PRIORITY": "777880",
+                "IP_TYPE": "IPv4ANY"
+            },
+            "V4-ACL-TABLE|Rule_140": {
+                "PACKET_ACTION": "FORWARD",
+                "DST_IP": "10.148.128.245/32",
+                "SRC_IP": "10.222.0.0/15",
+                "PRIORITY": "777860",
+                "IP_TYPE": "IPv4ANY"
+            },
+            "V4-ACL-TABLE|Rule_160": {
+                "PACKET_ACTION": "FORWARD",
+                "DST_IP": "10.222.1.245/32",
+                "SRC_IP": "10.222.0.0/15",
+                "PRIORITY": "777840",
+                "IP_TYPE": "IPv4ANY"
+            },
+            "V4-ACL-TABLE|Rule_180": {
+                "PACKET_ACTION": "FORWARD",
+                "DST_IP": "10.252.222.21/32",
+                "SRC_IP": "10.222.0.0/15",
+                "PRIORITY": "777820",
+                "IP_TYPE": "IPv4ANY"
+            },
+            "V4-ACL-TABLE|Rule_9000": {
+                "PACKET_ACTION": "DROP",
+                "DST_IP": "0.0.0.0/0",
+                "SRC_IP": "10.222.0.0/15",
+                "PRIORITY": "991110",
+                "IP_TYPE": "IPv4ANY"
+            },
+            "V4-ACL-TABLE|Rule_11100": {
+                "PACKET_ACTION": "FORWARD",
+                "DST_IP": "0.0.0.0/0",
+                "SRC_IP": "0.0.0.0/0",
+                "PRIORITY": "990000",
+                "IP_TYPE": "IPv4ANY"
+            },
+            "V6-ACL-TBLE|DEFAULT_DENY": {
+                "PACKET_ACTION": "DROP",
+                "IP_TYPE": "IPv6ANY",
+                "PRIORITY": "0"
+            },
+            "V6-ACL-TBLE|Rule_20": {
+                "PACKET_ACTION": "FORWARD",
+                "IP_TYPE": "IPv6ANY",
+                "SRC_IPV6": "2a04:5555:41::/48",
+                "PRIORITY": "777780",
+                "DST_IPV6": "2a04:5555:43:320::/64"
+            },
+            "V6-ACL-TBLE|Rule_40": {
+                "PACKET_ACTION": "FORWARD",
+                "IP_TYPE": "IPv6ANY",
+                "SRC_IPV6": "2a04:5555:41::/48",
+                "PRIORITY": "777760",
+                "DST_IPV6": "2a04:5555:43:321::/64"
+            },
+            "V6-ACL-TBLE|Rule_60": {
+                "PACKET_ACTION": "FORWARD",
+                "IP_TYPE": "IPv6ANY",
+                "SRC_IPV6": "2a04:5555:41::/48",
+                "PRIORITY": "777740",
+                "DST_IPV6": "2a04:5555:43:340::/64"
+            },
+            "V6-ACL-TBLE|Rule_80": {
+                "PACKET_ACTION": "FORWARD",
+                "IP_TYPE": "IPv6ANY",
+                "SRC_IPV6": "2a04:5555:41::/48",
+                "PRIORITY": "777720",
+                "DST_IPV6": "2a04:5555:43:341::/64"
+            },
+            "V6-ACL-TBLE|Rule_111": {
+                "PACKET_ACTION": "FORWARD",
+                "IP_TYPE": "IPv6ANY",
+                "SRC_IPV6": "2a04:5555:41::/48",
+                "PRIORITY": "777700",
+                "DST_IPV6": "2a04:5555:32:12::/64"
+            },
+            "V6-ACL-TBLE|Rule_9000": {
+                "PACKET_ACTION": "DROP",
+                "IP_TYPE": "IPv6ANY",
+                "SRC_IPV6": "2a04:5555:41::/48",
+                "PRIORITY": "991110",
+                "DST_IPV6": "::/0"
+            },
+            "V6-ACL-TBLE|Rule_11100": {
+                "PACKET_ACTION": "FORWARD",
+                "IP_TYPE": "IPv6ANY",
+                "SRC_IPV6": "::/0",
+                "PRIORITY": "990000",
+                "DST_IPV6": "::/0"
+            }
+        },
+        "DEVICE_METADATA": {
+            "localhost": {
+                "type": "ToRRouter",
+                "mac": "00:11:22:33:dd:5a",
+                "hostname": "asw.dc",
+                "bgp_asn": "64850",
+                "hwsku": "Stone",
+                "buffer_model": "dynamic"
+            }
+        },
+        "VLAN": {
+            "Vlan111": {
+                "description": "svlan",
+                "dhcp_servers": [
+                    "10.222.72.116"
+                ],
+                "dhcpv6_servers": [
+                    "2a04:5555:41::11"
+                ],
+                "vlanid": "111",
+                "mtu": "9216",
+                "admin_status": "up"
+            },
+            "Vlan777": {
+                "description": "pvlan",
+                "dhcp_servers": [
+                    "10.222.72.116"
+                ],
+                "dhcpv6_servers": [
+                    "2a04:5555:41::11"
+                ],
+                "vlanid": "777",
+                "mtu": "9216",
+                "admin_status": "up"
+            }
+        },
+        "DEVICE_NEIGHBOR": {
+            "Ethernet112": {
+                "name": "dccsw01.nw",
+                "port": "Eth18"
+            },
+            "Ethernet114": {
+                "name": "dccsw02.nw",
+                "port": "Eth18"
+            },
+            "Ethernet116": {
+                "name": "dccsw03.nw",
+                "port": "Eth18"
+            },
+            "Ethernet118": {
+                "name": "dccsw04.nw",
+                "port": "Eth18"
+            }
+        },
+        "MGMT_PORT": {
+            "eth0": {
+                "alias": "eth0",
+                "admin_status": "up",
+                "speed": "1000",
+                "autoneg": "off",
+                "description": "Management port",
+                "mtu": "3500"
+            }
+        },
+        "MGMT_INTERFACE": {
+            "eth0|10.11.150.11/16": {
+                "gwaddr": "10.11.0.1"
+            },
+            "eth0|fc00:2::32/64": {
+                "forced_mgmt_routes": [
+                    "10.3.145.14",
+                    "2001:aa:aa::aa",
+                    "10.0.0.100/31",
+                    "10.255.0.0/28"
+                ],
+                "gwaddr": "fc00:2::1"
+            }
+        },
+        "MGMT_VRF_CONFIG": {
+            "vrf_global": {
+                "mgmtVrfEnabled": "true"
+            }
+        },
+        "NTP": {
+            "global": {
+                "vrf": "mgmt",
+                "src_intf": [
+		    "eth0",
+		    "Loopback0"
+		]
+            }
+        },
+        "NTP_SERVER": {
+            "0.debian.pool.ntp.org": {},
+            "23.92.29.245": {},
+            "2001:aa:aa::aa": {}
+        },
+        "PORT": {
+            "Ethernet0": {
+                "alias": "Eth1/1",
+                "lanes": "65",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet1": {
+                "alias": "Eth1/2",
+                "lanes": "66",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet2": {
+                "alias": "Eth1/3",
+                "lanes": "67",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet3": {
+                "alias": "Eth1/4",
+                "lanes": "68",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x88A8",
+                "admin_status": "up"
+            },
+            "Ethernet4": {
+                "alias": "Eth2/1",
+                "lanes": "69",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x9100",
+                "admin_status": "up"
+            },
+            "Ethernet5": {
+                "alias": "Eth2/2",
+                "lanes": "70",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x9200",
+                "admin_status": "up"
+            },
+            "Ethernet6": {
+                "alias": "Eth2/3",
+                "lanes": "71",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet7": {
+                "alias": "Eth2/4",
+                "lanes": "72",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet8": {
+                "alias": "Eth3/1",
+                "lanes": "73",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet9": {
+                "alias": "Eth3/2",
+                "lanes": "74",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet10": {
+                "alias": "Eth3/3",
+                "lanes": "75",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet11": {
+                "alias": "Eth3/4",
+                "lanes": "76",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet12": {
+                "alias": "Eth4/1",
+                "lanes": "77",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet13": {
+                "alias": "Eth4/2",
+                "lanes": "78",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet14": {
+                "alias": "Eth4/3",
+                "lanes": "79",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet15": {
+                "alias": "Eth4/4",
+                "lanes": "80",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet16": {
+                "alias": "Eth5/1",
+                "lanes": "33",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet17": {
+                "alias": "Eth5/2",
+                "lanes": "34",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet18": {
+                "alias": "Eth5/3",
+                "lanes": "35",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet19": {
+                "alias": "Eth5/4",
+                "lanes": "36",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet20": {
+                "alias": "Eth6/1",
+                "lanes": "37",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet21": {
+                "alias": "Eth6/2",
+                "lanes": "38",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet22": {
+                "alias": "Eth6/3",
+                "lanes": "39",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet23": {
+                "alias": "Eth6/4",
+                "lanes": "40",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet24": {
+                "alias": "Eth7/1",
+                "lanes": "41",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet25": {
+                "alias": "Eth7/2",
+                "lanes": "42",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet26": {
+                "alias": "Eth7/3",
+                "lanes": "43",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet27": {
+                "alias": "Eth7/4",
+                "lanes": "44",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet28": {
+                "alias": "Eth8/1",
+                "lanes": "45",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet29": {
+                "alias": "Eth8/2",
+                "lanes": "46",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet30": {
+                "alias": "Eth8/3",
+                "lanes": "47",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet31": {
+                "alias": "Eth8/4",
+                "lanes": "48",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet32": {
+                "alias": "Eth9/1",
+                "lanes": "49",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet33": {
+                "alias": "Eth9/2",
+                "lanes": "50",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet34": {
+                "alias": "Eth9/3",
+                "lanes": "51",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet35": {
+                "alias": "Eth9/4",
+                "lanes": "52",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet36": {
+                "alias": "Eth10/1",
+                "lanes": "53",
+                "description": "",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            },
+            "Ethernet112": {
+                "alias": "Eth29/1",
+                "lanes": "113,114",
+                "description": "50G|dccsw01.nw|Eth18",
+                "fec": "fc",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
+            }
+        },
+        "ACL_TABLE": {
+            "V4-ACL-TABLE": {
+                "type": "L3",
+                "policy_desc": "V4-ACL-TABLE",
+                "ports": [
+                    "Ethernet26",
+                    "Ethernet27",
+                    "Ethernet24"
+                ],
+                "stage": "INGRESS",
+                "services": ["SNMP", "SSH"]
+            },
+            "V6-ACL-TBLE": {
+                "type": "L3V6",
+                "policy_desc": "V6-ACL-TBLE",
+                "ports": [
+                    "Ethernet14",
+                    "Ethernet15",
+                    "Ethernet23",
+                    "Ethernet30",
+                    "Ethernet31",
+                    "Ethernet18",
+                    "Ethernet19",
+                    "Ethernet25",
+                    "Ethernet24"
+                ]
+            }
+        },
+        "PBH_HASH_FIELD": {
+            "inner_ip_proto": {
+                "hash_field": "INNER_IP_PROTOCOL",
+                "sequence_id": "1"
+            },
+            "inner_l4_dst_port": {
+                "hash_field": "INNER_L4_DST_PORT",
+                "sequence_id": "2"
+            },
+            "inner_l4_src_port": {
+                "hash_field": "INNER_L4_SRC_PORT",
+                "sequence_id": "2"
+            },
+            "inner_dst_ipv4": {
+                "hash_field": "INNER_DST_IPV4",
+                "ip_mask": "255.0.0.0",
+                "sequence_id": "3"
+            },
+            "inner_src_ipv4": {
+                "hash_field": "INNER_SRC_IPV4",
+                "ip_mask": "0.0.0.255",
+                "sequence_id": "3"
+            },
+            "inner_dst_ipv6": {
+                "hash_field": "INNER_DST_IPV6",
+                "ip_mask": "ffff::",
+                "sequence_id": "4"
+            },
+            "inner_src_ipv6": {
+                "hash_field": "INNER_SRC_IPV6",
+                "ip_mask": "::ffff",
+                "sequence_id": "4"
+            }
+        },
+        "PBH_HASH": {
+            "inner_v4_hash": {
+                "hash_field_list": [
+                    "inner_ip_proto",
+                    "inner_l4_dst_port",
+                    "inner_l4_src_port",
+                    "inner_dst_ipv4",
+                    "inner_src_ipv4"
+                ]
+            },
+            "inner_v6_hash": {
+                "hash_field_list": [
+                    "inner_ip_proto",
+                    "inner_l4_dst_port",
+                    "inner_l4_src_port",
+                    "inner_dst_ipv6",
+                    "inner_src_ipv6"
+                ]
+            }
+        },
+        "PBH_RULE": {
+            "pbh_table|nvgre": {
+                "priority": "1",
+                "ether_type": "0x0800",
+                "ip_protocol": "0x2f",
+                "gre_key": "0x2500/0xffffff00",
+                "inner_ether_type": "0x86dd",
+                "hash": "inner_v6_hash",
+                "packet_action": "SET_ECMP_HASH",
+                "flow_counter": "DISABLED"
+            },
+            "pbh_table|vxlan": {
+                "priority": "2",
+                "ether_type": "0x0800",
+                "ip_protocol": "0x11",
+                "l4_dst_port": "0x12b5",
+                "inner_ether_type": "0x0800",
+                "hash": "inner_v4_hash",
+                "packet_action": "SET_LAG_HASH",
+                "flow_counter": "ENABLED"
+            }
+        },
+        "PBH_TABLE": {
+            "pbh_table": {
+                "interface_list": [
+                    "Ethernet0",
+                    "Ethernet4",
+                    "PortChannel0003",
+                    "PortChannel0004"
+                ],
+                "description": "NVGRE and VxLAN"
+            }
+        },
+        "INTERFACE": {
+            "Ethernet112": {},
+            "Ethernet14": {},
+            "Ethernet16": {},
+            "Ethernet18": {
+                "nat_zone": "1"
+            },
+            "Ethernet112|2a04:5555:40:a709::2/126": {
+                "scope": "global",
+                "family": "IPv6"
+            },
+            "Ethernet112|10.184.228.211/31": {
+                "scope": "global",
+                "family": "IPv4"
+            },
+            "Ethernet14|2a04:5555:40:a749::2/126": {
+                "scope": "global",
+                "family": "IPv6"
+            },
+            "Ethernet14|10.184.229.211/31": {
+                "scope": "global",
+                "family": "IPv4"
+            },
+            "Ethernet16|2a04:5555:40:a789::2/126": {
+                "scope": "global",
+                "family": "IPv6"
+            },
+            "Ethernet16|10.184.230.211/31": {
+                "scope": "global",
+                "family": "IPv4"
+            },
+            "Ethernet18|2a04:5555:40:a7c9::2/126": {
+                "scope": "global",
+                "family": "IPv6"
+            },
+            "Ethernet18|10.184.231.211/31": {
+                "scope": "global",
+                "family": "IPv4"
+            }
+        },
+        "VLAN_MEMBER": {
+            "Vlan111|Ethernet0": {
+                "tagging_mode": "untagged"
+            },
+            "Vlan111|Ethernet1": {
+                "tagging_mode": "untagged"
+            },
+            "Vlan111|Ethernet2": {
+                "tagging_mode": "untagged"
+            },
+            "Vlan111|Ethernet3": {
+                "tagging_mode": "untagged"
+            },
+            "Vlan111|Ethernet4": {
+                "tagging_mode": "untagged"
+            },
+            "Vlan111|Ethernet5": {
+                "tagging_mode": "untagged"
+            },
+            "Vlan111|Ethernet6": {
+                "tagging_mode": "untagged"
+            },
+            "Vlan111|Ethernet29": {
+                "tagging_mode": "untagged"
+            },
+            "Vlan111|Ethernet30": {
+                "tagging_mode": "untagged"
+            },
+            "Vlan111|Ethernet31": {
+                "tagging_mode": "untagged"
+            },
+            "Vlan111|Ethernet32": {
+                "tagging_mode": "untagged"
+            },
+            "Vlan111|Ethernet33": {
+                "tagging_mode": "untagged"
+            },
+            "Vlan111|Ethernet34": {
+                "tagging_mode": "untagged"
+            },
+            "Vlan111|Ethernet35": {
+                "tagging_mode": "untagged"
+            },
+            "Vlan111|Ethernet36": {
+                "tagging_mode": "untagged"
+            },
+            "Vlan111|PortChannel0003": {
+                "tagging_mode": "untagged"
+            }
+        },
+        "LOOPBACK_INTERFACE": {
+            "Loopback0": {
+               "nat_zone": "2"
+            },
+            "Loopback0|2a04:5555:40:4::4e9/128": {
+                "scope": "global",
+                "family": "IPv6"
+            },
+            "Loopback0|10.184.8.233/32": {
+                "scope": "global",
+                "family": "IPv4"
+            }
+        },
+        "BREAKOUT_CFG": {
+            "Ethernet0": {
+                "brkout_mode": "1x100G[40G]"
+            },
+            "Ethernet4": {
+                "brkout_mode": "4x25G[10G]"
+            },
+            "Ethernet8": {
+                "brkout_mode": "1x100G[40G]"
+            }
+        },
+        "VERSIONS": {
+            "DATABASE": {
+                "VERSION": "version_1_0_3"
+            }
+        },
+        "FLEX_COUNTER_TABLE": {
+            "PFCWD": {
+                "FLEX_COUNTER_STATUS": "enable"
+            },
+            "PG_WATERMARK": {
+                "FLEX_COUNTER_STATUS": "enable"
+            },
+            "PORT": {
+                "FLEX_COUNTER_STATUS": "enable"
+            },
+            "PORT_RATES": {
+                "FLEX_COUNTER_STATUS": "enable"
+            },
+            "PORT_BUFFER_DROP": {
+                "FLEX_COUNTER_STATUS": "enable"
+            },
+            "BUFFER_POOL_WATERMARK": {
+                "FLEX_COUNTER_STATUS": "enable"
+            },
+            "QUEUE": {
+                "FLEX_COUNTER_STATUS": "enable"
+            },
+            "QUEUE_WATERMARK": {
+                "FLEX_COUNTER_STATUS": "enable"
+            },
+            "DEBUG_COUNTER": {
+                "FLEX_COUNTER_STATUS": "enable"
+            }
+        },
+        "CRM": {
+            "Config": {
+                "acl_counter_high_threshold": "85",
+                "acl_counter_low_threshold": "70",
+                "acl_counter_threshold_type": "percentage",
+                "ipv6_neighbor_high_threshold": "67",
+                "ipv6_neighbor_low_threshold": "56",
+                "ipv6_neighbor_threshold_type": "percentage",
+                "nexthop_group_high_threshold": "67",
+                "nexthop_group_low_threshold": "56",
+                "nexthop_group_threshold_type": "percentage",
+                "polling_interval": "0"
+            }
+        },
+
+        "WARM_RESTART": {
+            "bgp": {
+                "bgp_timer": "500"
+            }
+        },
+
+        "PFC_WD": {
+            "Ethernet9": {
+               "action": "drop",
+               "detection_time": "100",
+               "restoration_time": "400"
+            }
+        },
+        "PFC_WD": {
+            "GLOBAL": {
+                "POLL_INTERVAL": "100"
+            }
+        },
+        "SFLOW_COLLECTOR": {
+            "collector1": {
+                "collector_ip": "10.100.12.13",
+                "collector_port": "6343"
+            },
+            "collector2": {
+                "collector_ip": "10.144.1.2"
+            }
+        },
+
+        "SFLOW_SESSION": {
+            "Ethernet0": {
+                "admin_state": "down",
+                "sample_rate": "40000"
+            },
+            "Ethernet16": {
+                "admin_state": "up",
+                "sample_rate": "32768"
+            }
+        },
+
+        "SFLOW" : {
+            "global": {
+                "admin_state": "up",
+                "polling_interval": "20",
+                "agent_id": "Ethernet0"
+            }
+        },
+        "AAA": {
+            "authentication": {
+                "login": "local" 
+            },
+            "authorization": {
+                "login": "local" 
+            },
+            "accounting": {
+                "login": "local" 
+            }
+        },
+        "TACPLUS": {
+            "global": {
+                "auth_type": "pap",
+                "timeout": "5"
+            }
+        },
+        "TACPLUS_SERVER": {
+            "192.168.1.1": {
+                "timeout": "10"
+            }
+        },
+        "NAT_BINDINGS": {
+            "bind1": {
+                "nat_pool": "pool1",
+                "nat_type": "snat",
+                "twice_nat_id": "1"
+            }
+        },
+        "NAT_GLOBAL": {
+            "Values": {
+                "admin_mode": "enabled",
+                "nat_tcp_timeout": "86400",
+                "nat_timeout": "600",
+                "nat_udp_timeout": "300"
+            }
+        },
+        "NAT_POOL": {
+            "pool1": {
+                "nat_ip": "125.56.90.50-125.56.90.100",
+                "nat_port": "50-100"
+            }
+        },
+        "STATIC_NAPT": {
+            "125.56.90.10|UDP|100": {
+                "local_ip": "12.12.0.2",
+                "local_port": "251"
+            }
+        },
+        "STATIC_NAT": {
+            "125.56.90.8": {
+                "local_ip": "12.12.0.2"
+            }
+        },
+        "BGP_GLOBALS": {
+            "default": {
+                "router_id": "5.5.5.5",
+                "local_asn": "65001"
+            }
+        },
+        "BGP_GLOBALS_AF": {
+            "default|ipv4_unicast": {
+                "max_ebgp_paths": "2",
+                "max_ibgp_paths": "2"
+            },
+            "default|ipv6_unicast": {
+                "max_ebgp_paths": "2",
+                "max_ibgp_paths": "2"
+            }
+        },
+        "BGP_GLOBALS_AF_AGGREGATE_ADDR": {
+            "default|ipv4_unicast|21.0.0.0/8": {
+            }
+        },
+        "BGP_GLOBALS_AF_NETWORK": {
+            "default|ipv4_unicast|21.0.0.0/8": {
+            }
+        },
+        "BGP_NEIGHBOR": {
+            "10.0.0.1": {
+                "asn": "65200",
+                "holdtime": "180",
+                "keepalive": "60",
+                "local_addr": "10.0.0.2",
+                "name":"PEER1",
+                "nhopself":"0",
+                "rrclient":"0"
+            },
+            "default|192.168.1.1": {
+                "local_asn": "65200",
+                "asn": "65100",
+                "name": "bgp peer 65100",
+                "ebgp_multihop_ttl": "3"
+            }
+        },
+        "BGP_NEIGHBOR_AF": {
+            "default|192.168.1.1|ipv4_unicast": {
+            }
+        },
+        "BGP_PEER_GROUP": {
+            "default|PG1": {
+            }
+        },
+        "BGP_PEER_GROUP_AF": {
+            "default|PG1|ipv4_unicast": {
+            }
+        },
+        "BGP_GLOBALS_LISTEN_PREFIX": {
+            "default|30.0.0.0/8": {
+                "peer_group": "PG1"
+            }
+        },
+        "ROUTE_MAP_SET": {
+            "map1": {
+            }
+        },
+        "ROUTE_MAP": {
+            "map1|1": {
+                "match_med" : "100"
+            }
+        },
+        "ROUTE_REDISTRIBUTE": {
+            "default|connected|bgp|ipv4": {
+            }
+        },
+        "PREFIX_SET": {
+            "prefix1": {
+            }
+        },
+        "PREFIX": {
+            "prefix1|1|10.0.0.0/8|8..16": {
+            }
+        },
+        "COPP_GROUP": {
+            "queue1_group1": {
+                "queue": "1",
+                "trap_priority":"1",
+                "trap_action":"trap",
+                "meter_type":"packets",
+                "mode":"sr_tcm",
+                "cir":"6000",
+                "cbs":"6000",
+                "red_action":"drop"
+            }
+        },
+        "COPP_TRAP": {
+            "ip2me": {
+                "trap_ids": "ip2me",
+                "trap_group": "queue1_group1"
+            }
+        },
+        "LLDP": {
+            "GLOBAL": {
+                "mode": "TRANSMIT",
+                "enabled": "true",
+                "hello_time": "12",
+                "multiplier": "5",
+                "supp_mgmt_address_tlv": "true",
+                "supp_system_capabilities_tlv": "false",
+                "system_name": "sonic",
+                "system_description": "sonic-system"
+            }
+        },
+        "LLDP_PORT": {
+            "Ethernet0": {
+                "mode": "TRANSMIT",
+                "enabled": "true"
+            }
+        },
+        "FEATURE": {
+            "bgp": {
+                "auto_restart": "enabled",
+                "has_global_scope": "false",
+                "has_per_asic_scope": "true",
+                "has_timer": "false",
+                "high_mem_alert": "disabled",
+                "state": "enabled"
+            },
+            "database": {
+                "auto_restart": "always_enabled",
+                "has_global_scope": "true",
+                "has_per_asic_scope": "true",
+                "has_timer": "false",
+                "high_mem_alert": "disabled",
+                "state": "always_enabled"
+            },
+            "snmp": {
+                "auto_restart": "enabled",
+                "has_global_scope": "true",
+                "has_per_asic_scope": "false",
+                "has_timer": "true",
+                "high_mem_alert": "disabled",
+                "state": "enabled"
+            },
+            "swss": {
+                "auto_restart": "enabled",
+                "has_global_scope": "false",
+                "has_per_asic_scope": "true",
+                "has_timer": "false",
+                "high_mem_alert": "disabled",
+                "state": "enabled"
+            },
+            "syncd": {
+                "auto_restart": "enabled",
+                "has_global_scope": "false",
+                "has_per_asic_scope": "true",
+                "has_timer": "false",
+                "high_mem_alert": "disabled",
+                "state": "enabled"
+            },
+            "lldp": {
+                "auto_restart": "enabled",
+                "has_global_scope": "false",
+                "has_per_asic_scope": "true",
+                "has_timer": "false",
+                "high_mem_alert": "disabled",
+                "state": "enabled"
+            }
+        },
+        "DHCP_RELAY": {
+            "Vlan111": {
+                "dhcpv6_servers": [
+                    "2a04:5555:41::11"
+                ],
+                "rfc6939_support": "true"
+            },
+            "Vlan777": {
+                "dhcpv6_servers": [
+                    "2a04:5555:41::11"
+                ],
+                "rfc6939_support": "true"
+            }
+        },
+        "SCHEDULER": {
+            "TEST@0": {
+                "cbs": "256",
+                "cir": "1250000",
+                "meter_type": "bytes",
+                "pbs": "1024",
+                "pir": "25000000",
+                "type": "DWRR",
+                "weight": "20"
+            },
+
+            "TEST@1": {
+                "cbs": "1024",
+                "cir": "1280000",
+                "meter_type": "bytes",
+                "pbs": "2048",
+                "pir": "2560000",
+                "type": "STRICT"
+            }
+        },
+
+        "WRED_PROFILE": {
+            "Wred1": {
+                "ecn": "ecn_all",
+                "green_drop_probability": "50",
+                "green_max_threshold": "2048000",
+                "green_min_threshold": "1024000",
+                "wred_green_enable": "true",
+                "yellow_drop_probability": "50",
+                "yellow_max_threshold": "2048000",
+                "yellow_min_threshold": "1024000",
+                "wred_yellow_enable": "true",
+                "red_drop_probability": "50",
+                "red_max_threshold": "2048000",
+                "red_min_threshold": "1024000",
+                "wred_red_enable": "true"
+            }
+        },
+
+        "QUEUE": {
+            "Ethernet0|0": {
+                "scheduler": "TEST@0",
+                "wred_profile": "Wred1"
+            },
+            "Ethernet0|1": {
+                "scheduler": "TEST@1",
+                "wred_profile": "Wred1"
+            }
+         },		
+
+        "DSCP_TO_TC_MAP": {
+           "Dscp_to_tc_map1": { 
+              "1": "1",
+              "2": "2"
+            }, 
+           "Dscp_to_tc_map2": { 
+              "3": "3",
+              "4": "4"
+            }
+        },
+
+        "DOT1P_TO_TC_MAP": {
+           "Dot1p_to_tc_map1": { 
+              "1": "1",
+              "2": "2"
+            }, 
+           "Dot1p_to_tc_map2": { 
+              "3": "3",
+              "4": "4"
+            }
+        },
+
+        "TC_TO_PRIORITY_GROUP_MAP": {
+           "tc_to_pg_map1": { 
+              "1": "1",
+              "2": "2"
+            }, 
+           "tc_to_pg_map2": { 
+              "3": "3",
+              "4": "4"
+            }
+        },
+
+        "TC_TO_QUEUE_MAP": {
+           "tc_to_q_map1": { 
+              "1": "1",
+              "2": "2"
+            }, 
+           "tc_to_q_map2": { 
+              "3": "3",
+              "4": "4"
+            }
+        },
+
+        "MAP_PFC_PRIORITY_TO_QUEUE": {
+           "pfc_prio_to_q_map1": { 
+              "1": "1",
+              "2": "2"
+           }, 
+           "pfc_prio_to_q_map2": { 
+              "3": "3",
+              "4": "4"
+            }
+        },
+
+        "PFC_PRIORITY_TO_PRIORITY_GROUP_MAP": {
+           "pfc_prio_to_pg_map1": { 
+              "1": "1",
+              "2": "2"
+            }, 
+            "pfc_prio_to_pg_map2": { 
+              "3": "3",
+              "4": "4"
+            }
+        },
+
+        "PORT_QOS_MAP": {
+           "Ethernet0": { 
+              "dot1p_to_tc_map" : "Dot1p_to_tc_map1",
+              "dscp_to_tc_map": "Dscp_to_tc_map1",
+	          "tc_to_queue_map": "tc_to_q_map1",
+	          "tc_to_pg_map": "tc_to_pg_map1",
+	          "pfc_to_queue_map": "pfc_prio_to_q_map1",
+	          "pfc_to_pg_map"   : "pfc_prio_to_pg_map1",
+	          "pfc_enable"      : "3,4"
+            }, 
+            "Ethernet4": { 
+              "dot1p_to_tc_map" : "Dot1p_to_tc_map2",
+              "dscp_to_tc_map": "Dscp_to_tc_map2",
+	          "tc_to_queue_map": "tc_to_q_map2",
+	          "tc_to_pg_map": "tc_to_pg_map2",
+	          "pfc_to_queue_map": "pfc_prio_to_q_map2",
+	          "pfc_to_pg_map"   : "pfc_prio_to_pg_map2",
+	          "pfc_enable"      : "3,4"
+            }
+        }
+    },
+
+    "SAMPLE_CONFIG_DB_UNKNOWN": {
+        "UNKNOWN_TABLE": {
+            "Error": "This Table is for testing, This Table does not have YANG models."
+        }
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/aaa.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/aaa.json
@@ -1,0 +1,19 @@
+{
+    "AAA_TEST": {
+        "desc": "Configure an authentication type in AAA table."
+    },
+    "AAA_TEST_WRONG_TYPE": {
+        "desc": "Configure a wrong type in AAA table.",
+        "eStrKey": "InvalidValue"
+    },
+    "AAA_TEST_WRONG_FAILTHROUGH": {
+        "desc": "Configure a wrong failthrough in AAA table.",
+        "eStrKey": "InvalidValue"
+    },
+    "AAA_AUTHORIZATION_TEST": {
+        "desc": "Configure an authorization type in AAA table."
+    },
+    "AAA_ACCOUNTING_TEST": {
+        "desc": "Configure an accounting type in AAA table."
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/aaa.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/aaa.json
@@ -1,0 +1,57 @@
+{
+    "AAA_TEST": {
+        "sonic-system-aaa:sonic-system-aaa": {
+            "sonic-system-aaa:AAA": {
+                "AAA_LIST": [{
+                        "type": "authentication",
+                        "login": "tacacs+,local",
+                        "failthrough": "true",
+                        "debug": "true"
+                }]
+            }
+        }
+    },
+
+    "AAA_TEST_WRONG_TYPE": {
+        "sonic-system-aaa:sonic-system-aaa": {
+            "sonic-system-aaa:AAA": {
+                "AAA_LIST": [{
+                        "type": "unknowntype"
+                }]
+            }
+        }
+    },
+
+    "AAA_TEST_WRONG_FAILTHROUGH": {
+        "sonic-system-aaa:sonic-system-aaa": {
+            "sonic-system-aaa:AAA": {
+                "AAA_LIST": [{
+                        "type": "authentication",
+                        "failthrough": "enable"
+                }]
+            }
+        }
+    },
+
+    "AAA_AUTHORIZATION_TEST": {
+        "sonic-system-aaa:sonic-system-aaa": {
+            "sonic-system-aaa:AAA": {
+                "AAA_LIST": [{
+                        "type": "authorization",
+                        "login": "tacacs+"
+                }]
+            }
+        }
+    },
+
+    "AAA_ACCOUNTING_TEST": {
+        "sonic-system-aaa:sonic-system-aaa": {
+            "sonic-system-aaa:AAA": {
+                "AAA_LIST": [{
+                        "type": "accounting",
+                        "login": "tacacs+"
+                }]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-system-aaa.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-aaa.yang
@@ -1,0 +1,50 @@
+module sonic-system-aaa {
+    namespace "http://github.com/Azure/sonic-system-aaa";
+    prefix ssys;
+    yang-version 1.1;
+
+    revision 2021-10-12 {
+        description "Add AAA authorization/accounting support.";
+    }
+
+    revision 2021-04-15 {
+        description "Initial revision.";
+    }
+
+    container sonic-system-aaa {
+        container AAA {
+            list AAA_LIST {
+                key "type";
+
+                leaf type {
+                    type enumeration {
+                        enum authentication;
+                        enum authorization;
+                        enum accounting;
+                    }
+                    description "AAA type authentication/authorization/accounting";
+                }
+
+                leaf login {
+                    type string;
+                    description "AAA authentication/authorization/accounting methods - local/tacacs+/disable";
+                    default "local";
+                }
+
+                leaf failthrough {
+                    type boolean;
+                    description "When set to true, authentication is attempted on next configured server/local in the list upon failure.";
+                    default false;
+                }
+                
+                leaf debug {
+                    type boolean;
+                    description "Enable/disable AAA debugging";
+                    default false;
+                }
+
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
This pull request add Config DB schema and HostCfg Enforcer plugin to support TACACS+ per-command authorization&accounting.

##### Work item tracking
- Microsoft ADO **(number only)**: 24433713

#### Why I did it
    Support TACACS per-command authorization&accounting.

#### How I did it
    Change ConfigDB schema and HostCfg enforcer.
    Add UT to cover changed code.

#### How to verify it
    Build following project and pass all UTs:
    make target/python-wheels/sonic_host_services-1.0-py3-none-any.whl

#### Which release branch to backport (provide reason below if selected)
    N/A

#### Tested branch (Please provide the tested image version)
Extract tacacs support functions into library, this will share TACACS config file parse code with other project.
Also fix memory leak issue in parse config code.

- [ ]  SONiC.202012-15723.309781-38d8852cd

#### Description for the changelog
    Add Config DB schema and HostCfg Enforcer plugin to support TACACS+ per-command authorization&accounting.

#### A picture of a cute animal (not mandatory but encouraged)

