### PR TITLE
Update openssh to 1:8.4p1-5+deb11u2

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -359,7 +359,7 @@ sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/restart_service
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install smartmontools=7.2-1
 
 # Install custom-built openssh sshd
-sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/openssh-server_${OPENSSH_VERSION}_*.deb
+sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/openssh-server_${OPENSSH_VERSION}_*.deb $debs_path/openssh-client_${OPENSSH_VERSION}_*.deb $debs_path/openssh-sftp-server_${OPENSSH_VERSION}_*.deb
 
 {% if sonic_asic_platform == 'broadcom' %}
 # Install custom-built flashrom

--- a/rules/openssh.mk
+++ b/rules/openssh.mk
@@ -9,6 +9,12 @@ $(OPENSSH_SERVER)_SRC_PATH = $(SRC_PATH)/openssh
 $(OPENSSH_SERVER)_DEPENDS +=  $(LIBNL3_DEV) $(LIBNL_ROUTE3_DEV)
 SONIC_MAKE_DEBS += $(OPENSSH_SERVER)
 
+OPENSSH_CLIENT = openssh-client_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
+$(eval $(call add_derived_package,$(OPENSSH_SERVER),$(OPENSSH_CLIENT)))
+
+OPENSSH_SFTP_SERVER = openssh-sftp-server_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
+$(eval $(call add_derived_package,$(OPENSSH_SERVER),$(OPENSSH_SFTP_SERVER)))
+
 # The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
 # are archived into debug one image to facilitate debugging.
 #

--- a/rules/openssh.mk
+++ b/rules/openssh.mk
@@ -10,10 +10,10 @@ $(OPENSSH_SERVER)_DEPENDS +=  $(LIBNL3_DEV) $(LIBNL_ROUTE3_DEV)
 SONIC_MAKE_DEBS += $(OPENSSH_SERVER)
 
 OPENSSH_CLIENT = openssh-client_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
-$(eval $(call add_derived_package,$(OPENSSH_SERVER),$(OPENSSH_CLIENT)))
+#$(eval $(call add_derived_package,$(OPENSSH_SERVER),$(OPENSSH_CLIENT)))
 
 OPENSSH_SFTP_SERVER = openssh-sftp-server_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
-$(eval $(call add_derived_package,$(OPENSSH_SERVER),$(OPENSSH_SFTP_SERVER)))
+#$(eval $(call add_derived_package,$(OPENSSH_SERVER),$(OPENSSH_SFTP_SERVER)))
 
 # The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
 # are archived into debug one image to facilitate debugging.

--- a/rules/openssh.mk
+++ b/rules/openssh.mk
@@ -1,6 +1,6 @@
 # openssh package
 
-OPENSSH_VERSION = 8.4p1-5+deb11u1
+OPENSSH_VERSION = 8.4p1-5+deb11u2
 
 export OPENSSH_VERSION
 

--- a/slave.mk
+++ b/slave.mk
@@ -1234,6 +1234,8 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
                 $(LIBNSS_TACPLUS) \
                 $(MONIT) \
                 $(OPENSSH_SERVER) \
+                $(OPENSSH_CLIENT) \
+                $(OPENSSH_SFTP_SERVER) \
                 $(PYTHON_SWSSCOMMON) \
                 $(PYTHON3_SWSSCOMMON) \
                 $(SONIC_DB_CLI) \

--- a/slave.mk
+++ b/slave.mk
@@ -1234,8 +1234,6 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
                 $(LIBNSS_TACPLUS) \
                 $(MONIT) \
                 $(OPENSSH_SERVER) \
-                $(OPENSSH_CLIENT) \
-                $(OPENSSH_SFTP_SERVER) \
                 $(PYTHON_SWSSCOMMON) \
                 $(PYTHON3_SWSSCOMMON) \
                 $(SONIC_DB_CLI) \

--- a/src/openssh/Makefile
+++ b/src/openssh/Makefile
@@ -3,7 +3,11 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = openssh-server_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
-DERIVED_TARGETS = openssh-server-dbgsym_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
+DERIVED_TARGETS = openssh-server-dbgsym_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb \
+				  openssh-client_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb \
+				  openssh-client-dbgsym_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb \
+				  openssh-sftp-server_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb \
+				  openssh-sftp-server-dbgsym_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Obtain openssh: https://salsa.debian.org/ssh-team/openssh/-/tree/debian/1%258.4p1-5


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Openssh in Debian Bullseye has been updated to 1:8.4p1-5+deb11u2 to fix CVE-2023-38408. Since we're building openssh with some patches, we need to update our version as well.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

