### PR TITLE
[202205][buffers] Add 'create_all_available_buffers.json' file for MSFT SKU

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-C28D8/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-C28D8/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D44C10/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D44C10/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_all_available_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D100C12S2/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D100C12S2/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D24C52/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D24C52/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-A96C8V8/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-A96C8V8/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-C128/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-C128/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V48C32/create_all_available_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V48C32/create_all_available_buffers.json
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700/create_all_available_buffers.json

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -335,6 +335,18 @@ start() {
         MOUNTPATH="$MOUNTPATH/$DEV"
     fi
     {%- endif %}
+
+    {%- if docker_container_name == "swss" %}
+    # Insert "create_all_available_buffers" attribute
+    HWSKU_FOLDER="/usr/share/sonic/device/$PLATFORM/$HWSKU"
+    if [ -d "$HWSKU_FOLDER" ]; then
+        CREATE_ALL_AVAILABLE_BUFFERS_JSON="$HWSKU_FOLDER/create_all_available_buffers.json"
+        if [ -f "$CREATE_ALL_AVAILABLE_BUFFERS_JSON" ]; then
+            $SONIC_CFGGEN -j $CREATE_ALL_AVAILABLE_BUFFERS_JSON --write-to-db
+        fi
+    fi
+    {%- endif %}
+
     DOCKERCHECK=`docker inspect --type container ${DOCKERNAME} 2>/dev/null`
     if [ "$?" -eq "0" ]; then
         {%- if docker_container_name == "database" %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

**DEPENDS ON:** [[202205][buffers] Add handler for the 'create_all_available_buffers' configuration knob](https://github.com/sonic-net/sonic-swss/pull/2882) 

#### Why I did it
Add the `create_all_available_buffers` attribute to the `DEVICE_METADATA|localhost`. If the "create_all_available_buffers" is equal to "true", the maximum available buffers (which are read from SAI) will be created, regardless of the config_db buffer config.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add the `create_all_available_buffers.json` files for MSFT SKU's, and inject the content to the `CONFIG_DB` during the `swss` docker container start.

#### How to verify it

Manual verification:
1. Install the image with this PR included on the `MSFT SKU` switch
2. Check the `show queue counters` output and verify that all available buffers are created
```
root@sonic:/home/admin# show queue counters
     Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
---------  -----  --------------  ---------------  -----------  ------------
Ethernet0    UC0               0                0            0           N/A
Ethernet0    UC1               0                0            0           N/A
Ethernet0    UC2               0                0            0           N/A
Ethernet0    UC3               0                0            0           N/A
Ethernet0    UC4               0                0            0           N/A
Ethernet0    UC5               0                0            0           N/A
Ethernet0    UC6               0                0            0           N/A
Ethernet0    UC7              60            15346            0           N/A
Ethernet0    MC8             N/A              N/A          N/A           N/A
Ethernet0    MC9             N/A              N/A          N/A           N/A
Ethernet0   MC10             N/A              N/A          N/A           N/A
Ethernet0   MC11             N/A              N/A          N/A           N/A
Ethernet0   MC12             N/A              N/A          N/A           N/A
Ethernet0   MC13             N/A              N/A          N/A           N/A
Ethernet0   MC14             N/A              N/A          N/A           N/A
Ethernet0   MC15             N/A              N/A          N/A           N/A
```
3. Open the `/usr/share/sonic/device/$DEVICE/$SKU/create_all_available_buffers.json` and change it to:
```
"create_all_available_buffers": "false"
```
4. Do `config reload`
5. Check the `show queue counters` output and verify that only configured in `CONFIG_DB` buffers are created
```
root@sonic:/home/admin# show queue counters
     Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
---------  -----  --------------  ---------------  -----------  ------------
Ethernet0    UC0               0                0            0           N/A
Ethernet0    UC1               0                0            0           N/A
Ethernet0    UC2               0                0            0           N/A
Ethernet0    UC3               0                0            0           N/A
Ethernet0    UC4               0                0            0           N/A
Ethernet0    UC5               0                0            0           N/A
Ethernet0    UC6               0                0            0           N/A
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

