### PR TITLE
[SNMP][IPv6]: Fix to use link local IPv6 address as snmp agentAddress

### DIFF
--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -30,12 +30,12 @@ agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% e
 {% endfor %}
 {% elif NAMESPACE_COUNT is not defined or NAMESPACE_COUNT|int <= 1 %}
 {% if MGMT_INTERFACE is defined %}
-{% for if, ip in MGMT_INTERFACE %}
+{% for intf, ip in MGMT_INTERFACE %}
 {% set agentip = ip.split('/')[0]|lower %}
 {% set zoneid = '' %}
 # Use interface as zoneid for link local ipv6
 {% if agentip.startswith('fe80') %}
-{% set zoneid = '%' + if %}
+{% set zoneid = '%' + intf %}
 {% endif %}
 agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
 {% endfor %}
@@ -43,12 +43,12 @@ agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
 {% if LOOPBACK_INTERFACE is defined %}
 {% for lo in LOOPBACK_INTERFACE %}
 {% if lo | length == 2 %}
-{% set if = lo[0] %}
+{% set intf = lo[0] %}
 {% set agentip = lo[1].split('/')[0]|lower %}
 {% set zoneid = '' %}
 # Use interface as zoneid for link local ipv6
 {% if agentip.startswith('fe80') %}
-{% set zoneid = '%' + if %}
+{% set zoneid = '%' + intf %}
 {% endif %}
 agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
 {% endif %}

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -16,7 +16,7 @@
 # Listen for connections on all ip addresses, including eth0, ipv4 lo for multi-asic platform
 # Listen on managment and loopback0 ips for single asic platform
 #
-{% macro protocol(ip_addr) %}
+{% macro get_protocol(ip_addr) %}
 {%- if ip_addr|ipv6 -%}
 {{ 'udp6' }}
 {%- else -%}
@@ -32,14 +32,25 @@ agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% e
 {% if MGMT_INTERFACE is defined %}
 {% for if, ip in MGMT_INTERFACE %}
 {% set agentip = ip.split('/')[0] %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}]:161
+{% set protocol = get_protocol(agentip) %}
+{% if protocol == 'udp6' %}
+agentAddress {{ protocol }}:[{{ agentip }}%{{ if }}]:161
+{% else %}
+agentAddress {{ protocol }}:[{{ agentip }}]:161
+{% endif %}
 {% endfor %}
 {% endif %}
 {% if LOOPBACK_INTERFACE is defined %}
 {% for lo in LOOPBACK_INTERFACE %}
 {% if lo | length == 2 %}
 {% set agentip = lo[1].split('/')[0] %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}]:161
+{% set if = lo[0] %}
+{% set protocol = get_protocol(agentip) %}
+{% if protocol == 'udp6' %}
+agentAddress {{ protocol }}:[{{ agentip }}%{{ if }}]:161
+{% else %}
+agentAddress {{ protocol }}:[{{ agentip }}]:161
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -33,8 +33,8 @@ agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% e
 {% for if, ip in MGMT_INTERFACE %}
 {% set agentip = ip.split('/')[0]|lower %}
 {% set zoneid = '' %}
-{% if agentip.startswith('fe80') %}
 # Use interface as zoneid for link local ipv6
+{% if agentip.startswith('fe80') %}
 {% set zoneid = '%' + if %}
 {% endif %}
 agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
@@ -46,11 +46,13 @@ agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
 {% set if = lo[0] %}
 {% set agentip = lo[1].split('/')[0]|lower %}
 {% set zoneid = '' %}
-{% if agentip.startswith('fe80') %}
 # Use interface as zoneid for link local ipv6
+{% if agentip.startswith('fe80') %}
 {% set zoneid = '%' + if %}
 {% endif %}
 agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
+{% endif %}
+{% endfor %}
 {% endif %}
 {% else %}
 agentAddress udp:161

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -16,7 +16,7 @@
 # Listen for connections on all ip addresses, including eth0, ipv4 lo for multi-asic platform
 # Listen on managment and loopback0 ips for single asic platform
 #
-{% macro get_protocol(ip_addr) %}
+{% macro protocol(ip_addr) %}
 {%- if ip_addr|ipv6 -%}
 {{ 'udp6' }}
 {%- else -%}
@@ -31,28 +31,26 @@ agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% e
 {% elif NAMESPACE_COUNT is not defined or NAMESPACE_COUNT|int <= 1 %}
 {% if MGMT_INTERFACE is defined %}
 {% for if, ip in MGMT_INTERFACE %}
-{% set agentip = ip.split('/')[0] %}
-{% set protocol = get_protocol(agentip) %}
-{% if protocol == 'udp6' %}
-agentAddress {{ protocol }}:[{{ agentip }}%{{ if }}]:161
-{% else %}
-agentAddress {{ protocol }}:[{{ agentip }}]:161
+{% set agentip = ip.split('/')[0]|lower %}
+{% set zoneid = '' %}
+{% if agentip.startswith('fe80') %}
+# Use interface as zoneid for link local ipv6
+{% set zoneid = '%' + if %}
 {% endif %}
+agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
 {% endfor %}
 {% endif %}
 {% if LOOPBACK_INTERFACE is defined %}
 {% for lo in LOOPBACK_INTERFACE %}
 {% if lo | length == 2 %}
-{% set agentip = lo[1].split('/')[0] %}
 {% set if = lo[0] %}
-{% set protocol = get_protocol(agentip) %}
-{% if protocol == 'udp6' %}
-agentAddress {{ protocol }}:[{{ agentip }}%{{ if }}]:161
-{% else %}
-agentAddress {{ protocol }}:[{{ agentip }}]:161
+{% set agentip = lo[1].split('/')[0]|lower %}
+{% set zoneid = '' %}
+{% if agentip.startswith('fe80') %}
+# Use interface as zoneid for link local ipv6
+{% set zoneid = '%' + if %}
 {% endif %}
-{% endif %}
-{% endfor %}
+agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
 {% endif %}
 {% else %}
 agentAddress udp:161


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fixes: https://github.com/sonic-net/sonic-buildimage/issues/16001
Caused by: https://github.com/sonic-net/sonic-buildimage/pull/15487

The above PR introduced change to use Management and Loopback Ipv4 and ipv6 addresses as snmpagent address in snmpd.conf file.
With this change, if Link local IP address is configured as management or Loopback IPv6 address, then snmpd tries to open socket on that ipv6 address and fails with the below error:
```
Error opening specified endpoint "udp6:[fe80::5054:ff:fe6f:16f0]:161"
Server Exiting with code 1
```
From RFC4007, if we need to specify non-global ipv6 address without ambiguity, we need to use zone id along with the ipv6 address: <address>%<zone_id>
Reference: https://datatracker.ietf.org/doc/html/rfc4007

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modify snmpd.conf file to use the %zone_id representation for ipv6 address.
#### How to verify it
In VS testbed, modify config_db to use link local ipv6 address as management address:
    "MGMT_INTERFACE": {
        "eth0|10.250.0.101/24": {
            "forced_mgmt_routes": [
                "172.17.0.1/24"
            ],
            "gwaddr": "10.250.0.1"
        },
        "eth0|fe80::5054:ff:fe6f:16f0/64": {
            "gwaddr": "fe80::1"
        }
    },

Execute config_reload after the above change.
snmpd comes up and check if snmpd is listening on ipv4 and ipv6 addresses:
```
admin@vlab-01:~$ sudo netstat -tulnp | grep 161
tcp        0      0 127.0.0.1:3161          0.0.0.0:*               LISTEN      274060/snmpd        
udp        0      0 10.1.0.32:161           0.0.0.0:*                           274060/snmpd        
udp        0      0 10.250.0.101:161        0.0.0.0:*                           274060/snmpd        
udp6       0      0 fc00:1::32:161          :::*                                274060/snmpd        
udp6       0      0 fe80::5054:ff:fe6f::161 :::*                                274060/snmpd      -- Link local 
 
admin@vlab-01:~$ sudo ifconfig eth0
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.250.0.101  netmask 255.255.255.0  broadcast 10.250.0.255
        inet6 fe80::5054:ff:fe6f:16f0  prefixlen 64  scopeid 0x20<link>
        ether 52:54:00:6f:16:f0  txqueuelen 1000  (Ethernet)
        RX packets 36384  bytes 22878123 (21.8 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 261265  bytes 46585948 (44.4 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@vlab-01:~$ docker exec -it snmp snmpget -v2c -c public fe80::5054:ff:fe6f:16f0 1.3.6.1.2.1.1.1.0
iso.3.6.1.2.1.1.1.0 = STRING: "SONiC Software Version: SONiC.master.327516-04a6031b2 - HwSku: Force10-S6000 - Distribution: Debian 11.7 - Kernel: 5.10.0-18-2-amd64"
```
Logs from snmpd:
```
Turning on AgentX master support.
NET-SNMP version 5.9
Connection from UDP/IPv6: [fe80::5054:ff:fe6f:16f0%eth0]:44308
```
Ran test_snmp_loopback test to check if loopback ipv4 and ipv6 works:
```
./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c snmp/test_snmp_loopback.py  -f vtestbed.yaml -i ../ansible/veos_vtb -e "--skip_sanity --disable_loganalyzer" -u
=== Running tests in groups ===
Running: pytest snmp/test_snmp_loopback.py --inventory ../ansible/veos_vtb --host-pattern vlab-01 --testbed vms-kvm-t0 --testbed_file vtestbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --junit-xml=logs/tr.xml --log-file=logs/test.log --skip_sanity --disable_loganalyzer
..                                                                        

snmp/test_snmp_loopback.py::test_snmp_loopback[vlab-01] PASSED 
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

