### PR TITLE
[E1031] add platform specific reboot command support

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/platform_reboot
+++ b/device/celestica/x86_64-cel_e1031-r0/platform_reboot
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-CPLD_SETREG_PATH="/sys/bus/platform/devices/e1031.smc/setreg"
+declare -r CPLD_SETREG_PATH="/sys/bus/platform/devices/e1031.smc/setreg"
+
+sync ; sync
+umount -fa > /dev/null 2&>1
 
 # Board level power cycle
 echo "0x0113 0xAA" > ${CPLD_SETREG_PATH}

--- a/device/celestica/x86_64-cel_e1031-r0/platform_reboot
+++ b/device/celestica/x86_64-cel_e1031-r0/platform_reboot
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+CPLD_SETREG_PATH="/sys/bus/platform/devices/e1031.smc/setreg"
+
+# Board level power cycle
+echo "0x0113 0xAA" > ${CPLD_SETREG_PATH}

--- a/device/celestica/x86_64-cel_e1031-r0/platform_update_reboot_cause
+++ b/device/celestica/x86_64-cel_e1031-r0/platform_update_reboot_cause
@@ -2,7 +2,7 @@
 
 REBOOT_USER=$(logname)
 REBOOT_TIME=$(date)
-REBOOT_CAUSE_FILE="/host/reboot-cause/reboot-cause.txt"
+declare -r REBOOT_CAUSE_FILE="/host/reboot-cause/reboot-cause.txt"
 
 echo "User issued 'reboot' with platform-specific command [User: ${REBOOT_USER}, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
 sync

--- a/device/celestica/x86_64-cel_e1031-r0/platform_update_reboot_cause
+++ b/device/celestica/x86_64-cel_e1031-r0/platform_update_reboot_cause
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+REBOOT_USER=$(logname)
+REBOOT_TIME=$(date)
+REBOOT_CAUSE_FILE="/host/reboot-cause/reboot-cause.txt"
+
+echo "User issued 'reboot' with platform-specific command [User: ${REBOOT_USER}, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
+sync
+/sbin/fstrim -av
+sleep 2

--- a/device/celestica/x86_64-cel_e1031-r0/platform_update_reboot_cause
+++ b/device/celestica/x86_64-cel_e1031-r0/platform_update_reboot_cause
@@ -6,5 +6,3 @@ declare -r REBOOT_CAUSE_FILE="/host/reboot-cause/reboot-cause.txt"
 
 echo "User issued 'reboot' with platform-specific command [User: ${REBOOT_USER}, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
 sync
-/sbin/fstrim -av
-sleep 2


### PR DESCRIPTION
#### Why I did it
E1031(HLX): add platform specific cold reboot support, using CPLD board level power cycle functionality for cold reboot.

#### How I did it
Use the CPLD to trigger board level power cycle when cold reboot

#### How to verify it
Do reboot stress test and check the reboot cause history

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

