### PR TITLE
[202211][SNMP][IPv6]: Revert PRs to support SNMP over IPv6

### DIFF
--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -13,36 +13,12 @@
 #  AGENT BEHAVIOUR
 #
 
-# Listen for connections on all ip addresses, including eth0, ipv4 lo for multi-asic platform
-# Listen on managment and loopback0 ips for single asic platform
+#  Listen for connections on all ip addresses, including eth0, ipv4 lo
 #
-{% macro protocol(ip_addr) %}
-{%- if ip_addr|ipv6 -%}
-{{ 'udp6' }}
-{%- else -%}
-{{ 'udp' }}
-{%- endif -%}
-{% endmacro %}
-
 {% if SNMP_AGENT_ADDRESS_CONFIG %}
 {% for (agentip, port, vrf) in SNMP_AGENT_ADDRESS_CONFIG %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% endif %}{% if vrf %}%{{ vrf }}{% endif %}{{ "" }}
+agentAddress {{ agentip }}{% if port %}:{{ port }}{% endif %}{% if vrf %}%{{ vrf }}{% endif %}{{ "" }}
 {% endfor %}
-{% elif NAMESPACE_COUNT is not defined or NAMESPACE_COUNT|int <= 1 %}
-{% if MGMT_INTERFACE is defined %}
-{% for if, ip in MGMT_INTERFACE %}
-{% set agentip = ip.split('/')[0] %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}]:161
-{% endfor %}
-{% endif %}
-{% if LOOPBACK_INTERFACE is defined %}
-{% for lo in LOOPBACK_INTERFACE %}
-{% if lo | length == 2 %}
-{% set agentip = lo[1].split('/')[0] %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}]:161
-{% endif %}
-{% endfor %}
-{% endif %}
 {% else %}
 agentAddress udp:161
 agentAddress udp6:161

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -30,27 +30,16 @@ agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% e
 {% endfor %}
 {% elif NAMESPACE_COUNT is not defined or NAMESPACE_COUNT|int <= 1 %}
 {% if MGMT_INTERFACE is defined %}
-{% for intf, ip in MGMT_INTERFACE %}
-{% set agentip = ip.split('/')[0]|lower %}
-{% set zoneid = '' %}
-# Use interface as zoneid for link local ipv6
-{% if agentip.startswith('fe80') %}
-{% set zoneid = '%' + intf %}
-{% endif %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
+{% for if, ip in MGMT_INTERFACE %}
+{% set agentip = ip.split('/')[0] %}
+agentAddress {{ protocol(agentip) }}:[{{ agentip }}]:161
 {% endfor %}
 {% endif %}
 {% if LOOPBACK_INTERFACE is defined %}
 {% for lo in LOOPBACK_INTERFACE %}
 {% if lo | length == 2 %}
-{% set intf = lo[0] %}
-{% set agentip = lo[1].split('/')[0]|lower %}
-{% set zoneid = '' %}
-# Use interface as zoneid for link local ipv6
-{% if agentip.startswith('fe80') %}
-{% set zoneid = '%' + intf %}
-{% endif %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
+{% set agentip = lo[1].split('/')[0] %}
+agentAddress {{ protocol(agentip) }}:[{{ agentip }}]:161
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/dockers/docker-snmp/start.sh
+++ b/dockers/docker-snmp/start.sh
@@ -16,14 +16,11 @@ mkdir -p /etc/ssw /etc/snmp
 # Parse snmp.yml and insert the data in Config DB
 /usr/bin/snmp_yml_to_configdb.py
 
-ADD_PARAM=$(printf '%s {"NAMESPACE_COUNT":"%s"}' "-a" "$NAMESPACE_COUNT")
-
 SONIC_CFGGEN_ARGS=" \
     -d \
     -y /etc/sonic/sonic_version.yml \
     -t /usr/share/sonic/templates/sysDescription.j2,/etc/ssw/sysDescription \
     -t /usr/share/sonic/templates/snmpd.conf.j2,/etc/snmp/snmpd.conf \
-    $ADD_PARAM \
 "
 
 sonic-cfggen $SONIC_CFGGEN_ARGS


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Reverting PR added to support SNMP over IPv6 as there is an open issue https://github.com/sonic-net/sonic-buildimage/issues/16165 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Revert https://github.com/sonic-net/sonic-buildimage/pull/16013 and https://github.com/sonic-net/sonic-buildimage/pull/15487 form 202211 branch

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

