### PR TITLE
[Arista] Disable CPU C-States other than C1

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -615,6 +615,14 @@ write_platform_specific_cmdline() {
         aboot_machine=arista_7280cr3mk_32p4
         flash_size=7382
     fi
+
+    # disable cpu c-state other than C1
+    local cpuvendor="$(sed -nr 's/vendor_id[\t ]*: (.*)/\1/p' /proc/cpuinfo | head -n 1)"
+    cmdline_add processor.max_cstate=1
+    if [ "$cpuvendor" = "GenuineIntel" ]; then
+        cmdline_add intel_idle.max_cstate=0
+    fi
+
     if in_array "$platform" "rook" "magpie" "woodpecker" "sprucefish"; then
         cmdline_add tsc=reliable
         cmdline_add pcie_ports=native
@@ -625,7 +633,6 @@ write_platform_specific_cmdline() {
     if in_array "$platform" "rook" "sprucefish"; then
         cmdline_add iommu=on
         cmdline_add intel_iommu=on
-        cmdline_add intel_idle.max_cstate=0
         read_system_eeprom
     fi
     if in_array "$platform" "rook"; then
@@ -643,7 +650,6 @@ write_platform_specific_cmdline() {
         read_system_eeprom
     fi
     if in_array "$platform" "lorikeet" "hedgehog"; then
-        cmdline_add processor.max_cstate=1
         cmdline_add reassign_prefmem
         read_system_eeprom
     fi


### PR DESCRIPTION
#### Why I did it

Networking devices need to be responsive. Such responsiveness is harmed when the CPU change state.
There is a latency penalty when a CPU is idle (e.g C2) and need to exit this state to come back to C1 state.
To prevent this from happening the CPU should be forced to remain in C1 state.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Generalize the cstate forcing to C1 to all Arista products.
This is done by adding `processor.max_cstate=1` to the kernel cmdline for all CPUs.
Additionally Intel CPUs also need `intel_idle.max_cstate=0` to fallback to the `acpi_idle` driver.

#### How to verify it

Check that `processor.max_cstate=1` is present on the cmdline for AMD CPUs
Check that both `processor.max_cstate=1` and `intel_idle.max_cstate=0` are present on the cmdline for Intel CPUs

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211
- [x] 202305

#### Description for the changelog

Disable CPU C-States other than C1 for Arista products

