### PR TITLE
update DOCKER_RAMFS_SIZE for docker_inram

### DIFF
--- a/onie-image-arm64.conf
+++ b/onie-image-arm64.conf
@@ -28,7 +28,7 @@ FILESYSTEM_DOCKERFS=dockerfs.tar.gz
 DOCKERFS_DIR=docker
 
 ## docker ramfs disk space
-DOCKER_RAMFS_SIZE=1500M
+DOCKER_RAMFS_SIZE=2500M
 
 ## Output file name for onie installer
 OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin

--- a/onie-image-armhf.conf
+++ b/onie-image-armhf.conf
@@ -28,7 +28,7 @@ FILESYSTEM_DOCKERFS=dockerfs.tar.gz
 DOCKERFS_DIR=docker
 
 ## docker ramfs disk space
-DOCKER_RAMFS_SIZE=1500M
+DOCKER_RAMFS_SIZE=2500M
 
 ## Output file name for onie installer
 OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin

--- a/onie-image.conf
+++ b/onie-image.conf
@@ -28,7 +28,7 @@ FILESYSTEM_DOCKERFS=dockerfs.tar.gz
 DOCKERFS_DIR=docker
 
 ## docker ramfs disk space
-DOCKER_RAMFS_SIZE=1500M
+DOCKER_RAMFS_SIZE=2500M
 
 ## Output file name for onie installer
 OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
docker folder size on 202305 image is more than 1.5G. larger than the max size of docker ramfs size.

##### Work item tracking
- Microsoft ADO **(number only)**:
24969589

#### How I did it
Update the docker ramfs size from 1500M to 2500M

#### How to verify it
Boot 202305 image.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

