### PR TITLE
Independent Module - sonic-buildimage code to support port SI configuration per speed

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -227,3 +227,29 @@ class DeviceDataManager:
             # Currently, only fetching BIOS version is supported
             return ComponentCPLDSN2201.get_component_list()
         return ComponentCPLD.get_component_list()
+
+    @classmethod
+    @utils.read_only_cache()
+    def platform_supports_independent_mode(cls):
+        from sonic_py_common import device_info
+        (_, hwsku_dir) = device_info.get_paths_to_platform_and_hwsku_dirs()
+
+        INDEPENDENT_MODULE_SUPPORT_FIELD = 'SAI_INDEPENDENT_MODULE_MODE'
+        INDEPENDENT_MODULE_SUPPORT_DELIMITER = '='
+        INDEPNENT_MODULE_SUPPORT_TRUE_VALUE = '1'
+        SAI_PROFILE_FILE_NAME = 'sai.profile'
+        sai_profile_path = hwsku_dir + '/' + SAI_PROFILE_FILE_NAME
+
+        try:
+            with open(sai_profile_path, "r", encoding='utf-8') as fd:
+                for line in fd:
+                    if line.startswith(INDEPENDENT_MODULE_SUPPORT_FIELD):
+                        if INDEPENDENT_MODULE_SUPPORT_DELIMITER in line:
+                            split_line = line.split(INDEPENDENT_MODULE_SUPPORT_DELIMITER)
+                            if (len(split_line) > 1):
+                                independent_mode_value = split_line[1].strip()
+                                return True if independent_mode_value == INDEPNENT_MODULE_SUPPORT_TRUE_VALUE else False
+                return False
+
+        except FileNotFoundError:
+            return False


### PR DESCRIPTION
… CMIS modules on a platform that support Independent Mode

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In order to enable module configuration by SONiC, it's necessary to ignore the platform code that prevents writing to the EEPROM if the platform supports this functionality and the module needs to be configured by the NOS.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
I used the 'TRANSCEIVER_MODULES_MGMT' table in STATE_DB to determine whether the module needs to be configured by the NOS. Additionally, I checked the 'sai.profile' file to verify if the platform supports the required functionality.

#### How to verify it
You can verify this by ensuring that when SONiC attempts to configure an active CMIS module, you do not encounter a 'write limited bytes' exception.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

