### PR TITLE
[build] Change raw image disk size to 1700MB

### DIFF
--- a/onie-image.conf
+++ b/onie-image.conf
@@ -37,7 +37,7 @@ OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin
 OUTPUT_RAW_IMAGE=target/sonic-$TARGET_MACHINE.raw
 
 ## Raw image size in MB
-RAW_IMAGE_DISK_SIZE=4096
+RAW_IMAGE_DISK_SIZE=1700
 
 ## Output file name for kvm image
 OUTPUT_KVM_IMAGE=target/sonic-$TARGET_MACHINE.img


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Maximum RAM availability for NOS to SONiC migration using raw image in Dell S6100 is 1700MB.
Raw images larger than that cannot be used for NOS to SONiC migration.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Change raw image disk size to 1700MB.

#### How to verify it

Initiate build for 'target/sonic-broadcom.raw' and verify that the build is successful only if the raw image generated is within the specified size.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[build] Change raw image disk size to 1700MB

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

