### PR TITLE
Skip wait_for_tunnel on mocked dualtor

### DIFF
--- a/files/scripts/write_standby.py
+++ b/files/scripts/write_standby.py
@@ -2,6 +2,7 @@
 
 import argparse
 import time
+import json
 
 from sonic_py_common import logger as log
 from swsscommon.swsscommon import ConfigDBConnector, DBConnector, FieldValuePairs, ProducerStateTable, SonicV2Connector, Table
@@ -92,6 +93,19 @@ class MuxStateWriter(object):
         return 'subtype' in metadata and 'dualtor' in metadata['subtype'].lower()
 
     @property
+    def is_mocked_dualtor(self):
+        """
+        Checks if script is running on a mocked dual ToR system
+        """
+        subtype = ''
+        with open("/etc/sonic/config_db.json", 'r') as config_file:
+            file_data = json.load(config_file)
+            if 'subtype' in file_data['DEVICE_METADATA']['localhost']:
+                subtype = file_data['DEVICE_METADATA']['localhost']['subtype']
+
+        return self.is_dualtor and 'dualtor' not in subtype.lower()
+
+    @property
     def is_warmrestart(self):
         """
         Checks if a warmrestart is going on
@@ -144,6 +158,10 @@ class MuxStateWriter(object):
             (bool) True if the tunnel has been created
                    False if the timeout period is exceeded
         """
+        if self.is_mocked_dualtor:
+            # If running on a mocked dual ToR system, do not wait
+            logger.log_info("Do not wait for tunnel on mocked dualtor")
+            return True
         logger.log_info("Waiting for tunnel {} with timeout {} seconds".format(self.tunnel_name, timeout))
         start = time.time()
         curr_time = time.time()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
hit a problem when running some dualtor test case on T0 testbed.
At that case ,the mock config is applied, and the tunnel interface is not created normally on standby at the mock case,
Which leads to the wait_for_tunnel() in write_standby.py timeout, and that timeout is 90s, so then it will lead to the stopping bpg service timeout, finally, the stopping swss doesn’t work normally and some test cases may fail.

tried to dump the ASIC_DB for checking the tunnel data.
Looks like there are tunnel data in ASIC_DB before restarting the swss, and we can see the MuxTunnel0 creation log,
But, looks like the case is, after swss started the restarting process, the earlier restarted service tunnelmgrd deleted the tunnel but didn’t add it back normally.
Here are main logs, the swss restarting happened about 11:29.01.
 
From the mgmt test log:
21/06/2023 11:29:01 dual_tor_mock.apply_peer_switch_table_to L0345 INFO   | Dump asic_db before restart swss:
21/06/2023 11:29:01 base._run                                L0063 DEBUG  | /data/tests/common/devices/multi_asic.py::_run_on_asics#112: [mth-t0-64] AnsibleModule::shell, args=[], kwargs={"cmd": "sonic-db-cli ASIC_DB keys 'ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL:*'"}
21/06/2023 11:29:01 base._run                                L0082 DEBUG  | /data/tests/common/devices/multi_asic.py::_run_on_asics#112: [mth-t0-64] AnsibleModule::shell Result => {"stderr_lines": [], "cmd": "sonic-db-cli ASIC_DB keys 'ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL:*'", "end": "2023-06-21 11:28:52.539676", "_ansible_no_log": false, "stdout": "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL:oid:0x2a0000000009ad\nASIC_STATE:SAI_OBJECT_TYPE_TUNNEL:oid:0x2a0000000009b5\nASIC_STATE:SAI_OBJECT_TYPE_TUNNEL:oid:0x2a000000000aae", "changed": true, "rc": 0, "start": "2023-06-21 11:28:52.531009", "stderr": "", "delta": "0:00:00.008667", "invocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "sonic-db-cli ASIC_DB keys 'ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL:*'", "removes": null, "argv": null, "warn": true, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL:oid:0x2a0000000009ad", "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL:oid:0x2a0000000009b5", "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL:oid:0x2a000000000aae"], "failed": false}
21/06/2023 11:29:01 dual_tor_mock.apply_peer_switch_table_to L0347 INFO   | Restarting swss service to regenerate config.bcm
 
