### PR TITLE
[staticroutebfd]  fix ipv6 letter case issue

### DIFF
--- a/src/sonic-bgpcfgd/staticroutebfd/main.py
+++ b/src/sonic-bgpcfgd/staticroutebfd/main.py
@@ -66,6 +66,9 @@ def static_route_split_key(key):
     :param key: key to split
     :return: valid, vrf name extracted from the key, ip prefix extracted from the key
     """
+    if key is None or len(key) == 0:
+        return False, "", ""
+
     l = tuple(key.split('|'))
 
     if len(l) == 1:
@@ -375,6 +378,11 @@ class StaticRouteBfd(object):
         if not valid:
             log_err("invalid ip prefix for static route: ", key)
             return True
+
+        #use lower case if there is letter in IPv6 address string
+        if 'nexthop' in data:
+            nh = data['nexthop']
+            data['nexthop'] = nh.lower()
 
         arg_list  = lambda v: [x.strip() for x in v.split(',')] if len(v.strip()) != 0 else None
         bfd_field = arg_list(data['bfd']) if 'bfd' in data else ["false"]

--- a/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
@@ -94,6 +94,82 @@ def intf_setup(dut):
         {},
         {}
     )
+    set_del_test(dut, "intf",
+        "SET",
+        ("if1|2603:10E2:400:1::1/64",{}
+        ),
+        {},
+        {}
+    )
+    set_del_test(dut, "intf",
+        "SET",
+        ("if2|2603:10E2:400:2::1/64",{}
+        ),
+        {},
+        {}
+    )
+    set_del_test(dut, "intf",
+        "SET",
+        ("if3|2603:10E2:400:3::1/64",{}
+        ),
+        {},
+        {}
+    )    
+
+def test_set_del_ipv6():
+    dut = constructor()
+    intf_setup(dut)
+
+    set_del_test(dut, "srt",
+        "SET",
+        ("2603:10e2:400::4/128", {
+            "bfd": "true",
+            "ifname": "if1, if2, if3",
+            "nexthop": "2603:10E2:400:1::2,2603:10E2:400:2::2,2603:10e2:400:3::2"
+        }),
+        { 
+            "set_default:default:2603:10e2:400:1::2" : {'multihop': 'true', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '2603:10E2:400:1::1'},
+            "set_default:default:2603:10e2:400:2::2" : {'multihop': 'true', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '2603:10E2:400:2::1'},
+            "set_default:default:2603:10e2:400:3::2" : {'multihop': 'true', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '2603:10E2:400:3::1'}
+        },
+        {}
+    )
+
+    set_del_test(dut, "bfd",
+        "SET",
+        ("2603:10e2:400:1::2", {
+            "state": "Up"
+        }),
+        {},
+        {'set_default:2603:10e2:400::4/128': {'nexthop': '2603:10e2:400:1::2', 'ifname': 'if1', 'nexthop-vrf': 'default', 'expiry': 'false'}}
+    )
+    set_del_test(dut, "bfd",
+        "SET",
+        ("2603:10e2:400:2::2", {
+            "state": "Up"
+        }),
+        {},
+        {'set_default:2603:10e2:400::4/128': {'nexthop': '2603:10e2:400:1::2,2603:10e2:400:2::2', 'ifname': 'if1,if2', 'nexthop-vrf': 'default,default', 'expiry': 'false'}}
+    )
+    set_del_test(dut, "bfd",
+        "SET",
+        ("2603:10e2:400:3::2", {
+            "state": "Up"
+        }),
+        {},
+        {'set_default:2603:10e2:400::4/128': {'nexthop': '2603:10e2:400:1::2,2603:10e2:400:2::2,2603:10e2:400:3::2', 'ifname': 'if1,if2,if3', 'nexthop-vrf': 'default,default,default', 'expiry': 'false'}}
+    )
+
+    set_del_test(dut, "srt",
+        "DEL",
+        ("2603:10e2:400::4/128", { }),
+        {
+            "del_default:default:2603:10e2:400:1::2" : {},
+            "del_default:default:2603:10e2:400:2::2" : {},
+            "del_default:default:2603:10e2:400:3::2" : {}
+        },
+        {'del_default:2603:10e2:400::4/128': { }}
+    )
 
 def test_set_del():
     dut = constructor()


### PR DESCRIPTION
use lower case for IPv6 address as internal key and bfd session key.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

fixes #15764 

#### Why I did it
staticroutebfd uses the IPv6 address string as a key to create bfd session and cache the bfd sessions using it as a key.
When the IPv6 address string has uppercase letter in the static route nexthop list,  the string with uppercase letter key is stored in the cache, but the BFD STATE_DB uses lowercase for IPv6 address, so when the staticroutebfd get the bfd state event, it cannot find the bfd session in its local cache because of the letter case.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
convert the IPv6 address string to lower case inside the staticroutebfd, and use the lowercase address to create BFD session.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Verified it both in UT and testbed.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

