### PR TITLE
[SNMP][IPv6][202012]: Fix SNMP IPv6 reachability issue in certain scenarios 

### DIFF
--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -30,16 +30,27 @@ agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% e
 {% endfor %}
 {% elif NAMESPACE_COUNT is not defined or NAMESPACE_COUNT|int <= 1 %}
 {% if MGMT_INTERFACE is defined %}
-{% for if, ip in MGMT_INTERFACE %}
-{% set agentip = ip.split('/')[0] %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}]:161
+{% for intf, ip in MGMT_INTERFACE %}
+{% set agentip = ip.split('/')[0]|lower %}
+{% set zoneid = '' %}
+# Use interface as zoneid for link local ipv6
+{% if agentip.startswith('fe80') %}
+{% set zoneid = '%' + intf %}
+{% endif %}
+agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
 {% endfor %}
 {% endif %}
 {% if LOOPBACK_INTERFACE is defined %}
 {% for lo in LOOPBACK_INTERFACE %}
 {% if lo | length == 2 %}
-{% set agentip = lo[1].split('/')[0] %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}]:161
+{% set intf = lo[0] %}
+{% set agentip = lo[1].split('/')[0]|lower %}
+{% set zoneid = '' %}
+# Use interface as zoneid for link local ipv6
+{% if agentip.startswith('fe80') %}
+{% set zoneid = '%' + intf %}
+{% endif %}
+agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -13,12 +13,36 @@
 #  AGENT BEHAVIOUR
 #
 
-#  Listen for connections on all ip addresses, including eth0, ipv4 lo
+# Listen for connections on all ip addresses, including eth0, ipv4 lo for multi-asic platform
+# Listen on managment and loopback0 ips for single asic platform
 #
+{% macro protocol(ip_addr) %}
+{%- if ip_addr|ipv6 -%}
+{{ 'udp6' }}
+{%- else -%}
+{{ 'udp' }}
+{%- endif -%}
+{% endmacro %}
+
 {% if SNMP_AGENT_ADDRESS_CONFIG %}
 {% for (agentip, port, vrf) in SNMP_AGENT_ADDRESS_CONFIG %}
-agentAddress {{ agentip }}{% if port %}:{{ port }}{% endif %}{% if vrf %}%{{ vrf }}{% endif %}{{ "" }}
+agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% endif %}{% if vrf %}%{{ vrf }}{% endif %}{{ "" }}
 {% endfor %}
+{% elif NAMESPACE_COUNT is not defined or NAMESPACE_COUNT|int <= 1 %}
+{% if MGMT_INTERFACE is defined %}
+{% for if, ip in MGMT_INTERFACE %}
+{% set agentip = ip.split('/')[0] %}
+agentAddress {{ protocol(agentip) }}:[{{ agentip }}]:161
+{% endfor %}
+{% endif %}
+{% if LOOPBACK_INTERFACE is defined %}
+{% for lo in LOOPBACK_INTERFACE %}
+{% if lo | length == 2 %}
+{% set agentip = lo[1].split('/')[0] %}
+agentAddress {{ protocol(agentip) }}:[{{ agentip }}]:161
+{% endif %}
+{% endfor %}
+{% endif %}
 {% else %}
 agentAddress udp:161
 agentAddress udp6:161

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -26,7 +26,7 @@
 
 {% if SNMP_AGENT_ADDRESS_CONFIG %}
 {% for (agentip, port, vrf) in SNMP_AGENT_ADDRESS_CONFIG %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% endif %}{% if vrf %}%{{ vrf }}{% endif %}{{ "" }}
+agentAddress {{ protocol(agentip) }}:{% if agentip|ipv6 %}[{% endif %}{{ agentip }}{% if agentip|ipv6 %}]{% endif %}{% if port %}:{{ port }}{% endif %}{% if vrf %}%{{ vrf }}{% endif %}{{ "" }}
 {% endfor %}
 {% elif NAMESPACE_COUNT is not defined or NAMESPACE_COUNT|int <= 1 %}
 {% if MGMT_INTERFACE is defined %}
