### PR TITLE
[Celestica-E1031] Enable CPU watchdog

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.install
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.install
@@ -1,5 +1,6 @@
 haliburton/cfg/haliburton-modules.conf etc/modules-load.d
 haliburton/systemd/platform-modules-haliburton.service lib/systemd/system
+haliburton/systemd/cpu_wdt.service lib/systemd/system
 haliburton/script/fancontrol.sh etc/init.d
 haliburton/script/fancontrol.service lib/systemd/system
 services/fancontrol/fancontrol  usr/local/bin
@@ -8,4 +9,5 @@ services/platform_api/platform_api_mgnt.sh usr/local/bin
 haliburton/script/popmsg.sh usr/local/bin
 haliburton/script/udev_prefix.sh usr/local/bin
 haliburton/script/reload_udev.sh usr/local/bin
+haliburton/script/cpu_wdt usr/local/bin
 haliburton/script/50-ttyUSB-C0.rules etc/udev/rules.d

--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.postinst
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.postinst
@@ -3,6 +3,7 @@ depmod -a
 sudo chmod +x /usr/local/bin/udev_prefix.sh
 sudo chmod +x /usr/local/bin/popmsg.sh
 sudo chmod +x /usr/local/bin/reload_udev.sh
+sudo chmod +x /usr/local/bin/cpu_wdt
 
 /usr/local/bin/platform_api_mgnt.sh install
 /etc/init.d/fancontrol.sh install
@@ -10,6 +11,8 @@ sudo chmod +x /usr/local/bin/reload_udev.sh
 
 systemctl enable platform-modules-haliburton.service
 systemctl enable fancontrol.service
+systemctl enable cpu_wdt.service
 
 systemctl start platform-modules-haliburton.service
 systemctl start fancontrol.service
+systemctl start cpu_wdt.service

--- a/platform/broadcom/sonic-platform-modules-cel/haliburton/script/cpu_wdt
+++ b/platform/broadcom/sonic-platform-modules-cel/haliburton/script/cpu_wdt
@@ -1,0 +1,10 @@
+#!/usr/bin/python
+
+import time
+
+def main():
+    while True:
+        time.sleep(1)
+
+if __name__ == '__main__':
+    main()

--- a/platform/broadcom/sonic-platform-modules-cel/haliburton/script/cpu_wdt
+++ b/platform/broadcom/sonic-platform-modules-cel/haliburton/script/cpu_wdt
@@ -20,8 +20,8 @@ function usage()
     echo ""
     echo "Options:"
     echo "  -h              Show this help"
-    echo "  -t <timeout>    WDT timeout period: {30|60|180}"
-    echo "  -k <keepalive>  WDT keep alive period, {1..(timeout-5)}"
+    echo "  -t <timeout>    WDT timeout period: {30|60|180}, default 180"
+    echo "  -k <keepalive>  WDT keep alive period, {1..(timeout-5)}, default 60"
     exit 1
 }
 

--- a/platform/broadcom/sonic-platform-modules-cel/haliburton/script/cpu_wdt
+++ b/platform/broadcom/sonic-platform-modules-cel/haliburton/script/cpu_wdt
@@ -1,10 +1,89 @@
-#!/usr/bin/python
+#!/bin/bash
 
-import time
+SYSLOG_IDENTIFIER="cpu_wdt"
+CPUWDT_MAIN_TASK_RUNNING_FLAG=true
+TIMEOUT=180
+KEEPALIVE=60
 
-def main():
-    while True:
-        time.sleep(1)
+function log_info()
+{
+    logger -p info -t ${SYSLOG_IDENTIFIER}  "$@"
+}
 
-if __name__ == '__main__':
-    main()
+function usage()
+{
+    echo "Usage: $0 ACTION [OPTIONS]..."
+    echo ""
+    echo "Actions:"
+    echo "  start    Start CPU WDT"
+    echo "  stop     Stop CPU WDT"
+    echo ""
+    echo "Options:"
+    echo "  -h              Show this help"
+    echo "  -t <timeout>    WDT timeout period: {30|60|180}"
+    echo "  -k <keepalive>  WDT keep alive period, {1..(timeout-5)}"
+    exit 1
+}
+
+function validate_action()
+{
+    if [[ "${ACTION}" != "start" && "${ACTION}" != "stop" ]]; then
+        echo -e "Invalid action: ${ACTION}\n"
+        usage
+    fi
+}
+
+function validate_options()
+{
+    if [[ ${TIMEOUT} != "30" && ${TIMEOUT} != "60" && ${TIMEOUT} != "180" ]]; then
+        echo -e "Invalid timeout value: ${TIMEOUT}\n"
+        usage
+    fi
+    if [[ ${KEEPALIVE} -le 0 || ${KEEPALIVE} -gt $((TIMEOUT - 5)) ]]; then
+        echo "Invalid keepalive value: ${KEEPALIVE}"
+        echo ""
+        usage
+    fi
+}
+
+trap 'log_info "Caught SIGHUP - ignoring..."' SIGHUP
+trap 'log_info "Caught SIGINT - exiting..."; CPUWDT_MAIN_TASK_RUNNING_FLAG=false' SIGINT
+trap 'log_info "Caught SIGTERM - exiting..."; CPUWDT_MAIN_TASK_RUNNING_FLAG=false' SIGTERM
+
+ACTION=$1
+shift
+validate_action
+
+while getopts "t:k:" OPTION; do
+    case $OPTION in
+    t)
+        TIMEOUT=${OPTARG}
+        ;;
+    k)
+        KEEPALIVE=${OPTARG}
+        ;;
+    *)
+        usage
+    esac
+done
+
+validate_options
+
+if [[ "${ACTION}" == "start" ]]; then
+    # enable
+    log_info "Enable CPU WDT.."
+    watchdogutil arm -s "${TIMEOUT}" > /dev/null
+    log_info "CPU WDT has been enabled with $TIMEOUT seconds timeout"
+
+    # keep alive
+    log_info "Enable keep alive messaging every $KEEPALIVE seconds"
+    while [[ ${CPUWDT_MAIN_TASK_RUNNING_FLAG} == "true" ]]; do
+        watchdogutil arm -s "${TIMEOUT}" > /dev/null
+        sleep "${KEEPALIVE}"
+    done
+    log_info "Keep alive messaging has been disabled"
+fi
+
+log_info "Disable CPU WDT.."
+watchdogutil disarm
+log_info "CPU WDT has been disabled!"

