### PR TITLE
[202205] Disable interrupt for intel i2c-i801 driver

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/installer.conf
+++ b/device/celestica/x86_64-cel_e1031-r0/installer.conf
@@ -1,4 +1,4 @@
 CONSOLE_PORT=0x2f8
 CONSOLE_DEV=1
 CONSOLE_SPEED=9600
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich processor.max_cstate=1 intel_idle.max_cstate=0"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich processor.max_cstate=1 intel_idle.max_cstate=0 i2c-i801.disable_features=0x10"

--- a/device/celestica/x86_64-cel_seastone-r0/installer.conf
+++ b/device/celestica/x86_64-cel_seastone-r0/installer.conf
@@ -1,3 +1,3 @@
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich i2c-i801.disable_features=0x10"

--- a/device/dell/x86_64-dell_s6100_c2538-r0/installer.conf
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/installer.conf
@@ -1,3 +1,3 @@
 CONSOLE_PORT=0x2f8
 CONSOLE_DEV=1
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich,wdat_wdt acpi_no_watchdog=1 nos-config-part=/dev/sda12 logs_inram=on"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich,wdat_wdt acpi_no_watchdog=1 nos-config-part=/dev/sda12 logs_inram=on i2c-i801.disable_features=0x10"

--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -503,7 +503,8 @@ write_platform_specific_cmdline() {
     if [ "$sid" = "Gardena" ] || [ "$sid" = "GardenaE" ]; then
         aboot_machine=arista_7260cx3_64
         flash_size=28000
-        cmdline_add logs_inram=on, i2c-i801.disable_features=0x10
+        cmdline_add logs_inram=on
+        cmdline_add i2c-i801.disable_features=0x10
     fi
     if [ "$sid" = "Alhambra" ]; then
         aboot_machine=arista_7170_64c

--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -503,7 +503,7 @@ write_platform_specific_cmdline() {
     if [ "$sid" = "Gardena" ] || [ "$sid" = "GardenaE" ]; then
         aboot_machine=arista_7260cx3_64
         flash_size=28000
-        cmdline_add logs_inram=on
+        cmdline_add logs_inram=on, i2c-i801.disable_features=0x10
     fi
     if [ "$sid" = "Alhambra" ]; then
         aboot_machine=arista_7170_64c


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

On S6100 we are seeing almost 100K interrupts per second on intels i801 SMBUS controller which affects systems performance. This interrupt storm has already been fixed in newer kernel with a fix here:-

In 202205 branch (using old kernel (5.10)) disable the interrupt and enable the polling for i2c-i801 driver

<img width="834" alt="image" src="https://github.com/sonic-net/sonic-buildimage/assets/45705344/c33296e7-4d34-45a9-a830-4d78c5450794">


##### Work item tracking
- Microsoft ADO **(number only)**:24910530

#### How I did it
Disable the interrupt by passing the interrupt disable feature argument to i2c-i801 driver

#### How to verify it
1. On SN2700 its already disabled in Mellanox hw-mgmt
2. Arista 7050CX3 don't use i801 
3. Celestica DX010 
4. Dell S6100 verified the interrupts are no longer incrementing.
5. 
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Disable interrupt for intel i2c-i801 driver
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

