### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202205.2.2.10
+ref=202205.2.2.11


### PR DESCRIPTION
Why I did it

Common Release Notes for 8102-64H, T0/DualTor, and 8101-32FH
 
- Fix for an issue where drop counters were incrementing twice for packets with invalid tag
- Fix for the ECC errors reported in SR 695600099
- Fix for fwutil show updates failure

How I did it

- Update platform version to 202205.2.2.11

#### A picture of a cute animal (not mandatory but encouraged)

