### PR TITLE
[sonic-yang-models] Add Path Tracing attributes to SONiC Port YANG model

### DIFF
--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-head.yang
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-head.yang
@@ -63,4 +63,14 @@ module test-head {
             enum priority_tagged;
         }
     }
+
+    typedef path_tracing_timestamp_template {
+        description "Path Tracing Timestamp Template ";
+        type enumeration {
+            enum template1;
+            enum template2;
+            enum template3;
+            enum template4;
+        }
+    }
 }

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-port.yang
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-port.yang
@@ -69,6 +69,16 @@ module test-port{
 					mandatory true;
 					type head:admin_status;
 				}
+
+				leaf pt_interface_id {
+					type uint16 {
+						range 1..4095;
+					}
+				}
+
+				leaf pt_timestamp_template {
+					type head:path_tracing_timestamp_template;
+				}
 			} /* end of list PORT_LIST */
 
 		} /* end of container PORT */

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -628,7 +628,8 @@
                 "speed": "11100",
                 "tpid": "0x8100",
                 "admin_status": "up",
-                "subport": "6"
+                "subport": "6",
+                "pt_interface_id": "128"
             },
             "Ethernet9": {
                 "alias": "Eth3/2",
@@ -637,7 +638,9 @@
                 "speed": "11100",
                 "tpid": "0x8100",
                 "admin_status": "up",
-                "subport": "7"
+                "subport": "7",
+                "pt_interface_id": "129",
+                "pt_timestamp_template": "template2"
             },
             "Ethernet10": {
                 "alias": "Eth3/3",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
@@ -131,5 +131,40 @@
      },
      "PORT_AUTO_FEC_TEST": {
          "desc": "PORT_AUTO_FEC_TEST validate auto mode in fec."
-     }
+     },
+    "PORT_VALID_PATH_TRACING_CONFIG_TEST_1": {
+        "desc": "Enable Path Tracing with valid Interface ID and default Timestamp Template.",
+        "eStrKey" : "Verify",
+        "verify": {
+            "xpath": "/sonic-port:sonic-port/PORT/PORT_LIST[name='Ethernet8']/pt_timestamp_template",
+            "key": "sonic-port:pt_timestamp_template",
+            "value": "template3"
+        }
+    },
+    "PORT_VALID_PATH_TRACING_CONFIG_TEST_2": {
+        "desc": "Enable Path Tracing with valid Interface ID and Timestamp Template.",
+        "eStrKey" : "Verify",
+        "verify": {
+            "xpath": "/sonic-port:sonic-port/PORT/PORT_LIST[name='Ethernet9']/pt_timestamp_template",
+            "key": "sonic-port:pt_timestamp_template",
+            "value": "template2"
+        }
+    },
+    "PORT_PATH_TRACING_NOT_ENABLED_BY_DEFAULT": {
+        "desc": "Do not configure Path Tracing. Verify that Path Tracing is disabled by default."
+    },
+    "PORT_INVALID_PATH_TRACING_INTERFACE_ID_TEST": {
+        "desc": "Configure Path Tracing with an Out of range Interface ID.",
+        "eStrKey": "Range",
+        "eStr": "1..4095"
+    },
+    "PORT_INVALID_PATH_TRACING_TIMESTAMP_TEMPLATE_TEST": {
+        "desc": "Configure Path Tracing with an invalid Timestamp Template.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["timestamp_template"]
+    },
+    "PORT_PATH_TRACING_TIMESTAMP_TEMPLATE_WHEN_NOT_ENABLED": {
+        "desc": "Configure Path Tracing Timestamp Template when Path Tracing is not enabled.",
+        "eStrKey": "When"
+    }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -657,5 +657,114 @@
                 ]
             }
         }
+    },
+
+    "PORT_VALID_PATH_TRACING_CONFIG_TEST_1": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet8",
+                        "name": "Ethernet8",
+                        "lanes": "65",
+                        "speed": 25000,
+                        "pt_interface_id": 128
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_VALID_PATH_TRACING_CONFIG_TEST_2": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth9",
+                        "description": "Ethernet9",
+                        "name": "Ethernet9",
+                        "lanes": "65",
+                        "speed": 25000,
+                        "pt_interface_id": 129,
+                        "pt_timestamp_template": "template2"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_PATH_TRACING_NOT_ENABLED_BY_DEFAULT": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth9",
+                        "description": "Ethernet9",
+                        "name": "Ethernet9",
+                        "lanes": "65",
+                        "speed": 25000
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_INVALID_PATH_TRACING_INTERFACE_ID_TEST": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet8",
+                        "name": "Ethernet8",
+                        "lanes": "65",
+                        "speed": 25000,
+                        "pt_interface_id": 4096
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_INVALID_PATH_TRACING_TIMESTAMP_TEMPLATE_TEST": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth9",
+                        "description": "Ethernet9",
+                        "name": "Ethernet9",
+                        "lanes": "65",
+                        "speed": 25000,
+                        "pt_interface_id": 129,
+                        "pt_timestamp_template": "template5"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_PATH_TRACING_TIMESTAMP_TEMPLATE_WHEN_NOT_ENABLED": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth9",
+                        "description": "Ethernet9",
+                        "name": "Ethernet9",
+                        "lanes": "65",
+                        "speed": 25000,
+                        "pt_timestamp_template": "template2"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -190,6 +190,20 @@ module sonic-port{
 						type int32;
 				}
 
+				leaf pt_interface_id {
+					description "Path Tracing Interface ID";
+					type uint16 {
+						range 1..4095;
+					}
+				}
+
+				leaf pt_timestamp_template {
+					when "current()/../pt_interface_id";
+					description "Path Tracing Timestamp Template";
+					type stypes:path_tracing_timestamp_template;
+					default template3;
+				}
+
 			} /* end of list PORT_LIST */
 
 		} /* end of container PORT */

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -367,4 +367,14 @@ module sonic-types {
     }
     {% else %}
     {% endif %}
+
+    typedef path_tracing_timestamp_template {
+        description "Path Tracing Timestamp Template ";
+        type enumeration {
+            enum template1;
+            enum template2;
+            enum template3;
+            enum template4;
+        }
+    }
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To support configuration of Path Tracing attributes via YANG.
Path Tracing HLD: https://github.com/cscarpitta/SONiC/blob/srv6_pt_midpoint_hld/doc/srv6/srv6_path_tracing_midpoint.md

<!--
##### Work item tracking
- Microsoft ADO **(number only)**:
-->

#### How I did it

Added Path Tracing Interface ID and Timestamp Template to the existing `sonic-port.yang`.

#### How to verify it

Added new test cases to verify the new attributes.
