### PR TITLE
[monit][dualtor] Periodically check mux neighbors consistency

### DIFF
--- a/files/image_config/monit/conf.d/sonic-host
+++ b/files/image_config/monit/conf.d/sonic-host
@@ -31,6 +31,13 @@ check program routeCheck with path "/usr/local/bin/route_check.py"
     every 5 cycles
     if status != 0 for 3 cycle then alert repeat every 1 cycles
 
+# dualtor_neighbor_check.py: script to check if the neighbor entries in APPL_DB
+# has correct neighbor or tunnel route entries in ASIC_DB based on the mux
+# states.
+check program dualtorNeighborCheck with path "/usr/local/bin/dualtor_neighbor_check.py -o SYSLOG -s ERROR"
+    every 5 cycles
+    if status != 0 for 3 cycle then alert repeat every 1 cycles
+
 # Check if /etc & /home are writable. If not, make them writable.
 # Raise syslog error message, in case of underlying issues
 #


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This depends on PR https://github.com/sonic-net/sonic-utilities/pull/2840.
And it is to enable `dualtor_neighbor_check.py` as a periodical check.


##### Work item tracking
- Microsoft ADO **(number only)**: 22571694

#### How I did it

#### How to verify it
Verify on testbed, for any inconsistencies, `monit` will write `ERROR` syslogs:
```
Jul 10 07:05:12.014885 lab-dev-1 ERR dualtor_neighbor_check.py: Found neighbors that are inconsistent with mux states: ['192.168.0.7', '192.168.0.35']
Jul 10 07:05:12.017086 lab-dev-1 ERR dualtor_neighbor_check.py: NEIGHBOR      MAC                PORT        MUX_STATE    IN_MUX_TOGGLE    NEIGHBOR_IN_ASIC    TUNNERL_IN_ASIC    HWSTATUS
Jul 10 07:05:12.017251 lab-dev-1 ERR dualtor_neighbor_check.py: ------------  -----------------  ----------  -----------  ---------------  ------------------  -----------------  ------------
Jul 10 07:05:12.017329 lab-dev-1 ERR dualtor_neighbor_check.py: 192.168.0.7   9e:5d:69:2e:44:a9  Ethernet12  active       no               no                  no                 inconsistent
Jul 10 07:05:12.017471 lab-dev-1 ERR dualtor_neighbor_check.py: 192.168.0.35  86:7c:75:45:a8:f1  Ethernet68  active       no               no                  no                 inconsistent
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

