### PR TITLE
[Bookworm] Update openssh version

### DIFF
--- a/rules/openssh.mk
+++ b/rules/openssh.mk
@@ -1,6 +1,6 @@
 # openssh package
 
-OPENSSH_VERSION = 9.2p1-2
+OPENSSH_VERSION = 9.2p1-2+deb12u1
 
 export OPENSSH_VERSION
 


### PR DESCRIPTION
#### Why I did it
Failures are seen while building sonic-broadcom.bin image in bookworm branch.
**Logs:**

        sudo dpkg --root=./fsroot-broadcom -i target/debs/bookworm/openssh-server_9.2p1-2_amd64.deb
        dpkg: warning: downgrading openssh-server from 1:9.2p1-2+deb12u1 to 1:9.2p1-2
        (Reading database ... 51746 files and directories currently installed.)
        Preparing to unpack .../openssh-server_9.2p1-2_amd64.deb ...
        Unpacking openssh-server (1:9.2p1-2) over (1:9.2p1-2+deb12u1) ...
        dpkg: dependency problems prevent configuration of openssh-server:
        openssh-server depends on openssh-client (= 1:9.2p1-2); however:
        Version of openssh-client on system is 1:9.2p1-2+deb12u1.
        dpkg: error processing package openssh-server (--install):
        dependency problems - leaving unconfigured
        Errors were encountered while processing:
        openssh-server

#### How I did it
Updated openssh server version.

#### How to verify it
Verify whether the image builds after the fix.
