### PR TITLE
[Nokia][DeviceData] Update the Nokia platform IXR-7250E device data

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_reboot
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_reboot
@@ -1,23 +1,24 @@
 #!/bin/bash
 
-update_reboot_cause_for_supervisor_reboot()
+update_reboot_cause()
 {
     DEVICE_MGR_REBOOT_FILE=/tmp/device_mgr_reboot
     REBOOT_CAUSE_FILE=/host/reboot-cause/reboot-cause.txt
-    TMP_REBOOT_CAUSE_FILE=/tmp/tmp-reboot-cause.txt
-    if [ -f  $DEVICE_MGR_REBOOT_FILE ]; then
-        if [ -f $REBOOT_CAUSE_FILE ]; then
-            t1=`sudo grep "User: ," $REBOOT_CAUSE_FILE`
-            if [ ! -z "$t1" ]; then
-                echo $t1 | sed 's/reboot/reboot from Supervisor/g' | sed 's/User: /User: admin/g' > $TMP_REBOOT_CAUSE_FILE
-                cp $TMP_REBOOT_CAUSE_FILE $REBOOT_CAUSE_FILE
-            fi
+    DEVICE_REBOOT_CAUSE_FILE=/etc/opt/srlinux/reboot-cause.txt
+    if [ -e  $DEVICE_MGR_REBOOT_FILE ]; then
+        if [ -e $DEVICE_REBOOT_CAUSE_FILE ]; then
+            cp -f $DEVICE_REBOOT_CAUSE_FILE $REBOOT_CAUSE_FILE
         fi
+        rm -f $DEVICE_MGR_REBOOT_FILE
+    else
+        touch /etc/opt/srlinux/devmgr_reboot_cause.done
+        rm -f $DEVICE_REBOOT_CAUSE_FILE &> /dev/null
     fi
+    sync
 }
 
 # update the reboot_cuase file when reboot is trigger by device-mgr
-update_reboot_cause_for_supervisor_reboot
+update_reboot_cause
 
 systemctl stop nokia-watchdog.service
 sleep 2
@@ -25,7 +26,5 @@ echo "w" > /dev/watchdog
 kick_date=`date -u`
 echo "last watchdog kick $kick_date" > /var/log/nokia-watchdog-last.log
 rm -f /sys/firmware/efi/efivars/dump-*
-touch /etc/opt/srlinux/devmgr_reboot_cause.done
-rm -f /etc/opt/srlinux/reboot-cause.txt
 sync
 exec /sbin/reboot $@


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Update the platform_reboot of Nokia Platform IXR-7250E-36x400G to displays the correct reboot-cause history when reboot from supervisor card. 


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modify the platform_reboot script to copy the correct reboo-cause.txt file from NDK to the /host/reboot-cause directory at the down cycle when the reboot is issued from Supervisor (for both reboot  right after install a new image and normal reboot)

#### How to verify it
1)  Execute a CLI command "sudo reboot" on the Supervisor
2)  After system is up, on the Linecard, execute the CLI show reboot-cause history
```
Name                 Cause                                                                           Time                             User    Comment
-------------------  ------------------------------------------------------------------------------  -------------------------------  ------  ---------
2023_08_03_16_41_30  reboot from Supervisor                                                          Thu 03 Aug 2023 04:39:48 PM UTC          N/A
2023_08_03_00_42_16  reboot from Supervisor                                                          Thu 03 Aug 2023 12:39:58 AM UTC  admin   N/A
2023_08_02_04_04_58  reboot                                                                          Wed 02 Aug 2023 04:02:56 AM UTC  admin   N/A
2023_08_02_03_20_21  reboot                                                                          Wed 02 Aug 2023 03:18:18 AM UTC  admin   N/A
2023_08_01_16_14_57  reboot                                                                          Tue 01 Aug 2023 02:49:45 PM UTC  admin   N/A
2023_08_01_14_46_45  reboot                                                                          Tue 01 Aug 2023 02:44:43 PM UTC  admin   N/A

```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)
branch 202205 latest
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

