### PR TITLE
[swss] Chassis db clean up optimization and bug fixes

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -124,12 +124,7 @@ function clean_up_tables()
 #       SYSTEM_LAG_ID_TABLE and SYSTEM_LAG_ID_SET are adjusted appropriately
 function clean_up_chassis_db_tables()
 {
-    if [[ !($($SONIC_DB_CLI CHASSIS_APP_DB PING | grep -c True) -gt 0) ]]; then
-        return
-    fi
 
-    lc=`$SONIC_DB_CLI CONFIG_DB  hget 'DEVICE_METADATA|localhost' 'hostname'`
-    asic=`$SONIC_DB_CLI CONFIG_DB  hget 'DEVICE_METADATA|localhost' 'asic_name'`
     switch_type=`$SONIC_DB_CLI CONFIG_DB  hget 'DEVICE_METADATA|localhost' 'switch_type'`
 
     # Run clean up only in swss running for voq switches
@@ -137,8 +132,16 @@ function clean_up_chassis_db_tables()
         return
     fi
 
+    if [[ !($($SONIC_DB_CLI CHASSIS_APP_DB PING | grep -c True) -gt 0) ]]; then
+        return
+    fi
+
+    lc=`$SONIC_DB_CLI CONFIG_DB  hget 'DEVICE_METADATA|localhost' 'hostname'`
+    asic=`$SONIC_DB_CLI CONFIG_DB  hget 'DEVICE_METADATA|localhost' 'asic_name'`
+
     # First, delete SYSTEM_NEIGH entries
-    $SONIC_DB_CLI CHASSIS_APP_DB EVAL "
+    num_neigh=`$SONIC_DB_CLI CHASSIS_APP_DB EVAL "
+    local nn = 0
     local host = string.gsub(ARGV[1], '%-', '%%-')
     local dev = ARGV[2]
     local ps = 'SYSTEM_NEIGH*|' .. host .. '|' .. dev
@@ -146,16 +149,22 @@ function clean_up_chassis_db_tables()
     for j,key in ipairs(keylist) do
         if string.match(key, ps) ~= nil then
             redis.call('DEL', key)
+            nn = nn + 1
         end
     end
-    return " 0 $lc $asic
+    return nn" 0 $lc $asic`
+
+    debug "Chassis db clean up for ${SERVICE}$DEV. Number of SYSTEM_NEIGH entries deleted: $num_neigh"
 
     # Wait for some time before deleting system interface so that the system interface's "object in use"
     # is cleared in both orchangent and in syncd. Without this delay, the orchagent clears the refcount
     # but the syncd (meta) still has no-zero refcount. Because of this, orchagent gets "object still in use"
     # error and aborts.
+    # This delay is needed only if some system neighbors were deleted.
 
-    sleep 30
+    if [[ $num_neigh > 0 ]]; then
+        sleep 30
+    fi
 
     # Next, delete SYSTEM_INTERFACE entries
     $SONIC_DB_CLI CHASSIS_APP_DB EVAL "
@@ -171,7 +180,8 @@ function clean_up_chassis_db_tables()
     return " 0 $lc $asic
 
     # Next, delete SYSTEM_LAG_MEMBER_TABLE entries
-    $SONIC_DB_CLI CHASSIS_APP_DB EVAL "
+    num_lag_mem=`$SONIC_DB_CLI CHASSIS_APP_DB EVAL "
+    local nlm = 0
     local host = string.gsub(ARGV[1], '%-', '%%-')
     local dev = ARGV[2]
     local ps = 'SYSTEM_LAG_MEMBER_TABLE*|' .. host .. '|' .. dev
@@ -179,14 +189,20 @@ function clean_up_chassis_db_tables()
     for j,key in ipairs(keylist) do
         if string.match(key, ps) ~= nil then
             redis.call('DEL', key)
+            nlm = nlm + 1
         end
     end
-    return " 0 $lc $asic
+    return nlm" 0 $lc $asic`
+
+    debug "Chassis db clean up for ${SERVICE}$DEV. Number of SYSTEM_LAG_MEMBER_TABLE entries deleted: $num_lag_mem"
 
     # Wait for some time before deleting system lag so that the all the memebers of the
     # system lag will be cleared. 
+    # This delay is needed only if some system lag members were deleted
 
-    sleep 15
+    if [[ $num_lag_mem > 0 ]]; then
+        sleep 15
+    fi
 
     # Finally, delete SYSTEM_LAG_TABLE entries and deallot LAG IDs
     $SONIC_DB_CLI CHASSIS_APP_DB EVAL "
@@ -275,7 +291,7 @@ start() {
         $SONIC_DB_CLI GB_ASIC_DB FLUSHDB
         $SONIC_DB_CLI GB_COUNTERS_DB FLUSHDB
         $SONIC_DB_CLI RESTAPI_DB FLUSHDB
-        clean_up_tables STATE_DB "'PORT_TABLE*', 'MGMT_PORT_TABLE*', 'VLAN_TABLE*', 'VLAN_MEMBER_TABLE*', 'LAG_TABLE*', 'LAG_MEMBER_TABLE*', 'INTERFACE_TABLE*', 'MIRROR_SESSION*', 'VRF_TABLE*', 'FDB_TABLE*', 'FG_ROUTE_TABLE*', 'BUFFER_POOL*', 'BUFFER_PROFILE*', 'MUX_CABLE_TABLE*', 'ADVERTISE_NETWORK_TABLE*', 'VXLAN_TUNNEL_TABLE*', 'VNET_ROUTE*', 'MACSEC_PORT_TABLE*', 'MACSEC_INGRESS_SA_TABLE*', 'MACSEC_EGRESS_SA_TABLE*', 'MACSEC_INGRESS_SC_TABLE*', 'MACSEC_EGRESS_SC_TABLE*', 'VRF_OBJECT_TABLE*', 'VNET_MONITOR_TABLE*', 'BFD_SESSION_TABLE*'"
+        clean_up_tables STATE_DB "'PORT_TABLE*', 'MGMT_PORT_TABLE*', 'VLAN_TABLE*', 'VLAN_MEMBER_TABLE*', 'LAG_TABLE*', 'LAG_MEMBER_TABLE*', 'INTERFACE_TABLE*', 'MIRROR_SESSION*', 'VRF_TABLE*', 'FDB_TABLE*', 'FG_ROUTE_TABLE*', 'BUFFER_POOL*', 'BUFFER_PROFILE*', 'MUX_CABLE_TABLE*', 'ADVERTISE_NETWORK_TABLE*', 'VXLAN_TUNNEL_TABLE*', 'VNET_ROUTE*', 'MACSEC_PORT_TABLE*', 'MACSEC_INGRESS_SA_TABLE*', 'MACSEC_EGRESS_SA_TABLE*', 'MACSEC_INGRESS_SC_TABLE*', 'MACSEC_EGRESS_SC_TABLE*', 'VRF_OBJECT_TABLE*', 'VNET_MONITOR_TABLE*', 'BFD_SESSION_TABLE*','SYSTEM_NEIGH_TABLE*'"
         $SONIC_DB_CLI APPL_STATE_DB FLUSHDB
         clean_up_chassis_db_tables
         rm -rf /tmp/cache


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The PR is for the following:
- For the following chassis DB clean up optimization:
    - To avoid delay before deleting system interfaces when no system neighbors were deleted before
    - To avoid delay before deleting system lag when no system lag members were deleted before
- To avoid stale kernel neighbor after clearing system neighbors when asic comes up.
- To avoid accessing CHASSIS_APP_DB in pizzabox devices (PR #16451) 

##### Work item tracking
N/A

#### How I did it
- Fix for regression failure due to error in finding CHASSIS_APP_DB in pizzabox (#PR 16451)
    - Chassis clean up code is re-arranged to avoid accessing CHASSIS_APP_DB for non voq switches.
- After attempting to delete the system neighbor entries from chassis db, before starting clearing the system interface entries,
wait for sometime only if some system neighbors were deleted. If there are no system neighbors entries deleted for the asic coming up, no need to wait.
- Similar changes for system lag delete. Before deleting the system lag, wait for some time only if some system lag memebers were deleted. If there are no system lag members deleted no need to wait.
- For the above two, the redis eval script to delete entries from chassis app db is made to return the number of entries deleted. Delay is introduced only if the number of entries deleted is greater than 0.
- Flush the SYSTEM_NEIGH_TABLE from the local STATE_DB. While asic is coming up, when system neigh entries are deleted from chassis ap db (as part of chassis db clean up), there is no orchs/process running to process the delete messages from chassis redis. Because of this, stale system neigh entries are present in the local STATE_DB. The stale entries result in
creation of orphan (no corresponding data path/asic db entry) kernel neigh entries during STATE_DB:SYSTEM_NEIGH_TABLE entries processing by nbrmgr (after the swss serive came up). This is avoided by flushing the SYSTEM_NEIGH_TABLE from
the local STATE_DB when sevice comes up.

#### How to verify it
- Tested during config reload and chassis reboot.
- When asic without system neigbor entries and system lag member entries are restarted it was observed that delay was not introduced. This was indirectly verified by checking the log for the number of entries deleted.
- No stale kernel neighbors were found after swss came up.
- Tested in pizzabox for config reload. The error "Invalid database name input : 'CHASSIS_APP_DB'" was not seen.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

master

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Changes done in swss.sh service start script in function clean_up_chassis_db_tables().

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

