### PR TITLE
[armhf][Nokia-7215] Enable Watchdog service 

### DIFF
--- a/platform/marvell-armhf/sonic-platform-nokia/7215/scripts/cpu_wdt.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/scripts/cpu_wdt.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python
+
+from sonic_platform.chassis import Chassis
+from sonic_py_common import logger
+import time
+import os
+import signal
+import sys
+
+
+TIMEOUT=170
+KEEPALIVE=55
+sonic_logger = logger.Logger('Watchdog')
+sonic_logger.set_min_log_priority_info()
+time.sleep(60)
+chassis = Chassis()
+watchdog = chassis.get_watchdog()
+
+def stopWdtService(signal, frame):
+    watchdog._disablewatchdog()
+    sonic_logger.log_notice("CPUWDT Disabled: watchdog armed=%s" % watchdog.is_armed() )
+    sys.exit()
+
+def main():
+
+    signal.signal(signal.SIGHUP, signal.SIG_IGN)
+    signal.signal(signal.SIGINT, stopWdtService)
+    signal.signal(signal.SIGTERM, stopWdtService)
+    
+    watchdog.arm(TIMEOUT)
+    sonic_logger.log_notice("CPUWDT Enabled: watchdog armed=%s" % watchdog.is_armed() )
+
+
+    while True:
+        time.sleep(KEEPALIVE)
+        watchdog._keepalive()
+        sonic_logger.log_info("CPUWDT keepalive")
+    done
+
+    stopWdtService
+
+    return
+
+
+if __name__ == '__main__':
+    main()

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/service/cpu_wdt.service
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/service/cpu_wdt.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=CPU WDT
+After=nokia-7215init.service
+[Service]
+ExecStart=/usr/local/bin/cpu_wdt.py
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/watchdog.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/watchdog.py
@@ -8,7 +8,7 @@ provides access to hardware watchdog
 import os
 import fcntl
 import array
-
+import time
 from sonic_platform_base.watchdog_base import WatchdogBase
 
 """ ioctl constants """
@@ -35,7 +35,7 @@ WDIOS_DISABLECARD = 0x0001
 WDIOS_ENABLECARD = 0x0002
 
 """ watchdog sysfs """
-WD_SYSFS_PATH = "/sys/class/watchdog/"
+WD_SYSFS_PATH = "/sys/class/watchdog/watchdog0/"
 
 WD_COMMON_ERROR = -1
 
@@ -52,15 +52,31 @@ class WatchdogImplBase(WatchdogBase):
         @param wd_device_path Path to watchdog device
         """
         super(WatchdogImplBase, self).__init__()
-
+        
+        self.watchdog=""
         self.watchdog_path = wd_device_path
-        self.watchdog = os.open(self.watchdog_path, os.O_WRONLY)
-
-        # Opening a watchdog descriptor starts
-        # watchdog timer; by default it should be stopped
-        self._disablewatchdog()
-        self.armed = False
+        self.wd_state_reg = WD_SYSFS_PATH+"state"
+        self.wd_timeout_reg = WD_SYSFS_PATH+"timeout"
+        self.wd_timeleft_reg = WD_SYSFS_PATH+"timeleft"
+    
         self.timeout = self._gettimeout()
+
+    def _read_sysfs_file(self, sysfs_file):
+        # On successful read, returns the value read from given
+        # reg_name and on failure returns 'ERR'
+        rv = 'ERR'
+
+        if (not os.path.isfile(sysfs_file)):
+            return rv
+        try:
+            with open(sysfs_file, 'r') as fd:
+                rv = fd.read()
+        except Exception as e:
+            rv = 'ERR'
+
+        rv = rv.rstrip('\r\n')
+        rv = rv.lstrip(" ")
+        return rv
 
     def _disablewatchdog(self):
         """
@@ -102,11 +118,10 @@ class WatchdogImplBase(WatchdogBase):
         Get watchdog timeout
         @return watchdog timeout
         """
+        timeout=0
+        timeout=self._read_sysfs_file(self.wd_timeout_reg)
 
-        req = array.array('I', [0])
-        fcntl.ioctl(self.watchdog, WDIOC_GETTIMEOUT, req, True)
-
-        return int(req[0])
+        return timeout
 
     def _gettimeleft(self):
         """
@@ -127,15 +142,20 @@ class WatchdogImplBase(WatchdogBase):
         ret = WD_COMMON_ERROR
         if seconds < 0:
             return ret
-
+        
+        # Stop the watchdog service to gain access of watchdog file pointer
+        if self.is_armed():
+            os.popen("systemctl stop cpu_wdt.service")
+            time.sleep(2)
+        if not self.watchdog:
+            self.watchdog = os.open(self.watchdog_path, os.O_WRONLY)
         try:
             if self.timeout != seconds:
                 self.timeout = self._settimeout(seconds)
