### PR TITLE
[SNMP]: Fix SNMP mgmt reachability when mgmt IP is obtained via DHCP

### DIFF
--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -29,12 +29,12 @@
 agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% endif %}{% if vrf %}%{{ vrf }}{% endif %}{{ "" }}
 {% endfor %}
 {% elif NAMESPACE_COUNT is not defined or NAMESPACE_COUNT|int <= 1 %}
-{% if MGMT_INTERFACE is defined and LOOPBACK_INTERFACE is defined%}
+{% if MGMT_INTERFACE is defined and LOOPBACK_INTERFACE is defined %}
 {% for intf, ip in MGMT_INTERFACE %}
 {% set agentip = ip.split('/')[0]|lower %}
 {% set zoneid = '' %}
-# Use interface as zoneid for link local ipv6
 {% if agentip.startswith('fe80') %}
+# Use interface as zoneid for link local ipv6
 {% set zoneid = '%' + intf %}
 {% endif %}
 agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
@@ -44,8 +44,8 @@ agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
 {% set intf = lo[0] %}
 {% set agentip = lo[1].split('/')[0]|lower %}
 {% set zoneid = '' %}
-# Use interface as zoneid for link local ipv6
 {% if agentip.startswith('fe80') %}
+# Use interface as zoneid for link local ipv6
 {% set zoneid = '%' + intf %}
 {% endif %}
 agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -29,7 +29,7 @@
 agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% endif %}{% if vrf %}%{{ vrf }}{% endif %}{{ "" }}
 {% endfor %}
 {% elif NAMESPACE_COUNT is not defined or NAMESPACE_COUNT|int <= 1 %}
-{% if MGMT_INTERFACE is defined %}
+{% if MGMT_INTERFACE is defined and LOOPBACK_INTERFACE is defined%}
 {% for intf, ip in MGMT_INTERFACE %}
 {% set agentip = ip.split('/')[0]|lower %}
 {% set zoneid = '' %}
@@ -39,8 +39,6 @@ agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% e
 {% endif %}
 agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
 {% endfor %}
-{% endif %}
-{% if LOOPBACK_INTERFACE is defined %}
 {% for lo in LOOPBACK_INTERFACE %}
 {% if lo | length == 2 %}
 {% set intf = lo[0] %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fixes https://github.com/sonic-net/sonic-buildimage/issues/16165

https://github.com/sonic-net/sonic-buildimage/pull/15487 made changes to ensure that SNMP works over IPv6 mgmt and loopback if snmpagentaddress configuration is not present in config_db. This change checks for MGMT_INTERFACE and LOOPBACK_INTERFACE tables in config_db and snmpd starts to listen on those IPs.
With this change, if MGMT_INTERFACE is not present in config_db and is configured via DHCP, snmpd will start to listen only on Loopback0 IP. So snmp query over DHCP configured mgmt IP does not work.

##### Work item tracking
- Microsoft ADO **(number only)**:
24914478

#### How I did it
Check if both Loopback and MGMT interface configurations are present in config_db to be used as snmpagentaddress. If both are not present, fall to listening on any IP.
new logic:
For single-asic platform:
- if SNMP_AGENT_ADDRESS_CONFIG configuration is present, use that as agentaddress
- elif MGMT_INTERFACE and LOOPBACK_INTERFACE are configured use that as agentaddress
- else listen on any IP.

Caveat: If DHCP is used to configure MGMT interface, then snmpd will listen on any IP and SNMP IPv6 reachability will not work.
Workaround will be to use SNMP_AGENT_ADDRESS_CONFIG  to specifically configure specific IPs for snmpd to listen on.

#### How to verify it
Verified change on 202211 single asic VS image.
```
admin@vlab-01:~$ show ver

SONiC Software Version: SONiC.202211.342905-adb43ff1f
SONiC OS Version: 11
Distribution: Debian 11.7
Kernel: 5.10.0-18-2-amd64
Build commit: adb43ff1f
Build date: Sun Aug 20 15:25:16 UTC 2023
Built by: AzDevOps@vmss-soni001TDF
admin@vlab-01:~$ sudo netstat -tulnp | grep 161
tcp        0      0 127.0.0.1:3161          0.0.0.0:*               LISTEN      48242/snmpd         
udp        0      0 10.1.0.32:161           0.0.0.0:*                           48242/snmpd         
udp        0      0 10.250.0.101:161        0.0.0.0:*                           48242/snmpd         
udp6       0      0 fc00:1::32:161          :::*                                48242/snmpd         
udp6       0      0 fec0::ffff:afa:1:161    :::*                                48242/snmpd
admin@vlab-01:~$ docker exec -it snmp bash
root@vlab-01:/# cat /etc/snmp/snmpd.conf | grep agentAddress
agentAddress udp:[10.250.0.101]:161
agentAddress udp6:[fec0::ffff:afa:1]:161
agentAddress udp:[10.1.0.32]:161
agentAddress udp6:[fc00:1::32]:161
root@vlab-01:/# 
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

