### PR TITLE
[pmon] update gRPC library and gRPC IO tools version to 1.57.0

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -35,8 +35,8 @@ RUN apt-get update &&   \
 # doesn't ensure all dependencies are installed in the container. So here we
 # install any dependencies required by the Arista sonic_platform package.
 # TODO: eliminate the need to install these explicitly.
-RUN pip3 install grpcio==1.39.0 \
-        grpcio-tools==1.39.0
+RUN pip3 install grpcio==1.57.0 \
+        grpcio-tools==1.57.0
 
 # Barefoot platform vendors' sonic_platform packages import these Python libraries
 RUN pip3 install thrift==0.13.0 netifaces

--- a/files/build/versions/dockers/docker-platform-monitor/versions-py3
+++ b/files/build/versions/dockers/docker-platform-monitor/versions-py3
@@ -1,8 +1,8 @@
 attrs==20.3.0
 certifi==2023.7.22
 charset-normalizer==3.2.0
-grpcio==1.39.0
-grpcio-tools==1.39.0
+grpcio==1.57.0
+grpcio-tools==1.57.0
 guacamole==0.9.2
 idna==3.4
 importlib-metadata==1.6.0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Updating the grpc and grpc tools library to 1.57.0 to get the latest changes. This is required to get the latest stable source from https://github.com/grpc/grpc
This gives a chance to use some more channel/stub attributes to be included in gRPC request and response monitoring service. This also helps in removing all the bugs which are known issues for gRPC before 1.57.0

##### Work item tracking
- Microsoft ADO **(number only)**:
- 24923612

#### How I did it

#### How to verify it
On the mixed topo testbed, these tests were run and passed successfully
```       
tests/dualtor_io/ test_tor_failure.py
tests/dualtor_io/test_heartbeat_failure.py    
tests/dualtor_io/test_tor_bgp_failure.py 



dualtor_io/test_heartbeat_failure.py::test_standby_tor_heartbeat_failure_downstream_active[active-standby] PASSED 
dualtor_io/test_heartbeat_failure.py::test_standby_tor_heartbeat_failure_downstream_standby[active-standby] PASSED 


dualtor_io/test_tor_failure.py::test_active_tor_reboot_upstream[active-standby] PASSED

```


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

