### PR TITLE
[multi-asic] sudo not required explicitly as /bin/ip netns identify present in sudoers

### DIFF
--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -157,7 +157,7 @@ def get_current_namespace(pid=None):
     """
 
     net_namespace = None
-    command = ["sudo", '/bin/ip', 'netns', 'identify', "{}".format(os.getpid() if not pid else pid)]
+    command = ['/bin/ip', 'netns', 'identify', "{}".format(os.getpid() if not pid else pid)]
     proc = subprocess.Popen(command,
                             stdout=subprocess.PIPE,
                             universal_newlines=True,


### PR DESCRIPTION
#### Why I did it
Few commands in multiasic platforms when run with the "sudo ip netns exec asic0 <show cmd>" option was taking like 15 mins to get the o/p. This behavior of sudo getting hung was seen by just doing this 

jujoseph@svcstr-server-2:~ sudo ip netns exec asic0 bash
jujoseph@svcstr-server-2:~ sudo ls

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

The reason was found that when a show command is issued, there is an API to get the current namespace 
```
def get_current_namespace(pid=None):
154     """
155     This API returns the network namespace in which it is
156     invoked. In case of global namepace the API returns None
157     """
158 
159     net_namespace = None
160     command = ['sudo', '/bin/ip', 'netns', 'identify', "{}".format(os.getpid() if not pid else pid)]
161     proc = subprocess.Popen(command,
162                             stdout=subprocess.PIPE,
163                             universal_newlines=True,
164                             stderr=subprocess.STDOUT)
```
and  we were doing it  with sufo prefixed. This was ok with usually show commands which is issued in linux host, but when issued with "sudo ip netns exec asic0" prefix ( i.e the command is executed in a linux network namespace )  sudo gets hung adding to overall delay to command o/p

Ideally sudo is not needed as we have /bin/ip netns identify present in /etc/sudoers file. Hence removing it

#### How to verify it

Verified with both RO and RW user in a multi-asic platform, confirmed the show commands work, and "sudo ip netns exec asic0 <show cmd>" command returns result quicker.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

