### PR TITLE
[Mellanox] Fix issue: watchdogutil command does not work

### DIFF
--- a/platform/mellanox/mlnx-platform-api/tests/test_watchdog.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_watchdog.py
@@ -84,46 +84,58 @@ class TestWatchdog:
         mock_exists.return_value = test_para
         assert is_wd_type2('') is test_para
 
-    @mock.patch('sonic_platform.watchdog.WatchdogImplBase.open_handle', mock.MagicMock())
-    @mock.patch('sonic_platform.watchdog.fcntl.ioctl', mock.MagicMock())
-    def test_arm_disarm_watchdog2(self):
+    @mock.patch('sonic_platform.utils.read_str_from_file')
+    def test_is_armed(self, mock_read):
         watchdog = WatchdogType2('watchdog2')
-        assert watchdog.arm(-1) == -1
+        mock_read.return_value = 'inactive'
         assert not watchdog.is_armed()
-        watchdog.arm(10)
+        mock_read.return_value = 'active'
         assert watchdog.is_armed()
-        watchdog.arm(5)
-        assert watchdog.is_armed()
-        watchdog.disarm()
-        assert not watchdog.is_armed()
 
     @mock.patch('sonic_platform.watchdog.WatchdogImplBase.open_handle', mock.MagicMock())
     @mock.patch('sonic_platform.watchdog.fcntl.ioctl', mock.MagicMock())
-    def test_arm_disarm_watchdog1(self):
+    @mock.patch('sonic_platform.watchdog.WatchdogImplBase.is_armed')
+    def test_arm_disarm_watchdog2(self, mock_is_armed):
+        watchdog = WatchdogType2('watchdog2')
+        assert watchdog.arm(-1) == -1
+        mock_is_armed.return_value = False
+        watchdog.arm(10)
+        mock_is_armed.return_value = True
+        watchdog.arm(5)
+        watchdog.disarm()
+
+    @mock.patch('sonic_platform.watchdog.WatchdogImplBase.open_handle', mock.MagicMock())
+    @mock.patch('sonic_platform.watchdog.fcntl.ioctl', mock.MagicMock())
+    @mock.patch('sonic_platform.watchdog.WatchdogImplBase.is_armed')
+    def test_arm_disarm_watchdog1(self, mock_is_armed):
         watchdog = WatchdogType1('watchdog1')
         assert watchdog.arm(-1) == -1
-        assert not watchdog.is_armed()
+        mock_is_armed.return_value = False
         watchdog.arm(10)
-        assert watchdog.is_armed()
+        mock_is_armed.return_value = True
         watchdog.arm(5)
-        assert watchdog.is_armed()
         watchdog.disarm()
-        assert not watchdog.is_armed()
 
     @mock.patch('sonic_platform.watchdog.WatchdogImplBase.open_handle', mock.MagicMock())
     @mock.patch('sonic_platform.watchdog.fcntl.ioctl', mock.MagicMock())
     @mock.patch('sonic_platform.watchdog.WatchdogImplBase._gettimeleft', mock.MagicMock(return_value=10))
-    def test_get_remaining_time_watchdog2(self):
+    @mock.patch('sonic_platform.watchdog.WatchdogImplBase.is_armed')
+    def test_get_remaining_time_watchdog2(self, mock_is_armed):
         watchdog = WatchdogType2('watchdog2')
+        mock_is_armed.return_value = False
         assert watchdog.get_remaining_time() == -1
         watchdog.arm(10)
+        mock_is_armed.return_value = True
         assert watchdog.get_remaining_time() == 10
 
     @mock.patch('sonic_platform.watchdog.WatchdogImplBase.open_handle', mock.MagicMock())
     @mock.patch('sonic_platform.watchdog.fcntl.ioctl', mock.MagicMock())
     @mock.patch('sonic_platform.watchdog.WatchdogImplBase._gettimeleft', mock.MagicMock(return_value=10))
-    def test_get_remaining_time_watchdog1(self):
+    @mock.patch('sonic_platform.watchdog.WatchdogImplBase.is_armed')
+    def test_get_remaining_time_watchdog1(self, mock_is_armed):
         watchdog = WatchdogType1('watchdog2')
+        mock_is_armed.return_value = False
         assert watchdog.get_remaining_time() == -1
         watchdog.arm(10)
+        mock_is_armed.return_value = True
         assert watchdog.get_remaining_time() > 0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

watchdogutil uses platform API watchdog instance to control/query watchdog status. In Nvidia watchdog status, it caches "armed" status in a object member "WatchdogImplBase.armed". This is not working for CLI infrastructure because each CLI will create a new watchdog instance, the status cached in previous instance will totally lose. Consider following commands:

```
admin@sonic:~$ sudo watchdogutil arm -s 100      =====> watchdog instance1, armed=True
Watchdog armed for 100 seconds
admin@sonic:~$ sudo watchdogutil status             ======> watchdog instance2, armed=False
Status: Unarmed
admin@sonic:~$ sudo watchdogutil disarm            =======> watchdog instance3, armed=False
Failed to disarm Watchdog
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Use sysfs to query watchdog status

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Manual test
Unit test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