@@ -37,7 +37,7 @@ agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% e
 {% if agentip.startswith('fe80') %}
 {% set zoneid = '%' + intf %}
 {% endif %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
+agentAddress {{ protocol(agentip) }}:{% if agentip|ipv6 %}[{% endif %}{{ agentip }}{{ zoneid }}{% if agentip|ipv6 %}]{% endif %}:161
 {% endfor %}
 {% endif %}
 {% if LOOPBACK_INTERFACE is defined %}
@@ -50,7 +50,7 @@ agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
 {% if agentip.startswith('fe80') %}
 {% set zoneid = '%' + intf %}
 {% endif %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
+agentAddress {{ protocol(agentip) }}:{% if agentip|ipv6 %}[{% endif %}{{ agentip }}{{ zoneid }}{% if agentip|ipv6 %}]{% endif %}:161
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -37,7 +37,7 @@ agentAddress {{ protocol(agentip) }}:{% if agentip|ipv6 %}[{% endif %}{{ agentip
 {% if agentip.startswith('fe80') %}
 {% set zoneid = '%' + intf %}
 {% endif %}
-agentAddress {{ protocol(agentip) }}:{% if agentip|ipv6 %}[{% endif %}{{ agentip }}{{ zoneid }}{% if agentip|ipv6 %}]{% endif %}:161
+agentAddress {{ protocol(agentip) }}:{% if agentip|ipv6 %}[{% endif %}{{ agentip }}{% if agentip|ipv6 %}]{% endif %}:161{{ zoneid }}
 {% endfor %}
 {% endif %}
 {% if LOOPBACK_INTERFACE is defined %}
@@ -50,7 +50,7 @@ agentAddress {{ protocol(agentip) }}:{% if agentip|ipv6 %}[{% endif %}{{ agentip
 {% if agentip.startswith('fe80') %}
 {% set zoneid = '%' + intf %}
 {% endif %}
-agentAddress {{ protocol(agentip) }}:{% if agentip|ipv6 %}[{% endif %}{{ agentip }}{{ zoneid }}{% if agentip|ipv6 %}]{% endif %}:161
+agentAddress {{ protocol(agentip) }}:{% if agentip|ipv6 %}[{% endif %}{{ agentip }}{% if agentip|ipv6 %}]{% endif %}:161{{ zoneid }}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/dockers/docker-snmp/start.sh
+++ b/dockers/docker-snmp/start.sh
@@ -16,11 +16,14 @@ mkdir -p /etc/ssw /etc/snmp
 # Parse snmp.yml and insert the data in Config DB
 /usr/bin/snmp_yml_to_configdb.py
 
+ADD_PARAM=$(printf '%s {"NAMESPACE_COUNT":"%s"}' "-a" "$NAMESPACE_COUNT")
+
 SONIC_CFGGEN_ARGS=" \
     -d \
     -y /etc/sonic/sonic_version.yml \
     -t /usr/share/sonic/templates/sysDescription.j2,/etc/ssw/sysDescription \
     -t /usr/share/sonic/templates/snmpd.conf.j2,/etc/snmp/snmpd.conf \
+    $ADD_PARAM \
 "
 
 sonic-cfggen $SONIC_CFGGEN_ARGS


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cherry pick of https://github.com/sonic-net/sonic-buildimage/pull/15487 and https://github.com/sonic-net/sonic-buildimage/pull/16013 along fixes in snmpd.conf for snmpd 5.7.3 version
SNMP over IPv6 is not working for all scenarios for a single asic platforms.
The expectation is that SNMP query over IPv6 should work over Management or Loopback0 addresses.
**Specific scenario where this issue is seen**
In case of Lab T0 device,  when SNMP request is sent from a directly connected T1 neighbor over Loopback IP, SNMP response was not received.
This was because the SRC IP address in SNMP response was not Loopback IP, it was the PortChannel IP connected to the neighboring device.
```
23:18:51.620897  In 22:26:27:e6:e0:07 ethertype IPv6 (0x86dd), length 105: fc00::72.41725 > **fc00:1::32**.161:  C="msft" **GetRequest**(28)  .1.3.6.1.2.1.1.1.0
23:18:51.621441 Out 28:99:3a:a0:97:30 ethertype IPv6 (0x86dd), length 241: **fc00::71**.161 > fc00::72.41725:  C="msft" **GetResponse**(162)  .1.3.6.1.2.1.1.1.0="SONiC Software Version: SONiC.xxx - HwSku: xx - Distribution: Debian 10.13 - Kernel: 4.19.0-12-2-amd64"
```
In case of IPv4, the SRC IP in SNMP response was correctly set to Loopback IP.
```
23:25:32.769712  In 22:26:27:e6:e0:07 ethertype IPv4 (0x0800), length 85: 10.0.0.57.56701 > **10.1.0.32**.161:  C="msft" **GetRequest**(28)  .1.3.6.1.2.1.1.1.0
23:25:32.975967 Out 28:99:3a:a0:97:30 ethertype IPv4 (0x0800), length 221: **10.1.0.32**.161 > 10.0.0.57.56701:  C="msft" **GetResponse**(162)  .1.3.6.1.2.1.1.1.0="SONiC Software Version: SONiC.xxx - HwSku: xx - Distribution: Debian 10.13 - Kernel: 4.19.0-12-2-amd64"
```

**Sequence of SNMP request and response**
1. SNMP request will be sent with SRC IP fc00::72 DST IP fc00:1::32
2. SNMP request is received at SONiC device is sent to snmpd which is listening on port 161 :::161/
3. snmpd process will parse the request create a response and sent to DST IP fc00::72. 
snmpd process does not track the DST IP on which the SNMP request was received, which in this case is Loopback IP.
snmpd process will only keep track what is tht IP to which the response should be sent to.
4. snmpd process will send the response packet.
5. Kernel will do a route look up on destination IP and find the best path.
ip -6 route get fc00::72
fc00::72 from :: dev PortChannel101 proto kernel src fc00::71 metric 256 pref medium
5. Using the "src" ip from about, the response is sent out. This SRC ip is that of the PortChannel and not the device Loopback IP.

The same issue is seen when SNMP query is sent from a remote server over Management IP.
SONiC device eth0 --------- Remote server
SNMP request comes with SRC IP <Remote_server> DST IP <Mgmt IP>
If kernel finds best route to Remote_server_IP is via BGP neighbors, then it will send the response via front-panel interface with SRC IP as Loopback IP instead of Management IP.

Main issue is that in case of IPv6, snmpd ignores the IP address to which SNMP request was sent, in case of IPv6.
In case of IPv4, snmpd keeps track of DST IP of SNMP request, it will keep track if the SNMP request was sent to mgmt IP or Loopback IP.
Later, this IP is used in ipi_spec_dst as SRC IP which helps kernel to find the route based on DST IP using the right SRC IP.
https://github.com/net-snmp/net-snmp/blob/master/snmplib/transports/snmpUDPBaseDomain.c#L300 
ipi.ipi_spec_dst.s_addr = srcip->s_addr
Reference: https://man7.org/linux/man-pages/man7/ip.7.html
```
If IP_PKTINFO is passed to sendmsg(2)
              and ipi_spec_dst is not zero, then it is used as the local
              source address for the routing table lookup and for
              setting up IP source route options.  When ipi_ifindex is
              not zero, the primary local address of the interface
              specified by the index overwrites ipi_spec_dst for the
              routing table lookup.
```

**This issue is not seen on multi-asic platform, why?**
on multi-asic platform, there exists different network namespaces.
SNMP docker with snmpd process runs on host namespace.
Management interface belongs to host namespace.
Loopback0 is configured on asic namespaces.
Additional inforamtion on how the packet coming over Loopback IP reaches snmpd process running on host namespace: https://github.com/sonic-net/sonic-buildimage/pull/5420
Because of this separation of network namespaces, the route lookup of destination IP is confined to routing table of specific namespace where packet is received.
if packet is received over management interface, SNMP response also is sent out of management interface. Same goes with packet received over Loopback Ip.

##### Work item tracking
- Microsoft ADO **17537063**:

#### How I did it
Have snmpd listen on specific Management and Loopback IPs specifically instead of listening on any IP for single-asic platform.
With this, snmpd will bind to different socket for each IP.
Any request coming in from Mgmt or Loopback IP will go through specific socket and response will have also use the same socket ensuring that the src IP of the response packet matches the dst ip of request packet.

#### How to verify it
on multi-asic image: no change.

Verified on singl-asic DUT with test_snmp_link_local and test_snmp_loopback test cases.

on single-asic VS image:
```
admin@vlab-01:~$ sudo netstat -tulnp | grep 161
tcp        0      0 127.0.0.1:3161          0.0.0.0:*               LISTEN      221837/snmpd        
udp        0      0 10.1.0.32:161           0.0.0.0:*                           221837/snmpd        
udp        0      0 10.250.0.101:161        0.0.0.0:*                           221837/snmpd        
udp6       0      0 fc00:1::32:161          :::*                                221837/snmpd        
udp6       0      0 fec0::ffff:afa:1:161    :::*                                221837/snmpd        
admin@vlab-01:~$ show ver

SONiC Software Version: SONiC.202012-15971.345477-dae0177c2
Distribution: Debian 10.13
Kernel: 4.19.0-12-2-amd64
Build commit: dae0177c2
Build date: Thu Aug 24 02:56:40 UTC 2023

```
snmpd.conf compatible with snmpd 5.7.3:
```
# Use interface as zoneid for link local ipv6
agentAddress udp:10.250.0.101:161
# Use interface as zoneid for link local ipv6
agentAddress udp6:[fec0::ffff:afa:1]:161
# Use interface as zoneid for link local ipv6
agentAddress udp:10.1.0.32:161
# Use interface as zoneid for link local ipv6
agentAddress udp6:[fc00:1::32]:161
```

snmpd.conf with linklocal ip:
```
# Use interface as zoneid for link local ipv6
agentAddress udp:10.250.0.101:161
# Use interface as zoneid for link local ipv6
agentAddress udp6:[fe80::5054:ff:fe62:e8a4]:161%eth0 ---- link local with eth0 as zoneid
# Use interface as zoneid for link local ipv6
agentAddress udp6:[fec0::ffff:afa:1]:161
# Use interface as zoneid for link local ipv6
agentAddress udp:10.1.0.32:161
# Use interface as zoneid for link local ipv6
agentAddress udp6:[fc00:1::32]:161
```
Ran IPv6 SNMP test cases:
```
./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c snmp/test_snmp_link_local.py  -f vtestbed.yaml -i ../ansible/veos_vtb -e "--skip_sanity --disable_loganalyzer" -u
--------------------------------------------------------------------------- generated xml file: /data/sonic-mgmt/tests/logs/tr.xml ----------------------------------------------------------------------------
=================================================================================== 1 passed, 1 warnings in 355.60 seconds ====================================================================================
INFO:root:Can not get Allure report URL. Please check logs
./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c snmp/test_snmp_loopback.py  -f vtestbed.yaml -i ../ansible/veos_vtb -e "--skip_sanity --disable_loganalyzer" -u 
snmp/test_snmp_loopback.py::test_snmp_loopback[vlab-01] PASSED                                                                                                                                          [100%]

--------------------------------------------------------------------------- generated xml file: /data/sonic-mgmt/tests/logs/tr.xml ----------------------------------------------------------------------------
========================================================================================== 1 passed in 25.71 seconds ==========================================================================================
INFO:root:Can not get Allure report URL. Please check logs
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

