### PR TITLE
[chassis] Fix the Loopback0 IPv6 address of LC's in chassis not reachable from peer devices

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -104,6 +104,9 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/128
 {% else %}
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/64
+{% if DEVICE_METADATA['localhost']['switch_type'] == 'voq' or DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
+    network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/128 route-map HIDE_INTERNAL
+{% endif %}
 {% endif %}
   exit-address-family
 {% endif %}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/packet_chassis.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/packet_chassis.conf
@@ -47,6 +47,7 @@ router bgp 55555
 !
   address-family ipv6
     network fc00::1/64
+    network fc00::1/128 route-map HIDE_INTERNAL
   exit-address-family
 !
   network 10.10.10.1/24

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/voq_chassis.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/voq_chassis.conf
@@ -48,6 +48,7 @@ router bgp 55555
 !
   address-family ipv6
     network fc00::1/64
+    network fc00::1/128 route-map HIDE_INTERNAL
   exit-address-family
   address-family ipv6
     network fc00::2/128 route-map HIDE_INTERNAL


### PR DESCRIPTION
What I did:
Fix the Loopback0 IPv6 address of LC's in chassis not reachable from peer devices.

Why I did:
For Ipv6 Loopback0 address we only advertise /64 subnet to the peer devices. However, in case of chassis each LC will have it own /128  address of that /64 subnet . Since this /128 address does not get advertised peer devices can-not ping/reach the LC's loopback0.

How I fix:
Advertise /128 Loopback0 Ipv6 address only between i-BGP peers. This way even though /64 is advertised to e-BGP peer devices when packet reaches any of LC's it can reach the appropriate LC's.

How I verify:
Manual verification
UT added for same.
