### PR TITLE
[Nokia-IXR7250E] Modify the platform_ndk.json for Nokia-IXR7250E platform

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_ndk.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_ndk.json
@@ -14,7 +14,7 @@
     },
     {
         "key": "monitor_action",
-        "stringval": "reboot"
+        "stringval": "warn"
     },
     {
         "key": "grpc_thermal_monitor",
@@ -42,7 +42,7 @@
     },
     {
       "key": "sonic_log_level",
-      "stringval": "error"
+      "stringval": "debug"
     }
     ]
 }

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_ndk.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_ndk.json
@@ -30,7 +30,7 @@
     },
     {
       "key": "sonic_log_level",
-      "stringval": "error"
+      "stringval": "debug"
     }
     ]
 }


### PR DESCRIPTION
#### Why I did it
On Nokia IXR7250E platform, per latest requirement,  linecard no longer to reboot itself when midplane heartbeat is missing.
This PR address issue https://github.com/Nokia-ION/ndk/issues/20

##### Work item tracking
- Microsoft ADO **(number only)**: 25036266

#### How I did it
Modify the platform_ndk.json file and change the value of "monitor_action" from "reboot" to "warn" to let Linecard's NDK to log the Error message instead of reboot itself. 

#### How to verify it
1) Log in supervisor card, issue the following command to bring down the midplane communication.
```
     sonic#> sudo ethtool -s xe0 autoneg on
```
2) On the linecard console, wait for 1 minute or more. The following log message should be shown up.  And No reboot action happened.
```
Aug 31 02:46:59.786135 ixre-egl-board25 WARNING sr_device_mgr: Unable to reach CPM over 10.6.0.100 (missing count: 6).
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

