### PR TITLE
[Mellanox] [PPI] Enable global port late create for SN5600

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5600-r0/ACS-SN5600/sai_5600.xml
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/ACS-SN5600/sai_5600.xml
@@ -27,6 +27,9 @@
         <!-- Number of ports in the following port list -->
         <number-of-physical-ports>65</number-of-physical-ports>
 
+        <!-- Global port late create -->
+        <late-create-all-ports>1</late-create-all-ports>
+
         <!-- List of ports in the device -->
         <ports-list>
             <port-info>

--- a/device/mellanox/x86_64-nvidia_sn5600_simx-r0/ACS-SN5600/sai_5600.xml
+++ b/device/mellanox/x86_64-nvidia_sn5600_simx-r0/ACS-SN5600/sai_5600.xml
@@ -27,6 +27,9 @@
         <!-- Number of ports in the following port list -->
         <number-of-physical-ports>65</number-of-physical-ports>
 
+        <!-- Global port late create -->
+        <late-create-all-ports>1</late-create-all-ports>
+
         <!-- List of ports in the device -->
         <ports-list>
             <port-info>


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

**DEPENDS:**
1. https://github.com/sonic-net/sonic-swss/pull/2564

**HLD:** https://github.com/sonic-net/SONiC/pull/1084

#### Why I did it
* Enabled port late create on SN5600 Spectrum-4 switch boots up with no ports

##### Work item tracking
* N/A

#### How I did it
* Updated SAI xml config file

#### How to verify it
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
1. make configure PLATFORM=mellanox
2. make target/sonic-mellanox.bin

#### Which release branch to backport (provide reason below if selected)
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [X] master <!-- image version 1 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
* N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```