### PR TITLE
Write error message to syslog when add user failed or connect to TACACS server failed.

### DIFF
--- a/src/tacacs/nss/patch/0001-Modify-user-map-profile.patch
+++ b/src/tacacs/nss/patch/0001-Modify-user-map-profile.patch
@@ -18,9 +18,9 @@ Subject: [PATCH] Modify user map profile
  debian/changelog              |   11 +
  debian/control                |   11 +-
  debian/libnss-tacplus.symbols |    1 -
- nss_tacplus.c                 | 1018 +++++++++++++++------------------
+ nss_tacplus.c                 | 1015 +++++++++++++++------------------
  tacplus_nss.conf              |   91 ++-
- 8 files changed, 527 insertions(+), 613 deletions(-)
+ 8 files changed, 525 insertions(+), 612 deletions(-)
 
 diff --git a/Makefile.am b/Makefile.am
 index 293951e..b33c455 100644
@@ -1083,7 +1083,7 @@ index 79e62b9..ecfa0b0 100644
          tac_add_attrib(attr, "service", tac_service);
          if(tac_protocol[0])
              tac_add_attrib(attr, "protocol", tac_protocol);
-@@ -598,34 +659,9 @@ lookup_tacacs_user(struct pwbuf *pb)
+@@ -598,52 +659,25 @@ lookup_tacacs_user(struct pwbuf *pb)
  {
      struct areply arep;
      int ret = 1, done = 0;
@@ -1119,11 +1119,17 @@ index 79e62b9..ecfa0b0 100644
      for(srvr=0; srvr < tac_srv_no && !done; srvr++) {
          arep.msg = NULL;
          arep.attr = NULL;
-@@ -636,14 +672,13 @@ lookup_tacacs_user(struct pwbuf *pb)
-                 syslog(LOG_WARNING, "%s: failed to connect TACACS+ server %s,"
-                     " ret=%d: %m", nssname, tac_srv[srvr].addr ?
-                     tac_ntop(tac_srv[srvr].addr->ai_addr) : "unknown", tac_fd);
+         arep.status = TAC_PLUS_AUTHOR_STATUS_ERROR; /* if author_send fails */
+         tac_fd = connect_tacacs(&attr, srvr);
+         if (tac_fd < 0) {
+-            if(debug)
+-                syslog(LOG_WARNING, "%s: failed to connect TACACS+ server %s,"
+-                    " ret=%d: %m", nssname, tac_srv[srvr].addr ?
+-                    tac_ntop(tac_srv[srvr].addr->ai_addr) : "unknown", tac_fd);
 -            tac_free_attrib(&attr);
++            syslog(LOG_ERR, "%s: failed to connect TACACS+ server %s,"
++                " ret=%d: %m", nssname, tac_srv[srvr].addr ?
++                tac_ntop(tac_srv[srvr].addr->ai_addr) : "unknown", tac_fd);
              continue;
          }
 -        ret = tac_author_send(tac_fd, pb->name, "", tac_rhost, attr);
@@ -1137,7 +1143,7 @@ index 79e62b9..ecfa0b0 100644
                      tac_ntop(tac_srv[srvr].addr->ai_addr) : "unknown", ret,
                      pb->name);
          }
-@@ -668,14 +703,11 @@ lookup_tacacs_user(struct pwbuf *pb)
+@@ -668,14 +702,11 @@ lookup_tacacs_user(struct pwbuf *pb)
          if(arep.status == AUTHOR_STATUS_PASS_ADD ||
             arep.status == AUTHOR_STATUS_PASS_REPL) {
              ret = got_tacacs_user(arep.attr, pb);
@@ -1154,7 +1160,7 @@ index 79e62b9..ecfa0b0 100644
              done = 1; /* break out of loop after arep cleanup */
          }
          else {
-@@ -685,6 +717,10 @@ lookup_tacacs_user(struct pwbuf *pb)
+@@ -685,6 +716,10 @@ lookup_tacacs_user(struct pwbuf *pb)
                      " invalid (%d)", nssname,
                      tac_ntop(tac_srv[srvr].addr->ai_addr), pb->name,
                      arep.status);
@@ -1165,7 +1171,7 @@ index 79e62b9..ecfa0b0 100644
          }
          if(arep.msg)
              free(arep.msg);
-@@ -692,30 +728,12 @@ lookup_tacacs_user(struct pwbuf *pb)
+@@ -692,30 +727,12 @@ lookup_tacacs_user(struct pwbuf *pb)
              tac_free_attrib(&arep.attr);
      }
  
@@ -1198,7 +1204,7 @@ index 79e62b9..ecfa0b0 100644
   *
   * We try the lookup to the tacacs server first.  If we can't make a
   * connection to the server for some reason, we also try looking up
