### PR TITLE
Fix dpkg lock

### DIFF
--- a/src/sonic-build-hooks/hooks/dpkg
+++ b/src/sonic-build-hooks/hooks/dpkg
@@ -2,17 +2,14 @@
 
 . /usr/local/share/buildinfo/scripts/buildinfo_base.sh
 REAL_COMMAND=$(get_command dpkg)
-COMMAND_INFO="Locked by command: $REAL_COMMAND $@"
-NEED_RELEASE_LOCK=n
-if [[ "$DPKG_HOOK_LOCKED" != "y" ]];then
+COMMAND_INFO="Locked by command: $REAL_COMMAND $*"
+DPKG_NEED_LOCK=$(check_dpkg_need_lock "$@")
+
+if [ "$DPKG_NEED_LOCK" == "y" ]; then
     lock_result=$(acquire_apt_installation_lock "$COMMAND_INFO" )
-    export DPKG_HOOK_LOCKED=y
-    NEED_RELEASE_LOCK=y
 fi
+
 $REAL_COMMAND "$@"
 command_result=$?
-if [[ "$NEED_RELEASE_LOCK" == "y" ]];then
-    unset DPKG_HOOK_LOCKED
-fi
 [ "$lock_result" == y ] && release_apt_installation_lock
 exit $command_result

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -374,6 +374,39 @@ check_apt_install()
     done
 }
 
+# Check if we need to use apt_installation_lock for this dpkg command
+check_dpkg_need_lock()
+{
+    for para in "$@"
+    do
+        if [ "$para" == "-i" ] || [ "$para" == "--install" ]; then
+            echo y
+            break
+        fi
+
+        if [ "$para" == "-P"  ] || [ "$para" == "--purge" ]; then
+            echo y
+            break
+        fi
+
+        if [ "$para" == "-r"  ] || [ "$para" == "--remove" ]; then
+            echo y
+            break
+        fi
+
+        if [ "$para" == "--unpack"  ] || [ "$para" == "--configure" ]; then
+            echo y
+            break
+        fi
+
+        if [ "$para" == "--update-avail"  ] || [ "$para" == "--merge-avail" ] || [ "$para" == "--clear-avail" ]; then
+            echo y
+            break
+        fi
+
+    done
+}
+
 # Print warning message if a debian package version not specified when debian version control enabled.
 check_apt_version()
 {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix #15722

We don't need to use a lock file every time we call dpkg.
For some commands, like `dpkg --print-architecture` or `dpkg --compare-versions`,  this action is not required.
Moreover, sometimes these commands are called by `apt-get` and `dpkg -i`, and we get a deadlock in this case.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Use dpkg lock only for dpkg commands that use /var/lib/dpkg/lock or /var/lib/dpkg/lock-frontend.
I mean `dpkg -i`, `dpkg -P`, ...

#### How to verify it

Check there is no dpkg lock errors in build log.
Check build time of docker-sonic-vs.gz:

old:
08:57:14[ building ] [ target/docker-sonic-vs.gz ] 
09:12:47 [ finished ] [ target/docker-sonic-vs.gz ] 

new:
01:45:12[ building ] [ target/docker-sonic-vs.gz ] 
01:50:39 [ finished ] [ target/docker-sonic-vs.gz ] 


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

