### PR TITLE
Fix potentially not having any loopback address on lo interface

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -26,7 +26,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 {% endblock loopback %}
 {% block mgmt_interface %}
 

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces
@@ -10,7 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt
@@ -10,7 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp
@@ -10,7 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband
@@ -10,7 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband_ip
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband_ip
@@ -10,7 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_ip
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_ip
@@ -10,7 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
@@ -19,7 +19,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces_nomgmt
@@ -19,7 +19,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py2/two_mgmt_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/two_mgmt_interfaces
@@ -10,7 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth1

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces
@@ -10,7 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt
@@ -10,7 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp
@@ -10,7 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband
@@ -10,7 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband_ip
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband_ip
@@ -10,7 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_ip
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_ip
@@ -10,7 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
@@ -19,7 +19,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces_nomgmt
@@ -19,7 +19,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/py3/two_mgmt_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/two_mgmt_interfaces
@@ -10,7 +10,7 @@ iface lo inet loopback
    netmask 255.255.0.0
    scope host
    post-up ip addr del 127.0.0.1/8 dev lo
-   down ip addr add 127.0.0.1/8 dev lo
+   pre-down ip addr add 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

In #15080, there was a command added to re-add 127.0.0.1/8 to the lo interface when the networking configuration is being brought down. However, the trigger for that command is `down`, which, looking at ifupdown2 configuration files, runs immediately after 127.0.0.1/16 is removed. This means there may be a period of time where there are no loopback addresses assigned to the lo interface, and redis commands will fail.

##### Work item tracking
- Microsoft ADO **(number only)**: 24833037

#### How I did it

Fix this by changing this to pre-down, which should run well before 127.0.0.1/16 is removed, and should always leave lo with a loopback address.

#### How to verify it

This is a race condition with a small timing window for the issue to occur. Killing the teamd container or repeated config reloads may be the best way to try to trigger this.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master branch, with a few config reloads
- [x] 20220531.38

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

