### PR TITLE
[SFLOW] Fixed SFLOW DROPMON patch to align with 2.0.45 version

### DIFF
--- a/src/sflow/hsflowd/patch/dropmon/0001-sflow-enabled-drop-monitor-support-for-SONiC.patch
+++ b/src/sflow/hsflowd/patch/dropmon/0001-sflow-enabled-drop-monitor-support-for-SONiC.patch
@@ -1,49 +1,32 @@
-From 4bdd892662c08a396066ba6a1c55eac3f8aa0a5f Mon Sep 17 00:00:00 2001
-From: Vadym Hlushko <vadymh@nvidia.com>
-Date: Tue, 25 Jan 2022 12:59:40 +0000
-Subject: [PATCH] [sflow] enabled drop monitor support for SONiC
+commit 530a0cfcefa88208b3527e0d1b6b43cf21d7dc20
+Author: marvell <marvell@cpss-build2.marvell.com>
+Date:   Mon Jul 24 16:06:57 2023 +0530
 
-Signed-off-by: Vadym Hlushko <vadymh@nvidia.com>
----
- src/Linux/Makefile                   | 2 +-
- src/Linux/hsflowd.c                  | 8 ++++++++
- src/Linux/scripts/hsflowd.conf.sonic | 2 ++
- 3 files changed, 11 insertions(+), 1 deletion(-)
+    [PATCH] [sflow] enabled drop monitor support for SONiC
+    
+    Signed-off-by: Rajkumar P R<rpennadamram@marvell.com>
 
-diff --git a/src/Linux/Makefile b/src/Linux/Makefile
-index 8128cf2..cf538e7 100644
---- a/src/Linux/Makefile
-+++ b/src/Linux/Makefile
-@@ -34,7 +34,7 @@ FEATURES_DENT= DENT PSAMPLE SYSTEMD DROPMON
- FEATURES_EOS= EAPI
- FEATURES_OS10= OS10 DBUS SYSTEMD
- FEATURES_OPX= OPX DBUS SYSTEMD
--FEATURES_SONIC= SONIC PSAMPLE DOCKER
-+FEATURES_SONIC= SONIC PSAMPLE DOCKER DROPMON
- FEATURES_XEN= XEN OVS
- FEATURES_HOST= NFLOG PCAP TCP DOCKER KVM OVS DBUS SYSTEMD
- 
 diff --git a/src/Linux/hsflowd.c b/src/Linux/hsflowd.c
-index 5d94e79..25031d1 100644
+index a29da54..4b6acc1 100644
 --- a/src/Linux/hsflowd.c
 +++ b/src/Linux/hsflowd.c
-@@ -1877,6 +1877,14 @@ extern "C" {
+@@ -1922,6 +1922,14 @@ extern "C" {
      sp->psample.ingress = YES;
-     sp->psample.egress = NO;
-     sp->psample.group = 1;
+     sp->psample.egress = YES;
+     sp->psample.group = 1; // Ingress PSAMPLE group number. Expects egress on (group+1).
 +    // drop-monitor support
 +    myLog(LOG_INFO, "drop-monitor support for SONiC");
 +    sp->dropmon.dropmon = YES;
-+    sp->dropmon.group = 1;
 +    sp->dropmon.start = NO;
 +    sp->dropmon.limit = 1000;
 +    sp->dropmon.sw = NO;
 +    sp->dropmon.hw = YES;
++
  #endif /* HSP_LOAD_SONIC */
  
  #ifdef HSP_LOAD_XEN
 diff --git a/src/Linux/scripts/hsflowd.conf.sonic b/src/Linux/scripts/hsflowd.conf.sonic
-index e675730..fb52a54 100644
+index e675730..0604c5d 100644
 --- a/src/Linux/scripts/hsflowd.conf.sonic
 +++ b/src/Linux/scripts/hsflowd.conf.sonic
 @@ -4,6 +4,8 @@
@@ -55,6 +38,3 @@ index e675730..fb52a54 100644
    # ====== detect new interfaces ======
    refreshAdaptors=60
    # ======  Agent IP selection ======
--- 
-2.17.1
-


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixed build failure when flag ENABLE_SFLOW_DROPMON=y set
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Fixed sflow dropmon patch to align with hsflowd version 2.0.45
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

