### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202205.2.2.13
+ref=202205.2.3.1


### PR DESCRIPTION
Why I did it

Release Notes for Cisco 8102-32FH-O:

    Fixed platform_test failures in test_component.py
    IOFPGA_SJTAG label under ‘fwutil show status’ changed to IOFPGA’
    Validated auto FPD upgrade


How I did it

Update to 202205.2.3.1 release

