### PR TITLE
[master] Mellanox: 2700, 4600c - Quoted device IDs to prevent false flags in pcied

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/pcie.yaml
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/pcie.yaml
@@ -35,7 +35,7 @@
 - bus: '00'
   dev: '01'
   fn: '2'
-  id: 0159
+  id: '0159'
   name: 'PCI bridge: Intel Corporation Xeon E3-1200 v2/3rd Gen Core processor PCI
     Express Root Port (rev 09)'
 - bus: '00'

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/pcie.yaml
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/pcie.yaml
@@ -154,7 +154,7 @@
 - bus: '09'
   dev: '00'
   fn: '0'
-  id: 1533
+  id: '1533'
   name: 'Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev
     03)'
 - bus: 'ff'


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Certain all-numeric device IDs of PCI devices in the pcie.yaml file are left unquoted, leading to false mismatch flags in the pcie daemon and subsequently leads to log flooding. This PR fixes that issue.

##### Work item tracking
- Microsoft ADO **(number only)**: 24578930

#### How I did it
Added quotes around numeric PCI devices in the pcie.yaml files of the following platforms:

x86_64-mlnx_msn2700-r0
x86_64-mlnx_msn4600c-r0

#### How to verify it

Install latest image after the merge and verify that syslogs are not flooded with PCI device mismatch errors

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->
Quoted device IDs to prevent false flags in pcied

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

