### PR TITLE
[202012][Dell] S6100 - Add iTCO watchdog support

### DIFF
--- a/device/dell/x86_64-dell_s6100_c2538-r0/installer.conf
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/installer.conf
@@ -1,3 +1,3 @@
 CONSOLE_PORT=0x2f8
 CONSOLE_DEV=1
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich nos-config-part=/dev/sda12 logs_inram=on"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich,wdat_wdt acpi_no_watchdog=1 nos-config-part=/dev/sda12 logs_inram=on"

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/track_reboot_reason.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/track_reboot_reason.sh
@@ -15,6 +15,7 @@ MAILBOX_POWERON_REASON=/sys/devices/platform/SMF.512/hwmon/*/mb_poweron_reason
 NVRAM_DEVICE_FILE=/dev/nvram
 RESET_REASON_FILE=/host/reboot-cause/platform/reset_reason
 SMF_DIR=/sys/devices/platform/SMF.512/hwmon/
+TCO_RESET_NVRAM_OFFSET=0x59
 
 while [[ ! -d $SMF_DIR ]]
 do
@@ -27,6 +28,7 @@ do
 done
 
 SMF_RESET=$(cat $SMF_RESET_REASON)
+TCO_WD_RESET=0
 
 if [[ -d /host/reboot-cause/platform ]]; then
     reboot_dir_found=true
@@ -80,6 +82,18 @@ _get_smf_reset_register(){
             echo "Fourth reset - $fourth_reset" >> $RESET_REASON_FILE
         fi
         logger -p user.info -t DELL_S6100_REBOOT_CAUSE "RST value in NVRAM: $first_reset, $second_reset, $third_reset, $fourth_reset"
+
+        if [[ $BIOS_VERSION_MINOR -gt 8 ]]; then
+            # Retrieve TCO reset status
+            tco_nvram=$((16#$(nvram_rd_wr.py --get --offset $TCO_RESET_NVRAM_OFFSET | cut -d " " -f 2)))
+            TCO_WD_RESET=$(($tco_nvram & 1))
+            logger -p user.info -t DELL_S6100_REBOOT_CAUSE "TCO status value in NVRAM: $TCO_WD_RESET"
+
+            # Clear TCO reset status in NVRAM
+            tco_nvram=$(printf "%x" $(($tco_nvram & 0xfe)))
+            nvram_rd_wr.py --set --val $tco_nvram --offset $TCO_RESET_NVRAM_OFFSET
+        fi
+
         # Clearing NVRAM values to holding next reset values
         nvram_rd_wr.py --set --val 0xee --offset 0x58
         nvram_rd_wr.py --set --val 0xee --offset 0x5c
@@ -131,7 +145,6 @@ _is_unknown_reset(){
         mb_poweron_reason=$(cat $MAILBOX_POWERON_REASON)
         echo "Unknown POR: $curr_poweron_reason RST: $curr_reset_reason MBR: $mb_poweron_reason" > $REBOOT_CAUSE_FILE
     fi
-    
 }
 
 update_mailbox_register(){
@@ -161,7 +174,9 @@ update_mailbox_register(){
            && [[ $SMF_MSS_VERSION_MAJOR -ge 2 ]] && [[ $SMF_MSS_VERSION_MINOR -ge 7 ]] \
            && [[ $SMF_FPGA_VERSION_MAJOR -ge 1 ]] && [[ $SMF_FPGA_VERSION_MINOR -ge 4 ]]; then
 
-            if [[ $reason = "cc" ]]; then
+            if [[ $TCO_WD_RESET = 1 ]]; then
+                echo 0xdd > $MAILBOX_POWERON_REASON
+            elif [[ $reason = "cc" ]]; then
                 echo 0xaa > $MAILBOX_POWERON_REASON
             elif [[ $SMF_RESET = "11" ]]; then
                 echo 0xee > $MAILBOX_POWERON_REASON
@@ -183,6 +198,8 @@ update_mailbox_register(){
             elif [[ $is_thermal_reboot = 1 ]]; then
                 echo 0xee > $MAILBOX_POWERON_REASON
             elif [[ $is_wd_reboot = 1 ]] && [[ $reason != "cc" ]]; then
+                echo 0xdd > $MAILBOX_POWERON_REASON
+            elif [[ $TCO_WD_RESET = 1 ]]; then
                 echo 0xdd > $MAILBOX_POWERON_REASON
             elif [[ $reason = "cc" ]]; then
                 echo 0xaa > $MAILBOX_POWERON_REASON


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

- To support iTCO watchdog in Dell S6100.
[Backport PR #9149]

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Update installer.conf for initializing the required drivers.
- Update the reboot cause determination logic to check for iTCO watchdog reset if the BIOS version supports iTCO watchdog.

#### How to verify it
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Verified that the watchdog APIs' return values are as expected.
UT logs: [202012_UT_logs.txt](https://github.com/sonic-net/sonic-buildimage/files/12737416/202012_UT_logs.txt)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

[202012][Dell] S6100 - Add iTCO watchdog support

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

