### PR TITLE
Deprecate the FIPS enforce option in Yang model

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -244,7 +244,7 @@ echo "ONIE_IMAGE_PART_SIZE=$demo_part_size"
 
 extra_cmdline_linux=%%EXTRA_CMDLINE_LINUX%%
 # Inherit the FIPS option, so not necessary to do another reboot after upgraded
-if grep -q '\bsonic_fips=1\b' /proc/cmdline && echo " $extra_cmdline_linux" | grep -qv '\bsonic_fips=.\b'; then
+if ( grep -q '\bsonic_fips=1\b' /proc/cmdline || "$SONIC_FIPS" == "1" ) && echo " $extra_cmdline_linux" | grep -qv '\bsonic_fips=.\b'; then
     extra_cmdline_linux="$extra_cmdline_linux sonic_fips=1"
 fi
 

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2564,8 +2564,7 @@ The FIPS table introduces FIPS  configuration.
 {
     "FIPS": {
         "global" : {
-            "enable": "true",
-            "enforce": "false"
+            "enable": "true"
         }
     }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2509,8 +2509,7 @@
         },
         "FIPS":{
             "global": {
-                "enable": "true",
-                "enforce": "true"
+                "enable": "true"
             }
         },
         "FG_NHG_MEMBER": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/fips.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/fips.json
@@ -3,8 +3,7 @@
         "sonic-fips:sonic-fips": {
             "sonic-fips:FIPS": {
                 "sonic-fips:global": {
-                    "enable": "true",
-                    "enforce": "false"
+                    "enable": "true"
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-fips.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fips.yang
@@ -30,11 +30,6 @@ module sonic-fips {
                     default "false";
                 }
 
-                leaf enforce {
-                    description "This configuration identicates whether enforce fips";
-                    type stypes:boolean_type;
-                    default "false";
-                }
             }
             /* end of container global */
         }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Deprecate the FIPS enforce option in Yang model

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

