### PR TITLE
[Master] fix v6relay dual tor source if selection issue, advance dhcprelay to 6a6ce24

### DIFF
--- a/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
@@ -13,7 +13,7 @@
 [program:dhcp6relay]
 command=/usr/sbin/dhcp6relay
 {#- Dual ToR Option #}
-{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %} -d{% endif %}
+{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %} -u Loopback0 {% endif %}
 
 priority=3
 autostart=false


### PR DESCRIPTION
#### Why I did it
1. sonic-build image side change to fix source interface selection in dual tor scenario.
dhcprelay related PR:
https://github.com/sonic-net/sonic-dhcp-relay/pull/42

2. Announce dhcprelay submodule to 6a6ce24([to invoke [#40](https://github.com/sonic-net/sonic-dhcp-relay/pull/40
) PR](https://github.com/sonic-net/sonic-dhcp-relay/pull/42))

##### Work item tracking
- Microsoft ADO 24243215

#### How I did it

#### How to verify it
run test case, dhcp_relay/test_dhcpv6_relay.py

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
