### PR TITLE
Fix the dependency grpcio-tools version

### DIFF
--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -501,6 +501,11 @@ RUN patch -p1 -i /disable-non-manylinux.patch /usr/local/lib/python3.9/dist-pack
 # For building sonic-utilities
 RUN pip3 install fastentrypoints mock
 
+# For building sonic_ycabled
+# Note: upstream build breaks with old version of setuptools
+# ref: https://github.com/grpc/grpc/issues/34569
+RUN pip3 install grpcio==1.58.0 grpcio-tools==1.58.0
+
 # For running Python unit tests
 RUN pip3 install pytest-runner==5.2
 RUN pip3 install nose==1.3.7


### PR DESCRIPTION
#### Why I did it
Fix the build break of marvell-armhf/sonic-ycabled

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

