### PR TITLE
Fix supervisor-proc-exit-listener false alert during warm reboot issue.

### DIFF
--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -78,15 +78,13 @@ def is_warm_reboot():
     Checks if a warm reboot is going on
     """
     try:
-        state_db_connector = swsscommon.DBConnector(swsscommon.STATE_DB, 0)
+        state_db_connector = swsscommon.DBConnector("STATE_DB", 0)
         tbl = swsscommon.Table(state_db_connector, 'WARM_RESTART_ENABLE_TABLE')
-
         (status, value) = tbl.hget('system', 'enable')
         if status and value == 'true':
             return True
     except RuntimeError as e:
         syslog.syslog(syslog.LOG_ERR, "Check warm reboot status failed: {}".format(e))
-
     return False
 
 

--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -101,16 +101,8 @@ def generate_alerting_message(process_name, status, dead_minutes):
     else:
         namespace = namespace_prefix + namespace_id
 
-    message = "Process '{}' is {} in namespace '{}' ({} minutes).".format(
-                                                                    process_name,
-                                                                    status,
-                                                                    namespace,
-                                                                    dead_minutes)
-    if is_warm_reboot():
-        syslog.syslog(syslog.LOG_INFO, "Warm rebooting, {}".format(message))
-        return
-
-    syslog.syslog(syslog.LOG_ERR, message)
+    syslog.syslog(syslog.LOG_ERR, "Process '{}' is {} in namespace '{}' ({} minutes)."
+                  .format(process_name, status, namespace, dead_minutes))
 
 
 def get_autorestart_state(container_name, use_unix_socket_path):
@@ -235,6 +227,10 @@ def main(argv):
             epoch_time = time.time()
             elapsed_secs = epoch_time - process_heart_beat_info[process]["last_heart_beat"]
             if elapsed_secs >= ALERTING_INTERVAL_SECS:
+                if is_warm_reboot() and process == "orchagent":
+                    # Orchagent will set to frozen during warm reboot.
+                    continue
+
                 elapsed_mins = elapsed_secs // 60
                 generate_alerting_message(process, "stuck", elapsed_mins)
 

--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -73,6 +73,23 @@ def get_group_and_process_list(process_file):
     return group_list, process_list
 
 
+def is_warm_reboot():
+    """
+    Checks if a warm reboot is going on
+    """
+    try:
+        state_db_connector = swsscommon.DBConnector(swsscommon.STATE_DB, 0)
+        tbl = swsscommon.Table(state_db_connector, 'WARM_RESTART_ENABLE_TABLE')
+
+        (status, value) = tbl.hget('system', 'enable')
+        if status and value == 'true':
+            return True
+    except RuntimeError as e:
+        syslog.syslog(syslog.LOG_ERR, "Check warm reboot status failed: {}".format(e))
+
+    return False
+
+
 def generate_alerting_message(process_name, status, dead_minutes):
     """
     @summary: If a critical process was not running, this function will determine it resides in host
@@ -86,8 +103,16 @@ def generate_alerting_message(process_name, status, dead_minutes):
     else:
         namespace = namespace_prefix + namespace_id
 
-    syslog.syslog(syslog.LOG_ERR, "Process '{}' is {} in namespace '{}' ({} minutes)."
-                  .format(process_name, status, namespace, dead_minutes))
+    message = "Process '{}' is {} in namespace '{}' ({} minutes).".format(
+                                                                    process_name,
+                                                                    status,
+                                                                    namespace,
+                                                                    dead_minutes)
+    if is_warm_reboot():
+        syslog.syslog(syslog.LOG_INFO, "Warm rebooting, {}".format(message))
+        return
+
+    syslog.syslog(syslog.LOG_ERR, message)
 
 
 def get_autorestart_state(container_name, use_unix_socket_path):


### PR DESCRIPTION
Fix supervisor-proc-exit-listener false alert during warm reboot issue: https://github.com/sonic-net/sonic-buildimage/issues/16686

#### Why I did it
supervisor-proc-exit-listener will generate false alert during warm reboot.

##### Work item tracking
- Microsoft ADO: 25295846

#### How I did it
Ignore alert message during warm reboot.

#### How to verify it
Pass all UT.
Manually verify issue fixed:

Sep 28 07:53:20.285652 vlab-01 ERR swss#supervisor-proc-exit-listener: message repeated 27 times: [ Process 'orchagent' is stuck in namespace 'host' (7.0 minutes).]
Sep 28 07:53:20.287377 vlab-01 INFO swss#supervisor-proc-exit-listener: Warm rebooting, Process 'orchagent' is stuck in namespace 'host' (7.0 minutes).


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [] 202205
- [] 202211
- [] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x]  master-16742.373711-493d8b7bf

#### Description for the changelog
Fix supervisor-proc-exit-listener false alert during warm reboot issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

