### PR TITLE
Update install.sh

### DIFF
--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -649,6 +649,7 @@ if [ "$install_env" = "onie" ]; then
     # ONIE distribution.
     $onie_root_dir/grub.d/50_onie_grub >> $grub_cfg
     mkdir -p $onie_initrd_tmp/$demo_mnt/grub
+    mkdir -p $onie_initrd_tmp/$demo_mnt/boot
 else
 cat <<EOF >> $grub_cfg
 $old_sonic_menuentry
@@ -661,6 +662,7 @@ if [ "$install_env" = "build" ]; then
     umount $demo_mnt
 else
     cp $grub_cfg $onie_initrd_tmp/$demo_mnt/grub/grub.cfg
+    cp $grub_cfg $onie_initrd_tmp/$demo_mnt/boot/grub/grub.cfg
 fi
 
 cd /


### PR DESCRIPTION
fix up the problem of not being able to enter the system after removing the coin cell battery.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The device can not enter sonic system when the con cell battery removed

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
copy grub.cfg file  into  /boot/grub

#### How to verify it
Without button battery system can start normally

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

