### PR TITLE
[docker-macsec] fix privileged and volumes settings

### DIFF
--- a/rules/docker-macsec.mk
+++ b/rules/docker-macsec.mk
@@ -38,10 +38,10 @@ endif
 $(DOCKER_MACSEC)_CONTAINER_NAME = macsec
 $(DOCKER_MACSEC)_VERSION = 1.0.0
 $(DOCKER_MACSEC)_PACKAGE_NAME = macsec
-$(DOCKER_MACSEC)_RUN_OPT += --privileged -t
-$(DOCKER_MACSEC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
-$(DOCKER_MACSEC)_RUN_OPT += -v /etc/timezone:/etc/timezone:ro 
-$(DOCKER_MACSEC)_RUN_OPT += -v /host/warmboot:/var/warmboot
+$(DOCKER_MACSEC)_CONTAINER_PRIVILEGED = false
+$(DOCKER_MACSEC)_CONTAINER_VOLUMES += /etc/sonic:/etc/sonic:ro
+$(DOCKER_MACSEC)_CONTAINER_VOLUMES += /etc/timezone:/etc/timezone:ro
+$(DOCKER_MACSEC)_CONTAINER_VOLUMES += /host/warmboot:/var/warmboot
 
 $(DOCKER_MACSEC)_SERVICE_REQUIRES = updategraph
 $(DOCKER_MACSEC)_SERVICE_AFTER = swss syncd


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Privileges and volumes were incorrectly set in macsec container. Privileged flag is set to false and volumes are not mounted properly.
 ```
admin@vlab-01:~$ docker inspect macsec0 | grep Privi
            "Privileged": false,
admin@vlab-01:~$ docker inspect macsec0 | grep -A 10 Binds
            "Binds": [
                "/var/run/redis0:/var/run/redis:rw",
                "/var/run/redis-chassis:/var/run/redis-chassis:ro",
                "/usr/share/sonic/device/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0:/usr/share/sonic/hwsku:ro",
                "/var/run/redis0/:/var/run/redis0/:rw",
                "/usr/share/sonic/device/x86_64-nokia_ixr7250e_36x400g-r0:/usr/share/sonic/platform:ro"
            ],
```
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
Make sure privileged settings remain unchanged and make sure volumes are properly mounted
```
admin@vlab-01:~$ docker inspect macsec | grep Privi
            "Privileged": false,
admin@vlab-01:~$ docker inspect macsec | grep -A 10 Binds
            "Binds": [
                "/etc/timezone:/etc/timezone:ro",
                "/var/run/redis:/var/run/redis:rw",
                "/var/run/redis-chassis:/var/run/redis-chassis:ro",
                "/etc/fips/fips_enable:/etc/fips/fips_enable:ro",
                "/usr/share/sonic/templates/rsyslog-container.conf.j2:/usr/share/sonic/templates/rsyslog-container.conf.j2:ro",
                "/etc/sonic:/etc/sonic:ro",
                "/host/warmboot:/var/warmboot",
                "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/Force10-S6000/:/usr/share/sonic/hwsku:ro",
                "/usr/share/sonic/device/x86_64-kvm_x86_64-r0:/usr/share/sonic/platform:ro"
            ],
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] <!-- image version 1 --> master.0-7d8bababa
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

