### PR TITLE
Handle service start-limit-hit failure event case in sysmonitor

### DIFF
--- a/src/system-health/health_checker/sysmonitor.py
+++ b/src/system-health/health_checker/sysmonitor.py
@@ -73,7 +73,7 @@ class MonitorSystemBusTask(ProcessTaskBase):
         self.task_queue = myQ
 
     def on_job_removed(self, id, job, unit, result):
-        if result == "done":
+        if result == "done" or result == "failed":
             timestamp = "{}".format(datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"))
             msg = {"unit": unit, "evt_src":"sysbus", "time":timestamp}
             self.task_notify(msg)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix https://github.com/sonic-net/sonic-buildimage/issues/15935

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
https://github.com/sonic-net/sonic-buildimage/issues/15935 mentioned issue occurring when a service encounters a start-limit-hit failure. Handling the failure result from sysbus event in sysmonitor processing code

#### How to verify it
Mimic start-limit-hit failure for a service. Issue show system-health sysready-status CLI.

[#]show system-health sysready-status
System is not ready - one or more services are not up

```
Service-Name                      Service-Status    App-Ready-Status    Down-Reason
--------------------------------  ----------------  ------------------  ---------------
as7326-56x-pddf-platform-monitor  OK                OK                  -
auditd                            OK                OK                  -
bgp                               OK                OK                  -
caclmgrd                          OK                OK                  -
config-chassisdb                  OK                OK                  -
config-setup                      OK                OK                  -
containerd                        OK                OK                  -
cron                              OK                OK                  -
database                          OK                OK                  -
determine-reboot-cause            OK                OK                  -
docker                            OK                OK                  -
eventd                            OK                OK                  -
kdump-tools                       OK                OK                  -
lldp                              OK                OK                  -
mgmt-framework                    OK                OK                  -
netfilter-persistent              OK                OK                  -
ntp                               OK                OK                  -
opennsl-modules                   OK                OK                  -
pddf-platform-init                OK                OK                  -
pmon                              OK                OK                  -
procdockerstatsd                  OK                OK                  -
radv                              OK                OK                  -
ras-mc-ctl                        OK                OK                  -
rasdaemon                         OK                OK                  -
rsyslog                           OK                OK                  -
smartmontools                     OK                OK                  -
snmp                              OK                OK                  -
sonic-hostservice                 OK                OK                  -
ssh                               OK                OK                  -
swss                              OK                OK                  -
syncd                             OK                OK                  -
sysstat                           OK                OK                  -
teamd                             OK                OK                  -
telemetry                         Down              Down                start-limit-hit
[#]
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

