### PR TITLE
Dell S6100 component API fix

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/component.py
@@ -321,3 +321,16 @@ class Component(ComponentBase):
             A boolean, True if install was successful, False if not
         """
         return False
+
+    def update_firmware(self,image_path):
+       """
+         Updates firmware to the componenent
+
+        Args:
+            image_path: A string, path to firmware image
+
+        Returns:
+            A boolean, True if install was successful, False if not
+
+       """
+       return False


### PR DESCRIPTION
#### Why I did it
sonic-mgmt test failure is seen for update_firmware component API
#### How I did it
Edited API 2.0 to fix this issue.
#### How to verify it
Run sonic-mgmt test after the fix and verify it passes.


#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305
