### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202205.2.2.8
+ref=202205.2.2.9


### PR DESCRIPTION
Why I did it
Release Notes for Cisco 8101-32FH-O:
	•	Fix for TX_DRP incrementing on Down Interfaces
Release Notes for Cisco 8102-64H:
	•	Aikido FPD 1.88 upgrade
	•	Fix for TX_DRP incrementing on Down Interfaces

How I did it
Update platform version to 202205.2.2.9

