### PR TITLE
[sonic-mgmt docker]Specify the pytest-ansible version for the python3 in sonic-mgmt docker

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -80,7 +80,7 @@ RUN pip3 install aiohttp \
                  pyro4 \
                  pysnmp==4.4.12 \
                  pysubnettree \
-                 pytest-ansible \
+                 pytest-ansible=2.2.4 \
                  pytest-html \
                  pytest-repeat \
                  pytest-xdist==1.28.0 \
@@ -294,7 +294,7 @@ RUN python3 -m pip install aiohttp \
                            pyro4 \
                            pysnmp==4.4.12 \
                            pysubnettree \
-                           pytest-ansible \
+                           pytest-ansible==2.2.4 \
                            pytest-html \
                            pytest-repeat \
                            pytest-xdist==1.28.0 \


### PR DESCRIPTION
1. For python 3.8.10, pytest-ansible dose not recommend to use the version upper than 3.0.0.
2. There is a bug in the latest pytest-ansible:https://github.com/ansible-community/pytest-ansible/issues/135

> (env-python3) root@63d996c03291:~# pip install pytest-ansible==
> ERROR: Ignored the following versions that require a different python version: 3.0.0 Requires-Python >=3.9; 3.1.0 Requires-Python >=3.9
> ERROR: Could not find a version that satisfies the requirement pytest-ansible== (from versions: 1.1, 1.2.1, 1.2.2, 1.2.3, 1.2.4, 1.2.5, 1.3.0, 1.3.1, 2.0.1, 2.0.2, 2.1.1, 2.2.2, 2.2.3, 2.2.4, 3.1.2, 3.1.4, 3.1.5)
> ERROR: No matching distribution found for pytest-ansible==
> 
> (env-python3) root@63d996c03291:~# python --version
> Python 3.8.10
> 
> (env-python3) root@63d996c03291:~# pip list | grep pytest-ansible
> pytest-ansible                   3.1.5

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. There is a bug in the latest pytest-ansible:https://github.com/ansible-community/pytest-ansible/issues/135
2. For python 3.8.10, pytest-ansible dose not recommend to use the version upper than 3.0.0.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Specify the pytest-ansible verion to always use 2.2.4 instead of latest one.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

