### PR TITLE
Fix dhcp relay regex and process name

### DIFF
--- a/dockers/docker-dhcp-relay/dhcp_relay_regex.json
+++ b/dockers/docker-dhcp-relay/dhcp_relay_regex.json
@@ -6,7 +6,7 @@
     },
     {
         "tag": "dhcp-relay-bind-failure",
-        "regex": "Failed to bind socket to (link local|global) ipv6 address on interface ([a-zA-Z0-9]*)",
-        "params": [ "type:ret=(arg==\"link local\")and\"local\"or\"global\")", "vlan" ]
+        "regex": ".*Failed to bind socket to (link local|global) ipv6 address on interface ([a-zA-Z0-9]*).*",
+        "params": [ "type:ret=(arg==\"link local\")and\"local\"or\"global\"", "vlan" ]
     }
 ]

--- a/dockers/docker-dhcp-relay/events_info.json
+++ b/dockers/docker-dhcp-relay/events_info.json
@@ -2,7 +2,7 @@
     "yang_module": "sonic-events-dhcp-relay",
     "proclist": [
         {
-            "name": "dhcp_relay",
+            "name": "dhc*",
             "parse_json": "dhcp_relay_regex.json"
         }
     ]


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Fix regex such that dhcp bind failure event is detected as well as process name since dhcp relay processes that need to be detected are dhcprelay6 and dhcrelay.

#### How to verify it

Manual testing and nightly test event

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

