### PR TITLE
Updated total headroom pool size to accommodate 100G ports on T2 uplinks

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/buffers_defaults_t2.j2
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/buffers_defaults_t2.j2
@@ -22,7 +22,7 @@
             "size": "6441610000",
             "type": "both",
             "mode": "dynamic",
-            "xoff": "7785676"
+            "xoff": "396096307"
         }
     },
     "BUFFER_PROFILE": {

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/buffers_defaults_t2.j2
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/buffers_defaults_t2.j2
@@ -22,7 +22,7 @@
             "size": "6441610000",
             "type": "both",
             "mode": "dynamic",
-            "xoff": "7785676"
+            "xoff": "396096307"
         }
     },
     "BUFFER_PROFILE": {

--- a/src/sonic-config-engine/tests/sample_output/py2/buffer-nokia-ixr7250e-36x100g.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffer-nokia-ixr7250e-36x100g.json
@@ -27,7 +27,7 @@
             "size": "6441610000",
             "type": "both",
             "mode": "dynamic",
-            "xoff": "7785676"
+            "xoff": "396096307"
         }
     },
     "BUFFER_PROFILE": {

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-nokia-ixr7250e-36x100g.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-nokia-ixr7250e-36x100g.json
@@ -27,7 +27,7 @@
             "size": "6441610000",
             "type": "both",
             "mode": "dynamic",
-            "xoff": "7785676"
+            "xoff": "396096307"
         }
     },
     "BUFFER_PROFILE": {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
sonic-mgmt xoff test was failing for [100g,120km]. Needed to update total headroom pool size when 100G line card is used as T2 uplink.

##### Work item tracking
- Microsoft ADO **(25266920)**:

#### How I did it
Updated total headroom size in buffer config

#### How to verify it
Verified with sonic-mgmt xoff test passing for [100g,120km]

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

