### PR TITLE
[PRTest, 202211] Skip telemetry/test_telemetry.py::test_on_change_updates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -228,6 +228,7 @@ stages:
           MGMT_BRANCH: "master"
           COMMON_EXTRA_PARAMS: "--neighbor_type=sonic "
           VM_TYPE: vsonic
+          SCRIPTS_EXCLUDE: "platform_tests/test_advanced_reboot.py::test_warm_reboot"
 
 #  - job: wan_elastictest
 #    pool: ubuntu-20.04

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -154,6 +154,7 @@ stages:
         MIN_WORKER: $(T0_INSTANCE_NUM)
         MAX_WORKER: $(T0_INSTANCE_NUM)
         MGMT_BRANCH: "master"
+        SPECIFIC_PARAM: '[{"name": "telemetry/test_telemetry.py", "param": "--deselect=telemetry/test_telemetry.py::test_on_change_updates"}]'
 
   - job: t0_2vlans_elastictest
     pool: ubuntu-20.04


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Test_telemetry test module is currently failing at “test_on_change_updates” as the code to support the test is not in 202211,
Skip the newly added test within test_telemetry for 202211 for now

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

