### PR TITLE
enable parallel build for snmpd 5.9

### DIFF
--- a/src/snmpd/Makefile
+++ b/src/snmpd/Makefile
@@ -14,6 +14,8 @@ DERIVED_TARGETS = snmptrapd_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp-dev_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp-perl_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  tkmib_$(SNMPD_VERSION_FULL)_all.deb
+
+SNMPD_MAKE_JOBS_NUM = $(SONIC_CONFIG_MAKE_JOBS)
 else
 DERIVED_TARGETS = snmptrapd_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  snmp_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
@@ -25,6 +27,8 @@ DERIVED_TARGETS = snmptrapd_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp-dev_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp-perl_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  tkmib_$(SNMPD_VERSION_FULL)_all.deb
+
+SNMPD_MAKE_JOBS_NUM = 1
 endif
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
@@ -43,9 +47,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	stg import -s ../patch-$(SNMPD_VERSION)/series
 
 ifneq ($(CROSS_BUILD_ENVIRON), y)
-	dpkg-buildpackage -rfakeroot -b -d -us -uc -j1 --admindir $(SONIC_DPKG_ADMINDIR)
+	dpkg-buildpackage -rfakeroot -b -d -us -uc -j$(SNMPD_MAKE_JOBS_NUM) --admindir $(SONIC_DPKG_ADMINDIR)
 else
-	PYTHONPATH=/usr/lib/python2.7/plat-arm-linux-gnueabihf/ dpkg-buildpackage -rfakeroot -b -d -us -uc -a$(CONFIGURED_ARCH) -Pcross,nocheck -j1 --admindir $(SONIC_DPKG_ADMINDIR)
+	PYTHONPATH=/usr/lib/python2.7/plat-arm-linux-gnueabihf/ dpkg-buildpackage -rfakeroot -b -d -us -uc -a$(CONFIGURED_ARCH) -Pcross,nocheck -j$(SNMPD_MAKE_JOBS_NUM) --admindir $(SONIC_DPKG_ADMINDIR)
 endif
 	popd
 

--- a/src/snmpd/patch-5.9+dfsg/0009-Makefile.in-agent-Makefile.in-Fix-parallel-compilati.patch
+++ b/src/snmpd/patch-5.9+dfsg/0009-Makefile.in-agent-Makefile.in-Fix-parallel-compilati.patch
@@ -1,0 +1,40 @@
+From 855e1c28dad53d6263c6c0c302438d2dc3128cc5 Mon Sep 17 00:00:00 2001
+From: Bart Van Assche <bvanassche@acm.org>
+Date: Wed, 14 Apr 2021 09:35:24 -0700
+Subject: [PATCH] Makefile.in, agent/Makefile.in: Fix parallel compilation
+
+See also https://github.com/net-snmp/net-snmp/issues/283 .
+---
+ Makefile.in       | 2 +-
+ agent/Makefile.in | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index ed729604fc..3271823143 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -179,7 +179,7 @@ perlmodules: perlmakefiles subdirs
+ 
+ perlmakefiles: perl/Makefile net-snmp-config-x
+ 
+-perl/Makefile: perl/Makefile.PL
++perl/Makefile: perl/Makefile.PL subdirs
+ 	dir=`pwd` &&							\
+ 	cd perl &&							\
+ 	if false; then							\
+diff --git a/agent/Makefile.in b/agent/Makefile.in
+index b5d692d7fe..3dab06eabd 100644
+--- a/agent/Makefile.in
++++ b/agent/Makefile.in
+@@ -303,7 +303,7 @@ libnetsnmpagent.$(LIB_EXTENSION)$(LIB_VERSION):    ${LLIBAGENTOBJS} $(USELIBS)
+ 	$(LIB_LD_CMD) $(AGENTLIB) ${LLIBAGENTOBJS} $(USELIBS) ${LAGENTLIBS} @LD_NO_UNDEFINED@ $(LDFLAGS) $(PERLLDOPTS_FOR_LIBS) @AGENTLIBS@
+ 	$(RANLIB) $(AGENTLIB)
+ 
+-libnetsnmpmibs.$(LIB_EXTENSION)$(LIB_VERSION): ${LMIBOBJS} $(AGENTLIB) $(USELIBS)
++libnetsnmpmibs.$(LIB_EXTENSION)$(LIB_VERSION): ${LMIBOBJS} $(AGENTLIB) $(USELIBS) subdirs
+ 	$(LIB_LD_CMD) $(MIBLIB) ${LMIBOBJS} $(AGENTLIB) $(USELIBS) @LD_NO_UNDEFINED@ $(LDFLAGS) ${LMIBLIBS} $(PERLLDOPTS_FOR_LIBS) @AGENTLIBS@
+ 	$(RANLIB) $(MIBLIB)
+ 
+-- 
+2.34.1
+

