### PR TITLE
Fix faketime package downloading issue.

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -196,8 +196,8 @@ SONIC_BUILD_INSTRUCTION :=  make \
 
 .DEFAULT_GOAL :=  all
 FAKETIME := rm -rf faketime_0.9.7-2_amd64.deb libfaketime_0.9.7-2_amd64.deb; \
-		curl "https://sonicstoragepublic.blob.core.windows.net/packages/libfaketime_0.9.7-2_amd64.deb?sp=r&st=2022-12-05T06:39:44Z&se=2032-12-05T14:39:44Z&spr=https&sv=2021-06-08&sr=b&sig=SDqUC7DtESpNHTc1Dsh%2B9%2Finxfo4OwNiXGw762OV2tM%3D" -o libfaketime_0.9.7-2_amd64.deb; \
-		curl "https://sonicstoragepublic.blob.core.windows.net/packages/faketime_0.9.7-2_amd64.deb?sp=r&st=2022-12-05T04:50:15Z&se=2033-12-06T12:50:15Z&spr=https&sv=2021-06-08&sr=b&sig=7l4dm4tyO73RwwAbRM6zNEglkOjs8bLV%2BJe9coiEHxo%3D" -o faketime_0.9.7-2_amd64.deb; \
+		curl "https://sonicstoragepublic.blob.core.windows.net/public/libfaketime_0.9.7-2_amd64.deb" -o libfaketime_0.9.7-2_amd64.deb; \
+		curl "https://sonicstoragepublic.blob.core.windows.net/public/faketime_0.9.7-2_amd64.deb" -o faketime_0.9.7-2_amd64.deb; \
 		cp faketime_0.9.7-2_amd64.deb libfaketime_0.9.7-2_amd64.deb dockers/docker-base/; \
 		cp faketime_0.9.7-2_amd64.deb libfaketime_0.9.7-2_amd64.deb sonic-slave-jessie/
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix: https://github.com/sonic-net/sonic-buildimage/issues/16086
faketime package url expired. It breaks 201911 build.
Update package url.
##### Work item tracking
- Microsoft ADO **(number only)**:  24930879

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

