### PR TITLE
chassis-packet: Update arp_update script for FAILED and STALE check

### DIFF
--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -25,29 +25,35 @@ while /bin/true; do
       for i in ${!STATIC_ROUTE_NEXTHOPS[@]}; do
           nexthop="${STATIC_ROUTE_NEXTHOPS[i]}"
           if [[ $nexthop == *"."* ]]; then
-              neigh_state=( $(ip -4 neigh show | grep -w $nexthop | tr -s ' ' | cut -d ' ' -f 3,4) )
+              neigh_state=$(ip -4 neigh show | grep -w $nexthop | tr -s ' ')
               ping_prefix=ping
           elif [[ $nexthop == *":"* ]] ; then
-              neigh_state=( $(ip -6 neigh show | grep -w $nexthop | tr -s ' ' | cut -d ' ' -f 3,4) )
+              neigh_state=$(ip -6 neigh show | grep -w $nexthop | tr -s ' ')
               ping_prefix=ping6
           fi
-          if [[ -z "${neigh_state}" ]] || [[ "${neigh_state[1]}" == "INCOMPLETE" ]] || [[ "${neigh_state[1]}" == "FAILED" ]]; then
+          # Check if there is an INCOMPLETE, FAILED, or STALE entry and try to resolve it again.
+          # STALE entries may be present if there is no traffic on a path. A far-end down event may not
+          # clear the STALE entry. Refresh the STALE entry to clear the table.
+          if [[ -z "${neigh_state}" ]] || [[ -n $(echo ${neigh_state} | grep 'INCOMPLETE\|FAILED\|STALE') ]]; then
               interface="${STATIC_ROUTE_IFNAMES[i]}"
               if [[ -z "$interface" ]]; then
                   # should never be here, handling just in case
                   logger "ERR: arp_update: missing interface entry for static route $nexthop"
-                  interface=${neigh_state[0]}
+                  continue
               fi
               intf_up=$(ip link show $interface | grep "state UP")
               if [[ -n "$intf_up" ]]; then
                   pingcmd="timeout 0.2 $ping_prefix -I ${interface} -n -q -i 0 -c 1 -W 1 $nexthop >/dev/null"
                   eval $pingcmd
-                  logger "arp_update: static route nexthop not resolved, pinging $nexthop on ${neigh_state[0]}"
+                  # STALE entries may appear more often, not logging to prevent periodic syslogs
+                  if [[ -z $(echo ${neigh_state} | grep 'STALE') ]]; then
+                      logger "arp_update: static route nexthop not resolved ($neigh_state), pinging $nexthop on $interface"
+                  fi
               fi
           fi
       done
 
-      sleep 300
+      sleep 150
       continue
   fi
   # find L3 interfaces which are UP, send ipv6 multicast pings


### PR DESCRIPTION
Signed-off-by: anamehra anamehra@cisco.com


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes https://github.com/sonic-net/sonic-buildimage/issues/16312

1. Fixing an issue with FAILED entry resolution retry. Neighbor entries in arp table may sometimes enter a FAILED state when the far end is down and reports the state as follows:
```
2603:10e2:400:3::1 dev PortChannel19 router FAILED
```

While the arp_update script handles the entries for FAILED in the following format, the above was not handled due to the token location (extra router keyword at index 4):
```
2603:10e2:400:3::1 dev PortChannel19 FAILED
```

The former format may appear if an arp resolution is tried on a link that is known but the far end goes down, e.g., pinging a STALE entry while the far end is down.

2. Refreshing STALE entries to make sure the far end is reachable. STALE entries for some backend ports may appear in chassis-packet when no traffic is received for a while on the port. When the far end goes down, it is expected for BFD to stop sending packets on the session for which the far end is not reachable. But as the entry is known as stale, on the Cisco chassis, BFD keeps sending packets. Refreshing the stale entry will keep active links as reachable in the neighbor table while the entries for the far end down will enter a failed state. FAILED state entries will be retired and entered reachable when far end comes back up.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modified arp_update state check to use grep for states in neighbor data string place of using the position. If a string contains any of the matching patterns from INCOMPLETE, FAILED or STALE, try ping to resolve.


#### How to verify it

On a chassis-packet Chassis LC:

1. Bring down far end asic or LC.
2. run arp_update on local namespace swss docker
3. check ip netns exec ip -4 neigh show
4. There will be FAILED entries
5. bringup far end and wait for links to be up
6. run arp_update on local namespace swss docker
7. Failed entries for this far end should change to reachable
8. Wait for couple of mins and check for STALE entries.
9. run arp_update and this should resolve STALE entries to reachable

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