-            if self.armed:
+            if self.is_armed():
                 self._keepalive()
             else:
                 self._enablewatchdog()
-                self.armed = True
             ret = self.timeout
         except IOError:
             pass
@@ -150,13 +170,17 @@ class WatchdogImplBase(WatchdogBase):
             A boolean, True if watchdog is disarmed successfully, False
             if not
         """
-
-        try:
-            self._disablewatchdog()
-            self.armed = False
-            self.timeout = 0
-        except IOError:
-            return False
+        
+        if self.is_armed():
+            os.popen("systemctl stop cpu_wdt.service")
+            time.sleep(2)
+            if not self.watchdog:
+                self.watchdog = os.open(self.watchdog_path, os.O_WRONLY)
+            try:
+                self._disablewatchdog()
+                self.timeout = 0
+            except IOError:
+                return False
 
         return True
 
@@ -164,8 +188,13 @@ class WatchdogImplBase(WatchdogBase):
         """
         Implements is_armed WatchdogBase API
         """
+        status = False
 
-        return self.armed
+        state = self._read_sysfs_file(self.wd_state_reg)
+        if (state != 'inactive'):
+            status = True
+
+        return status
 
     def get_remaining_time(self):
         """
@@ -174,10 +203,7 @@ class WatchdogImplBase(WatchdogBase):
 
         timeleft = WD_COMMON_ERROR
 
-        if self.armed:
-            try:
-                timeleft = self._gettimeleft()
-            except IOError:
-                pass
+        if self.is_armed():
+            timeleft=self._read_sysfs_file(self.wd_timeleft_reg)
 
-        return timeleft
+        return int(timeleft)

--- a/platform/marvell-armhf/sonic-platform-nokia/debian/sonic-platform-nokia-7215.install
+++ b/platform/marvell-armhf/sonic-platform-nokia/debian/sonic-platform-nokia-7215.install
@@ -1,6 +1,8 @@
 nokia-7215_plt_setup.sh usr/sbin
 7215/scripts/nokia-7215init.sh  usr/local/bin
+7215/scripts/cpu_wdt.py  usr/local/bin
 7215/service/nokia-7215init.service  etc/systemd/system
+7215/service/cpu_wdt.service  etc/systemd/system
 7215/service/fstrim.timer/timer-override.conf  /lib/systemd/system/fstrim.timer.d
 7215/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/armhf-nokia_ixs7215_52x-r0
 inband_mgmt.sh etc/

--- a/platform/marvell-armhf/sonic-platform-nokia/debian/sonic-platform-nokia-7215.postinst
+++ b/platform/marvell-armhf/sonic-platform-nokia/debian/sonic-platform-nokia-7215.postinst
@@ -7,5 +7,8 @@ sh /usr/sbin/nokia-7215_plt_setup.sh
 systemctl enable nokia-7215init.service
 systemctl start nokia-7215init.service
 
+systemctl enable cpu_wdt.service
+systemctl start cpu_wdt.service
+
 exit 0
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Enable watchdog for Nokia 7215 platform

##### Work item tracking
- Microsoft ADO **(number only)**: 24981141 

#### How I did it
Implement service which arm's the watchdog and send keep alive every minute.
start service be default on boot up

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Verify Watchdog is enabled on boot up:
"sudo systemctl status cpu_wdt.service" should show that service as active 
admin@sonic:~$ sudo watchdogutil status
Status: Armed
Time remaining: 138 seconds

Stop Service and verify watchdog is disarmed:
admin@sonic:$ sudo systemctl stop cpu_wdt.service 
admin@sonic:$ sudo watchdogutil status
Status: Unarmed


Logs added to notify service being armed/Disarmed and for every keep alive(every 55 seconds) 
```
2430:2023-10-13T01:42:11.077639+00:00 sonic Watchdog: CPUWDT Enabled: watchdog armed=True
2988:Oct 13 01:43:06.132343 sonic INFO Watchdog: CPUWDT keepalive
11925:Oct 13 01:44:01.186558 sonic INFO Watchdog: CPUWDT keepalive
12418:Oct 13 01:44:56.240061 sonic INFO Watchdog: CPUWDT keepalive

47159:Oct 13 02:27:15.490356 sonic NOTICE Watchdog: CPUWDT Disabled: watchdog armed=False
```
Also verified OC test suits and created seperate PR to uptate sonic-mgmt 
https://github.com/sonic-net/sonic-mgmt/pull/10082

https://github.com/sonic-net/sonic-mgmt/blob/master/tests/platform_tests/api/test_watchdog.py
https://github.com/sonic-net/sonic-mgmt/blob/master/tests/common/helpers/platform_api/watchdog.py

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Enable watchdog service for Nokia-7215 platform
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

