### PR TITLE
[yang][dhcp_server] Add dhcp_server_ipv4 yang model

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -29,6 +29,7 @@ Table of Contents
          * [Device Metadata](#device-metadata)
          * [Device neighbor metada](#device-neighbor-metada)
          * [DHCP_RELAY](#dhcp_relay)
+         * [DHCP Server IPV4](#dhcp_server_ipv4)
          * [DSCP_TO_TC_MAP](#dscp_to_tc_map)
          * [FG_NHG](#fg_nhg)
          * [FG_NHG_MEMBER](#fg_nhg_member)
@@ -984,6 +985,50 @@ instance is supported in SONiC.
     "interface_id": "true"
 }
 
+```
+
+### DHCP_SERVER_IPV4
+IPV4 DHPC Server related configuration are defined in **DHCP_SERVER_IPV4**, **DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS**, **DHCP_SERVER_IPV4_RANGE**, **DHCP_SERVER_IPV4_PORT** tables.
+```
+{
+    "DHCP_SERVER_IPV4": {
+        "Vlan100": {
+            "gateway": "100.1.1.1",
+            "lease_time": 3600,
+            "mode": "PORT",
+            "netmask": "255.255.255.0",
+            "customized_options": [
+                "option60"
+            ],
+            "state": "enabled"
+        }
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+        "option60": {
+            "id": 60,
+            "type": "text",
+            "value": "dummy_value"
+        }
+    },
+    "DHCP_SERVER_IPV4_RANGE": {
+        "range1": {
+            "ip_start": "100.1.1.3",
+            "ip_end": "100.1.1.5"
+        }
+    },
+    "DHCP_SERVER_IPV4_PORT": {
+        "Vlan100|PortChannel0003": {
+            "ips": [
+                "100.1.1.10"
+            ]
+        },
+        "Vlan100|PortChannel2": {
+            "ranges": [
+                "range1"
+            ]
+        }
+    }
+}
 ```
 
 ### DSCP_TO_TC_MAP

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -178,6 +178,7 @@ setup(
                          './yang-models/sonic-dscp-fc-map.yang',
                          './yang-models/sonic-exp-fc-map.yang',
                          './yang-models/sonic-dscp-tc-map.yang',
+                         './yang-models/sonic-dhcp-server-ipv4.yang',
                          './yang-models/sonic-dot1p-tc-map.yang',
                          './yang-models/sonic-storm-control.yang',
                          './yang-models/sonic-tc-priority-group-map.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1880,6 +1880,45 @@
                 "interface_id": "true"
             }
         },
+        "DHCP_SERVER_IPV4": {
+            "Vlan100": {
+                "gateway": "100.1.1.1",
+                "lease_time": "3600",
+                "mode": "PORT",
+                "netmask": "255.255.255.0",
+                "customized_options": [
+                    "option60"
+                ],
+                "state": "enabled"
+            }
+        },
+        "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+            "option60": {
+                "id": "60",
+                "type": "text",
+                "value": "dummy_value"
+            }
+        },
+        "DHCP_SERVER_IPV4_RANGE": {
+            "range1": {
+                "range": [
+                    "100.1.1.3",
+                    "100.1.1.5"
+                ]
+            }
+        },
+        "DHCP_SERVER_IPV4_PORT": {
+            "Vlan100|Ethernet0": {
+                "ips": [
+                    "100.1.1.10"
+                ]
+            },
+            "Vlan100|Ethernet1": {
+                "ranges": [
+                    "range1"
+                ]
+            }
+        },
         "SCHEDULER": {
             "TEST@0": {
                 "cbs": "256",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/dhcp_server_ipv4.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/dhcp_server_ipv4.json
@@ -1,0 +1,100 @@
+{
+    "DHCP_SERVER_IPV4_VALID_FORMAT": {
+        "desc": "Add dhcp_server_ipv4 in correct format."
+    },
+    "DHCP_SERVER_IPV4_WITH_INVALID_VLAN": {
+        "desc": "Configure vlan-id in DHCP_SERVER_IPV4 table which is invalid.",
+        "eStrKey" : "Pattern"
+    },
+    "DHCP_SERVER_IPV4_INCORRECT_GATEWAY": {
+        "desc": "Add gateway which is not in correct ip-prefix format.",
+        "eStrKey": "Pattern"
+    },
+    "DHCP_SERVER_IPV4_INCORRECT_NETMASK": {
+        "desc": "Add netmask which is not in correct ip-prefix format.",
+        "eStrKey": "Pattern"
+    },
+    "DHCP_SERVER_IPV4_STATE_WRONG_VALUE": {
+        "desc": "Configure wrong value for state.",
+        "eStrKey": "InvalidValue"
+    },
+    "DHCP_SERVER_IPV4_MODE_WRONG_VALUE": {
+        "desc": "Configure wrong value for mode.",
+        "eStrKey": "InvalidValue"
+    },
+    "DHCP_SREVER_IPV4_NON_EXIST_OPTION": {
+        "desc": "Configure option in DHCP_SERVER_IPV4 table which does not exist in DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS table.",
+        "eStrKey": "LeafRef"
+    },
+    "DHCP_SERVER_IPV4_PORT_WITH_NO_EXIST_NAME": {
+        "desc": "Configure DHCP interface in DHCP_SERVER_IPV4_PORT table which is no exist.",
+        "eStrKey": "LeafRef"
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_WRONG_VALUE": {
+        "desc": "Configure wrong value for type.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["type"]
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_TEXT": {
+        "desc": "Add text type of DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS."
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_IPV4_ADDRESS": {
+        "desc": "Add ipv4-address type of DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS."
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_UINT8": {
+        "desc": "Add uint8 type of DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS."
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_UINT16": {
+        "desc": "Add uint16 type of DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS."
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_UINT32": {
+        "desc": "Add uint32 type of DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS."
+    },
+    "DHCP_SERVER_IPV4_RANGE_INVALID_END": {
+        "desc": "Configure wrong end ip of range.",
+        "eStrKey": "Pattern"
+    },
+    "DHCP_SERVER_IPV4_RANGE_RANGES_WITH_IP": {
+        "desc": "Configure both ip and ranges in DHCP_SERVER_IPV4_RANGE_RANGES",
+        "eStr": ["Statement of 'ips' and 'ranges' cannot both exist"]
+    },
+    "DHCP_SERVER_IPV4_GATEWAY_ABSENT": {
+        "desc": "Missing gateway in DHCP_SERVER_IPV4",
+        "eStrKey" : "Mandatory"
+    },
+    "DHCP_SERVER_IPV4_LEASE_TIME_ABSENT": {
+        "desc": "Missing lease_time in DHCP_SERVER_IPV4",
+        "eStrKey" : "Mandatory"
+    },
+    "DHCP_SERVER_IPV4_MODE_ABSENT": {
+        "desc": "Missing mode in DHCP_SERVER_IPV4",
+        "eStrKey" : "Mandatory"
+    },
+    "DHCP_SERVER_IPV4_NETMASK_ABSENT": {
+        "desc": "Missing netmask in DHCP_SERVER_IPV4",
+        "eStrKey" : "Mandatory"
+    },
+    "DHCP_SERVER_IPV4_STATE_ABSENT": {
+        "desc": "Missing state in DHCP_SERVER_IPV4",
+        "eStrKey" : "Mandatory"
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_ID_ABSENT": {
+        "desc": "Missing id in DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS",
+        "eStrKey" : "Mandatory"
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_VALUE_ABSENT": {
+        "desc": "Missing value in DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS",
+        "eStrKey" : "Mandatory"
+    },
+    "DHCP_SERVER_IPV4_RANGE_RANGE_ABSENT": {
+        "desc": "Missing ranges in DHCP_SERVER_IPV4_RANGE",
+        "eStrKey": "Must"
+    },
+    "DHCP_SERVER_IPV4_RANGE_SINGLE_IP": {
+        "desc": "Single ip in DHCP_SERVER_IPV4_RANGE"
+    },
+    "DHCP_SERVER_IPV4_RANGE_THREE_IP": {
+        "desc": "Three ips in DHCP_SERVER_IPV4_RANGE",
+        "eStrKey": "Must"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcp_server_ipv4.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcp_server_ipv4.json
@@ -1,0 +1,878 @@
+{
+    "DHCP_SERVER_IPV4_VALID_FORMAT": {
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "name": "PortChannel1",
+                        "admin_status": "up"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "etp1",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "gateway": "192.168.0.1",
+                        "lease_time": 3600,
+                        "mode": "PORT",
+                        "netmask": "255.255.255.0",
+                        "customized_options": [
+                            "option60"
+                        ],
+                        "state": "enabled"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "id": 60,
+                        "type": "text",
+                        "value": "dummy_value"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_RANGE": {
+                "DHCP_SERVER_IPV4_RANGE_LIST": [
+                    {
+                        "name": "range1",
+                        "range": [
+                            "192.168.0.2",
+                            "192.168.0.3"
+                        ]
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_PORT": {
+                "DHCP_SERVER_IPV4_PORT_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "port": "Ethernet0",
+                        "ranges": [
+                            "range1"
+                        ]
+                    },
+                    {
+                        "name": "Vlan1000",
+                        "port": "PortChannel1",
+                        "ips": [
+                            "192.168.0.4"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_WITH_INVALID_VLAN": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "Vlan8090",
+                        "gateway": "192.168.0.1",
+                        "lease_time": 3600,
+                        "mode": "PORT",
+                        "netmask": "255.255.255.0",
+                        "state": "enabled"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_INCORRECT_GATEWAY": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "gateway": "192.168.0.300",
+                        "lease_time": 3600,
+                        "mode": "PORT",
+                        "netmask": "255.255.255.0",
+                        "customized_options": [],
+                        "state": "enabled"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_INCORRECT_NETMASK": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "gateway": "192.168.0.1",
+                        "lease_time": 3600,
+                        "mode": "PORT",
+                        "netmask": "255.255.255.300",
+                        "customized_options": [],
+                        "state": "enabled"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_STATE_WRONG_VALUE": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "gateway": "192.168.0.1",
+                        "lease_time": 3600,
+                        "mode": "PORT",
+                        "netmask": "255.255.255.0",
+                        "state": "dis-abled"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_MODE_WRONG_VALUE": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "gateway": "192.168.0.1",
+                        "lease_time": 3600,
+                        "mode": "pool",
+                        "netmask": "255.255.255.0",
+                        "state": "enabled"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SREVER_IPV4_NON_EXIST_OPTION": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "id": 60,
+                        "type": "text",
+                        "value": "dummy_value"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "gateway": "192.168.0.1",
+                        "lease_time": 3600,
+                        "mode": "PORT",
+                        "netmask": "255.255.255.0",
+                        "customized_options": [
+                            "option61"
+                        ],
+                        "state": "enabled"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_PORT_WITH_NO_EXIST_NAME": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "etp1",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "gateway": "192.168.0.1",
+                        "lease_time": 3600,
+                        "mode": "PORT",
+                        "netmask": "255.255.255.0",
+                        "customized_options": [
+                            "option60"
+                        ],
+                        "state": "enabled"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "id": 60,
+                        "type": "text",
+                        "value": "dummy_value"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_PORT": {
+                "DHCP_SERVER_IPV4_PORT_LIST": [
+                    {
+                        "name": "Vlan2000",
+                        "port": "Ethernet0",
+                        "ips": [
+                            "192.168.0.4"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_TEXT": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "id": 60,
+                        "type": "text",
+                        "value": "dummy_value"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_IPV4_ADDRESS": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "id": 60,
+                        "type": "ipv4-address",
+                        "value": "dummy_value"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_UINT8": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "id": 60,
+                        "type": "uint8",
+                        "value": "dummy_value"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_UINT16": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "id": 60,
+                        "type": "uint16",
+                        "value": "dummy_value"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_UINT32": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "id": 60,
+                        "type": "uint32",
+                        "value": "dummy_value"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_WRONG_VALUE": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "id": 60,
+                        "type": "texts",
+                        "value": "dummy_value"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_RANGE_INVALID_END": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_RANGE": {
+                "DHCP_SERVER_IPV4_RANGE_LIST": [
+                    {
+                        "name": "range1",
+                        "range": [
+                            "192.168.0.2",
+                            "192.168.0.300"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_RANGE_RANGES_WITH_IP": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "etp1",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "gateway": "192.168.0.1",
+                        "lease_time": 3600,
+                        "mode": "PORT",
+                        "netmask": "255.255.255.0",
+                        "state": "enabled"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_RANGE": {
+                "DHCP_SERVER_IPV4_RANGE_LIST": [
+                    {
+                        "name": "range1",
+                        "range": [
+                            "192.168.0.2",
+                            "192.168.0.3"
+                        ]
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_PORT": {
+                "DHCP_SERVER_IPV4_PORT_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "port": "Ethernet0",
+                        "ranges": [
+                            "range1"
+                        ],
+                        "ips": [
+                            "192.168.0.4"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_GATEWAY_ABSENT": {
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "name": "PortChannel1"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "etp1",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "lease_time": 3600,
+                        "mode": "PORT",
+                        "netmask": "255.255.255.0",
+                        "customized_options": [
+                            "option60"
+                        ],
+                        "state": "enabled"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "id": 60,
+                        "type": "text",
+                        "value": "dummy_value"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_RANGE": {
+                "DHCP_SERVER_IPV4_RANGE_LIST": [
+                    {
+                        "name": "range1",
+                        "range": [
+                            "192.168.0.2",
+                            "192.168.0.3"
+                        ]
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_PORT": {
+                "DHCP_SERVER_IPV4_PORT_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "port": "Ethernet0",
+                        "ranges": [
+                            "range1"
+                        ]
+                    },
+                    {
+                        "name": "Vlan1000",
+                        "port": "PortChannel1",
+                        "ips": [
+                            "192.168.0.4"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_LEASE_TIME_ABSENT": {
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "name": "PortChannel1"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "etp1",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "gateway": "192.168.0.1",
+                        "mode": "PORT",
+                        "netmask": "255.255.255.0",
+                        "customized_options": [
+                            "option60"
+                        ],
+                        "state": "enabled"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "id": 60,
+                        "type": "text",
+                        "value": "dummy_value"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_RANGE": {
+                "DHCP_SERVER_IPV4_RANGE_LIST": [
+                    {
+                        "name": "range1",
+                        "range": [
+                            "192.168.0.2",
+                            "192.168.0.3"
+                        ]
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_PORT": {
+                "DHCP_SERVER_IPV4_PORT_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "port": "Ethernet0",
+                        "ranges": [
+                            "range1"
+                        ]
+                    },
+                    {
+                        "name": "Vlan1000",
+                        "port": "PortChannel1",
+                        "ips": [
+                            "192.168.0.4"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_MODE_ABSENT": {
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "name": "PortChannel1"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "etp1",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "gateway": "192.168.0.1",
+                        "lease_time": 3600,
+                        "netmask": "255.255.255.0",
+                        "customized_options": [
+                            "option60"
+                        ],
+                        "state": "enabled"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "id": 60,
+                        "type": "text",
+                        "value": "dummy_value"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_RANGE": {
+                "DHCP_SERVER_IPV4_RANGE_LIST": [
+                    {
+                        "name": "range1",
+                        "range": [
+                            "192.168.0.2",
+                            "192.168.0.3"
+                        ]
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_PORT": {
+                "DHCP_SERVER_IPV4_PORT_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "port": "Ethernet0",
+                        "ranges": [
+                            "range1"
+                        ]
+                    },
+                    {
+                        "name": "Vlan1000",
+                        "port": "PortChannel1",
+                        "ips": [
+                            "192.168.0.4"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_NETMASK_ABSENT": {
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "name": "PortChannel1"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "etp1",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "gateway": "192.168.0.1",
+                        "lease_time": 3600,
+                        "mode": "PORT",
+                        "customized_options": [
+                            "option60"
+                        ],
+                        "state": "enabled"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "id": 60,
+                        "type": "text",
+                        "value": "dummy_value"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_RANGE": {
+                "DHCP_SERVER_IPV4_RANGE_LIST": [
+                    {
+                        "name": "range1",
+                        "range": [
+                            "192.168.0.2",
+                            "192.168.0.3"
+                        ]
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_PORT": {
+                "DHCP_SERVER_IPV4_PORT_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "port": "Ethernet0",
+                        "ranges": [
+                            "range1"
+                        ]
+                    },
+                    {
+                        "name": "Vlan1000",
+                        "port": "PortChannel1",
+                        "ips": [
+                            "192.168.0.4"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_STATE_ABSENT": {
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "name": "PortChannel1"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "etp1",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "gateway": "192.168.0.1",
+                        "lease_time": 3600,
+                        "mode": "PORT",
+                        "netmask": "255.255.255.0",
+                        "customized_options": [
+                            "option60"
+                        ]
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "id": 60,
+                        "type": "text",
+                        "value": "dummy_value"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_RANGE": {
+                "DHCP_SERVER_IPV4_RANGE_LIST": [
+                    {
+                        "name": "range1",
+                        "range": [
+                            "192.168.0.2",
+                            "192.168.0.3"
+                        ]
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_PORT": {
+                "DHCP_SERVER_IPV4_PORT_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "port": "Ethernet0",
+                        "ranges": [
+                            "range1"
+                        ]
+                    },
+                    {
+                        "name": "Vlan1000",
+                        "port": "PortChannel1",
+                        "ips": [
+                            "192.168.0.4"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_ID_ABSENT": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "type": "text",
+                        "value": "dummy_value"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_VALUE_ABSENT": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
+                "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
+                    {
+                        "name": "option60",
+                        "id": 60,
+                        "type": "text"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_RANGE_RANGE_ABSENT": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_RANGE": {
+                "DHCP_SERVER_IPV4_RANGE_LIST": [
+                    {
+                        "name": "range1"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_RANGE_SINGLE_IP": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_RANGE": {
+                "DHCP_SERVER_IPV4_RANGE_LIST": [
+                    {
+                        "name": "range1",
+                        "range": [
+                            "192.168.0.2"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_RANGE_THREE_IP": {
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_RANGE": {
+                "DHCP_SERVER_IPV4_RANGE_LIST": [
+                    {
+                        "name": "range1",
+                        "range": [
+                            "192.168.0.2",
+                            "192.168.0.3",
+                            "192.168.0.4"
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-dhcp-server-ipv4.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dhcp-server-ipv4.yang
@@ -1,0 +1,240 @@
+module sonic-dhcp-server-ipv4 {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/sonic-net/sonic-dhcp-server-ipv4";
+
+    prefix dhcp-server-ipv4;
+
+    import ietf-inet-types {
+        prefix inet;
+    }
+
+    import sonic-types {
+        prefix stypes;
+    }
+
+    // Comment sonic-vlan import here until libyang back-links issue is resolved for VLAN leaf reference.
+    // import sonic-vlan {
+    //     prefix vlan;
+    // }
+
+    import sonic-port {
+        prefix port;
+    }
+
+    import sonic-portchannel {
+        prefix lag;
+    }
+
+    description "DHCP_SERVER_IPV4 YANG module for SONiC OS";
+
+    revision 2023-07-19 {
+        description "Initial version";
+    }
+
+    container sonic-dhcp-server-ipv4 {
+        container DHCP_SERVER_IPV4 {
+
+            description "DHCP_SERVER_IPV4 part of config_db.json";
+
+            list DHCP_SERVER_IPV4_LIST {
+
+                description "DHCP_SERVER_IPV4 list part of config_db.json";
+
+                key "name";
+
+                leaf name {
+                    description "Interface name for DHCP server";
+                    // Comment VLAN leaf reference here until libyang back-links issue is resolved and use VLAN string pattern
+                    // type leafref {
+                    //     path "/vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:name";
+                    // }
+                    type string {
+                        pattern 'Vlan([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
+                    }
+                }
+
+                leaf gateway {
+                    description "Gateway IP for DHCP server";
+                    mandatory true;
+                    type inet:ipv4-address;
+                }
+
+                leaf lease_time {
+                    description "Lease time of DHCP IP in second";
+                    mandatory true;
+                    type uint32 {
+                        range "1..4294967295";
+                    }
+                }
+
+                leaf mode {
+                    description "Mode of assigning IP";
+                    mandatory true;
+                    type enumeration {
+                        enum PORT;
+                    }
+                }
+
+                leaf netmask {
+                    description "Subnet mask value for DHCP server";
+                    mandatory true;
+                    type inet:ipv4-address-no-zone;
+                }
+
+                leaf-list customized_options {
+                    description "Customized options list";
+                    type leafref {
+                        path "/dhcp-server-ipv4:sonic-dhcp-server-ipv4/dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS/dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST/dhcp-server-ipv4:name";
+                    }
+                }
+
+                leaf state {
+                    description "State of DHCP server";
+                    mandatory true;
+                    type stypes:admin_mode;
+                }
+            }
+            /* end of DHCP_SERVER_IPV4_LIST */
+        }
+        /* end of DHCP_SERVER_IPV4 container */
+
+        container DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS {
+
+            description "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS part of config_db.json";
+
+            list DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST {
+
+                description "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS list part of config_db.json";
+
+                key "name";
+
+                leaf name {
+                    description "Name of customized option";
+                    type string {
+                        length 1..255 {
+                            error-message "Invalid length for the customized options name";
+                        }
+                    }
+                }
+
+                leaf id {
+                    description "Customized PortChannel0003option ID";
+                    mandatory true;
+                    type uint8 {
+                        range "1..254";
+                    }
+                }
+
+                leaf type {
+                    description "Type of customized option, for standard DHCP option, this field is invalid";
+                    type enumeration {
+                        enum text;
+                        enum ipv4-address;
+                        enum uint8;
+                        enum uint16;
+                        enum uint32;
+                    }
+                }
+
+                leaf value {
+                    description "Value of customized option";
+                    mandatory true;
+                    type union {
+                        type string {
+                            length 0..255;
+                        }
+                        type inet:ipv4-address;
+                        type uint8;
+                        type uint16;
+                        type uint32;
+                    }
+                }
+            }
+            /* end of DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST */
+        }
+        /* end of DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS container */
+
+        container DHCP_SERVER_IPV4_RANGE {
+
+            description "DHCP_SERVER_IPV4_RANGE part of config_db.json";
+
+            list DHCP_SERVER_IPV4_RANGE_LIST {
+
+                description "DHCP_SERVER_IPV4_RANGE list part of config_db.json";
+
+                key "name";
+
+                leaf name {
+                    description "Name of IP range";
+                    type string {
+                        length 1..255 {
+                            error-message "Invalid length for the IP range name";
+                        }
+                    }
+                }
+
+                leaf-list range {
+                    description "Range of IPs";
+                    type inet:ipv4-address;
+                }
+
+                must "((count(range) <= 2) and (count(range) >= 1))";
+            }
+            /* end of DHCP_SERVER_IPV4_RANGE_LIST */
+        }
+        /* end of DHCP_SERVER_IPV4_RANGE */
+
+        container DHCP_SERVER_IPV4_PORT {
+
+            description "DHCP_SERVER_IPV4_PORT part of config_db.json";
+
+            list DHCP_SERVER_IPV4_PORT_LIST {
+
+                description "DHCP_SERVER_IPV4_PORT list part of config_db.json";
+
+                key "name port";
+
+                leaf name {
+                    description "Name of DHCP interface";
+                    type leafref {
+                        path "/dhcp-server-ipv4:sonic-dhcp-server-ipv4/dhcp-server-ipv4:DHCP_SERVER_IPV4/dhcp-server-ipv4:DHCP_SERVER_IPV4_LIST/dhcp-server-ipv4:name";
+                    }
+                }
+
+                leaf port {
+                    description "Interface under vlan";
+                    type union {
+                        type leafref {
+                            path "/port:sonic-port/port:PORT/port:PORT_LIST/port:name";
+                        }
+                        type leafref {
+                            path "/lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name";
+                        }
+                    }
+                }
+
+                leaf-list ips {
+                    description "Assigned IPs";
+                    must "(not(boolean(../ranges)))"{
+                        error-message "Statement of 'ips' and 'ranges' cannot both exist";
+                    }
+                    type inet:ipv4-address;
+                }
+
+                leaf-list ranges {
+                    description "IP ranges";
+                    must "(not(boolean(../ips)))"{
+                        error-message "Statement of 'ips' and 'ranges' cannot both exist";
+                    }
+                    type leafref {
+                        path "/dhcp-server-ipv4:sonic-dhcp-server-ipv4/dhcp-server-ipv4:DHCP_SERVER_IPV4_RANGE/dhcp-server-ipv4:DHCP_SERVER_IPV4_RANGE_LIST/dhcp-server-ipv4:name";
+                    }
+                }
+            }
+            /* end of DHCP_SERVER_IPV4_PORT_LIST */
+        }
+        /* end of DHCP_SERVER_IPV4_PORT container */
+    }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
https://github.com/sonic-net/sonic-buildimage/pull/15955 import sonic-vlan in yang model, which would cause YANG backlink issue. So https://github.com/sonic-net/sonic-buildimage/pull/15955 was reverted by https://github.com/sonic-net/sonic-buildimage/pull/16322.

This PR is re-submitted of https://github.com/sonic-net/sonic-buildimage/pull/15955 without import sonic-vlan.

Add yang model for IPv4 DHCP Server.

##### Work item tracking
- Microsoft ADO **(number only)**: 24905905

#### How I did it
Add yang model for IPv4 DHCP Server.
Add four new tables: DHCP_SERVER_IPV4, DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS, DHCP_SERVER_IPV4_RANGE, DHCP_SERVER_IPV4_PORT.
Add related unit test.

HLD: https://github.com/yaqiangz/SONiC/blob/master_dhcp_server_hld/doc/dhcp_server/port_based_dhcp_server_high_level_design.md#rev-01

#### How to verify it
Build sonic_yang_models packages.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