--- a/src/snmpd/patch-5.9+dfsg/0010-Makefile.in-Make-sure-that-sedscript-is-built-before.patch
+++ b/src/snmpd/patch-5.9+dfsg/0010-Makefile.in-Make-sure-that-sedscript-is-built-before.patch
@@ -1,0 +1,41 @@
+From 9ea3d8b93c9bb7da7fea13ee6c92356a6b82a5fb Mon Sep 17 00:00:00 2001
+From: Bart Van Assche <bvanassche@acm.org>
+Date: Wed, 14 Apr 2021 20:03:15 -0700
+Subject: [PATCH] Makefile.in: Make sure that 'sedscript' is built before
+ subdirectories
+
+This is a follow-up for commit 855e1c28dad5 ("Makefile.in, agent/Makefile.in:
+Fix parallel compilation").
+---
+ Makefile.in    | 1 +
+ Makefile.rules | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index 3271823143..f1cbbf5ca3 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -6,6 +6,7 @@
+ VPATH		= @srcdir@
+ 
+ SUBDIRS		= snmplib @MAINSUBS@
++SUBDIRDEPS      = sedscript
+ FTSUBDIRS	= @FTMAINSUBS@ snmplib
+ TESTDIRS	= testing
+ 
+diff --git a/Makefile.rules b/Makefile.rules
+index 92082e5429..100e0011ee 100644
+--- a/Makefile.rules
++++ b/Makefile.rules
+@@ -70,7 +70,7 @@ cleanfeaturessubdirs:
+ 		> $(top_builddir)/include/net-snmp/feature-details.h
+ 	$(FEATURECHECK) --feature-global $(top_builddir)/include/net-snmp/feature-details.h $(mysubdir) $< $@ $(CC) -E $(CPPFLAGS) $(CFLAGS) -c
+ 
+-subdirs:
++subdirs: $(SUBDIRDEPS)
+ 	@if test "$(SUBDIRS)" != ""; then \
+ 		it="$(SUBDIRS)" ; \
+ 		for i in $$it ; do \
+-- 
+2.34.1
+

--- a/src/snmpd/patch-5.9+dfsg/0011-agent-Makefile.in-Build-the-MIB-module-code-once.patch
+++ b/src/snmpd/patch-5.9+dfsg/0011-agent-Makefile.in-Build-the-MIB-module-code-once.patch
@@ -1,0 +1,46 @@
+From 51128ad095074488992982fa23ae641f7c7be4ae Mon Sep 17 00:00:00 2001
+From: Bart Van Assche <bvanassche@acm.org>
+Date: Sun, 11 Jul 2021 14:40:56 -0700
+Subject: [PATCH] agent/Makefile.in: Build the MIB module code once
+
+Fixes: 91033077790c ("remake make's Makefile's to make better making")
+Signed-off-by: Srivalli231@github.com
+[bvanassche: added patch description]
+---
+ agent/Makefile.in | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/agent/Makefile.in b/agent/Makefile.in
+index 634e912b8c..047d880bf4 100644
+--- a/agent/Makefile.in
++++ b/agent/Makefile.in
+@@ -15,8 +15,8 @@ mysubdir=agent
+ #
+ # what to install
+ #
+-SUBDIRS=helpers mibgroup
+-FTSUBDIRS=mibgroup helpers
++SUBDIRS=helpers
++FTSUBDIRS=helpers
+ 
+ INSTALLSBINPROGS= @SNMPD@
+ INSTALLLIBS	= libnetsnmpagent.$(LIB_EXTENSION)$(LIB_VERSION)
+@@ -273,9 +273,12 @@ FTAGENTOBJS=snmpd.ft @other_ftagentobjs@
+ #
+ # Define OBJS and LOBJS for clean target (just this directory)
+ #
+-OBJS		= $(LIBAGENTOBJS)  $(AGENTOBJS)  mib_modules.o  auto_nlist.o
+-LOBJS		= $(LLIBAGENTOBJS) $(LAGENTOBJS) mib_modules.lo auto_nlist.lo
+-FTOBJS		= $(LLIBAGENTFTS) $(FTAGENTOBJS) mib_modules.ft auto_nlist.ft
++OBJS		= $(LIBAGENTOBJS)  $(MIBOBJS)   $(AGENTOBJS)   \
++		  mib_modules.o  auto_nlist.o
++LOBJS		= $(LLIBAGENTOBJS) $(LMIBOBJS)  $(LAGENTOBJS)  \
++		  mib_modules.lo auto_nlist.lo
++FTOBJS		= $(LLIBAGENTFTS)  $(FTMIBOBJS) $(FTAGENTOBJS) \
++		  mib_modules.ft auto_nlist.ft
+ 
+ FEATUREFILE     = $(top_builddir)/include/net-snmp/agent/features.h
+ 
+-- 
+2.34.1
+

--- a/src/snmpd/patch-5.9+dfsg/0012-agent-Makefile.in-Unbreak-the-enable-minimalist-buil.patch
+++ b/src/snmpd/patch-5.9+dfsg/0012-agent-Makefile.in-Unbreak-the-enable-minimalist-buil.patch
@@ -1,0 +1,30 @@
+From 51f315046a0bec13934930edde9c145b31bf7d53 Mon Sep 17 00:00:00 2001
+From: Bart Van Assche <bvanassche@acm.org>
+Date: Sun, 24 Jul 2022 16:45:05 -0700
+Subject: [PATCH] agent/Makefile.in: Unbreak the --enable-minimalist build
+
+Build the features rules in the mibgroup directory before building the
+features rules in the helpers directory.
+
+Fixes: 51128ad09507 ("agent/Makefile.in: Build the MIB module code once")
+Fixes: https://github.com/net-snmp/net-snmp/issues/438
+---
+ agent/Makefile.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/agent/Makefile.in b/agent/Makefile.in
+index 047d880bf4..44f8818d29 100644
+--- a/agent/Makefile.in
++++ b/agent/Makefile.in
+@@ -16,7 +16,7 @@ mysubdir=agent
+ # what to install
+ #
+ SUBDIRS=helpers
+-FTSUBDIRS=helpers
++FTSUBDIRS=mibgroup helpers
+ 
+ INSTALLSBINPROGS= @SNMPD@
+ INSTALLLIBS	= libnetsnmpagent.$(LIB_EXTENSION)$(LIB_VERSION)
+-- 
+2.34.1
+

--- a/src/snmpd/patch-5.9+dfsg/0013-enable-parallel-build-for-net-snmp.patch
+++ b/src/snmpd/patch-5.9+dfsg/0013-enable-parallel-build-for-net-snmp.patch
@@ -1,0 +1,18 @@
+diff --git a/debian/rules b/debian/rules
+index b23b335..d37413c 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -31,10 +31,6 @@ endif
+ %:
+ 	dh $@
+ 
+-# The net-snmp Makefiles cannot handle parallel builds
+-override_dh_auto_build:
+-	dh_auto_build --no-parallel
+-
+ override_dh_auto_configure:
+ 	dh_auto_configure -- --prefix=/usr --sysconfdir=/etc --mandir=/usr/share/man \
+ 	  --with-persistent-directory=/var/lib/snmp \
+-- 
+2.34.1
+

--- a/src/snmpd/patch-5.9+dfsg/series
+++ b/src/snmpd/patch-5.9+dfsg/series
@@ -3,4 +3,9 @@
 #0006-From-Jiri-Cervenka-snmpd-Fixed-agentx-crashing-and-or-freezing-on-timeout.patch
 #0007-Linux-VRF-5.7.3-Support.patch
 0008-Enable-macro-DEB_BUILD_ARCH_OS-in-order-to-build-ipv.patch
+0009-Makefile.in-agent-Makefile.in-Fix-parallel-compilati.patch
+0010-Makefile.in-Make-sure-that-sedscript-is-built-before.patch
+0011-agent-Makefile.in-Build-the-MIB-module-code-once.patch
+0012-agent-Makefile.in-Unbreak-the-enable-minimalist-buil.patch
+0013-enable-parallel-build-for-net-snmp.patch
 cross-compile-changes.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

parallel build is available for net-snmp since 2021 year:
https://github.com/net-snmp/net-snmp/issues/283
So we can also build net-snmp 5.9 in parallel to reduce build time.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Use patches for parallel build from net-snmp upstream and enable parallel build in debian/rules for version 5.9

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

