### PR TITLE
[tph]: Detect LAG flaps from APPL_DB

### DIFF
--- a/dockers/docker-orchagent/tunnel_packet_handler.py
+++ b/dockers/docker-orchagent/tunnel_packet_handler.py
@@ -263,7 +263,6 @@ class TunnelPacketHandler(object):
         """
         oper_status = dict(fvs).get(OPER_STATUS_KEY)
         if lag not in self.sniff_intfs and oper_status == 'up':
-            import pdb; pdb.set_trace()
             logger.log_info('{} came back up, sniffer restart required'
                             .format(lag))
             # Don't need to modify self.sniff_intfs here since it is repopulated


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- A race condition exists while the TPH is processing a netlink message - if a second netlink message arrives during processing it will be missed since TPH is not listening for other messages.
- Another bug was found where TPH was unnecessarily restarting since it was checking admin status instead of operational status of portchannels.

##### Work item tracking
- Microsoft ADO **(number only)**: 23622217

#### How I did it
- Subscribe to APPL_DB for updates on LAG operational state
- Track currently sniffed interfaces

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

- Send tunnel packets with destination IP of an unresolved neighbor, verify that `ping` commands are run
- Shut down a portchannel interface, verify that sniffer does not restart
- Send tunnel packets, verify `ping` commands are still run
- Bring up portchannel interface, verify that sniffer restarts

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)


