### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202205.2.2.11
+ref=202205.2.2.12


### PR DESCRIPTION
Why I did it

Release Notes for 8102-64H
• Fix NHG drop when route is added before members are added (MIGSMSFT-333 / SR 696141124)
• Added a new system device property "acl_set_dscp_encap_outer_only"
• IN_DISCARD counters report back per-port counters only instead of all counters that are per-port and also that are shared.

How I did it

Update platform version to 202205.2.2.12



#### A picture of a cute animal (not mandatory but encouraged)