-@@ -730,20 +748,25 @@ enum nss_status _nss_tacplus_getpwnam_r(const char *name, struct passwd *pw,
+@@ -730,20 +747,25 @@ enum nss_status _nss_tacplus_getpwnam_r(const char *name, struct passwd *pw,
      int result;
      struct pwbuf pbuf;
  
@@ -1233,7 +1239,7 @@ index 79e62b9..ecfa0b0 100644
          /* marshal the args for the lower level functions */
          pbuf.name = (char *)name;
          pbuf.pw = pw;
-@@ -751,126 +774,13 @@ enum nss_status _nss_tacplus_getpwnam_r(const char *name, struct passwd *pw,
+@@ -751,126 +773,13 @@ enum nss_status _nss_tacplus_getpwnam_r(const char *name, struct passwd *pw,
          pbuf.buflen = buflen;
          pbuf.errnop = errnop;
  
@@ -1468,4 +1474,3 @@ index bb4eb1e..7cb756f 100644
 +# many_to_one=y
 -- 
 2.7.4
-

--- a/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
+++ b/src/tacacs/nss/patch/0010-Send-remote-address-in-TACACS-authorization-message.patch
@@ -113,8 +113,8 @@ index 2de00a6..048745a 100644
  
      for(srvr=0; srvr < tac_srv_no && !done; srvr++) {
          arep.msg = NULL;
-@@ -748,7 +823,7 @@ lookup_tacacs_user(struct pwbuf *pb)
-                     tac_ntop(tac_srv[srvr].addr->ai_addr) : "unknown", tac_fd);
+@@ -747,7 +822,7 @@ lookup_tacacs_user(struct pwbuf *pb)
+                 tac_ntop(tac_srv[srvr].addr->ai_addr) : "unknown", tac_fd);
              continue;
          }
 -        ret = tac_author_send(tac_fd, pb->name, "", "", attr);

--- a/src/tacacs/nss/patch/0011-Replace-popen-shell-execution-with-safer-execle.patch
+++ b/src/tacacs/nss/patch/0011-Replace-popen-shell-execution-with-safer-execle.patch
@@ -4,11 +4,11 @@ Date: Mon, 26 Jun 2023 09:18:44 -0700
 Subject: [PATCH] Replace popen shell execution with safer execle
 
 ---
- nss_tacplus.c | 63 ++++++++++++++++++++++++++++++++++++++++++---------
- 1 file changed, 52 insertions(+), 11 deletions(-)
+ nss_tacplus.c | 54 ++++++++++++++++++++++++++++++++++++++++++++-------
+ 1 file changed, 47 insertions(+), 7 deletions(-)
 
 diff --git a/nss_tacplus.c b/nss_tacplus.c
-index cd73870..7574374 100644
+index 50e560d..33e3e8c 100644
 --- a/nss_tacplus.c
 +++ b/nss_tacplus.c
 @@ -34,6 +34,8 @@
@@ -72,7 +72,7 @@ index cd73870..7574374 100644
      fp = fopen(user_conf, "ab+");
      if(!fp) {
          syslog(LOG_ERR, "%s: %s fopen failed", nssname, user_conf);
-@@ -495,18 +535,19 @@ static int create_or_modify_local_user(const char *name, int level, bool existin
+@@ -495,18 +535,18 @@ static int create_or_modify_local_user(const char *name, int level, bool existin
      while(lvl >= MIN_TACACS_USER_PRIV) {
          user = &useradd_grp_list[lvl];
          if(user->info && user->secondary_grp && user->shell) {
@@ -83,21 +83,16 @@ index cd73870..7574374 100644
 -            if(!fp || -1 == pclose(fp)) {
 -                syslog(LOG_ERR, "%s: %s popen failed errno=%d %s",
 -                        nssname, command, errno, strerror(errno));
--                delete_conf_line(name);
--                return -1;
--            }
--            if(debug)
 +            char sgid[10] = {0};
 +            char home[64] = {0};
 +            snprintf(sgid, 10, "%d", user->gid);
 +            snprintf(home, 63, "/home/%s", name);
 +            if(0 != user_mod_add(command, name, sgid, user->secondary_grp, user->info, home, user->shell)) {
-+                if(debug)
-+                    syslog(LOG_ERR, "%s: %s %s failed", nssname, command, name);
-+                 delete_conf_line(name);
-+                 return -1;
-+             }
-+             if(debug)
++                syslog(LOG_ERR, "%s: %s %s failed", nssname, command, name);
+                 delete_conf_line(name);
+                 return -1;
+             }
+             if(debug)
                  syslog(LOG_DEBUG, "%s: %s %s success", nssname, command, name);
 +
              delete_conf_line(name);


### PR DESCRIPTION
Write error message to syslog when add user failed or connect to TACACS server failed.

#### Why I did it
With these messages, we can downgrade TACACS server with issue to lower priority.

##### Work item tracking
- Microsoft ADO: 24667696

#### How I did it
Write error message to syslog when add user failed or connect to TACACS server failed.

#### How to verify it
Pass all UT.
Manually verify error message generated.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x]  master-16240.344768-113309b9d
- [ ] <!-- image version 2 -->

#### Description for the changelog
Write error message to syslog when add user failed or connect to TACACS server failed.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

