### PR TITLE
[Arista] Update phy-credo package to support 40G/100G speed change on 7800R3-48CQ2-LC

### DIFF
--- a/rules/phy-credo.mk
+++ b/rules/phy-credo.mk
@@ -1,3 +1,3 @@
 PHY_CREDO = phy-credo_1.0_amd64.deb
-$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/blob/446f30ccd8626f904d89d5798da7294948e090a6/phy/phy-credo_1.0_amd64.deb"
+$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/raw/446f30ccd8626f904d89d5798da7294948e090a6/phy/phy-credo_1.0_amd64.deb"
 SONIC_ONLINE_DEBS += $(PHY_CREDO)

--- a/rules/phy-credo.mk
+++ b/rules/phy-credo.mk
@@ -1,3 +1,3 @@
 PHY_CREDO = phy-credo_1.0_amd64.deb
-$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/raw/e89a1696954fd381e1e95edf208cffc97caf15d4/phy/phy-credo_1.0_amd64.deb"
+$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/blob/446f30ccd8626f904d89d5798da7294948e090a6/phy/phy-credo_1.0_amd64.deb"
 SONIC_ONLINE_DEBS += $(PHY_CREDO)


### PR DESCRIPTION
#### Why I did it
1. A recent migration of SonicV2Connector from swsssdk to swsscommon.swsscommon broke phy-credo.
2. Support 40G/100G speed change on 7800R3-48CQ2-LC

##### Work item tracking
N/A

#### How I did it
1. Change the import path while keeping a fallback on the previous one for 202205.
2. Handle the lane mapping for speed change.

#### How to verify it
This updated of phy-credo package was already merged into the master branch (https://github.com/sonic-net/sonic-buildimage/commit/1302a31eee5f5284eccb13d0f16ba229cfd528bf). for 202205, I have verified that:
1. phy-credo.service no longer fails due to an import error
2. links come up after the speed change between 40G and 100G.

#### Which release branch to backport (provide reason below if selected)
N/A

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x ] <202205>


#### Description for the changelog
N/A

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)
N/A