### PR TITLE
[202205][syncd.sh] Clear semaphore before updating firmware (#15818)

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -2,6 +2,18 @@
 
 . /usr/local/bin/syncd_common.sh
 
+declare -r UNKN_MST="unknown"
+
+function GetMstDevice() {
+    local _MST_DEVICE="$(ls /dev/mst/*_pci_cr0 2>&1)"
+
+    if [[ ! -c "${_MST_DEVICE}" ]]; then
+        echo "${UNKN_MST}"
+    else
+        echo "${_MST_DEVICE}"
+    fi
+}
+
 function startplatform() {
 
     # platform specific tasks
@@ -23,6 +35,12 @@ function startplatform() {
 
         debug "Starting Firmware update procedure"
         /usr/bin/mst start --with_i2cdev
+
+        local -r _MST_DEVICE="$(GetMstDevice)"
+        if [[ "${_MST_DEVICE}" != "${UNKN_MST}" ]]; then
+            /usr/bin/flint -d $_MST_DEVICE --clear_semaphore
+        fi
+
         /usr/bin/mlnx-fw-upgrade.sh
         /etc/init.d/sxdkernel restart
         debug "Firmware update procedure ended"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Backport of https://github.com/sonic-net/sonic-buildimage/pull/15818 

#### Why I did it
The hw resources should be released before updating firmware.

#### How I did it
Added logic to release hw resources in `syncd.sh` script

#### How to verify it
Scenario:
1. Write a bash script to kill `mlxfwmanager` process in the infinite loop and run it in the background.
```
#!/bin/bash

while :;
do
    pkill -9 mlnxfwmanager
done
```
2. Try to start the `mlnfwmanager` utility a few times.
3. Stop the bash script.
4. Start the `mlxfwmanager` and make sure that the semaphore is taken.
5. Run the `config reload -y` command and make sure that all the dockers are in up state.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

