### PR TITLE
enable parallel build for isc-dhcp-relay

### DIFF
--- a/src/isc-dhcp/patch/0014-enable-parallel-build.patch
+++ b/src/isc-dhcp/patch/0014-enable-parallel-build.patch
@@ -1,0 +1,42 @@
+diff --git a/debian/rules b/debian/rules
+index 3c8318f..28f4657 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -37,6 +37,13 @@ export DO_LPF=1
+ CONFFLAGS+=--enable-use-sockets
+ endif
+ 
++ifeq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
++  PARALLEL :=
++else
++  PARALLEL := \
++       -j$(patsubst parallel=%,%,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
++endif
++
+ %:
+ 	dh $@ --parallel --with autoreconf
+ 
+@@ -46,17 +53,17 @@ override_dh_auto_build:
+ 	# ldap-enabled build
+ 	test -f Makefile && $(MAKE) distclean || true
+ 	./configure --with-ldap --with-ldapcrypto CFLAGS="$(CFLAGS) -DNSUPDATE" LIBS="-lirs-export $(LIBS)" $(CONFFLAGS)
+-	$(MAKE)
++	$(MAKE) $(PARALLEL)
+ 	mv server/dhcpd dhcpd
+ 	# ddns-disabled build
+ 	test -f Makefile && $(MAKE) distclean || true
+ 	./configure CFLAGS="$(CFLAGS)" $(CONFFLAGS)
+-	$(MAKE)
++	$(MAKE) $(PARALLEL)
+ 	mv client/dhclient dhclient
+ 	# ldap-disabled build
+ 	test -f Makefile && $(MAKE) distclean || true
+ 	./configure CFLAGS="$(CFLAGS) -DNSUPDATE" LIBS="-lirs-export $(LIBS)" $(CONFFLAGS)
+-	$(MAKE)
++	$(MAKE) $(PARALLEL)
+ 
+ override_dh_install:
+ 	# rename some upstream files
+-- 
+2.34.1
+

--- a/src/isc-dhcp/patch/series
+++ b/src/isc-dhcp/patch/series
@@ -12,3 +12,4 @@
 0011-dhcp-relay-Prevent-Buffer-Overrun.patch
 0012-add-option-si-to-support-using-src-intf-ip-in-relay.patch
 0013-Fix-dhcrelay-agent-option-buffer-pointer-logic.patch
+0014-enable-parallel-build.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To speed up build

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Fix debian/rules for isc-dhcp to run make in parallel

#### How to verify it

Before: 52s
After: 26s

md5sum of isc-dhcp-relay_4.4.1-2.3+deb11u2_amd64.deb is not changed.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

