### PR TITLE
[201911][nvidia] Fix broken FW links 

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -527,7 +527,7 @@ sudo mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/cpld/
 for MLNX_CPLD_ARCHIVE in $MLNX_CPLD_ARCHIVES; do
     sudo cp $files_path/$MLNX_CPLD_ARCHIVE $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/cpld/
     # Link old BIOS location to not break existing automation/scripts
-    sudo ln -s /host/image-$SONIC_IMAGE_VERSION/$PLATFORM_DIR/fw/cpld/$MLNX_CPLD_ARCHIVE $FILESYSTEM_ROOT/etc/mlnx/cpld/$MLNX_BIOS_ARCHIVE
+    sudo ln -s /host/image-$(sonic_get_version)/$PLATFORM_DIR/fw/cpld/$MLNX_CPLD_ARCHIVE $FILESYSTEM_ROOT/etc/mlnx/cpld/$MLNX_BIOS_ARCHIVE
 done
 fi
 if [ -n "$MLNX_BIOS_ARCHIVES" ]; then
@@ -536,7 +536,7 @@ sudo mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/bios/
 for MLNX_BIOS_ARCHIVE in $MLNX_BIOS_ARCHIVES; do
     sudo cp $files_path/$MLNX_BIOS_ARCHIVE $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/bios/
     # Link old BIOS location to not break existing automation/scripts
-    sudo ln -s /host/image-$SONIC_IMAGE_VERSION/$PLATFORM_DIR/fw/bios/$MLNX_BIOS_ARCHIVE $FILESYSTEM_ROOT/etc/mlnx/bios/$MLNX_BIOS_ARCHIVE
+    sudo ln -s /host/image-$(sonic_get_version)/$PLATFORM_DIR/fw/bios/$MLNX_BIOS_ARCHIVE $FILESYSTEM_ROOT/etc/mlnx/bios/$MLNX_BIOS_ARCHIVE
 done
 fi
 declare -rA FW_FILE_MAP=( \
@@ -549,10 +549,10 @@ sudo mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/asic/
 for fw_file_name in ${!FW_FILE_MAP[@]}; do
     sudo cp $files_path/$fw_file_name $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/asic/${FW_FILE_MAP[$fw_file_name]}
     # Link old FW location to not break existing automation/scripts
-    sudo ln -s /host/image-$SONIC_IMAGE_VERSION/$PLATFORM_DIR/fw/asic/${FW_FILE_MAP[$fw_file_name]} $FILESYSTEM_ROOT/etc/mlnx/${FW_FILE_MAP[$fw_file_name]}
+    sudo ln -s /host/image-$(sonic_get_version)/$PLATFORM_DIR/fw/asic/${FW_FILE_MAP[$fw_file_name]} $FILESYSTEM_ROOT/etc/mlnx/${FW_FILE_MAP[$fw_file_name]}
 done
 sudo cp $files_path/$ISSU_VERSION_FILE $FILESYSTEM_ROOT/$PLATFORM_DIR/fw/asic/issu-version
-sudo ln -s /host/image-$SONIC_IMAGE_VERSION/$PLATFORM_DIR/fw/asic/issu-version $FILESYSTEM_ROOT/etc/mlnx/issu-version
+sudo ln -s /host/image-$(sonic_get_version)/$PLATFORM_DIR/fw/asic/issu-version $FILESYSTEM_ROOT/etc/mlnx/issu-version
 sudo cp $files_path/$MLNX_FFB_SCRIPT $FILESYSTEM_ROOT/usr/bin/mlnx-ffb.sh
 sudo cp $files_path/$MLNX_ONIE_FW_UPDATE $FILESYSTEM_ROOT/usr/bin/$MLNX_ONIE_FW_UPDATE
 sudo cp $files_path/$MLNX_SSD_FW_UPDATE $FILESYSTEM_ROOT/usr/bin/$MLNX_SSD_FW_UPDATE


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To fix broken FW link.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

```$SONIC_IMAGE_VERSION``` does not exist in 201911 build system. Use ```$(sonic_get_version)``` instead of ```$SONIC_IMAGE_VERSION```.

#### How to verify it

Boot the system and see the links are correct:
```
admin@arc-switch1025:~$ ls -al /etc/mlnx/
total 4
drwxr-xr-x 3 root root  103 Jul 17 11:22 .
drwxr-xr-x 1 root root 4096 Jul 17 11:56 ..
drwxr-xr-x 2 root root   42 Jul 17 11:22 cpld
lrwxrwxrwx 1 root root   73 Jul 17 11:22 fw-SPC2.mfa -> /host/image-1911-fix-broken-link.0-6aef24420/platform/fw/asic/fw-SPC2.mfa
lrwxrwxrwx 1 root root   73 Jul 17 11:22 fw-SPC3.mfa -> /host/image-1911-fix-broken-link.0-6aef24420/platform/fw/asic/fw-SPC3.mfa
lrwxrwxrwx 1 root root   72 Jul 17 11:22 fw-SPC.mfa -> /host/image-1911-fix-broken-link.0-6aef24420/platform/fw/asic/fw-SPC.mfa
lrwxrwxrwx 1 root root   74 Jul 17 11:22 issu-version -> /host/image-1911-fix-broken-link.0-6aef24420/platform/fw/asic/issu-version
admin@arc-switch1025:~$ ls -al /host/image-1911-fix-broken-link.0-6aef24420/platform/fw/asic/fw-SPC.mfa
-rw-r--r-- 1 root root 1868380 Jul 17 11:22 /host/image-1911-fix-broken-link.0-6aef24420/platform/fw/asic/fw-SPC.mfa
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

