### PR TITLE
Fix eth0 hardware numbering using udev for AS4630-54PE platform.

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/udev/70-persistent-net.rules
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/udev/70-persistent-net.rules
@@ -1,0 +1,3 @@
+ACTION=="add", SUBSYSTEM=="net", DRIVERS=="ixgbe", KERNELS=="0000:08:00.0", NAME:="eth0"
+ACTION=="add", SUBSYSTEM=="net", DRIVERS=="ixgbe", KERNELS=="0000:06:00.1", NAME:="eth1"
+ACTION=="add", SUBSYSTEM=="net", DRIVERS=="ixgbe", KERNELS=="0000:06:00.0", NAME:="eth3"

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/restart_ixgbe.sh
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/restart_ixgbe.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+/etc/init.d/netfilter-persistent stop
+modprobe -r ixgbe
+udevadm control --reload-rules
+udevadm trigger
+modprobe ixgbe
+/etc/init.d/netfilter-persistent start
+

--- a/platform/broadcom/sonic-platform-modules-accton/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/rules
@@ -25,6 +25,7 @@ MODULE_DIRS += as5835-54x as9716-32d as9726-32d as5835-54t as7312-54xs as7315-27
 MODULE_DIR := modules
 UTILS_DIR := utils
 SERVICE_DIR := service
+UDEV_DIR := udev
 CONF_DIR := conf
 
 %:
@@ -69,9 +70,11 @@ binary-indep:
 		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} $(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
 		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} usr/local/bin; \
 		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} lib/systemd/system; \
+                dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} etc/udev/rules.d; \
 		cp $(MOD_SRC_DIR)/$${mod}/$(MODULE_DIR)/*.ko debian/$(PACKAGE_PRE_NAME)-$${mod}/$(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
 		cp $(MOD_SRC_DIR)/$${mod}/$(UTILS_DIR)/* debian/$(PACKAGE_PRE_NAME)-$${mod}/usr/local/bin/; \
 		cp $(MOD_SRC_DIR)/$${mod}/$(SERVICE_DIR)/*.service debian/$(PACKAGE_PRE_NAME)-$${mod}/lib/systemd/system/; \
+                cp $(MOD_SRC_DIR)/$${mod}/$(UDEV_DIR)/* debian/$(PACKAGE_PRE_NAME)-$${mod}/etc/udev/rules.d/; \
 		$(PYTHON3) $${mod}/setup.py install --root=$(MOD_SRC_DIR)/debian/$(PACKAGE_PRE_NAME)-$${mod} --install-layout=deb; \
 	done)
 	# Resuming debhelper scripts

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as4630-54pe.postinst
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as4630-54pe.postinst
@@ -1,8 +1,10 @@
 # Special arrangement to make PDDF mode default
 # Disable monitor, monitor-fan, monitor-psu (not enabling them would imply they will be disabled by default)
 # Enable pddf-platform-monitor
+# Retrigger eth0-eth2 renumbering
 depmod -a
 systemctl enable pddf-platform-init.service
 systemctl start pddf-platform-init.service
 systemctl enable as4630-54pe-pddf-platform-monitor.service
 systemctl start as4630-54pe-pddf-platform-monitor.service
+/usr/local/bin/restart_ixgbe.sh


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Management port currently broken for Edgecore AS4630-54PE platform due to NIC hardware numbering.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Created new PR with typo from Edgecore in original PR fixed.  Here is a link to the old PR that has broken logic:
https://github.com/sonic-net/sonic-buildimage/pull/9560

#### How to verify it
Here is current master branch on AS4630-54PE with broken eth0 (note RUNNING flag):

root@t9845swta0001:/home/admin# ifconfig eth0
eth0: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
        inet 10.121.38.158  netmask 255.255.254.0  broadcast 10.121.39.255
        ether 90:3c:b3:2c:ab:67  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

Here is master branch with fix applied:

root@t9845swta0001:/home/admin# ifconfig eth0
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.121.38.158  netmask 255.255.254.0  broadcast 10.121.39.255
        inet6 fe80::923c:b3ff:fe2c:ab66  prefixlen 64  scopeid 0x20<link>
        ether 90:3c:b3:2c:ab:66  txqueuelen 1000  (Ethernet)
        RX packets 1718  bytes 264071 (257.8 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 461  bytes 53985 (52.7 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

With fix applied, able to ssh to management port IP.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
SONiC-OS-as4630_udev.0-dirty-20230727.132558

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Edgecore (Accton) AS4630-54PE platform fix for management port using udev method.  Hardware uses 3rd NIC port wired to management port RJ45.  This requires renumbering eth2->eth0.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

