### PR TITLE
[build] Make the build to fail if raw image generation is not successful

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -139,7 +139,11 @@ elif [ "$IMAGE_TYPE" = "raw" ]; then
     ## Run the installer
     ## The 'build' install mode of the installer is used to generate this dump.
     sudo chmod a+x $tmp_output_onie_image
-    sudo ./$tmp_output_onie_image
+    sudo ./$tmp_output_onie_image || {
+        ## Failure during 'build' install mode of the installer results in an incomplete raw image.
+        ## Delete the incomplete raw image.
+        sudo rm -f $OUTPUT_RAW_IMAGE
+    }
     rm $tmp_output_onie_image
 
     [ -r $OUTPUT_RAW_IMAGE ] || {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To report a build failure if the raw image generation is not successful.
[Port from 201811 PR #15448]

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

If the 'build' install mode of the installer exits with an error, delete the incomplete raw image file generated.

#### How to verify it
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Modify the raw image disk size to an insufficient value and verify that the raw image build fails.

```
tar: ./overlay2/cd7e6cba703af8f06e049f6677c6ba3ca8189b259131df6a62bb76bdf2b9cf02/diff/etc/ssl/certs/AffirmTrust_Premium_ECC.pem: Cannot create symlink to '/usr/share/ca-certificates/mozilla/AffirmTrust_Premium_ECC.crt': No space left on device
tar: ./overlay2/cd7e6cba703af8f06e049f6677c6ba3ca8189b259131df6a62bb76bdf2b9cf02/diff/etc/ssl/certs/UCA_Extended_Validation_Root.pem: Cannot create symlink to '/usr/share/ca-certificates/mozilla/UCA_Extended_Validation_Root.crt': No space left on device
tar: ./overlay2/cd7e6cba703af8f06e049f6677c6ba3ca8189b259131df6a62bb76bdf2b9cf02/diff/etc/ssl/certs/Baltimore_CyberTrust_Root.pem: Cannot create symlink to '/usr/share/ca-certificates/mozilla/Baltimore_CyberTrust_Root.crt': No space left on device
tar: ./overlay2/cd7e6cba703af8f06e049f6677c6ba3ca8189b259131df6a62bb76bdf2b9cf02/diff/etc/ssl/certs/GlobalSign_Root_CA_-_R6.pem: Cannot create symlink to '/usr/share/ca-certificates/mozilla/GlobalSign_Root_CA_-_R6.crt': No space left on device
tar: ./overlay2/cd7e6cba703af8f06e049f6677c6ba3ca8189b259131df6a62bb76bdf2b9cf02/diff/etc/ssl/certs/SSL.com_Root_Certification_Authority_ECC.pem: Cannot create symlink to '/usr/share/ca-certificates/mozilla/SSL.com_Root_Certification_Authority_ECC.crt': No space left on device
tar: ./overlay2/cd7e6cba703af8f06e049f6677c6ba3ca8189b259131df6a62bb76bdf2b9cf02/diff/etc/ssl/certs/D-TRUST_Root_Class_3_CA_2_2009.pem: Cannot create symlink to '/usr/share/ca-certificates/mozilla/D-TRUST_Root_Class_3_CA_2_2009.crt': No space left on device
tar: ./overlay2/cd7e6cba703af8f06e049f6677c6ba3ca8189b259131df6a62bb76bdf2b9cf02/diff/etc/ssl/certs/TUBITAK_Kamu_SM_SSL_Kok_Sertifikasi_-_Surum_1.pem: Cannot create symlink to '/usr/share/ca-certificates/mozilla/TUBITAK_Kamu_SM_SSL_Kok_Sertifikasi_-_Surum_1.crt': No space left on device
tar: ./overlay2/cd7e6cba703af8f06e049f6677c6ba3ca8189b259131df6a62bb76bdf2b9cf02/diff/etc/ssl/certs/Buypass_Class_2_Root_CA.pem: Cannot create symlink to '/usr/share/ca-certificates/mozilla/Buypass_Class_2_Root_CA.crt': No space left on device
tar: ./overlay2/cd7e6cba703af8f06e049f6677c6ba3ca8189b259131df6a62bb76bdf2b9cf02/diff/etc/ssl/certs/Global_Chambersign_Root_-_2008.pem: Cannot create symlink to '/usr/share/ca-certificates/mozilla/Global_Chambersign_Root_-_2008.crt': No space left on device
tar: ./overlay2/cd7e6cba703af8f06e049f6677c6ba3ca8189b259131df6a62bb76bdf2b9cf02/diff/etc/ssl/certs/AffirmTrust_Networking.pem: Cannot create symlink to '/usr/share/ca-certificates/mozilla/AffirmTrust_Networking.crt': No space left on device
tar: ./overlay2/cd7e6cba703af8f06e049f6677c6ba3ca8189b259131df6a62bb76bdf2b9cf02/diff/usr/sbin/collect_version_files: Cannot create symlink to '../../usr/local/share/buildinfo/scripts/collect_version_files': No space left on device
tar: Exiting with failure status due to previous errors
umount: /tmp/tmp.sLBEFJXeGi: target is busy.
rm: cannot remove '/tmp/tmp.sLBEFJXeGi/installer/build_raw_image_mnt': Device or resource busy
+ sudo rm -f target/sonic-broadcom.raw
+ rm target/sonic-broadcom.bin.tmp
+ '[' -r target/sonic-broadcom.raw ']'
+ echo 'Error : target/sonic-broadcom.raw not generated!'
Error : target/sonic-broadcom.raw not generated!
+ exit 1
[  FAIL LOG END  ] [ target/sonic-broadcom.raw ]
make: *** [slave.mk:1267: target/sonic-broadcom.raw] Error 1
make[1]: *** [Makefile.work:602: target/sonic-broadcom.raw] Error 2
make[1]: Leaving directory '/home/abalac/repos/master/sonic-buildimage'
make: *** [Makefile:41: target/sonic-broadcom.raw] Error 2
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[build] Make the build to fail if raw image generation is not successful

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

