### PR TITLE
[logrotate] Fix logrotate failure when asic.conf absent.

### DIFF
--- a/files/image_config/logrotate/rsyslog.j2
+++ b/files/image_config/logrotate/rsyslog.j2
@@ -105,7 +105,7 @@
             if [ -f "$ASIC_CONF" ]; then
                 . $ASIC_CONF
             fi
-            if [ $NUM_ASIC -gt 1 ]; then
+            if [ ${NUM_ASIC:-1} -gt 1 ]; then
                 log_file=$1
                 log_file_name=${log_file#/var/log/swss/}
                 logger -p syslog.info -t "logrotate" "Sending SIGHUP to OA log_file_name: $log_file_name"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
fixes #15932 
#### Why I did it
The current logrotate postrotate script can be able to rotate swss.rec and sairedis.rec for multiasic platform. However, for single asic platform, the postrotate script doesn't work due to $NUM_ASIC is unset.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Use brace expansion to set default value 1 if NUM_ASIC is null or unset. Please note that the postrotate script will be executed by posix shell only.

#### How to verify it
logrotate manually:
<pre>
admin@sonic:~$ ls /var/log/swss -la
total 16
drwxr-xr-x 2 root root 4096 Jul 21 14:56 .
drwxr-xr-x 7 root root 4096 Jul 21 14:54 ..
-rw-r--r-- 1 root root  831 Jul 21 14:57 sairedis.rec
-rw-r--r-- 1 root root   45 Jul 21 14:57 swss.rec
admin@sonic:~$ sudo /usr/sbin/logrotate -f /etc/logrotate.conf
admin@sonic:~$ ls /var/log/swss -la
total 396
drwxr-xr-x 2 root root   4096 Jul 21 14:58 .
drwxr-xr-x 7 root root   4096 Jul 21 14:58 ..
-rw-r--r-- 1 root root  17743 Jul 21 14:58 sairedis.rec
-rw-r--r-- 1 root root 331513 Jul 21 14:58 sairedis.rec.1
-rw-r--r-- 1 root root      0 Jul 21 14:58 swss.rec
-rw-r--r-- 1 root root  41857 Jul 21 14:57 swss.rec.1
admin@sonic:~$ sudo cat /var/log/syslog|grep logrotate
Jul 21 14:58:03.481929 sonic INFO logrotate: Sending SIGHUP to OA log_file_name: /var/log/swss/sairedis.rec
Jul 21 14:58:04.673242 sonic INFO logrotate: Sending SIGHUP to OA log_file_name: /var/log/swss/swss.rec

</pre>
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

