### PR TITLE
Media_settings.json Validator Update

### DIFF
--- a/src/sonic-device-data/tests/media_checker
+++ b/src/sonic-device-data/tests/media_checker
@@ -49,20 +49,20 @@ def check_media_dict(vendor_dict):
             print("Expecting settings for vendor type " + vendor_key)
             return False
 
-        lane_speed_heirarchy_exists = None
+        lane_speed_hierarchy_exists = None
 
         for value_key in value_dict:
             if value_key.startswith(lane_speed_key_prefix):
-                if lane_speed_heirarchy_exists == False:
-                    print("Inconsistent lane speed heirarchy levels for the same entry")
+                if lane_speed_hierarchy_exists == False:
+                    print("Inconsistent lane speed hierarchy levels for the same entry")
                     return False
-                lane_speed_heirarchy_exists = True
+                lane_speed_hierarchy_exists = True
                 settings_dict = value_dict[value_key]
             else:
-                if lane_speed_heirarchy_exists == True:
-                    print("Inconsistent lane speed heirarchy levels for the same entry")
+                if lane_speed_hierarchy_exists == True:
+                    print("Inconsistent lane speed hierarchy levels for the same entry")
                     return False
-                lane_speed_heirarchy_exists = False
+                lane_speed_hierarchy_exists = False
                 settings_dict = value_dict
 
             for settings_key in settings_dict:

--- a/src/sonic-device-data/tests/media_checker
+++ b/src/sonic-device-data/tests/media_checker
@@ -7,11 +7,11 @@ import sys
 
 level1_keys = ["GLOBAL_MEDIA_SETTINGS","PORT_MEDIA_SETTINGS"]
 
-setting_keys = ["preemphasis", "idriver", "ipredriver", \
-                "main", "pre1", "pre2", "pre3", \
-                "post1", "post2", "post3", "attn", \
-                "ob_m2lp", "ob_alev_out", "obplev", "obnlev", \
-                "regn_bfm1p", "regn_bfm1n"]
+si_param_list = ["preemphasis", "idriver", "ipredriver", \
+                 "main", "pre1", "pre2", "pre3", \
+                 "post1", "post2", "post3", "attn", \
+                 "ob_m2lp", "ob_alev_out", "obplev", "obnlev", \
+                 "regn_bfm1p", "regn_bfm1n"]
 lane_speed_key_prefix = 'speed:'
 lane_prefix = "lane"
 comma_separator = ","
@@ -53,24 +53,24 @@ def check_media_dict(vendor_dict):
 
         for value_key in value_dict:
             if value_key.startswith(lane_speed_key_prefix):
-                if lane_speed_hierarchy_exists == False:
+                if lane_speed_hierarchy_exists is False:
                     print("Inconsistent lane speed hierarchy levels for the same entry")
                     return False
                 lane_speed_hierarchy_exists = True
                 settings_dict = value_dict[value_key]
             else:
-                if lane_speed_hierarchy_exists == True:
+                if lane_speed_hierarchy_exists is True:
                     print("Inconsistent lane speed hierarchy levels for the same entry")
                     return False
                 lane_speed_hierarchy_exists = False
                 settings_dict = value_dict
 
-            for settings_key in settings_dict:
-                if settings_key not in setting_keys:
-                    print("Unknown media setting " + settings_key)
+            for si_param in settings_dict:
+                if si_param not in si_param_list:
+                    print("Unknown media setting " + si_param)
                     return False
 
-                lane_dict = settings_dict[settings_key]
+                lane_dict = settings_dict[si_param]
                 for lanes in lane_dict:
                     if not check_lane_and_value(lanes, lane_dict[lanes]):
                         return False

--- a/src/sonic-device-data/tests/media_checker
+++ b/src/sonic-device-data/tests/media_checker
@@ -7,9 +7,12 @@ import sys
 
 level1_keys = ["GLOBAL_MEDIA_SETTINGS","PORT_MEDIA_SETTINGS"]
 
-setting_keys = ["preemphasis","idriver","ipredriver",\
-                "main","pre1","pre2","pre3",\
-                "post1","post2","post3","attn"]
+setting_keys = ["preemphasis", "idriver", "ipredriver", \
+                "main", "pre1", "pre2", "pre3", \
+                "post1", "post2", "post3", "attn", \
+                "ob_m2lp", "ob_alev_out", "obplev", "obnlev", \
+                "regn_bfm1p", "regn_bfm1n"]
+lane_speed_key_prefix = 'speed:'
 lane_prefix = "lane"
 comma_separator = ","
 range_separator = "-"
@@ -46,17 +49,32 @@ def check_media_dict(vendor_dict):
             print("Expecting settings for vendor type " + vendor_key)
             return False
 
+        lane_speed_heirarchy_exists = None
+
         for value_key in value_dict:
-            if value_key not in setting_keys:
-                print("Unknown media setting " + value_key)
-                return False
-
-            lane_dict = value_dict[value_key]
-            for lanes in lane_dict:
-                if not check_lane_and_value(lanes, lane_dict[lanes]):
+            if value_key.startswith(lane_speed_key_prefix):
+                if lane_speed_heirarchy_exists == False:
+                    print("Inconsistent lane speed heirarchy levels for the same entry")
                     return False
-    return True
+                lane_speed_heirarchy_exists = True
+                settings_dict = value_dict[value_key]
+            else:
+                if lane_speed_heirarchy_exists == True:
+                    print("Inconsistent lane speed heirarchy levels for the same entry")
+                    return False
+                lane_speed_heirarchy_exists = False
+                settings_dict = value_dict
 
+            for settings_key in settings_dict:
+                if settings_key not in setting_keys:
+                    print("Unknown media setting " + settings_key)
+                    return False
+
+                lane_dict = settings_dict[settings_key]
+                for lanes in lane_dict:
+                    if not check_lane_and_value(lanes, lane_dict[lanes]):
+                        return False
+    return True
 
 def check_valid_port(port_name):
     try:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The format of the media_settings.json file was updated to support the Port SI Per Speed Enhancements. Since media_checker is the validator for the media_settings.json file, it needs to be updated to align with the new format.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
I added six new SI parameter names introduced as part of the Port SI Per Speed Enhancements. Additionally, I implemented handling for the new hierarchy level (lane_speed_key) in the updated media_settings.json format while maintaining backward compatibility with vendors whose JSON does not support port SI per speed.

#### How to verify it
I locally built the Debian package using 'make target/debs/bullseye/sonic-device-data_1.0-1_all.deb,' and it completed successfully. Jenkins also built the entire image, which includes the media_checker as part of its process.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

