### PR TITLE
[protobuf]: Fix protoc-dev cache error

### DIFF
--- a/rules/protobuf.mk
+++ b/rules/protobuf.mk
@@ -17,9 +17,9 @@ $(eval $(call add_derived_package,$(PROTOBUF),$(PROTOBUF_DEV)))
 PROTOBUF_LITE = libprotobuf-lite32_$(PROTOBUF_VERSION_FULL)_$(CONFIGURED_ARCH).deb
 $(eval $(call add_derived_package,$(PROTOBUF),$(PROTOBUF_LITE)))
 
-PROTOC = libprotoc_$(PROTOBUF_VERSION_FULL)_$(CONFIGURED_ARCH).deb
-$(PROTOC)_RDEPENDS = $(PROTOBUF) $(PROTOBUF_LITE)
-$(eval $(call add_derived_package,$(PROTOBUF),$(PROTOC)))
+PROTOC_DEV = libprotoc-dev_$(PROTOBUF_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+$(PROTOC_DEV)_RDEPENDS = $(PROTOBUF) $(PROTOBUF_LITE)
+$(eval $(call add_derived_package,$(PROTOBUF),$(PROTOC_DEV)))
 
 PROTOC32 = libprotoc32_$(PROTOBUF_VERSION_FULL)_$(CONFIGURED_ARCH).deb
 $(PROTOC32)_RDEPENDS = $(PROTOBUF) $(PROTOBUF_LITE)
@@ -27,7 +27,7 @@ $(eval $(call add_derived_package,$(PROTOBUF),$(PROTOC32)))
 
 PROTOBUF_COMPILER = protobuf-compiler_$(PROTOBUF_VERSION_FULL)_$(CONFIGURED_ARCH).deb
 $(PROTOBUF_COMPILER)_DEPENDS = $(PROTOC32)
-$(PROTOBUF_COMPILER)_RDEPENDS = $(PROTOC)
+$(PROTOBUF_COMPILER)_RDEPENDS = $(PROTOC32)
 $(eval $(call add_derived_package,$(PROTOBUF),$(PROTOBUF_COMPILER)))
 
 PYTHON3_PROTOBUF = python3-protobuf_$(PROTOBUF_VERSION_FULL)_$(CONFIGURED_ARCH).deb


### PR DESCRIPTION
tar: target/debs/bullseye/libprotoc_3.21.12-3_amd64.deb: Cannot stat: No such file or directory

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The protoc-dev library with the wrong declaration.

##### Work item tracking
- Microsoft ADO **(number only)**: 24707066

#### How I did it

Revise the wrong declaration from: 
`PROTOC = libprotoc_$(PROTOBUF_VERSION_FULL)_$(CONFIGURED_ARCH).deb` to `PROTOC_DEV = libprotoc-dev$(PROTOBUF_VERSION_FULL)_$(CONFIGURED_ARCH).deb`

#### How to verify it

Check Azp log error.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

