### PR TITLE
add minpoll&maxpoll for NTP server in sonic-ntp.yang

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -482,7 +482,11 @@
         "NTP_SERVER": {
             "0.debian.pool.ntp.org": {},
             "23.92.29.245": {},
-            "2001:aa:aa::aa": {}
+            "2001:aa:aa::aa": {},
+            "122.22.22.22": {
+                "minpoll": "7",
+                "maxpoll": "12"
+            }
         },
         "SYSLOG_SERVER" : {
             "10.13.14.17": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/ntp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/ntp.json
@@ -58,5 +58,46 @@
         "desc": "CONFIGURE NON-EXISTING MGMT INTERFACE AS NTP SOURCE INTERFACE.",
         "eStrKey": "InvalidValue",
         "eStr": ["src"]
+    },
+    "NTP_SERVER_WITH_DEFAULT_MINPOLL_MAXPOLL": {
+        "desc": "CONFIGURE NTP SERVER WITH DEFAULT VALUES OF MINPOLL AND MAXPOLL."
+    },
+    "NTP_SERVER_WITH_MIN_MINPOLL_MAXPOLL": {
+        "desc": "CONFIGURE NTP SERVER WITH MIN VALUE FOR MINPOLL."
+    },
+    "NTP_SERVER_WITH_MINPOLL_MAX_MAXPOLL": {
+        "desc": "CONFIGURE NTP SERVER WITH MAX VALUE FOR MAXPOLL."
+    },
+    "NTP_SERVER_NEG_WITHOUT_MINPOLL": {
+        "desc": "CONFIGURE NTP SERVER WITH MAXPOLL BUT WITHOUT MINPOLL."
+    },
+    "NTP_SERVER_NEG_WITHOUT_MINPOLL_INVALID_MAXPOLL": {
+        "desc": "CONFIGURE NTP SERVER WITHOUT MINPOLL AND INVALID MAXPOLL.",
+        "eStr": ["maxpoll has to be larger than minpoll."]
+    },
+    "NTP_SERVER_NEG_WITHOUT_MAXPOLL": {
+        "desc": "CONFIGURE NTP SERVER WITH MINPOLL BUT WITHOUT MAXPOLL."
+    },
+    "NTP_SERVER_NEG_WITHOUT_MAXPOLL_INVALID_MINPOLL": {
+        "desc": "CONFIGURE NTP SERVER WITHOUT MAXPOLL AND INVALID MINPOLL.",
+        "eStr": ["maxpoll has to be larger than minpoll."]
+    },
+    "NTP_SERVER_NEG_MINPOLL_EQUAL_MAXPOLL": {
+        "desc": "CONFIGURE NTP SERVER WITH MINPOLL EQUAL TO MAXPOLL.",
+        "eStr": ["maxpoll has to be larger than minpoll."]
+    },
+    "NTP_SERVER_NEG_MINPOLL_LARGER_THAN_MAXPOLL": {
+        "desc": "CONFIGURE NTP SERVER WITH MINPOLL LARGER THAN MAXPOLL.",
+        "eStr": ["maxpoll has to be larger than minpoll."]
+    },
+    "NTP_SERVER_NEG_INVALID_MINPOLL": {
+        "desc": "CONFIGURE NTP SERVER WITH INVALID MINPOLL VALUE.",
+        "eStrKey": "Range",
+        "eStr": "3..17"
+    },
+    "NTP_SERVER_NEG_INVALID_MAXPOLL": {
+        "desc": "CONFIGURE NTP SERVER WITH INVALID MAXPOLL VALUE.",
+        "eStrKey": "Range",
+        "eStr": "3..17"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/ntp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/ntp.json
@@ -237,5 +237,144 @@
                 ]
             }
         }
