### PR TITLE
Fix tcpdump report error when tacacs enabled.

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -407,6 +407,10 @@ LogsDirectory=audit
 LogsDirectoryMode=0750
 EOF
 
+# latest tcpdump control resource access with AppArmor.
+# override tcpdump profile to allow tcpdump access TACACS config file.
+sudo cp files/apparmor/usr.bin.tcpdump $FILESYSTEM_ROOT/etc/apparmor.d/local/usr.bin.tcpdump
+
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
 ## Pre-install the fundamental packages for amd64 (x86)
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install      \

--- a/files/apparmor/usr.bin.tcpdump
+++ b/files/apparmor/usr.bin.tcpdump
@@ -1,0 +1,2 @@
+# tcpdump will call getpwnam get current user information, the NSS plugin nss_tacplus hook this API and need access tacacs config file.
+/etc/tacplus_nss.conf r,


### PR DESCRIPTION
Fix tcpdump report error when tacacs enabled.

#### Why I did it
Fix tcpdump report error when tacacs enabled:
Sep  1 09:25:18.189395 vlab-01 ERR tcpdump: nss_tacplus: /etc/tacplus_nss.conf fopen failed
Sep  1 09:25:18.189606 vlab-01 ERR tcpdump: nss_tacplus: bad config or server line for nss_tacplus

This is because debian add a patch create AppArmor profile for resource access control. The profile need update to allow tcpdump access /etc/tacplus_nss.conf.

##### Work item tracking
- Microsoft ADO: 17667308

#### How I did it
Modify tcpdump AppArmor profile, add new line to allow tcpdump access TACACS config file:

  /etc/tacplus_nss.conf r,

#### How to verify it
Pass all UT.
Manually verify error fixed.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x]  SONiC.master-16372.360223-d5d6c64c5
- [X] SONiC.202205-16610.367814-d52a71b48
- [X] SONiC.202211-16611.367823-11a8b8d55

#### Description for the changelog
Fix tcpdump report error when tacacs enabled.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

