### PR TITLE
vtysh buffer overflow solution in 202012

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/rvtysh
+++ b/dockers/docker-fpm-frr/base_image_files/rvtysh
@@ -1,22 +1,35 @@
 #!/bin/bash
 
-# The command rvtysh can be run as root priviledge by any user without password, only allow to execute readonly commands.
+QUOTED_OUTPUT=''
+for var in "$@"; do
+    if [ "$var" == "-c" ]
+    then
+        QUOTED_OUTPUT="${QUOTED_OUTPUT} ${var}"
+    elif [ "$var" == "-n" ]
+    then
+        QUOTED_OUTPUT="${QUOTED_OUTPUT} #${var}#"
+    else
+        QUOTED_OUTPUT="${QUOTED_OUTPUT} #${var:Q}#"
+    fi
+done
 
-# The options in the show command cannot contains any charactors to run multiple sub-commands potentially, such as "\n", "\r", "|", "&", "$" and ";".
-if printf -- "$*" | grep -qPz '[\n\r|&$;]'; then
-    echo "Not allow to run the command, please use the comand 'sudo vtysh' instead." 1>&2
+SHOW_MATCHED_PATTERN=`echo ${QUOTED_OUTPUT}|grep -Eo "\-[c][ ]+#show[ a-zA-Z0-9!%()*+,./:<=>@^_~ -]+#"|grep -Eo "#show[ a-zA-Z0-9!%()*+,./:<=>@^_~ -]+#" |sed -e 's/#//g'`
+if [ "${SHOW_MATCHED_PATTERN}" == "" ]
+then
+    echo "Not allowed to run command. Please run sudo vtysh instead."
     exit 1
 fi
 
-# The sub commands must start with "show"
-LAST_PARAM=
-for param in "$@"
-do
-    if [ "$LAST_PARAM" == "-c" ] && [[ "$param" != show*  ]]; then
-        echo "Not allow to run the command '$param', please use the comand 'sudo vtysh' instead." 1>&2
-        exit 1
-    fi
-    LAST_PARAM=$param
-done
+# The command includes '-c' option (required) and '-n' option (optional)
+# '-c' option must start with show and the subcommand only allows a specific number of special characters.
+ARGUMENTS=()
+N_MATCHED_PATTERN=`echo ${QUOTED_OUTPUT}|grep -Eo "#-[n]#[ ]+#[0-9]#" |grep -Eo "#[0-9]#" |sed -e 's/#//g'`
+if [ "${N_MATCHED_PATTERN}" != "" ]
+then
+    ARGUMENTS+=('-n')
+    ARGUMENTS+=(${N_MATCHED_PATTERN})
+fi
+ARGUMENTS+=('-c')
+ARGUMENTS+=("${SHOW_MATCHED_PATTERN}")
 
-vtysh "$@"
+vtysh "${ARGUMENTS[@]}"


### PR DESCRIPTION
#### Why I did it
fix a potential risk for vtysh buffer overflow with -f option.
Limit options in rvtysh for a workaround solution.

##### Work item tracking
- Microsoft ADO **(17850851)**:

#### How I did it
fix a potential risk for vtysh buffer overflow with -f option.
Limit options in rvtysh for a workaround solution.

Sync with MSFT internal code which already has the fix.

#### How to verify it
vtysh -c "show ip bgp summary" ... 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

