### PR TITLE
Add show dhcp_relay ipv4 counter entry, fix interface name offset issue

### DIFF
--- a/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
@@ -56,7 +56,7 @@ class DHCPv4_Counter(object):
         interfaces = []
         for key in self.db.keys(self.db.STATE_DB):
             if DHCPv4_COUNTER_TABLE in key:
-                interfaces.append(key[21:])
+                interfaces.append(key[19:])
         return interfaces
 
     def get_dhcp4relay_msg_count(self, interface, dir):
@@ -274,6 +274,10 @@ def dhcp_relay_ipv4_destination():
 def dhcp_relay_ipv6_destination():
     get_dhcp_relay(DHCP_RELAY, DHCPV6_SERVERS, with_header=True)
 
+@dhcp_relay_ipv4.command("counters")
+@click.option('-i', '--interface', required=False)
+def dhcp_relay_ip4counters(interface):
+    ipv4_counters(interface)
 
 @dhcp_relay_ipv6.command("counters")
 @click.option('-i', '--interface', required=False)


### PR DESCRIPTION
#### Why I did it
Add another cli entry: show dhcp_relay ipv4 counter
Fix get all interface offset issue

##### Work item tracking
- Microsoft ADO **(17271822)**:

#### How I did it
show dhcp_relay ipv4 counter -i [ifname]
show dhcp4relay_counters counts -i [ifname]

#### How to verify it
show dhcp4relay_counters counts | more 10
  Message Type    Ethernet144(RX)
--------------  -----------------
       Unknown                  0
      Discover                  0
         Offer                  0
       Request                  0
       Decline                  0
           Ack                  0
           Nak                  0
       Release                  0
        Inform                  0

  Message Type    Ethernet144(TX)
--------------  -----------------
           Ack                  1
       Decline                  0
      Discover                  1
        Inform                  0
           Nak                  0
         Offer                  1
       Release                  0
       Request                  0
       Unknown                  0

  Message Type    Ethernet76(RX)
--------------  ----------------
       Unknown                 0
      Discover                 0
         Offer                 0
       Request                 0
       Decline                 0
           Ack                 0
           Nak                 0
       Release                 0
        Inform                 0

  Message Type    Ethernet76(TX)
--------------  ----------------
           Ack                 0
       Decline                 0
      Discover                 7
        Inform                 0
           Nak                 0
         Offer                 0
       Release                 0
       Request                21
       Unknown                 0

show dhcp_relay ipv4 counters -i Vlan1000
  Message Type    Vlan1000(RX)
--------------  --------------
           Ack               0
       Decline               0
      Discover               2
        Inform               0
           Nak               0
         Offer               0
       Release               0
       Request               6
       Unknown               0

  Message Type    Vlan1000(TX)
--------------  --------------
           Ack              57
       Decline               0
      Discover               0
        Inform               0
           Nak               0
         Offer              57
       Release               0
       Request               0
       Unknown               0

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