From the syslog:
Jun 21 11:28:50.543496 mth-t0-64 NOTICE swss#tunnelmgrd: :- doTunnelTask: Peer/Remote IP not configured
Jun 21 11:28:50.544121 mth-t0-64 NOTICE swss#tunnelmgrd: :- doTunnelTask: Tunnel MuxTunnel0 task, op SET
Jun 21 11:28:50.546930 mth-t0-64 NOTICE swss#orchagent: :- addDecapTunnel: Create overlay loopback router interface oid:6000000000aad
Jun 21 11:28:50.549307 mth-t0-64 NOTICE swss#orchagent: :- addDecapTunnelTermEntries: 10.1.0.32 already exists. Did not create entry.
Jun 21 11:28:50.549307 mth-t0-64 NOTICE swss#orchagent: :- doTask: Tunnel(s) added to ASIC_DB.
…
 
Jun 21 11:29:02.903535 mth-t0-64 INFO swss#supervisord 2023-06-21 11:29:02,903 INFO stopped: tunnelmgrd (terminated by SIGTERM)
Jun 21 11:30:03.191076 mth-t0-64 NOTICE swss#tunnelmgrd: :- main: --- Starting Tunnelmgrd ---
 
Jun 21 11:30:04.347362 mth-t0-64 NOTICE swss#tunnelmgrd: :- main: starting main loop
Jun 21 11:30:04.347400 mth-t0-64 NOTICE swss#tunnelmgrd: :- doTunnelTask: Peer/Remote IP not configured
Jun 21 11:30:04.347422 mth-t0-64 INFO swss#supervisord: tunnelmgrd delete tunnel "tun0" failed: No such device
Jun 21 11:30:04.347631 mth-t0-64 INFO swss#supervisord 2023-06-21 11:30:04,347 INFO success: arp_update entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Jun 21 11:30:04.347658 mth-t0-64 NOTICE swss#tunnelmgrd: :- doTunnelTask: Tunnel MuxTunnel0 task, op SET
…
 
Jun 21 11:34:01.745938 mth-t0-64 INFO container: docker cmd: wait for bgp
Jun 21 11:34:01.746309 mth-t0-64 INFO container: docker cmd: stop for bgp
Jun 21 11:34:01.746385 mth-t0-64 DEBUG container: container_stop: END
Jun 21 11:34:01.788168 mth-t0-64 NOTICE cisco: Stopped bgp service...
Jun 21 11:34:01.883200 mth-t0-64 INFO swss#supervisord 2023-06-21 11:34:01,882 WARN received SIGTERM indicating exit request
Jun 21 11:34:01.883333 mth-t0-64 INFO swss#supervisord 2023-06-21 11:34:01,883 INFO waiting for supervisor-proc-exit-listener, rsyslogd, portsyncd, coppmgrd, arp_update, ndppd, neighsyncd, vlanmgrd, intfmgrd, portmgrd, buffermgrd, tunnel_packet_handler, vrfmgrd, nbrmgrd, vxlanmgrd, fdbsyncd, tunnelmgrd to die
Jun 21 11:34:01.883836 mth-t0-64 INFO swss#supervisord 2023-06-21 11:34:01,883 INFO stopped: tunnelmgrd (terminated by SIGTERM)
 
 
Jun 21 11:35:31.009842 mth-t0-64 WARNING systemd[1]: swss.service: Stopping timed out. Terminating.
Jun 21 11:35:31.011433 mth-t0-64 INFO swss.sh[578580]: Terminated
Jun 21 11:35:31.012724 mth-t0-64 WARNING systemd[1]: swss.service: Control process exited, code=killed, status=15/TERM
Jun 21 11:35:31.012911 mth-t0-64 WARNING systemd[1]: swss.service: Failed with result 'timeout'.
Jun 21 11:35:31.014462 mth-t0-64 INFO systemd[1]: Stopped switch state service.
Jun 21 11:35:31.957011 mth-t0-64 ERR write_standby: Timed out waiting for tunnel MuxTunnel0, mux state will not be written

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
it’s related to the swss restarting flow, in the restarting, the tunnelmgrd deleted the tunnel interfaces and didn’t have the chance to recreate it before the checking, so, to be the simple, for the dualtor on T0 mock case, just skip the wait_for_tunnel() step in the write_standby.py

#### How to verify it
running the test script a few times, didn't see the bpg stopping timeout issue.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

