### PR TITLE
[201911] add checking the connection between zebra and bgp

### DIFF
--- a/dockers/docker-fpm-frr/start.sh
+++ b/dockers/docker-fpm-frr/start.sh
@@ -82,6 +82,18 @@ fi
 # Start Quagga processes
 supervisorctl start zebra
 supervisorctl start staticd
+
+addr="127.0.0.1"
+port=2601
+start=$(date +%s.%N)
+timeout 5s bash -c -- "until </dev/tcp/${addr}/${port}; do sleep 0.1;done"
+if [ "$?" != "0" ]; then
+    logger -p error "Error: zebra is not ready to accept connections"
+else
+    timespan=$(awk "BEGIN {print $(date +%s.%N)-$start; exit}")
+    logger -p info "It took ${timespan} seconds to wait for zebra to be ready to accept connections"
+fi
+
 supervisorctl start bgpd
 
 if [ "$CONFIG_TYPE" == "unified" ]; then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Back port https://github.com/sonic-net/sonic-buildimage/pull/6478 and https://github.com/sonic-net/sonic-buildimage/pull/6519 to 201911 branch.

##### Work item tracking
- Microsoft ADO **(number only)**:
24978836

#### How I did it
Add checking the connection between zebra and bgp during bgpd start.

#### How to verify it
Modify start.h, add debug log and check the syslog

      _Sep 22 02:41:29.716356 str-a7060cx-acs-10 INFO bgp#root: ####: start zebra
      Sep 22 02:41:30.815341 str-a7060cx-acs-10 INFO bgp#root: ####: start check connection
      Sep 22 02:41:30.868784 str-a7060cx-acs-10 INFO bgp#root: ####: It took 0.029979 seconds to wait for zebra to be ready to accept connections
      Sep 22 02:41:30.873685 str-a7060cx-acs-10 INFO bgp#root: ####: start bgpd
      Sep 22 02:41:35.270569 str-a7060cx-acs-10 INFO bgp#root: ####: done_

      _Sep 22 03:28:02.423438 str-a7060cx-acs-10 INFO bgp#root: ####: start zebra
      Sep 22 03:28:03.731320 str-a7060cx-acs-10 INFO bgp#root: ####: start check connection
      Sep 22 03:28:33.749152 str-a7060cx-acs-10 INFO bgp#root: ####: Error: zebra is not ready to accept connections
      Sep 22 03:28:33.752490 str-a7060cx-acs-10 INFO bgp#root: ####: start bgpd
      Sep 22 03:28:34.259735 str-a7060cx-acs-10 INFO bgp#root: ####: start bgpd done
      Sep 22 03:28:34.755538 str-a7060cx-acs-10 INFO bgp#root: ####: start bgpcfgd
      Sep 22 03:28:35.800906 str-a7060cx-acs-10 INFO bgp#root: ####: done_

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

