### PR TITLE
[build] Fix frr dpkg cache calculation issue on symbolic link file.

### DIFF
--- a/rules/frr.dep
+++ b/rules/frr.dep
@@ -9,6 +9,8 @@ DEP_FILES   += $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files |grep -
 FRR_SPATH   := $(SPATH)/frr
 SMDEP_FILES := $(addprefix $(FRR_SPATH)/,$(shell cd $(FRR_SPATH) && git ls-files \
 			| grep -Ev -e 'debian/changelog$$$$' \
+			-e '^tests/topotests/grpc_basic/lib$$$$' \
+			-e '^tests/topotests/ospfapi/lib$$$$' \
 			-e '^tests/topotests/bgp_instance_del_test/ce[0-9]$$$$' \
 			-e '^tests/topotests/bgp_instance_del_test/r[0-9]$$$$' \
 			-e '^tests/topotests/bgp_instance_del_test/scripts$$$$' \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Now build will fail on:
```
fatal: Unable to hash src/sonic-frr/frr/tests/topotests/grpc_basic/lib
fatal: Unable to hash src/sonic-frr/frr/tests/topotests/ospfapi/lib
make: *** [Makefile.cache:528: target/debs/buster/frr_8.5.1-sonic-0_amd64.deb.smdep] Error 123
make: *** Waiting for unfinished jobs....
```
Root cause is that these files are symbol links.
git hash-object can't hash symbol links.
##### Work item tracking
- Microsoft ADO **(number only)**:  25271730

#### How I did it
These two files are symbol links.
When calculate sha value, skip these two files.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

