### PR TITLE
qos template change for backend compute-ai deployment

### DIFF
--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -79,6 +79,12 @@
 {
 {% if (generate_tc_to_pg_map is defined) and tunnel_qos_remap_enable %}
     {{- generate_tc_to_pg_map() }}
+{% elif (generate_tc_to_pg_map is defined) and
+        ('type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['type'] in backend_device_types) and
+        ('resource_type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['resource_type'] == 'Compute-AI') %}
+    {{- generate_tc_to_pg_map() }}
 {% else %}
     "TC_TO_PRIORITY_GROUP_MAP": {
         "AZURE": {
@@ -136,6 +142,12 @@
         }
     },
 {% elif (generate_dscp_to_tc_map is defined) and tunnel_qos_remap_enable %}
+    {{- generate_dscp_to_tc_map() }}
+{% elif (generate_dscp_to_tc_map is defined) and
+         ('type' in DEVICE_METADATA['localhost'] and
+           DEVICE_METADATA['localhost']['type'] in backend_device_types) and
+         ('resource_type' in DEVICE_METADATA['localhost'] and
+           DEVICE_METADATA['localhost']['resource_type'] == 'Compute-AI') %}
     {{- generate_dscp_to_tc_map() }}
 {% else %}
     "DSCP_TO_TC_MAP": {
@@ -225,6 +237,29 @@
             "weight": "100"
         }
     },
+{% elif (generate_tc_to_pg_map is defined) and
+        ('type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['type'] in backend_device_types) and
+        ('resource_type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['resource_type'] == 'Compute-AI') %}
+    "SCHEDULER": {
+        "scheduler.0": {
+            "type"  : "DWRR",
+            "weight": "40"
+        },
+        "scheduler.1": {
+            "type"  : "DWRR",
+            "weight": "30"
+        },
+        "scheduler.2": {
+            "type"  : "DWRR",
+            "weight": "25"
+        },
+        "scheduler.3": {
+            "type"  : "DWRR",
+            "weight": "5"
+        }
+    },
 {% else %}
     "SCHEDULER": {
         "scheduler.0": {
@@ -297,10 +332,24 @@
 {% endif %}
 {% if port in port_names_list_extra_queues %}
             "pfc_enable"      : "2,3,4,6",
+{% elif (generate_tc_to_pg_map is defined) and
+        ('type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['type'] in backend_device_types) and
+        ('resource_type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['resource_type'] == 'Compute-AI') %}
+            "pfc_enable"      : "2,3",
 {% else %}
             "pfc_enable"      : "3,4",
 {% endif %}
+{% if (generate_tc_to_pg_map is defined) and
+        ('type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['type'] in backend_device_types) and
+        ('resource_type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['resource_type'] == 'Compute-AI') %}
+            "pfcwd_sw_enable" : "2,3"
+{% else %}
             "pfcwd_sw_enable" : "3,4"
+{% endif %}
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -368,12 +417,24 @@
     }
 {% else %}
    "QUEUE": {
+{% if ('type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['type'] in backend_device_types) and
+        ('resource_type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['resource_type'] == 'Compute-AI') %}
+{% for port in PORT_ACTIVE %}
+        "{{ port }}|3": {
+            "scheduler"   : "scheduler.3",
+            "wred_profile": "AZURE_LOSSLESS"
+        },
+{% endfor %}
+{% else %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3": {
             "scheduler"   : "scheduler.1",
             "wred_profile": "AZURE_LOSSLESS"
         },
 {% endfor %}
+{% endif %}
 {% if 'resource_type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['resource_type'] in apollo_resource_types %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|4": {
@@ -381,7 +442,10 @@
             "wred_profile": "AZURE_LOSSLESS"
         },
 {% endfor %}
-{% else %}
+{% elif not ('type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['type'] in backend_device_types) and
+        ('resource_type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['resource_type'] == 'Compute-AI') %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|4": {
             "scheduler"   : "scheduler.1",
@@ -394,11 +458,33 @@
             "scheduler": "scheduler.0"
         },
 {% endfor %}
+{% if ('type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['type'] in backend_device_types) and
+        ('resource_type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['resource_type'] == 'Compute-AI') %}
+{% for port in PORT_ACTIVE %}
+        "{{ port }}|1": {
+            "scheduler": "scheduler.1"
+        },
+{% endfor %}
+{% else %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|1": {
             "scheduler": "scheduler.0"
         },
 {% endfor %}
+{% endif %}
+{% if ('type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['type'] in backend_device_types) and
+        ('resource_type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['resource_type'] == 'Compute-AI') %}
+{% for port in PORT_ACTIVE %}
+        "{{ port }}|2": {
+            "scheduler": "scheduler.2",
+            "wred_profile": "AZURE_LOSSLESS"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+{% else %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|2": {
 {% if port in port_names_list_extra_queues %}
@@ -409,6 +495,11 @@
 {% endif %}
         },
 {% endfor %}
+{% endif %}
+{% if not ('type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['type'] in backend_device_types) and
+        ('resource_type' in DEVICE_METADATA['localhost'] and
+          DEVICE_METADATA['localhost']['resource_type'] == 'Compute-AI') %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5": {
             "scheduler": "scheduler.0"
@@ -431,6 +522,7 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% endif %}
     }
 {% endif %}
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To enable qos config for a certain backend deployment mode, for resource-type "Compute-AI".
This deployment has the following requirement:

- Config below enabled if DEVICE_TYPE as one of backend_device_types
- Config below enabled if ResourceType is 'Compute-AI'
- 2 lossless TCs' (2, 3)
- 2 lossy TCs' (0,1)
- DSCP to TC map uses 4 DSCP code points and maps to the TCs' as follows:
   "DSCP_TO_TC_MAP": {
        "AZURE": {
             "48" : "0",
            "46" : "1",
            "3"  : "3",
            "4"  : "4"
        }
    }

- WRED profile has green {min/max/mark%} as {2M/10M/5%}

This required template change <as in the PR> in addition to the vendor qos.json.j2 file (not included here).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
- with the above change and the vendor config change, generated the qos.json file and verified that the objective stated in "Why I did it" was met

- verified no error

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update qos_config.j2 for Comptue-AI deployment on one of backend device type roles
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

