### PR TITLE
Dell S6100: Change the order of platform components

### DIFF
--- a/device/dell/x86_64-dell_s6100_c2538-r0/platform.json
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/platform.json
@@ -11,10 +11,10 @@
                 "name": "BIOS"
             },
             {
-                "name": "CPLD"
+                "name": "FPGA"
             },
             {
-                "name": "FPGA"
+                "name": "CPLD"
             },
             {
                 "name": "SSD"


### PR DESCRIPTION
ADO: 25136360

#### Why I did it
sonic-mgmt component test failed 

#### How I did it
Change the order of components in platform file.
#### How to verify it
Run sonic-mgmt component API test scripts 

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
