### PR TITLE
[Mellanox] Add support for BIOS update on Spectrum-4

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2019-2023 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -130,7 +130,7 @@ class ONIEUpdater(object):
     ONIE_FW_UPDATE_CMD_INSTALL = ['/usr/bin/mlnx-onie-fw-update.sh', 'update', '--no-reboot']
     ONIE_FW_UPDATE_CMD_SHOW_PENDING = ['/usr/bin/mlnx-onie-fw-update.sh', 'show-pending']
 
-    ONIE_VERSION_PARSE_PATTERN = '([0-9]{4})\.([0-9]{2})-([0-9]+)\.([0-9]+)\.([0-9]+)-([0-9]+)'
+    ONIE_VERSION_PARSE_PATTERN = '([0-9]{4})\.([0-9]{2})-([0-9]+)\.([0-9]+)\.([0-9]+)-?(dev)?-([0-9]+)'
     ONIE_VERSION_BASE_PARSE_PATTERN = '([0-9]+)\.([0-9]+)\.([0-9]+)'
     ONIE_VERSION_REQUIRED = '5.2.0016'
 
@@ -279,7 +279,8 @@ class ONIEUpdater(object):
         onie_major = m.group(3)
         onie_minor = m.group(4)
         onie_release = m.group(5)
-        onie_baudrate = m.group(6)
+        onie_signtype = m.group(6)
+        onie_baudrate = m.group(7)
 
         return onie_year, onie_month, onie_major, onie_minor, onie_release, onie_baudrate
 
@@ -422,7 +423,7 @@ class Component(ComponentBase):
 
         name_list = os.path.splitext(image_path)
         if self.image_ext_name is not None:
-            if name_list[1] != self.image_ext_name:
+            if name_list[1] not in self.image_ext_name:
                 print("ERROR: Extend name of file {} is wrong. Image for {} should have extend name {}".format(image_path, self.name, self.image_ext_name))
                 return False
 
@@ -478,7 +479,7 @@ class ComponentONIE(Component):
 class ComponentSSD(Component):
     COMPONENT_NAME = 'SSD'
     COMPONENT_DESCRIPTION = 'SSD - Solid-State Drive'
-    COMPONENT_FIRMWARE_EXTENSION = '.pkg'
+    COMPONENT_FIRMWARE_EXTENSION = ['.pkg']
 
     FIRMWARE_VERSION_ATTR = 'Firmware Version'
     AVAILABLE_FIRMWARE_VERSION_ATTR = 'Available Firmware Version'
@@ -641,7 +642,7 @@ class ComponentSSD(Component):
 class ComponentBIOS(Component):
     COMPONENT_NAME = 'BIOS'
     COMPONENT_DESCRIPTION = 'BIOS - Basic Input/Output System'
-    COMPONENT_FIRMWARE_EXTENSION = '.rom'
+    COMPONENT_FIRMWARE_EXTENSION = ['.rom', '.cap', '.cab']
 
     BIOS_VERSION_COMMAND = ['dmidecode', '--oem-string', '1']
 
@@ -725,7 +726,7 @@ class ComponentBIOSSN2201(Component):
 class ComponentCPLD(Component):
     COMPONENT_NAME = 'CPLD{}'
     COMPONENT_DESCRIPTION = 'CPLD - Complex Programmable Logic Device'
-    COMPONENT_FIRMWARE_EXTENSION = '.vme'
+    COMPONENT_FIRMWARE_EXTENSION = ['.vme']
 
     MST_DEVICE_PATH = '/dev/mst'
     MST_DEVICE_PATTERN = 'mt[0-9]*_pci_cr0'

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -146,7 +146,7 @@ class ONIEUpdater(object):
     PLATFORM_ALWAYS_SUPPORT_UPGRADE = ['x86_64-nvidia_sn2201-r0']
 
     BIOS_UPDATE_FILE_EXT_ROM = '.rom'
-    BIOS_UPDATE_FILE_EXT_CAB = '.CAB'
+    BIOS_UPDATE_FILE_EXT_CAB = '.cab'
 
     def __init__(self):
         self.platform = device_info.get_platform()
@@ -154,7 +154,7 @@ class ONIEUpdater(object):
     def __add_prefix(self, image_path):
         if image_path.endswith(self.BIOS_UPDATE_FILE_EXT_CAB):
             return image_path;
-        elif self.BIOS_UPDATE_FILE_EXT not in image_path:
+        elif self.BIOS_UPDATE_FILE_EXT_ROM not in image_path:
             rename_path = "/tmp/00-{}".format(os.path.basename(image_path))
         else:
             rename_path = "/tmp/99-{}".format(os.path.basename(image_path))

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -145,14 +145,16 @@ class ONIEUpdater(object):
     # For SN2201, upgrading fireware from ONIE is supported from day one so we do not need to check it.
     PLATFORM_ALWAYS_SUPPORT_UPGRADE = ['x86_64-nvidia_sn2201-r0']
 
-    BIOS_UPDATE_FILE_EXT = '.rom'
-    
+    BIOS_UPDATE_FILE_EXT_ROM = '.rom'
+    BIOS_UPDATE_FILE_EXT_CAB = '.CAB'
 
     def __init__(self):
         self.platform = device_info.get_platform()
 
     def __add_prefix(self, image_path):
-        if self.BIOS_UPDATE_FILE_EXT not in image_path:
+        if image_path.endswith(self.BIOS_UPDATE_FILE_EXT_CAB):
+            return image_path;
+        elif self.BIOS_UPDATE_FILE_EXT not in image_path:
             rename_path = "/tmp/00-{}".format(os.path.basename(image_path))
         else:
             rename_path = "/tmp/99-{}".format(os.path.basename(image_path))
@@ -642,7 +644,7 @@ class ComponentSSD(Component):
 class ComponentBIOS(Component):
     COMPONENT_NAME = 'BIOS'
     COMPONENT_DESCRIPTION = 'BIOS - Basic Input/Output System'
-    COMPONENT_FIRMWARE_EXTENSION = ['.rom', '.cap', '.cab']
+    COMPONENT_FIRMWARE_EXTENSION = ['.rom', '.cab']
 
     BIOS_VERSION_COMMAND = ['dmidecode', '--oem-string', '1']
 


### PR DESCRIPTION
Add support for updating BIOS through dev signed ONIE. Add support for update BIOS using cap/cab files

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Bios on new generation switch can come with a file type of cap or cab. Needs to add support to these file type.
Also ONIE version on new devices can have a suffix of 'dev'. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added cap & cab as possible component extensions for ComponentBIOS.
Update the ONIE version regex to include dev signed versions.

#### How to verify it
Update bios.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

