### PR TITLE
[build] Add DOCKER_USER_ENV option

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -348,6 +348,11 @@ ifneq ($(SIGNING_CERT),)
 endif
 endif
 
+# Allow user-defined environmental variables to be imported into the build containers
+ifneq ($(DOCKER_USER_ENV),)
+	DOCKER_RUN += $(foreach var,$(subst $(comma), ,$(DOCKER_USER_ENV)), $(addprefix -e , $(var)))
+endif
+
 # User name and tag for "docker-*" images created by native dockerd mode.
 ifeq ($(strip $(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD)),y)
 DOCKER_USERNAME = $(USER_LC)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To enable users to pass environmental variables into the SONiC build containers, especially values that cannot be safely written to disk, like authentication tokens.

The `DOCKER_USER_ENV` parameter supports any format allowed by Docker's `-e` flag. Values can be set explicitly or inherited from the host environment. For example, both of these are valid:

```
$ make DOCKER_USER_ENV="A=foo,B=bar" sonic-slave-bash

$ export A=foo
$ export B=bar
$ make DOCKER_USER_ENV="A,B" sonic-slave-bash
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

The optional Makefile parameter, `DOCKER_USER_ENV`, accepts comma-separated values to be passed as `-e` arguments to the `$(DOCKER_RUN)` call. This is the environmental variable equivalent of the `DOCKER_BUILDER_USER_MOUNT` parameter.

#### How to verify it

Build the `sonic-slave-bash` pseudotarget and check the environmental variables set inside of the build container(s):

1. Passing values explicitly:
```
$ make DOCKER_USER_ENV="A=foo,B=bar" sonic-slave-bash

BLDENV=buster make -f Makefile.work sonic-slave-bash
jusherma@630c70f71b19:/sonic$ echo ${A} ${B}
foo bar

BLDENV=bullseye make -f Makefile.work sonic-slave-bash
jusherma@02e2af7ed76c:/sonic$ echo ${A} ${B}
foo bar
```

2. Inheriting values from the host environment:
```
$ export A=foo
$ export B=bar
$ make DOCKER_USER_ENV="A,B" sonic-slave-bash

BLDENV=buster make -f Makefile.work sonic-slave-bash
jusherma@6a7ffcba48c5:/sonic$ echo ${A} ${B}
foo bar

BLDENV=bullseye make -f Makefile.work sonic-slave-bash
jusherma@e6a22c6175d4:/sonic$ echo ${A} ${B}
foo bar
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master 5ce2a71d <!-- image version 1 -->
- [x] 202205 8e945fb2<!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Enable users to pass environmental variables into the SONiC build containers

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
n/A

#### A picture of a cute animal (not mandatory but encouraged)