### PR TITLE
Update phy-credo package to fix sonic-mgmt test issue and support the AOC module.

### DIFF
--- a/rules/phy-credo.mk
+++ b/rules/phy-credo.mk
@@ -1,3 +1,3 @@
 PHY_CREDO = phy-credo_1.0_amd64.deb
-$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/raw/446f30ccd8626f904d89d5798da7294948e090a6/phy/phy-credo_1.0_amd64.deb"
+$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/raw/4c6fa09910656b78103416652651b486deaba4aa/phy/phy-credo_1.0_amd64.deb"
 SONIC_ONLINE_DEBS += $(PHY_CREDO)


### PR DESCRIPTION
#### Why I did it
1. Fix an error on platforms with external phy but not using phy-credo service. Some sonic-mgmt tests fail due to this error.
2. Add AOC support for platforms that use the phy-credo service.

##### Work item tracking
N/A

#### How I did it
1. Gracefully return if the platform does not use the phy-credo service.
2. Determine the medium type based on the compliance code.

#### How to verify it

1. Sonic-mgmt tests no longer fail due to this phy-credo error.
2. A port with an AOC module can come up reliably.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)


- [x ] <202205>


#### Description for the changelog
N/A

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)
N/A