### PR TITLE
[docker-ptf-sai]: Pin setuptools_scm to versions older than 8.0.0

### DIFF
--- a/dockers/docker-ptf-sai/Dockerfile.j2
+++ b/dockers/docker-ptf-sai/Dockerfile.j2
@@ -38,6 +38,8 @@ RUN dpkg -r python-ptf
 # Install new ptf package
 RUN git clone https://github.com/p4lang/ptf.git \
         && cd ptf                               \
+        && sed -i 's,setuptools_scm\[toml\],setuptools_scm[toml]<8.0.0,' pyproject.toml \
+        && sed -i 's,setuptools_scm,setuptools_scm<8.0.0,' setup.cfg \
         && python3.7 setup.py install --single-version-externally-managed --record /tmp/ptf_install.txt
 
 run echo "declare -x LANG=\"C.UTF-8\"" >> /root/.bashrc


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

setuptools_scm 8.0.0 dropped support for Python 3.7. Unfortunately, the docker-ptf container (that docker-ptf-sai depends on) is still on Buster, and uses Python 3.7. This causes installation failures.

##### Work item tracking
- Microsoft ADO **(number only)**: 25235158

#### How I did it

Add a restriction to the ptf source files to use versions older than 8.0.0 to get around this.

#### How to verify it

docker-ptf-sai.gz should succeed in its build.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

