### PR TITLE
Common Authentication Template fix

### DIFF
--- a/src/sonic-host-services-data/templates/common-auth-sonic.j2
+++ b/src/sonic-host-services-data/templates/common-auth-sonic.j2
@@ -22,11 +22,16 @@ auth	[success=done new_authtok_reqd=done default=ignore{{ ' auth_err=die' if not
 auth	[success=1 default=ignore]	pam_tacplus.so server={{ last_server.ip }}:{{ last_server.tcp_port }} secret={{ last_server.passkey }} login={{ last_server.auth_type }} timeout={{ last_server.timeout }} {% if last_server.vrf %} vrf={{ last_server.vrf }} {% endif %} {{ 'source_ip=%s' % src_ip if src_ip }} try_first_pass
 
 {% endif %}
-{% elif auth['login'] == 'tacacs+' or auth['login'] == 'tacacs+,local' %}
+{% elif auth['login'] == 'tacacs+' %}
 {% for server in servers %}
 auth	[success=done new_authtok_reqd=done default=ignore{{ ' auth_err=die' if not auth['failthrough'] }}]	pam_tacplus.so server={{ server.ip }}:{{ server.tcp_port }} secret={{ server.passkey }} login={{ server.auth_type }} timeout={{ server.timeout }} {%if server.vrf %} vrf={{ server.vrf }} {% endif %} {{ 'source_ip=%s' % src_ip if src_ip }} try_first_pass
 {% endfor %}
-auth	[success=1 default=ignore]	pam_unix.so nullok try_first_pass
+
+{% elif auth['login'] == 'tacacs+,local' %}
+{% for server in servers %}
+auth    [success=done new_authtok_reqd=done default=ignore{{ ' auth_err=die' if not auth['failthrough'] }}]     pam_tacplus.so server={{ server.ip }}:{{ server.tcp_port }} secret={{ server.passkey }} login={{ server.auth_type }} timeout={{ server.timeout }} {%if server.vrf %} vrf={{ server.vrf }} {% endif %} {{ 'source_ip=%s' % src_ip if src_ip }} try_first_pass
+{% endfor %}
+auth    [success=done new_authtok_reqd=done default=ignore{{ ' auth_err=die' if not auth['failthrough'] }}]     pam_unix.so nullok try_first_pass
 
 {% elif auth['login'] == 'local,radius' %}
 auth	[success=done new_authtok_reqd=done default=ignore{{ ' auth_err=die maxtries=die' if not auth['failthrough'] }}]	pam_unix.so nullok try_first_pass


### PR DESCRIPTION
Issue Description: Local authentication succeeds (admin user) even when only tacacs+ is configured for login authentication Root-Cause: Authentication of Tacacs and tacacs,local was being handled in the same way in the template file common-auth-sonic.j2 
What i did: Separated the condition such that tacacs+,local is handled differently from tacacs+ configuration

#### Why I did it
Local authentication succeeds (admin user) even when only TACACS+  is configured for login authentication

#### How I did it
Separated the condition such that tacacs+,local is handled differently from tacacs+ configuration
#### How to verify it
Configure aaa authentication login as tacacs+. open a new ssh session, and try to login using local user credentials. The authentication should not succeed.

#### Description for the changelog
Separated the condition such that tacacs+,local is handled differently from tacacs+ configuration in common-auth-sonic.j2 file.


