### PR TITLE
[ci] Fix pipeline 'Check if vstest is needed.' issue.

### DIFF
--- a/.azure-pipelines/template-skipvstest.yml
+++ b/.azure-pipelines/template-skipvstest.yml
@@ -4,7 +4,7 @@ steps:
       set -ex
       tar_branch=origin/$(System.PullRequest.TargetBranchName)
       # Check if k8s master entrance script is changed
-      k8s_master_changed=$(git diff $tar_branch..HEAD --name-only | grep -F files/image_config/kubernetes/kubernetes_master_entrance.sh || trye)
+      k8s_master_changed=$(git diff $tar_branch..HEAD --name-only | grep -F files/image_config/kubernetes/kubernetes_master_entrance.sh || true)
       if [ -z "$k8s_master_changed" ]; then
         echo "##vso[task.setvariable variable=K8S_OPTIONS;]INCLUDE_KUBERNETES_MASTER=n"
       else

--- a/.azure-pipelines/template-skipvstest.yml
+++ b/.azure-pipelines/template-skipvstest.yml
@@ -4,10 +4,10 @@ steps:
       set -ex
       tar_branch=origin/$(System.PullRequest.TargetBranchName)
       # Check if k8s master entrance script is changed
-      if git diff $tar_branch..HEAD --name-only | grep -F files/image_config/kubernetes/kubernetes_master_entrance.sh; then
-        echo "##vso[task.setvariable variable=K8S_OPTIONS;]INCLUDE_KUBERNETES_MASTER=y"
-      else
+      if ! git diff $tar_branch..HEAD --name-only | grep -F files/image_config/kubernetes/kubernetes_master_entrance.sh; then
         echo "##vso[task.setvariable variable=K8S_OPTIONS;]INCLUDE_KUBERNETES_MASTER=n"
+      else
+        echo "##vso[task.setvariable variable=K8S_OPTIONS;]INCLUDE_KUBERNETES_MASTER=y"
       fi
       git diff $tar_branch..HEAD --name-only | grep -v -f .azure-pipelines/vstest-exclude && exit 0
       git diff $tar_branch..HEAD --name-only | grep -f .azure-pipelines/vstest-include && exit 0

--- a/.azure-pipelines/template-skipvstest.yml
+++ b/.azure-pipelines/template-skipvstest.yml
@@ -4,7 +4,7 @@ steps:
       set -ex
       tar_branch=origin/$(System.PullRequest.TargetBranchName)
       # Check if k8s master entrance script is changed
-      k8s_master_changed=$(git diff $tar_branch..HEAD --name-only | grep -F files/image_config/kubernetes/kubernetes_master_entrance.sh)
+      k8s_master_changed=$(git diff $tar_branch..HEAD --name-only | grep -F files/image_config/kubernetes/kubernetes_master_entrance.sh || trye)
       if [ -z "$k8s_master_changed" ]; then
         echo "##vso[task.setvariable variable=K8S_OPTIONS;]INCLUDE_KUBERNETES_MASTER=n"
       else

--- a/.azure-pipelines/template-skipvstest.yml
+++ b/.azure-pipelines/template-skipvstest.yml
@@ -2,7 +2,7 @@ steps:
 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
   - script: |
       set -ex
-      tar_branch=origin/$(System.PullRequest.TargetBranch)
+      tar_branch=origin/$(System.PullRequest.TargetBranchName)
       # Check if k8s master entrance script is changed
       k8s_master_changed=$(git diff $tar_branch..HEAD --name-only | grep -F files/image_config/kubernetes/kubernetes_master_entrance.sh)
       if [ -z "$k8s_master_changed" ]; then

--- a/.azure-pipelines/template-skipvstest.yml
+++ b/.azure-pipelines/template-skipvstest.yml
@@ -4,11 +4,10 @@ steps:
       set -ex
       tar_branch=origin/$(System.PullRequest.TargetBranchName)
       # Check if k8s master entrance script is changed
-      k8s_master_changed=$(git diff $tar_branch..HEAD --name-only | grep -F files/image_config/kubernetes/kubernetes_master_entrance.sh || true)
-      if [ -z "$k8s_master_changed" ]; then
-        echo "##vso[task.setvariable variable=K8S_OPTIONS;]INCLUDE_KUBERNETES_MASTER=n"
-      else
+      if git diff $tar_branch..HEAD --name-only | grep -F files/image_config/kubernetes/kubernetes_master_entrance.sh; then
         echo "##vso[task.setvariable variable=K8S_OPTIONS;]INCLUDE_KUBERNETES_MASTER=y"
+      else
+        echo "##vso[task.setvariable variable=K8S_OPTIONS;]INCLUDE_KUBERNETES_MASTER=n"
       fi
       git diff $tar_branch..HEAD --name-only | grep -v -f .azure-pipelines/vstest-exclude && exit 0
       git diff $tar_branch..HEAD --name-only | grep -f .azure-pipelines/vstest-include && exit 0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. Line:7 will exit when k8s file didn't change.
2. Use 'System.PullRequest.TargetBranchName' instead of 'System.PullRequest.TargetBranch'. Because git server in AzDevOps don't support 'System.PullRequest.TargetBranch'.
##### Work item tracking
- Microsoft ADO **(number only)**:    24636791

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

