### PR TITLE
patch fix to ignore dup nh in netlink msg

### DIFF
--- a/src/sonic-frr/patch/0030-zebra-remove-duplicated-nexthops-when-sending-fpm-msg.patch
+++ b/src/sonic-frr/patch/0030-zebra-remove-duplicated-nexthops-when-sending-fpm-msg.patch
@@ -1,0 +1,32 @@
+From 4aa1aace3e32039b668c04cd682b01e0397144ea Mon Sep 17 00:00:00 2001
+
+From: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>
+
+From: =?UTF-8?q?=E6=81=AD=E7=AE=80?= <gongjian.lhr@alibaba-inc.com>
+Date: Wed, 26 Jul 2023 09:51:51 +0800
+Subject: [PATCH] zebra: remove duplicated nexthops when sending fpm msg
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When zebra send msg to fpm client, it doesn't handle duplicated nexthops especially, which means if zebra has a route with NUM1 recursive nexthops, each resolved to the same NUM2 connected nexthops, it will send to fpm client a route with NUM1*NUM2 nexthops. But actually there are only NUM2 useful nexthops, the left NUM1*NUM2-NUM2 nexthops are all duplicated nexthops. By the way, zebra has duplicated nexthop remove logic when sending msg to kernel.
+Add duplicated nexthop remove logic to zebra when sending msg to fpm client.
+
+Signed-off-by: 恭简 <gongjian.lhr@alibaba-inc.com>
+---
+ zebra/zebra_fpm_netlink.c |    2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/zebra/zebra_fpm_netlink.c b/zebra/zebra_fpm_netlink.c
+index d6c875a7e..6f0fdce2a 100644
+--- a/zebra/zebra_fpm_netlink.c
++++ b/zebra/zebra_fpm_netlink.c
+@@ -322,6 +322,8 @@ static int netlink_route_info_fill(struct netlink_route_info *ri, int cmd,
+ 
+ 		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
+ 			continue;
++		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE))
++			continue;
+ 
+ 		if (nexthop->type == NEXTHOP_TYPE_BLACKHOLE) {
+ 			switch (nexthop->bh_type) {

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -14,3 +14,4 @@ Disable-ipv6-src-address-test-in-pceplib.patch
 0027-bgpd-Ensure-FRR-has-enough-data-to-read-in-peek_for_as4_capability-and-bgp_open_option_parse.patch
 0028-bgpd-Ensure-that-bgp-open-message-stream-has-enough-data-to-read.patch
 0029-bgpd-Change-log-level-for-graceful-restart-events.patch
+0030-zebra-remove-duplicated-nexthops-when-sending-fpm-msg.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes #15803 

In SONiC chassis, routes have recursive nexthop resolution when the routes are learnt from remote linecard. 
In some cases after recursive nexthop resolution the number of nexthop for a route could reach `256`.
Zebra ran out of space when filling up 256 nexthops which causes zebra crash.


##### Work item tracking
- Microsoft ADO **(24997365)**:

#### How I did it
Create a patch to port https://github.com/FRRouting/frr/pull/14096 which has change to ignore duplicate nexthop when filling up fpm message 

The Fix was commit in this PR in master https://github.com/sonic-net/sonic-buildimage/pull/16275. This PR is port of the fix to 202205

#### How to verify it
Testing on voq chassis

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

