### PR TITLE
Add special rsyslog filter for MSN2700 platform

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -47,10 +47,10 @@ function updateSyslogConf()
     {%- if docker_container_name == "database" %}
     python -c "import jinja2, os; paths=['/usr/share/sonic/templates']; loader = jinja2.FileSystemLoader(paths); env = jinja2.Environment(loader=loader, trim_blocks=True); template_file='/usr/share/sonic/templates/rsyslog-container.conf.j2'; template = env.get_template(os.path.basename(template_file)); data=template.render({\"target_ip\":\"$TARGET_IP\",\"container_name\":\"$CONTAINER_NAME\"}); print(data)" > $TMP_FILE
     {%- else %}
-    sonic-cfggen -d -t /usr/share/sonic/templates/rsyslog-container.conf.j2 -a "{\"target_ip\": \"$TARGET_IP\", \"container_name\": \"$CONTAINER_NAME\" }"  > $TMP_FILE
+    sonic-cfggen -d -t /usr/share/sonic/templates/rsyslog-container.conf.j2 -a "{\"target_ip\": \"$TARGET_IP\", \"container_name\": \"$CONTAINER_NAME\", \"platform\": \"$PLATFORM\" }"  > $TMP_FILE
     if [ $? -ne 0 ]; then
       echo "Error: Execute sonic-cfggen -d failed. Execute without '-d'."
-      sonic-cfggen -t /usr/share/sonic/templates/rsyslog-container.conf.j2 -a "{\"target_ip\": \"$TARGET_IP\", \"container_name\": \"$CONTAINER_NAME\" }"  > $TMP_FILE
+      sonic-cfggen -t /usr/share/sonic/templates/rsyslog-container.conf.j2 -a "{\"target_ip\": \"$TARGET_IP\", \"container_name\": \"$CONTAINER_NAME\", \"platform\": \"$PLATFORM\" }"  > $TMP_FILE
     fi
     {%- endif %}
     docker cp $TMP_FILE ${DOCKERNAME}:/etc/rsyslog.conf

--- a/files/image_config/rsyslog/rsyslog-container.conf.j2
+++ b/files/image_config/rsyslog/rsyslog-container.conf.j2
@@ -52,7 +52,18 @@ $SystemLogRateLimitBurst 20000
 ###########################
 #### GLOBAL DIRECTIVES ####
 ###########################
+{% if container_name == 'pmon' %}
+{% if platform == 'x86_64-mlnx_msn2700-r0' or platform == 'x86_64-mlnx_msn2700a1-r0' %}
 
+# This rsyslog configuration is intended to resolve the following error message that only appears on the MSN2700 platform:
+# "ERR pmon#sensord: Error getting sensor data: dps460/#10: Can't read"
+# This error is because of firmware issue with some type of PSU, we are not able to upgrade the FW online.
+# Since there is no functional impact, this error log can be ignored safely.
+
+if $programname contains "sensord" and $msg contains "Error getting sensor data: dps460/#" then stop
+
+{% endif %}
+{% endif %}
 # Set remote syslog server
 template (name="ForwardFormatInContainer" type="string" string="<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% {{container_name}}#%syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
 *.* action(type="omfwd" target="{{target_ip}}" port="514" protocol="udp" Template="ForwardFormatInContainer")


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

Mellanox MSN2700 platforms have a non-functional error log:  "ERR pmon#sensord: Error getting sensor data: dps460/#10: Can't read".  This error is because of a firmware issue with some PSU, we are not able to upgrade the FW online. Since there is no functional impact, this error log can be ignored safely.

#### How I did it

Add a new rsyslog rule to the rsyslog-container.conf.j2, if the docker name is pmon and the platform name matches, the new rule will be inserted into the docker rsyslogd.conf

#### How to verify it

run regression on the MSN2700 platform to make the error log will not be printed to the syslog.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

