### PR TITLE
build: Adding Cgroups unified mode and hybrid mode support

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -64,6 +64,12 @@ clean_sys() {
 trap_push clean_sys
 sudo LANG=C chroot $FILESYSTEM_ROOT mount sysfs /sys -t sysfs
 
+# cgroup2 unified mode
+# https://github.com/systemd/systemd/blob/main/docs/CGROUP_DELEGATION.md#three-different-tree-setups-
+if [ "$(stat -fc '%T' /sys/fs/cgroup)" = "cgroup2fs" ]; then
+    sudo LANG=C chroot $FILESYSTEM_ROOT mount sysfs /sys/fs/cgroup -t cgroup2
+fi
+
 sudo bash -c "echo \"DOCKER_OPTS=\"--storage-driver=overlay2\"\" >> $FILESYSTEM_ROOT/etc/default/docker"
 # Copy docker start script to be able to start docker in chroot
 sudo mkdir -p "$FILESYSTEM_ROOT/$DOCKER_CTL_DIR"

--- a/files/docker/docker
+++ b/files/docker/docker
@@ -68,13 +68,13 @@ cgroupfs_mount() {
 		return
 	fi
 	if ! mountpoint -q /sys/fs/cgroup; then
-		# cgroup2
-		# https://github.com/systemd/systemd/blob/5c6c587ce24096d36826418b5390599d1e5ad55c/src/shared/cgroup-setup.c#L35-L74
-		if awk '!/^#/ && $4 == 1 && $2 != 0 { count++ } END { exit count != 0 }' /proc/cgroups; then
-			mount -t cgroup2 cgroup2 /sys/fs/cgroup
-			return
+		# cgroup hybrid mode
+		# https://github.com/systemd/systemd/blob/main/docs/CGROUP_DELEGATION.md#three-different-tree-setups-
+		if [ "$(stat -fc '%T' /sys/fs/cgroup/unified)" = "cgroup2fs" ]; then
+		    mount -t cgroup2 cgroup2 /sys/fs/cgroup
+		    return
 		fi
-		# cgroup1
+		# cgroup legacy mode
 		mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
 	fi
 	(


### PR DESCRIPTION
* This change adds appropriate cgroup mounting for the new v2 mode and also the hybrid mode (legacy+v2 both). more info on these 3 cgroup modes is here - https://github.com/systemd/systemd/blob/main/docs/CGROUP_DELEGATION.md#three-different-tree-setups-
* For cgroup v2, building in debian env requires mounting /sys/fs/cgroup as cgroup2 type fs
* Hybrid mode is determined by the type of unified mount fs (as described in the systemd doc linked)
* For  hybrid mode, both old fs and new one needs to be mounted

Signed-off-by: ishahx@google.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

