### PR TITLE
[YANG SONIC-ACL] Fix Yang definition of IN_PORTS and OUT_PORTS

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -14,6 +14,12 @@
         "eStrKey" : "Mandatory",
         "eStr": ["ACL_RULE", "PRIORITY"]
     },
+    "ACL_RULE_WITH_VALID_IN_PORTS": {
+        "desc": "Configure ACL_RULE with valid IN_PORTS."
+    },
+    "ACL_RULE_WITH_VALID_OUT_PORTS": {
+        "desc": "Configure ACL_RULE with valid OUT_PORTS."
+    },
     "ACL_TABLE_EMPTY_PORTS": {
         "desc": "Configure ACL_TABLE with empty ports."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -482,6 +482,66 @@
             }
         }
     },
+    "ACL_RULE_WITH_VALID_IN_PORTS": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "NO-NSW-PACL-V4",
+                        "IN_PORTS": "Ethernet0,Ethernet1",
+                        "PACKET_ACTION": "FORWARD",
+                        "PRIORITY": 9999,
+                        "RULE_NAME": "Rule_20",
+                        "SRC_IPV6": "2001::1/64"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "NO-NSW-PACL-V4",
+                        "policy_desc": "Filter IPv4",
+                        "ports": [
+                            "Ethernet0",
+                            "Ethernet1"
+                        ],
+                        "stage": "INRESS",
+                        "type": "L3"
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_RULE_WITH_VALID_OUT_PORTS": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "NO-NSW-PACL-V4",
+                        "OUT_PORTS": "Ethernet0,Ethernet1",
+                        "PACKET_ACTION": "FORWARD",
+                        "PRIORITY": 9999,
+                        "RULE_NAME": "Rule_20",
+                        "SRC_IPV6": "2001::1/64"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "NO-NSW-PACL-V4",
+                        "policy_desc": "Filter IPv4",
+                        "ports": [
+                            "Ethernet0",
+                            "Ethernet1"
+                        ],
+                        "stage": "EGRESS",
+                        "type": "L3"
+                    }
+                ]
+            }
+        }
+    },
     "ACL_TABLE_DEFAULT_VALUE_STAGE": {
         "sonic-acl:sonic-acl": {
             "sonic-acl:ACL_TABLE": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -505,7 +505,7 @@
                             "Ethernet0",
                             "Ethernet1"
                         ],
-                        "stage": "INRESS",
+                        "stage": "INGRESS",
                         "type": "L3"
                     }
                 ]
@@ -537,6 +537,28 @@
                         ],
                         "stage": "EGRESS",
                         "type": "L3"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    },
+                    {
+                        "admin_status": "up",
+                        "alias": "eth1",
+                        "description": "Ethernet1",
+                        "mtu": 9000,
+                        "name": "Ethernet1",
+                        "speed": 25000
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -510,6 +510,30 @@
                     }
                 ]
             }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "0,1,2,3",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    },
+                    {
+                        "admin_status": "up",
+                        "alias": "eth1",
+                        "description": "Ethernet1",
+                        "lanes": "4,5,6,7",
+                        "mtu": 9000,
+                        "name": "Ethernet1",
+                        "speed": 25000
+                    }
+                ]
+            }
         }
     },
     "ACL_RULE_WITH_VALID_OUT_PORTS": {
@@ -548,6 +572,7 @@
                         "admin_status": "up",
                         "alias": "eth0",
                         "description": "Ethernet0",
+                        "lanes": "0,1,2,3",
                         "mtu": 9000,
                         "name": "Ethernet0",
                         "speed": 25000
@@ -556,6 +581,7 @@
                         "admin_status": "up",
                         "alias": "eth1",
                         "description": "Ethernet1",
+                        "lanes": "4,5,6,7",
                         "mtu": 9000,
                         "name": "Ethernet1",
                         "speed": 25000

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -128,14 +128,14 @@ module sonic-acl {
 					}
 				}
 
-				leaf-list IN_PORTS {
-					/* Values in leaf list are UNIQUE */
-					type uint16;
+				leaf IN_PORTS {
+					/* Values is a list of SONiC port name (/port:sonic-port/port:PORT/port:PORT_LIST/port:name) joined by comma */
+					type string;
 				}
 
-				leaf-list OUT_PORTS {
-					/* Values in leaf list are UNIQUE */
-					type uint16;
+				leaf OUT_PORTS {
+					/* Values is a list of SONiC port name (/port:sonic-port/port:PORT/port:PORT_LIST/port:name) joined by comma */
+					type string;
 				}
 
 				choice src_port {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix #16190 .

##### Work item tracking
- Microsoft ADO **(number only)**: 24905710

#### How I did it

Update Yang definition of `IN_PORTS` and `OUT_PORTS` to string.
Since we cannot split the string with comma (`,`) and validate each substring is a valid SONiC port name. The only restriction for them is must be a `string`.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

1. Verified by building `sonic_yang_models-1.0-py3-none-any.whl`. While building the target package, unit tests were run and passed.
2. Build a SONiC image based on 202205 branch and installed on physical DUT. Re try the steps in #16190 and can see below success response:

```
$ sudo config apply-patch patch.json
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "add", "path": "/ACL_RULE/SAMPLE_ACL_TABLE|RULE_3000", "value": {"PACKET_ACTION": "FORWARD", "PRIORITY": "7000", "IN_PORTS": "Ethernet2"}}]
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating all JsonPatch operations are permitted on the specified fields
Patch Applier: Validating target config does not have empty tables, since they do not show up in ConfigDb.
Patch Applier: Sorting patch updates.
Patch Applier: The patch was sorted into 1 change:
Patch Applier:   * [{"op": "add", "path": "/ACL_RULE/SAMPLE_ACL_TABLE|RULE_3000", "value": {"PACKET_ACTION": "FORWARD", "PRIORITY": "7000", "IN_PORTS": "Ethernet2"}}]
Patch Applier: Applying 1 change in order:
Patch Applier:   * [{"op": "add", "path": "/ACL_RULE/SAMPLE_ACL_TABLE|RULE_3000", "value": {"PACKET_ACTION": "FORWARD", "PRIORITY": "7000", "IN_PORTS": "Ethernet2"}}]
Patch Applier: Verifying patch updates are reflected on ConfigDB.
Patch Applier: Patch application completed.
Patch applied successfully.
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

