### PR TITLE
[supervisor] Add use_unix_socket_path to supervisor-proc-exit-listener

### DIFF
--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -90,12 +90,12 @@ def generate_alerting_message(process_name, status, dead_minutes):
                   .format(process_name, status, namespace, dead_minutes))
 
 
-def get_autorestart_state(container_name):
+def get_autorestart_state(container_name, use_unix_socket_path):
     """
     @summary: Read the status of auto-restart feature from Config_DB.
     @return: Return the status of auto-restart feature.
     """
-    config_db = swsscommon.ConfigDBConnector()
+    config_db = swsscommon.ConfigDBConnector(use_unix_socket_path=use_unix_socket_path)
     config_db.connect()
     features_table = config_db.get_table(FEATURE_TABLE_NAME)
     if not features_table:
@@ -122,10 +122,13 @@ def publish_events(events_handle, process_name, container_name):
 
 def main(argv):
     container_name = None
-    opts, args = getopt.getopt(argv, "c:", ["container-name="])
+    use_unix_socket_path = False
+    opts, args = getopt.getopt(argv, "c:s", ["container-name=", "use-unix-socket-path"])
     for opt, arg in opts:
         if opt in ("-c", "--container-name"):
             container_name = arg
+        if opt in ("-s", "--use-unix-socket-path"):
+            use_unix_socket_path = True
 
     if not container_name:
         syslog.syslog(syslog.LOG_ERR, "Container name not specified. Exiting...")
@@ -159,7 +162,7 @@ def main(argv):
                 group_name = payload_headers['groupname']
 
                 if (process_name in critical_process_list or group_name in critical_group_list) and expected == 0:
-                    is_auto_restart = get_autorestart_state(container_name)
+                    is_auto_restart = get_autorestart_state(container_name, use_unix_socket_path)
                     if is_auto_restart != "disabled":
                         MSG_FORMAT_STR = "Process '{}' exited unexpectedly. Terminating supervisor '{}'"
                         msg = MSG_FORMAT_STR.format(payload_headers['processname'], container_name)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
ConfigDBConnector in supervisor-proc-exit-listener uses default parameter to connect CONFIG_DB (connect by 127.0.0.1:6379) which would fail at non-host network mode container, because they are not sharing the same network and socket.

##### Work item tracking
- Microsoft ADO **(number only)**: 25156255

#### How I did it
Add a new parameter `use_unix_socket_path` to this script to indicate whether to use socket to connect CONFIG_DB.

#### How to verify it
Build image and install it, kill critical processes in container and container crushed.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