--- a/platform/broadcom/sonic-platform-modules-cel/haliburton/systemd/cpu_wdt.service
+++ b/platform/broadcom/sonic-platform-modules-cel/haliburton/systemd/cpu_wdt.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=CPU WDT
+After=platform-modules-haliburton.service
+Requires=platform-modules-haliburton.service
+
+[Service]
+ExecStart=-/usr/local/bin/cpu_wdt
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/broadcom/sonic-platform-modules-cel/haliburton/systemd/cpu_wdt.service
+++ b/platform/broadcom/sonic-platform-modules-cel/haliburton/systemd/cpu_wdt.service
@@ -4,7 +4,7 @@ After=platform-modules-haliburton.service
 Requires=platform-modules-haliburton.service
 
 [Service]
-ExecStart=-/usr/local/bin/cpu_wdt
+ExecStart=-/usr/local/bin/cpu_wdt start
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Enable CPU watchdog on Celestica-E1031.

##### Work item tracking
- Microsoft ADO **(number only)**: 24792364

#### How I did it
Add a system service `cpu_wdt` to enable CPU watchdog and send keep-alive signal to watchdog periodically.

#### How to verify it
Build SONiC image and installed on physical device. Can see the `cpu_wdt` work as expected.
```
$ sudo systemctl status cpu_wdt.service
● cpu_wdt.service - CPU WDT
     Loaded: loaded (/lib/systemd/system/cpu_wdt.service; enabled; vendor preset: enabled)
     Active: active (running) since Wed 2023-08-09 14:37:12 UTC; 1min 11s ago
   Main PID: 324656 (cpu_wdt)
      Tasks: 2 (limit: 2329)
     Memory: 2.1M
     CGroup: /system.slice/cpu_wdt.service
             ├─324656 /bin/bash /usr/local/bin/cpu_wdt start
             └─325540 sleep 60

Aug 09 14:37:12 e1031-1 systemd[1]: Started CPU WDT.
Aug 09 14:37:12 e1031-1 cpu_wdt[324657]: Enable CPU WDT..
Aug 09 14:37:13 e1031-1 cpu_wdt[324675]: CPU WDT has been enabled with 180 seconds timeout
Aug 09 14:37:13 e1031-1 cpu_wdt[324676]: Enable keep alive messaging every 60 seconds
```

When I stopped `cpu_wtd` service, it will disarm watchdog before exit:
```
$ sudo systemctl stop cpu_wdt.service
$ sudo systemctl status cpu_wdt.service
● cpu_wdt.service - CPU WDT
     Loaded: loaded (/lib/systemd/system/cpu_wdt.service; enabled; vendor preset: enabled)
     Active: inactive (dead) since Wed 2023-08-09 14:47:24 UTC; 18s ago
    Process: 324656 ExecStart=/usr/local/bin/cpu_wdt start (code=exited, status=0/SUCCESS)
   Main PID: 324656 (code=exited, status=0/SUCCESS)

Aug 09 14:37:12 e1031-1 cpu_wdt[324657]: Enable CPU WDT..
Aug 09 14:37:13 e1031-1 cpu_wdt[324675]: CPU WDT has been enabled with 180 seconds timeout
Aug 09 14:37:13 e1031-1 cpu_wdt[324676]: Enable keep alive messaging every 60 seconds
Aug 09 14:46:23 e1031-1 systemd[1]: Stopping CPU WDT...
Aug 09 14:46:23 e1031-1 cpu_wdt[324656]: Terminated
Aug 09 14:46:23 e1031-1 cpu_wdt[331991]: Caught SIGTERM - exiting...
Aug 09 14:47:24 e1031-1 cpu_wdt[332812]: Watchdog disarmed successfully
Aug 09 14:47:24 e1031-1 cpu_wdt[332826]: CPU WDT has been disabled!
Aug 09 14:47:24 e1031-1 systemd[1]: cpu_wdt.service: Succeeded.
Aug 09 14:47:24 e1031-1 systemd[1]: Stopped CPU WDT.
```



<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

