### PR TITLE
add minpoll&maxpoll in ntp.conf.j2 when generating ntp.conf

### DIFF
--- a/files/image_config/ntp/ntp.conf.j2
+++ b/files/image_config/ntp/ntp.conf.j2
@@ -28,7 +28,14 @@ filegen clockstats file clockstats type day enable
 # pick a different set every time it starts up.  Please consider joining the
 # pool: <http://www.pool.ntp.org/join.html>
 {% for ntp_server in NTP_SERVER %}
-server {{ ntp_server }} iburst
+{% set ns = namespace(minpoll='') %}
+{% if NTP_SERVER[ntp_server]['minpoll'] %}
+{% set ns.minpoll = "minpoll " + NTP_SERVER[ntp_server]['minpoll'] %}
+{% endif %}
+{% if NTP_SERVER[ntp_server]['maxpoll'] %}
+{% set ns.maxpoll = "maxpoll " + NTP_SERVER[ntp_server]['maxpoll'] %}
+{% endif %}
+server {{ ntp_server }} iburst {{ ns.minpoll }} {{ns.maxpoll}}
 {% endfor %}
 
 #listen on source interface if configured, else 


### PR DESCRIPTION
#### Why I did it
When generating ntp.conf upon CONFIG_DB NTP_SERVER change, get the minpoll & maxpoll values from db entry and populate these in ntp.conf

PR to update NTP HLD is https://github.com/sonic-net/SONiC/pull/1478

#### How I did it
Add the minpoll & maxpoll handling code in ntp.conf.j2

#### How to verify it
Use click ntp server add command with optional minpoll & maxpoll commands. 
Verify ntp.conf is generated correctly.

unit tests results in PR https://github.com/sonic-net/sonic-utilities/pull/2964