### PR TITLE
[HLX] Add info syslog for cpu_wdt.service when trigger watchdog arm action

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/haliburton/script/cpu_wdt
+++ b/platform/broadcom/sonic-platform-modules-cel/haliburton/script/cpu_wdt
@@ -79,6 +79,7 @@ if [[ "${ACTION}" == "start" ]]; then
     log_info "Enable keep alive messaging every $KEEPALIVE seconds"
     while [[ ${CPUWDT_MAIN_TASK_RUNNING_FLAG} == "true" ]]; do
         watchdogutil arm -s "${TIMEOUT}" > /dev/null
+        log_info "Keep alive message sent [RC=$?]. Will sleep ${KEEPALIVE} seconds."
         sleep "${KEEPALIVE}"
     done
     log_info "Keep alive messaging has been disabled"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add info syslog for cpu_wdt.service when trigger watchdog arm action.

##### Work item tracking
- Microsoft ADO **(number only)**: 25267950

#### How I did it
Add info syslog for cpu_wdt.service when trigger watchdog arm action.

#### How to verify it
Verified on Celestica-E1031 device with SONiC.202012 image installed. Can find below logs from `/var/log/syslog`:

```
admin@e1031$ sudo grep -i cpu_wdt /var/log/syslog
Sep 25 03:47:32.952409 str-e1031-acs-3 INFO systemd[1]: cpu_wdt.service: Succeeded.
Sep 25 03:47:32.996541 str-e1031-acs-3 INFO cpu_wdt: Enable CPU WDT..
Sep 25 03:47:34.411250 str-e1031-acs-3 INFO cpu_wdt: CPU WDT has been enabled with 180 seconds timeout
Sep 25 03:47:34.417476 str-e1031-acs-3 INFO cpu_wdt: Enable keep alive messaging every 60 seconds
Sep 25 03:47:35.810653 str-e1031-acs-3 INFO cpu_wdt: Keep alive message sent [RC=0]. Will sleep 60 seconds.
Sep 25 03:48:37.645600 str-e1031-acs-3 INFO cpu_wdt: Keep alive message sent [RC=0]. Will sleep 60 seconds.
Sep 25 03:49:39.075609 str-e1031-acs-3 INFO cpu_wdt: Keep alive message sent [RC=0]. Will sleep 60 seconds.
Sep 25 03:50:40.488495 str-e1031-acs-3 INFO cpu_wdt: Keep alive message sent [RC=0]. Will sleep 60 seconds.
Sep 25 03:51:42.002038 str-e1031-acs-3 INFO cpu_wdt: Keep alive message sent [RC=0]. Will sleep 60 seconds.
```


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

