### PR TITLE
Enable Kdump config by default for cisco-8000

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -144,5 +144,16 @@
 {% endif %}
         }
 {% endif %}
+    },
+    "KDUMP": {
+        "config": {
+{%- if sonic_asic_platform == "cisco-8000" %}
+            "enabled": "true",
+{% else %}
+            "enabled": "false",
+{% endif %}
+            "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+            "num_dumps": "3"
+        }
     }
 }


### PR DESCRIPTION
#### Why I did it
Enabling kdump by default for cisco-8000 by setting crashkernel cmdline arg in device installer.conf.
After bootup, sonic-kdump-config wipes crashkernel arg from /host/grub/grub.cfg, and resets USE_KDUMP in /etc/default/kdump-tools, so kdump will not be enabled on subsequent reboot.

#### How I did it
Setting kdump enable config as part of init_cfg.json for cisco-8000 platforms.

#### How to verify it
Install SONiC image with kdump enabled by default (device/hwsku/installer.conf), then reboot.
Kdump config should persist on subsequent reboots and kdump loaded during bootup.

#### Which release branch to backport (provide reason below if selected)
- [x] 202205

#### Description for the changelog
Enabling kdump by default for cisco-8000 platforms.