### PR TITLE
Fixing netaddr build issue

### DIFF
--- a/src/sonic-ctrmgrd/setup.py
+++ b/src/sonic-ctrmgrd/setup.py
@@ -26,7 +26,7 @@ setup(
         'pytest-cov',
         'sonic-py-common',
     ],
-    install_requires=['netaddr', 'pyyaml'],
+    install_requires=['netaddr==0.8.0', 'pyyaml'],
     license="GNU General Public License v3",
     long_description=readme + '\n\n',
     include_package_data=True,


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixing the following build issue

```
[2023-09-20T04:42:00.004Z] [ FAIL LOG START ] [ target/python-wheels/bullseye/sonic_bgpcfgd-1.0-py3-none-any.whl ]
[2023-09-20T04:42:00.004Z] Build start time: Wed Sep 20 04:41:54 UTC 2023
[2023-09-20T04:42:00.004Z] [ REASON ] :      target/python-wheels/bullseye/sonic_bgpcfgd-1.0-py3-none-any.whl does not exist   NON-EXISTENT PREREQUISITES: target/python-wheels/bullseye/sonic_config_engine-1.0-py3-none-any.whl-install target/python-wheels/bullseye/sonic_yang_mgmt-1.0-py3-none-any.whl-install target/python-wheels/bullseye/sonic_yang_models-1.0-py3-none-any.whl-install target/debs/bullseye/libyang_1.0.73_amd64.deb-install target/debs/bullseye/libyang-cpp_1.0.73_amd64.deb-install target/debs/bullseye/python3-yang_1.0.73_amd64.deb-install target/debs/bullseye/python3-swsscommon_1.0.0_amd64.deb-install 
[2023-09-20T04:42:00.004Z] [ FLAGS  FILE    ] : [] 
[2023-09-20T04:42:00.005Z] [ FLAGS  DEPENDS ] : [mellanox amd64 bullseye] 
[2023-09-20T04:42:00.005Z] [ FLAGS  DIFF    ] : [mellanox amd64 bullseye ] 
[2023-09-20T04:42:00.005Z] /sonic/src/sonic-bgpcfgd /sonic
[2023-09-20T04:42:00.005Z] running pytest
[2023-09-20T04:42:00.005Z] Searching for netaddr==0.8.0
[2023-09-20T04:42:00.005Z] Best match: netaddr 0.8.0
[2023-09-20T04:42:00.005Z] 
[2023-09-20T04:42:00.005Z] Using /var/sw-r2d2-bot/.local/lib/python3.9/site-packages
[2023-09-20T04:42:00.005Z] running egg_info
[2023-09-20T04:42:00.005Z] writing sonic_bgpcfgd.egg-info/PKG-INFO
[2023-09-20T04:42:00.005Z] writing dependency_links to sonic_bgpcfgd.egg-info/dependency_links.txt
[2023-09-20T04:42:00.005Z] writing entry points to sonic_bgpcfgd.egg-info/entry_points.txt
[2023-09-20T04:42:00.005Z] writing requirements to sonic_bgpcfgd.egg-info/requires.txt
[2023-09-20T04:42:00.005Z] writing top-level names to sonic_bgpcfgd.egg-info/top_level.txt
[2023-09-20T04:42:00.005Z] reading manifest file 'sonic_bgpcfgd.egg-info/SOURCES.txt'
[2023-09-20T04:42:00.005Z] writing manifest file 'sonic_bgpcfgd.egg-info/SOURCES.txt'
[2023-09-20T04:42:00.005Z] running build_ext
[2023-09-20T04:42:00.005Z] Traceback (most recent call last):
[2023-09-20T04:42:00.005Z]   File "/sonic/src/sonic-bgpcfgd/setup.py", line 3, in <module>
[2023-09-20T04:42:00.005Z]     setuptools.setup(
[2023-09-20T04:42:00.005Z]   File "/usr/local/lib/python3.9/dist-packages/setuptools/__init__.py", line 163, in setup
[2023-09-20T04:42:00.005Z]     return distutils.core.setup(**attrs)
[2023-09-20T04:42:00.005Z]   File "/usr/lib/python3.9/distutils/core.py", line 148, in setup
[2023-09-20T04:42:00.005Z]     dist.run_commands()
[2023-09-20T04:42:00.006Z]   File "/usr/lib/python3.9/distutils/dist.py", line 966, in run_commands
[2023-09-20T04:42:00.006Z]     self.run_command(cmd)
[2023-09-20T04:42:00.006Z]   File "/usr/lib/python3.9/distutils/dist.py", line 985, in run_command
[2023-09-20T04:42:00.006Z]     cmd_obj.run()
[2023-09-20T04:42:00.006Z]   File "/usr/local/lib/python3.9/dist-packages/ptr.py", line 208, in run
[2023-09-20T04:42:00.006Z]     with self.project_on_sys_path():
[2023-09-20T04:42:00.006Z]   File "/usr/lib/python3.9/contextlib.py", line 117, in __enter__
[2023-09-20T04:42:00.006Z]     return next(self.gen)
[2023-09-20T04:42:00.006Z]   File "/usr/local/lib/python3.9/dist-packages/setuptools/command/test.py", line 168, in project_on_sys_path
[2023-09-20T04:42:00.006Z]     require('%s==%s' % (ei_cmd.egg_name, ei_cmd.egg_version))
[2023-09-20T04:42:00.006Z]   File "/usr/local/lib/python3.9/dist-packages/pkg_resources/__init__.py", line 899, in require
[2023-09-20T04:42:00.006Z]     needed = self.resolve(parse_requirements(requirements))
[2023-09-20T04:42:00.006Z]   File "/usr/local/lib/python3.9/dist-packages/pkg_resources/__init__.py", line 790, in resolve
[2023-09-20T04:42:00.006Z]     raise VersionConflict(dist, req).with_context(dependent_req)
[2023-09-20T04:42:00.006Z] pkg_resources.ContextualVersionConflict: (netaddr 0.9.0 (/var/sw-r2d2-bot/.local/lib/python3.9/site-packages), Requirement.parse('netaddr==0.8.0'), {'sonic-bgpcfgd'})
[2023-09-20T04:42:00.007Z] [  FAIL LOG END  ] [ target/python-wheels/bullseye/sonic_bgpcfgd-1.0-py3-none-any.whl ]
[2023-09-20T04:42:00.007Z] make: *** [slave.mk:881: target/python-wheels/bullseye/sonic_bgpcfgd-1.0-py3-none-any.whl] Error 1
[2023-09-20T04:42:00.007Z] make: *** Waiting for unfinished jobs....
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Specified the netaddr version to download
#### How to verify it
Build with changes
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