+    },
+    "NTP_SERVER_WITH_DEFAULT_MINPOLL_MAXPOLL": {
+        "sonic-ntp:sonic-ntp": {
+            "sonic-ntp:NTP_SERVER": {
+                "NTP_SERVER_LIST": [
+                    {
+                        "server_address": "10.11.12.13",
+                        "minpoll": "6",
+                        "maxpoll": "10"
+                    }
+                ]
+            }
+        }
+    },
+    "NTP_SERVER_WITH_MIN_MINPOLL_MAXPOLL": {
+        "sonic-ntp:sonic-ntp": {
+            "sonic-ntp:NTP_SERVER": {
+                "NTP_SERVER_LIST": [
+                    {
+                        "server_address": "10.11.12.13",
+                        "minpoll": "3",
+                        "maxpoll": "4"
+                    }
+                ]
+            }
+        }
+    },
+    "NTP_SERVER_WITH_MINPOLL_MAX_MAXPOLL": {
+        "sonic-ntp:sonic-ntp": {
+            "sonic-ntp:NTP_SERVER": {
+                "NTP_SERVER_LIST": [
+                    {
+                        "server_address": "10.11.12.13",
+                        "minpoll": "12",
+                        "maxpoll": "17"
+                    }
+                ]
+            }
+        }
+    },
+    "NTP_SERVER_NEG_WITHOUT_MINPOLL": {
+        "sonic-ntp:sonic-ntp": {
+            "sonic-ntp:NTP_SERVER": {
+                "NTP_SERVER_LIST": [
+                    {
+                        "server_address": "10.11.12.13",
+                        "maxpoll": "11"
+                    }
+                ]
+            }
+        }
+    },
+    "NTP_SERVER_NEG_WITHOUT_MINPOLL_INVALID_MAXPOLL": {
+        "sonic-ntp:sonic-ntp": {
+            "sonic-ntp:NTP_SERVER": {
+                "NTP_SERVER_LIST": [
+                    {
+                        "server_address": "10.11.12.13",
+                        "maxpoll": "5"
+                    }
+                ]
+            }
+        }
+    },
+    "NTP_SERVER_NEG_WITHOUT_MAXPOLL": {
+        "sonic-ntp:sonic-ntp": {
+            "sonic-ntp:NTP_SERVER": {
+                "NTP_SERVER_LIST": [
+                    {
+                        "server_address": "10.11.12.13",
+                        "minpoll": "7"
+                    }
+                ]
+            }
+        }
+    },
+    "NTP_SERVER_NEG_WITHOUT_MAXPOLL_INVALID_MINPOLL": {
+        "sonic-ntp:sonic-ntp": {
+            "sonic-ntp:NTP_SERVER": {
+                "NTP_SERVER_LIST": [
+                    {
+                        "server_address": "10.11.12.13",
+                        "minpoll": "12"
+                    }
+                ]
+            }
+        }
+    },
+    "NTP_SERVER_NEG_MINPOLL_EQUAL_MAXPOLL": {
+        "sonic-ntp:sonic-ntp": {
+            "sonic-ntp:NTP_SERVER": {
+                "NTP_SERVER_LIST": [
+                    {
+                        "server_address": "10.11.12.13",
+                        "minpoll": "7",
+                        "maxpoll": "7"
+                    }
+                ]
+            }
+        }
+    },
+    "NTP_SERVER_NEG_MINPOLL_LARGER_THAN_MAXPOLL": {
+        "sonic-ntp:sonic-ntp": {
+            "sonic-ntp:NTP_SERVER": {
+                "NTP_SERVER_LIST": [
+                    {
+                        "server_address": "10.11.12.13",
+                        "minpoll": "17",
+                        "maxpoll": "16"
+                    }
+                ]
+            }
+        }
+    },
+    "NTP_SERVER_NEG_INVALID_MINPOLL": {
+        "sonic-ntp:sonic-ntp": {
+            "sonic-ntp:NTP_SERVER": {
+                "NTP_SERVER_LIST": [
+                    {
+                        "server_address": "10.11.12.13",
+                        "minpoll": "1",
+                        "maxpoll": "16"
+                    }
+                ]
+            }
+        }
+    },
+    "NTP_SERVER_NEG_INVALID_MAXPOLL": {
+        "sonic-ntp:sonic-ntp": {
+            "sonic-ntp:NTP_SERVER": {
+                "NTP_SERVER_LIST": [
+                    {
+                        "server_address": "10.11.12.13",
+                        "minpoll": "17",
+                        "maxpoll": "18"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-ntp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-ntp.yang
@@ -112,6 +112,35 @@ module sonic-ntp {
                 leaf server_address {
                     type inet:host;
                 }
+
+                leaf minpoll {
+                    must "(current()/../maxpoll > current())" {
+                        error-message "maxpoll has to be larger than minpoll.";
+                    }
+                    default 6;
+                    type uint8 {
+                        range "3..17";
+                    }
+                    description
+		        "The minimum poll interval used in this association.";
+                    reference
+                        "RFC 5905: Network Time Protocol Version 4: Protocol and Algorithms Specification";
+                }
+
+                leaf maxpoll {
+                    must "(current()/../minpoll < current())" {
+                        error-message "maxpoll has to be larger than minpoll.";
+                    }
+                    default 10;
+                    type uint8 {
+                        range "3..17";
+                    }
+                    description
+                        "The maximum poll interval used in this association.";
+                    reference
+                        "RFC 5905: Network Time Protocol Version 4: Protocol and Algorithms Specification";
+                }
+
             } /* end of list NTP_SERVER_LIST */
 
         } /* end of container NTP_SERVER */


### PR DESCRIPTION
#### Why I did it
Add minpoll and maxpoll for NTP server in sonic-ntp.yang

#### How I did it
Add minpoll and maxpoll for NTP server in sonic-ntp.yang. Added additional test cases in ntp.json and sample_config_db.json

#### How to verify it
Successfully built
sonic_yang_mgmt-1.0-py3-none-any.whl
sonic_yang_models-1.0-py3-none-any.whl




