### PR TITLE
Adding new secondary field to VLAN_INTERFACE table

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -680,6 +680,17 @@ def parse_dpg(dpg, hname):
             if vlanmac is not None and vlanmac.text is not None:
                 vlan_attributes['mac'] = vlanmac.text
 
+            vintf_node = vintf.find(str(QName(ns, "SecondarySubnets")))
+            if vintf_node is not None and vintf_node.text is not None:
+                subnets = vintf_node.text.split(';')
+                for subnet in subnets:
+                    if sys.version_info >= (3, 0):
+                        network_def = ipaddress.ip_network(subnet, strict=False)
+                    else:
+                        network_def = ipaddress.ip_network(unicode(subnet), strict=False)
+                    prefix = str(network_def[1]) + "/" + str(network_def.prefixlen)
+                    intfs[(vintfname, prefix)]["secondary"] = "true"
+
             sonic_vlan_name = "Vlan%s" % vlanid
             if sonic_vlan_name != vintfname:
                 vlan_attributes['alias'] = vintfname
@@ -1723,6 +1734,9 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         if intf[0][0:4] == 'Vlan':
             vlan_intfs[intf] = {}
 
+            if "secondary" in intfs[intf]:
+                vlan_intfs[intf]["secondary"] = "true"
+
             if bool(results['PEER_SWITCH']):
                 vlan_intfs[intf[0]] = {
                     'proxy_arp': 'enabled',
@@ -1732,6 +1746,9 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
                 vlan_intfs[intf[0]] = {}
         elif intf[0] in vlan_invert_mapping:
             vlan_intfs[(vlan_invert_mapping[intf[0]], intf[1])] = {}
+
+            if "secondary" in intfs[intf]:
+                vlan_intfs[(vlan_invert_mapping[intf[0]], intf[1])]["secondary"] = "true"
 
             if bool(results['PEER_SWITCH']):
                 vlan_intfs[vlan_invert_mapping[intf[0]]] = {

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -138,6 +138,7 @@
           <VlanID>1000</VlanID>
           <Tag>1000</Tag>
           <Subnets>192.168.0.0/27</Subnets>
+          <SecondarySubnets>192.168.1.0/27</SecondarySubnets>
           <MacAddress>00:aa:bb:cc:dd:ee</MacAddress>
         </VlanInterface>
         <VlanInterface>
@@ -175,6 +176,11 @@
           <Name i:nil="true"/>
           <AttachTo>ab1</AttachTo>
           <Prefix>192.168.0.1/27</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>ab1</AttachTo>
+          <Prefix>192.168.1.1/27</Prefix>
         </IPInterface>
       </IPInterfaces>
       <DataAcls/>

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -139,7 +139,7 @@ class TestCfgGenCaseInsensitive(TestCase):
     def test_minigraph_vlan_interfaces_keys(self):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "VLAN_INTERFACE.keys()|list"]
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "[('Vlan1000', '192.168.0.1/27'), 'Vlan1000', ('Vlan1000', '192.168.1.1/27')]")
+        self.assertEqual(output.strip(), "[('Vlan1000', '192.168.0.1/27'), ('Vlan1000', '192.168.1.1/27'), 'Vlan1000']")
 
     def test_minigraph_vlan_interfaces(self):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "VLAN_INTERFACE"]

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -139,7 +139,7 @@ class TestCfgGenCaseInsensitive(TestCase):
     def test_minigraph_vlan_interfaces_keys(self):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "VLAN_INTERFACE.keys()|list"]
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "[('Vlan1000', '192.168.0.1/27'), ('Vlan1000', '192.168.1.1/27'), 'Vlan1000']")
+        self.assertEqual(output.strip(), "[('Vlan1000', '192.168.1.1/27'), ('Vlan1000', '192.168.0.1/27'), 'Vlan1000']")
 
     def test_minigraph_vlan_interfaces(self):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "VLAN_INTERFACE"]

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -139,7 +139,7 @@ class TestCfgGenCaseInsensitive(TestCase):
     def test_minigraph_vlan_interfaces_keys(self):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "VLAN_INTERFACE.keys()|list"]
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "[('Vlan1000', '192.168.0.1/27'), 'Vlan1000']")
+        self.assertEqual(output.strip(), "[('Vlan1000', '192.168.0.1/27'), 'Vlan1000', ('Vlan1000', '192.168.1.1/27')]")
 
     def test_minigraph_vlan_interfaces(self):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "VLAN_INTERFACE"]
@@ -149,6 +149,9 @@ class TestCfgGenCaseInsensitive(TestCase):
             'Vlan1000': {
                 'proxy_arp': 'enabled',
                 'grat_arp': 'enabled'
+            },
+            'Vlan1000|192.168.1.1/27': {
+                'secondary': "true"
             }
         }
         self.assertEqual(utils.to_dict(output.strip()), expected_table)

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -139,7 +139,10 @@ class TestCfgGenCaseInsensitive(TestCase):
     def test_minigraph_vlan_interfaces_keys(self):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "VLAN_INTERFACE.keys()|list"]
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "[('Vlan1000', '192.168.1.1/27'), ('Vlan1000', '192.168.0.1/27'), 'Vlan1000']")
+        expected_list_dict = {
+            'list': ['Vlan1000', 'Vlan1000|192.168.0.1/27', 'Vlan1000|192.168.1.1/27']
+        }
+        self.assertEqual(utils.liststr_to_dict(output.strip()), expected_list_dict)
 
     def test_minigraph_vlan_interfaces(self):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "VLAN_INTERFACE"]

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -154,7 +154,7 @@ class TestCfgGenCaseInsensitive(TestCase):
                 'grat_arp': 'enabled'
             },
             'Vlan1000|192.168.1.1/27': {
-                'secondary': "true"
+                'secondary': 'true'
             }
         }
         self.assertEqual(utils.to_dict(output.strip()), expected_table)

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -160,7 +160,7 @@ module sonic-vlan {
 				}
 
 				leaf secondary	{
-					description "Optional field to specify if the prefix is secondary subnet"
+					description "Optional field to specify if the prefix is secondary subnet";
 					type boolean;
 				}
 			}

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -160,6 +160,7 @@ module sonic-vlan {
 				}
 
 				leaf secondary	{
+					description "Optional field to specify if the prefix is secondary subnet"
 					type boolean;
 				}
 			}

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -158,6 +158,10 @@ module sonic-vlan {
 						(contains(../ip-prefix, '.') and current()='IPv4')";
 					type stypes:ip-family;
 				}
+
+				leaf secondary	{
+					type boolean;
+				}
 			}
 			/* end of VLAN_INTERFACE_LIST */
 		}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This is change taken as part of the HLD: https://github.com/sonic-net/SONiC/pull/1470. 
In this PR we add the logic to parse the SecondarySubnets field in the minigraph and add a flag in "secondary" in the vlan_interface table of the config db.

##### Work item tracking
- Microsoft ADO **(number only)**: 16784946

#### How I did it

Made changes in the minigraph.py to parse the xml entry and add the parsed value to the config db 

#### How to verify it

Added python tests in the sonic-config-engine folder to test the config db entries.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Adding new secondary field to VLAN_INTERFACE table
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

