### PR TITLE
Enable ZMQ between GNMI and Orchanget

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -69,6 +69,10 @@ else
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"
 fi
 
-ORCHAGENT_ARGS+=" -q tcp://127.0.0.1:8100"
+# Enable ZMQ for SmartSwitch
+LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget localhost "subtype"`
+if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
+    ORCHAGENT_ARGS+=" -q tcp://127.0.0.1:8100"
+fi
 
 exec /usr/bin/orchagent ${ORCHAGENT_ARGS}

--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -69,4 +69,6 @@ else
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"
 fi
 
+ORCHAGENT_ARGS+=" -q tcp://127.0.0.1:8100"
+
 exec /usr/bin/orchagent ${ORCHAGENT_ARGS}

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -70,7 +70,11 @@ else
     TELEMETRY_ARGS+=" -v=2"
 fi
 
-TELEMETRY_ARGS+=" -zmq_address=tcp://127.0.0.1:8100"
+# Enable ZMQ for SmartSwitch
+LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget localhost "subtype"`
+if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
+    TELEMETRY_ARGS+=" -zmq_address=tcp://127.0.0.1:8100"
+fi
 
 # Server will handle threshold connections consecutively
 THRESHOLD_CONNECTIONS=$(echo $GNMI | jq -r '.threshold')

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -70,6 +70,8 @@ else
     TELEMETRY_ARGS+=" -v=2"
 fi
 
+TELEMETRY_ARGS+=" -zmq_address=tcp://127.0.0.1:8100"
+
 # Server will handle threshold connections consecutively
 THRESHOLD_CONNECTIONS=$(echo $GNMI | jq -r '.threshold')
 if [[ $THRESHOLD_CONNECTIONS =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
Enable ZMQ on gnmi and orchagent

#### Why I did it
Improve GNMI API performance for Dash resources

#### How I did it
Modify gnmi and orchagent service start script, add ZMQ parameter.

#### How to verify it
Pass all UT & E2E test
Manually verify with create Dash resources via gnmi API.