### PR TITLE
[202012] [TACACS+] When load-minigraph enable per-command accounting by default

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -331,6 +331,14 @@ def main():
         else:
             deep_update(data, parse_xml(minigraph, port_config_file=args.port_config, asic_name=asic_name, hwsku_config_file=args.hwsku_config))
 
+        # enable TACACS per-command accounting by default on 202012 branch
+        tacacs_accounting = {
+                'AAA': {
+                    'accounting': {
+                        "login": "tacacs+"
+                }}}
+        deep_update(data, tacacs_accounting)
+
     if args.device_description is not None:
         deep_update(data, parse_device_desc_xml(args.device_description))
 


### PR DESCRIPTION
When load-minigraph enable per-command accounting by default.

##### Work item tracking
- Microsoft ADO **(number only)**: 24433713
- 
#### Why I did it
Enable per-command accounting by default.

#### How I did it
Add hard code config in sonic-cfggen.

#### How to verify it
Also pass all current UT.
Manually check the TACACS per-command accounting enabled after load minigraph.

#### Which release branch to backport (provide reason below if selected)
    N/A

#### Tested branch (Please provide the tested image version)
Extract tacacs support functions into library, this will share TACACS config file parse code with other project.
Also fix memory leak issue in parse config code.

- [ ]  SONiC.202012-15723.312602-e230e2d3e

#### Description for the changelog
When load-minigraph enable per-command accounting by default.

#### A picture of a cute animal (not mandatory but encouraged)

