### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202205.2.2.9
+ref=202205.2.2.10


### PR DESCRIPTION
Why I did it

Release Notes for Cisco T0 and 8102-64H.
	    •	Fix for PSUD crash when PSUs are inserted in an operational system
	    •	Fix for VxLAN counters not incrementing in show vxlan counter' and 'show platform npu vxlan counters'
	    •	Fix for continuous error messages reported by thermalctld
	    •	Fix for dshell client enable/disable causing syncd crash
	    •	Support for 9100 TPID for Cisco fanout.
	    •	Caveat: Drop counters for packets with invalid VLAN tag are counted twice.

Release Notes for Cisco 8101-32FH:
	    •	Aikido FPD 1.89 Upgrade

How I did it

    Update platform version to 202205.2.2.10

#### A picture of a cute animal (not mandatory but encouraged)

