### PR TITLE
[minigraph-parser] Disable unsupported counters on management devices

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -41,6 +41,11 @@ chassis_backend_role = 'ChassisBackendRouter'
 backend_device_types = ['BackEndToRRouter', 'BackEndLeafRouter']
 console_device_types = ['MgmtTsToR']
 dhcp_server_enabled_device_types = ['BmcMgmtToRRouter']
+mgmt_device_types = ['BmcMgmtToRRouter', 'MgmtToRRouter', 'MgmtTsToR']
+
+# Counters disabled on management devices
+mgmt_disabled_counters = ["BUFFER_POOL_WATERMARK", "PFCWD", "PG_DROP", "PG_WATERMARK", "PORT_BUFFER_DROP", "QUEUE", "QUEUE_WATERMARK"]
+
 VLAN_SUB_INTERFACE_SEPARATOR = '.'
 VLAN_SUB_INTERFACE_VLAN_ID = '10'
 
@@ -2103,6 +2108,10 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     # Enable DHCP Server feature for specific device type
     if current_device and current_device['type'] in dhcp_server_enabled_device_types:
         results['DEVICE_METADATA']['localhost']['dhcp_server'] = 'enabled'
+
+    # Disable unused counters on management devices
+    if current_device and current_device['type'] in mgmt_device_types:
+        results["FLEX_COUNTER_TABLE"] = {counter: {"FLEX_COUNTER_STATUS": "disable"} for counter in mgmt_disabled_counters}
 
     return results
 

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2109,7 +2109,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     if current_device and current_device['type'] in dhcp_server_enabled_device_types:
         results['DEVICE_METADATA']['localhost']['dhcp_server'] = 'enabled'
 
-    # Disable unused counters on management devices
+    # Disable unsupported counters on management devices
     if current_device and current_device['type'] in mgmt_device_types:
         results["FLEX_COUNTER_TABLE"] = {counter: {"FLEX_COUNTER_STATUS": "disable"} for counter in mgmt_disabled_counters}
 

--- a/src/sonic-config-engine/tests/simple-sample-graph-m0.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-m0.xml
@@ -318,28 +318,28 @@
         <ClusterName>AAA00PrdStr00</ClusterName>
       </Device>
       <Device i:type="MgmtLeafRouter">
-         <Hostname>ARISTA04M1</Hostname>
-         <HwSku>Arista</HwSku>
+        <Hostname>ARISTA04M1</Hostname>
+        <HwSku>Arista</HwSku>
       </Device>
       <Device i:type="MgmtLeafRouter">
-         <Hostname>ARISTA02M1</Hostname>
-         <HwSku>Arista</HwSku>
+        <Hostname>ARISTA02M1</Hostname>
+        <HwSku>Arista</HwSku>
       </Device>
       <Device i:type="BmcMgmtToRRouter">
-         <Hostname>ARISTA02MX</Hostname>
-         <HwSku>Arista</HwSku>
+        <Hostname>ARISTA02MX</Hostname>
+        <HwSku>Arista</HwSku>
       </Device>
       <Device i:type="BmcMgmtToRRouter">
-         <Hostname>ARISTA01MX</Hostname>
-         <HwSku>Arista</HwSku>
+        <Hostname>ARISTA01MX</Hostname>
+        <HwSku>Arista</HwSku>
       </Device>
       <Device i:type="MgmtLeafRouter">
-         <Hostname>ARISTA01M1</Hostname>
-         <HwSku>Arista</HwSku>
+        <Hostname>ARISTA01M1</Hostname>
+        <HwSku>Arista</HwSku>
       </Device>
       <Device i:type="MgmtLeafRouter">
-         <Hostname>ARISTA03M1</Hostname>
-         <HwSku>Arista</HwSku>
+        <Hostname>ARISTA03M1</Hostname>
+        <HwSku>Arista</HwSku>
       </Device>
     </Devices>
   </PngDec>

--- a/src/sonic-config-engine/tests/simple-sample-graph-m0.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-m0.xml
@@ -373,7 +373,7 @@
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA01M1</EndDevice>
         <EndPort>Ethernet1</EndPort>
-        <StartDevice>bjw-can-7215-1</StartDevice>
+        <StartDevice>switch-m0</StartDevice>
         <StartPort>etp49</StartPort>
         <Bandwidth>10000</Bandwidth>
       </DeviceLinkBase>
@@ -381,7 +381,7 @@
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA01MX</EndDevice>
         <EndPort>Ethernet1</EndPort>
-        <StartDevice>bjw-can-7215-1</StartDevice>
+        <StartDevice>switch-m0</StartDevice>
         <StartPort>etp47</StartPort>
         <Bandwidth>1000</Bandwidth>
       </DeviceLinkBase>
@@ -389,7 +389,7 @@
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA02M1</EndDevice>
         <EndPort>Ethernet1</EndPort>
-        <StartDevice>bjw-can-7215-1</StartDevice>
+        <StartDevice>switch-m0</StartDevice>
         <StartPort>etp50</StartPort>
         <Bandwidth>10000</Bandwidth>
       </DeviceLinkBase>
@@ -397,7 +397,7 @@
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA02MX</EndDevice>
         <EndPort>Ethernet1</EndPort>
-        <StartDevice>bjw-can-7215-1</StartDevice>
+        <StartDevice>switch-m0</StartDevice>
         <StartPort>etp48</StartPort>
         <Bandwidth>1000</Bandwidth>
       </DeviceLinkBase>
@@ -405,7 +405,7 @@
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA03M1</EndDevice>
         <EndPort>Ethernet1</EndPort>
-        <StartDevice>bjw-can-7215-1</StartDevice>
+        <StartDevice>switch-m0</StartDevice>
         <StartPort>etp51</StartPort>
         <Bandwidth>10000</Bandwidth>
       </DeviceLinkBase>
@@ -413,20 +413,20 @@
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA04M1</EndDevice>
         <EndPort>Ethernet1</EndPort>
-        <StartDevice>bjw-can-7215-1</StartDevice>
+        <StartDevice>switch-m0</StartDevice>
         <StartPort>etp52</StartPort>
         <Bandwidth>10000</Bandwidth>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>bjw-can-7215-1</EndDevice>
+        <EndDevice>switch-m0</EndDevice>
         <EndPort>etp1</EndPort>
         <StartDevice>Servers0</StartDevice>
         <StartPort>eth0</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>bjw-can-7215-1</EndDevice>
+        <EndDevice>switch-m0</EndDevice>
         <EndPort>etp2</EndPort>
         <StartDevice>Servers1</StartDevice>
         <StartPort>eth0</StartPort>

--- a/src/sonic-config-engine/tests/simple-sample-graph-m0.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-m0.xml
@@ -2,96 +2,134 @@
   <CpgDec>
     <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     <PeeringSessions>
-       <BGPSession>
-         <StartRouter>switch-t0</StartRouter>
-         <StartPeer>10.1.0.32</StartPeer>
-         <EndRouter>BGPMonitor</EndRouter>
-         <EndPeer>10.20.30.40</EndPeer>
-         <Multihop>30</Multihop>
-         <HoldTime>10</HoldTime>
-         <KeepAliveTime>3</KeepAliveTime>
-      </BGPSession>
       <BGPSession>
         <MacSec>false</MacSec>
-        <StartRouter>switch-t0</StartRouter>
+        <StartRouter>switch-m0</StartRouter>
         <StartPeer>10.0.0.56</StartPeer>
-        <EndRouter>ARISTA01T1</EndRouter>
+        <EndRouter>ARISTA01M1</EndRouter>
         <EndPeer>10.0.0.57</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch-t0</StartRouter>
+        <StartRouter>switch-m0</StartRouter>
         <StartPeer>FC00::71</StartPeer>
-        <EndRouter>ARISTA01T1</EndRouter>
+        <EndRouter>ARISTA01M1</EndRouter>
         <EndPeer>FC00::72</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
       </BGPSession>
       <BGPSession>
         <MacSec>false</MacSec>
-        <StartRouter>switch-t0</StartRouter>
+        <StartRouter>switch-m0</StartRouter>
+        <StartPeer>10.0.0.64</StartPeer>
+        <EndRouter>ARISTA01MX</EndRouter>
+        <EndPeer>10.0.0.65</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-m0</StartRouter>
+        <StartPeer>FC00::81</StartPeer>
+        <EndRouter>ARISTA01MX</EndRouter>
+        <EndPeer>FC00::82</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>switch-m0</StartRouter>
         <StartPeer>10.0.0.58</StartPeer>
-        <EndRouter>ARISTA02T1</EndRouter>
+        <EndRouter>ARISTA02M1</EndRouter>
         <EndPeer>10.0.0.59</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch-t0</StartRouter>
+        <StartRouter>switch-m0</StartRouter>
         <StartPeer>FC00::75</StartPeer>
-        <EndRouter>ARISTA02T1</EndRouter>
+        <EndRouter>ARISTA02M1</EndRouter>
         <EndPeer>FC00::76</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>switch-t0</StartRouter>
-        <StartPeer>FC00::75</StartPeer>
-        <EndRouter>ARISTA02T1</EndRouter>
-        <EndPeer>FC00::76</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
       </BGPSession>
       <BGPSession>
         <MacSec>false</MacSec>
-        <StartRouter>switch-t0</StartRouter>
-        <StartPeer>10.2.0.20</StartPeer>
-        <EndRouter>CHASSIS_PEER</EndRouter>
-        <EndPeer>10.2.0.21</EndPeer>
+        <StartRouter>switch-m0</StartRouter>
+        <StartPeer>10.0.0.66</StartPeer>
+        <EndRouter>ARISTA02MX</EndRouter>
+        <EndPeer>10.0.0.67</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-        <ChassisInternal>voq</ChassisInternal>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-m0</StartRouter>
+        <StartPeer>FC00::85</StartPeer>
+        <EndRouter>ARISTA02MX</EndRouter>
+        <EndPeer>FC00::86</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>switch-m0</StartRouter>
+        <StartPeer>10.0.0.60</StartPeer>
+        <EndRouter>ARISTA03M1</EndRouter>
+        <EndPeer>10.0.0.61</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-m0</StartRouter>
+        <StartPeer>FC00::79</StartPeer>
+        <EndRouter>ARISTA03M1</EndRouter>
+        <EndPeer>FC00::7A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>switch-m0</StartRouter>
+        <StartPeer>10.0.0.62</StartPeer>
+        <EndRouter>ARISTA04M1</EndRouter>
+        <EndPeer>10.0.0.63</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-m0</StartRouter>
+        <StartPeer>FC00::7D</StartPeer>
+        <EndRouter>ARISTA04M1</EndRouter>
+        <EndPeer>FC00::7E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
       </BGPSession>
     </PeeringSessions>
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
-          <a:ASN>1</a:ASN>
-          <a:BgpGroups/>
-          <a:Hostname>BGPMonitor</a:Hostname>
-          <a:Peers>
-              <BGPPeer>
-                  <ElementType>BGPPeer</ElementType>
-                  <Address>10.1.0.32</Address>
-                  <RouteMapIn i:nil="true"/>
-                  <RouteMapOut i:nil="true"/>
-                  <Vrf i:nil="true"/>
-              </BGPPeer>
-          </a:Peers>
-          <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch-t0</a:Hostname>
+        <a:Hostname>switch-m0</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.57</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.65</Address>
             <RouteMapIn i:nil="true"/>
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
@@ -103,37 +141,72 @@
             <Vrf i:nil="true"/>
           </BGPPeer>
           <BGPPeer>
-            <Address>10.2.0.21</Address>
+            <Address>10.0.0.67</Address>
             <RouteMapIn i:nil="true"/>
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.61</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.63</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer i:type="a:BGPPeerPassive">
+            <ElementType>BGPPeer</ElementType>
+            <Address>10.1.0.32</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+            <a:Name>BGPSLBPassive</a:Name>
+            <a:PeersRange>10.255.0.0/25</a:PeersRange>
+          </BGPPeer>
+          <BGPPeer i:type="a:BGPPeerPassive">
+            <ElementType>BGPPeer</ElementType>
+            <Address>10.1.0.32</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+            <a:Name>BGPVac</a:Name>
+            <a:PeersRange>192.168.0.0/21</a:PeersRange>
           </BGPPeer>
         </a:Peers>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
       <a:BGPRouterDeclaration>
-        <a:ASN>64600</a:ASN>
-        <a:Hostname>ARISTA01T1</a:Hostname>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA01M1</a:Hostname>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
       <a:BGPRouterDeclaration>
-        <a:ASN>64600</a:ASN>
-        <a:Hostname>ARISTA02T1</a:Hostname>
+        <a:ASN>64001</a:ASN>
+        <a:Hostname>ARISTA01MX</a:Hostname>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
       <a:BGPRouterDeclaration>
-        <a:ASN>64600</a:ASN>
-        <a:Hostname>ARISTA03T1</a:Hostname>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA02M1</a:Hostname>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
       <a:BGPRouterDeclaration>
-        <a:ASN>64600</a:ASN>
-        <a:Hostname>ARISTA04T1</a:Hostname>
+        <a:ASN>64002</a:ASN>
+        <a:Hostname>ARISTA02MX</a:Hostname>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
       <a:BGPRouterDeclaration>
-        <a:ASN>65100</a:ASN>
-        <a:Hostname>CHASSIS_PEER</a:Hostname>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA03M1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA04M1</a:Hostname>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
     </Routers>
@@ -173,11 +246,26 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch-t0</Hostname>
+      <Hostname>switch-m0</Hostname>
       <PortChannelInterfaces>
         <PortChannel>
-          <Name>PortChannel1</Name>
-          <AttachTo>fortyGigE0/4</AttachTo>
+          <Name>PortChannel101</Name>
+          <AttachTo>etp49</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel103</Name>
+          <AttachTo>etp50</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel105</Name>
+          <AttachTo>etp51</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel106</Name>
+          <AttachTo>etp52</AttachTo>
           <SubInterface/>
         </PortChannel>
       </PortChannelInterfaces>
@@ -281,34 +369,67 @@
   </DpgDec>
   <PngDec>
     <DeviceInterfaceLinks>
-      <DeviceLinkBase i:type="DeviceInterfaceLink">
+      <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <Bandwidth>1000</Bandwidth>
-        <EndDevice>ARISTA01T1</EndDevice>
-        <EndPort>et1</EndPort>
-        <FlowControl>true</FlowControl>
-        <StartDevice>switch-t0</StartDevice>
-        <StartPort>fortyGigE0/8</StartPort>
-        <Validate>true</Validate>
+        <EndDevice>ARISTA01M1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>bjw-can-7215-1</StartDevice>
+        <StartPort>etp49</StartPort>
+        <Bandwidth>10000</Bandwidth>
       </DeviceLinkBase>
-      <DeviceLinkBase i:type="DeviceMgmtLink">
-        <ElementType>DeviceMgmtLink</ElementType>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA01MX</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>bjw-can-7215-1</StartDevice>
+        <StartPort>etp47</StartPort>
         <Bandwidth>1000</Bandwidth>
-        <EndDevice>switch-t0</EndDevice>
-        <EndPort>fortyGigE0/16</EndPort>
-        <FlowControl>true</FlowControl>
-        <StartDevice>ChassisMTS1</StartDevice>
-        <StartPort>mgmt0</StartPort>
-        <Validate>true</Validate>
       </DeviceLinkBase>
-      <DeviceLinkBase i:type="DeviceMgmtLink">
-      <ElementType>DeviceMgmtLink</ElementType>
-      <Bandwidth>1000</Bandwidth>
-      <EndDevice>switch-t0</EndDevice>
-      <EndPort>Management1</EndPort>
-      <StartDevice>switch-m0</StartDevice>
-      <StartPort>Management1</StartPort>
-      <Validate>true</Validate>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA02M1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>bjw-can-7215-1</StartDevice>
+        <StartPort>etp50</StartPort>
+        <Bandwidth>10000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA02MX</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>bjw-can-7215-1</StartDevice>
+        <StartPort>etp48</StartPort>
+        <Bandwidth>1000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA03M1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>bjw-can-7215-1</StartDevice>
+        <StartPort>etp51</StartPort>
+        <Bandwidth>10000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA04M1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>bjw-can-7215-1</StartDevice>
+        <StartPort>etp52</StartPort>
+        <Bandwidth>10000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>bjw-can-7215-1</EndDevice>
+        <EndPort>etp1</EndPort>
+        <StartDevice>Servers0</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>bjw-can-7215-1</EndDevice>
+        <EndPort>etp2</EndPort>
+        <StartDevice>Servers1</StartDevice>
+        <StartPort>eth0</StartPort>
       </DeviceLinkBase>
     </DeviceInterfaceLinks>
     <Devices>
@@ -776,7 +897,7 @@
 <MetadataDeclaration>
  <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
   <a:DeviceMetadata>
-   <a:Name>switch-t0</a:Name>
+   <a:Name>switch-m0</a:Name>
    <a:Properties>
     <a:DeviceProperty>
      <a:Name>DeploymentId</a:Name>
@@ -788,6 +909,6 @@
  </Devices>
  <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
 </MetadataDeclaration>
-  <Hostname>switch-t0</Hostname>
-  <HwSku>Force10-S6000</HwSku>
+  <Hostname>switch-m0</Hostname>
+  <HwSku>Nokia-M0-7215</HwSku>
 </DeviceMiniGraph>

--- a/src/sonic-config-engine/tests/simple-sample-graph-m0.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-m0.xml
@@ -274,16 +274,6 @@
           <InAcl>SNMP_ACL</InAcl>
           <Type>SNMP</Type>
         </AclInterface>
-        <AclInterface>
-        <AttachTo>Ethernet0;Ethernet1</AttachTo>
-        <InAcl>BMC_ACL_NORTHBOUND</InAcl>
-        <Type>BmcData</Type>
-      </AclInterface>
-      <AclInterface>
-        <AttachTo>Ethernet0;Ethernet1</AttachTo>
-        <InAcl>BMC_ACL_NORTHBOUND_V6</InAcl>
-        <Type>BmcData</Type>
-      </AclInterface>
       </AclInterfaces>
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
@@ -322,26 +312,34 @@
       </DeviceLinkBase>
     </DeviceInterfaceLinks>
     <Devices>
-      <Device i:type="ToRRouter">
-        <Hostname>switch-t0</Hostname>
-        <HwSku>Force10-S6000</HwSku>
+      <Device i:type="MgmtToRRouter">
+        <Hostname>switch-m0</Hostname>
+        <HwSku>Nokia-M0-7215</HwSku>
         <ClusterName>AAA00PrdStr00</ClusterName>
       </Device>
-      <Device i:type="LeafRouter">
-        <Hostname>ARISTA01T1</Hostname>
-        <HwSku>Arista</HwSku>
+      <Device i:type="MgmtLeafRouter">
+         <Hostname>ARISTA04M1</Hostname>
+         <HwSku>Arista</HwSku>
       </Device>
-      <Device i:type="LeafRouter">
-        <Hostname>ARISTA02T1</Hostname>
-        <HwSku>Arista</HwSku>
+      <Device i:type="MgmtLeafRouter">
+         <Hostname>ARISTA02M1</Hostname>
+         <HwSku>Arista</HwSku>
       </Device>
-      <Device i:type="LeafRouter">
-        <Hostname>ARISTA03T1</Hostname>
-        <HwSku>Arista</HwSku>
+      <Device i:type="BmcMgmtToRRouter">
+         <Hostname>ARISTA02MX</Hostname>
+         <HwSku>Arista</HwSku>
       </Device>
-      <Device i:type="LeafRouter">
-        <Hostname>ARISTA04T1</Hostname>
-        <HwSku>Arista</HwSku>
+      <Device i:type="BmcMgmtToRRouter">
+         <Hostname>ARISTA01MX</Hostname>
+         <HwSku>Arista</HwSku>
+      </Device>
+      <Device i:type="MgmtLeafRouter">
+         <Hostname>ARISTA01M1</Hostname>
+         <HwSku>Arista</HwSku>
+      </Device>
+      <Device i:type="MgmtLeafRouter">
+         <Hostname>ARISTA03M1</Hostname>
+         <HwSku>Arista</HwSku>
       </Device>
     </Devices>
   </PngDec>

--- a/src/sonic-config-engine/tests/simple-sample-graph-m0.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-m0.xml
@@ -369,7 +369,7 @@
   </DpgDec>
   <PngDec>
     <DeviceInterfaceLinks>
-      <DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA01M1</EndDevice>
         <EndPort>Ethernet1</EndPort>
@@ -377,7 +377,7 @@
         <StartPort>etp49</StartPort>
         <Bandwidth>10000</Bandwidth>
       </DeviceLinkBase>
-      <DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA01MX</EndDevice>
         <EndPort>Ethernet1</EndPort>
@@ -385,7 +385,7 @@
         <StartPort>etp47</StartPort>
         <Bandwidth>1000</Bandwidth>
       </DeviceLinkBase>
-      <DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA02M1</EndDevice>
         <EndPort>Ethernet1</EndPort>
@@ -393,7 +393,7 @@
         <StartPort>etp50</StartPort>
         <Bandwidth>10000</Bandwidth>
       </DeviceLinkBase>
-      <DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA02MX</EndDevice>
         <EndPort>Ethernet1</EndPort>
@@ -401,7 +401,7 @@
         <StartPort>etp48</StartPort>
         <Bandwidth>1000</Bandwidth>
       </DeviceLinkBase>
-      <DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA03M1</EndDevice>
         <EndPort>Ethernet1</EndPort>
@@ -409,7 +409,7 @@
         <StartPort>etp51</StartPort>
         <Bandwidth>10000</Bandwidth>
       </DeviceLinkBase>
-      <DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA04M1</EndDevice>
         <EndPort>Ethernet1</EndPort>
@@ -417,14 +417,14 @@
         <StartPort>etp52</StartPort>
         <Bandwidth>10000</Bandwidth>
       </DeviceLinkBase>
-      <DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>switch-m0</EndDevice>
         <EndPort>etp1</EndPort>
         <StartDevice>Servers0</StartDevice>
         <StartPort>eth0</StartPort>
       </DeviceLinkBase>
-      <DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>switch-m0</EndDevice>
         <EndPort>etp2</EndPort>

--- a/src/sonic-config-engine/tests/simple-sample-graph-mx.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-mx.xml
@@ -328,12 +328,12 @@
         <ClusterName>AAA00PrdStr00</ClusterName>
       </Device>
       <Device i:type="MgmtToRRouter">
-         <Hostname>ARISTA01M0</Hostname>
-         <HwSku>Arista</HwSku>
+        <Hostname>ARISTA01M0</Hostname>
+        <HwSku>Arista</HwSku>
       </Device>
       <Device i:type="MgmtToRRouter">
-         <Hostname>ARISTA02M0</Hostname>
-         <HwSku>Arista</HwSku>
+        <Hostname>ARISTA02M0</Hostname>
+        <HwSku>Arista</HwSku>
       </Device>
     </Devices>
   </PngDec>

--- a/src/sonic-config-engine/tests/simple-sample-graph-mx.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-mx.xml
@@ -2,138 +2,91 @@
   <CpgDec>
     <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     <PeeringSessions>
-       <BGPSession>
-         <StartRouter>switch-t0</StartRouter>
-         <StartPeer>10.1.0.32</StartPeer>
-         <EndRouter>BGPMonitor</EndRouter>
-         <EndPeer>10.20.30.40</EndPeer>
-         <Multihop>30</Multihop>
-         <HoldTime>10</HoldTime>
-         <KeepAliveTime>3</KeepAliveTime>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>switch-mx</StartRouter>
+        <StartPeer>10.0.0.64</StartPeer>
+        <EndRouter>ARISTA01M0</EndRouter>
+        <EndPeer>10.0.0.65</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-mx</StartRouter>
+        <StartPeer>FC00::81</StartPeer>
+        <EndRouter>ARISTA01M0</EndRouter>
+        <EndPeer>FC00::82</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
       </BGPSession>
       <BGPSession>
         <MacSec>false</MacSec>
-        <StartRouter>switch-t0</StartRouter>
-        <StartPeer>10.0.0.56</StartPeer>
-        <EndRouter>ARISTA01T1</EndRouter>
-        <EndPeer>10.0.0.57</EndPeer>
+        <StartRouter>switch-mx</StartRouter>
+        <StartPeer>10.0.0.66</StartPeer>
+        <EndRouter>ARISTA02M0</EndRouter>
+        <EndPeer>10.0.0.67</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch-t0</StartRouter>
-        <StartPeer>FC00::71</StartPeer>
-        <EndRouter>ARISTA01T1</EndRouter>
-        <EndPeer>FC00::72</EndPeer>
+        <StartRouter>switch-mx</StartRouter>
+        <StartPeer>FC00::85</StartPeer>
+        <EndRouter>ARISTA02M0</EndRouter>
+        <EndPeer>FC00::86</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <MacSec>false</MacSec>
-        <StartRouter>switch-t0</StartRouter>
-        <StartPeer>10.0.0.58</StartPeer>
-        <EndRouter>ARISTA02T1</EndRouter>
-        <EndPeer>10.0.0.59</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>switch-t0</StartRouter>
-        <StartPeer>FC00::75</StartPeer>
-        <EndRouter>ARISTA02T1</EndRouter>
-        <EndPeer>FC00::76</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>switch-t0</StartRouter>
-        <StartPeer>FC00::75</StartPeer>
-        <EndRouter>ARISTA02T1</EndRouter>
-        <EndPeer>FC00::76</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <MacSec>false</MacSec>
-        <StartRouter>switch-t0</StartRouter>
-        <StartPeer>10.2.0.20</StartPeer>
-        <EndRouter>CHASSIS_PEER</EndRouter>
-        <EndPeer>10.2.0.21</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-        <ChassisInternal>voq</ChassisInternal>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
       </BGPSession>
     </PeeringSessions>
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
-          <a:ASN>1</a:ASN>
-          <a:BgpGroups/>
-          <a:Hostname>BGPMonitor</a:Hostname>
-          <a:Peers>
-              <BGPPeer>
-                  <ElementType>BGPPeer</ElementType>
-                  <Address>10.1.0.32</Address>
-                  <RouteMapIn i:nil="true"/>
-                  <RouteMapOut i:nil="true"/>
-                  <Vrf i:nil="true"/>
-              </BGPPeer>
-          </a:Peers>
-          <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65100</a:ASN>
-        <a:Hostname>switch-t0</a:Hostname>
+        <a:ASN>64001</a:ASN>
+        <a:Hostname>switch-mx</a:Hostname>
         <a:Peers>
           <BGPPeer>
-            <Address>10.0.0.57</Address>
+            <Address>10.0.0.65</Address>
             <RouteMapIn i:nil="true"/>
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
           </BGPPeer>
           <BGPPeer>
-            <Address>10.0.0.59</Address>
+            <Address>10.0.0.67</Address>
             <RouteMapIn i:nil="true"/>
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
           </BGPPeer>
-          <BGPPeer>
-            <Address>10.2.0.21</Address>
+          <BGPPeer i:type="a:BGPPeerPassive">
+            <ElementType>BGPPeer</ElementType>
+            <Address>10.1.0.32</Address>
             <RouteMapIn i:nil="true"/>
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
+            <a:Name>BGPSLBPassive</a:Name>
+            <a:PeersRange>10.255.0.0/25</a:PeersRange>
+          </BGPPeer>
+          <BGPPeer i:type="a:BGPPeerPassive">
+            <ElementType>BGPPeer</ElementType>
+            <Address>10.1.0.32</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+            <a:Name>BGPVac</a:Name>
+            <a:PeersRange>192.168.0.0/21</a:PeersRange>
           </BGPPeer>
         </a:Peers>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
       <a:BGPRouterDeclaration>
-        <a:ASN>64600</a:ASN>
-        <a:Hostname>ARISTA01T1</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64600</a:ASN>
-        <a:Hostname>ARISTA02T1</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64600</a:ASN>
-        <a:Hostname>ARISTA03T1</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64600</a:ASN>
-        <a:Hostname>ARISTA04T1</a:Hostname>
+        <a:ASN>65100</a:ASN>
+        <a:Hostname>ARISTA01M0</a:Hostname>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>CHASSIS_PEER</a:Hostname>
+        <a:Hostname>ARISTA02M0</a:Hostname>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
     </Routers>
@@ -173,13 +126,8 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch-t0</Hostname>
+      <Hostname>switch-mx</Hostname>
       <PortChannelInterfaces>
-        <PortChannel>
-          <Name>PortChannel1</Name>
-          <AttachTo>fortyGigE0/4</AttachTo>
-          <SubInterface/>
-        </PortChannel>
       </PortChannelInterfaces>
       <VlanInterfaces>
         <VlanInterface>
@@ -291,34 +239,35 @@
   </DpgDec>
   <PngDec>
     <DeviceInterfaceLinks>
-      <DeviceLinkBase i:type="DeviceInterfaceLink">
+      <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA01M0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>bjw-can-720dt-2</StartDevice>
+        <StartPort>etp47</StartPort>
         <Bandwidth>1000</Bandwidth>
-        <EndDevice>ARISTA01T1</EndDevice>
-        <EndPort>et1</EndPort>
-        <FlowControl>true</FlowControl>
-        <StartDevice>switch-t0</StartDevice>
-        <StartPort>fortyGigE0/8</StartPort>
-        <Validate>true</Validate>
       </DeviceLinkBase>
-      <DeviceLinkBase i:type="DeviceMgmtLink">
-        <ElementType>DeviceMgmtLink</ElementType>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA02M0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>bjw-can-720dt-2</StartDevice>
+        <StartPort>etp48</StartPort>
         <Bandwidth>1000</Bandwidth>
-        <EndDevice>switch-t0</EndDevice>
-        <EndPort>fortyGigE0/16</EndPort>
-        <FlowControl>true</FlowControl>
-        <StartDevice>ChassisMTS1</StartDevice>
-        <StartPort>mgmt0</StartPort>
-        <Validate>true</Validate>
       </DeviceLinkBase>
-      <DeviceLinkBase i:type="DeviceMgmtLink">
-      <ElementType>DeviceMgmtLink</ElementType>
-      <Bandwidth>1000</Bandwidth>
-      <EndDevice>switch-t0</EndDevice>
-      <EndPort>Management1</EndPort>
-      <StartDevice>switch-m0</StartDevice>
-      <StartPort>Management1</StartPort>
-      <Validate>true</Validate>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>bjw-can-720dt-2</EndDevice>
+        <EndPort>etp1</EndPort>
+        <StartDevice>Servers0</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>bjw-can-720dt-2</EndDevice>
+        <EndPort>etp2</EndPort>
+        <StartDevice>Servers1</StartDevice>
+        <StartPort>eth0</StartPort>
       </DeviceLinkBase>
     </DeviceInterfaceLinks>
     <Devices>
@@ -770,7 +719,7 @@
 <MetadataDeclaration>
  <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
   <a:DeviceMetadata>
-   <a:Name>switch-t0</a:Name>
+   <a:Name>switch-mx</a:Name>
    <a:Properties>
     <a:DeviceProperty>
      <a:Name>DeploymentId</a:Name>
@@ -782,6 +731,6 @@
  </Devices>
  <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
 </MetadataDeclaration>
-  <Hostname>switch-t0</Hostname>
-  <HwSku>Force10-S6000</HwSku>
+  <Hostname>switch-mx</Hostname>
+  <HwSku>Arista-720DT-G48S4</HwSku>
 </DeviceMiniGraph>

--- a/src/sonic-config-engine/tests/simple-sample-graph-mx.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-mx.xml
@@ -238,7 +238,7 @@
     </DeviceDataPlaneInfo>
   </DpgDec>
   <PngDec>
-    <DeviceInterfaceLink>
+    <DeviceInterfaceLinks>
       <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA01M0</EndDevice>

--- a/src/sonic-config-engine/tests/simple-sample-graph-mx.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-mx.xml
@@ -1,0 +1,787 @@
+<DeviceMiniGraph xmlns="Microsoft.Search.Autopilot.Evolution" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <CpgDec>
+    <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    <PeeringSessions>
+       <BGPSession>
+         <StartRouter>switch-t0</StartRouter>
+         <StartPeer>10.1.0.32</StartPeer>
+         <EndRouter>BGPMonitor</EndRouter>
+         <EndPeer>10.20.30.40</EndPeer>
+         <Multihop>30</Multihop>
+         <HoldTime>10</HoldTime>
+         <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>switch-t0</StartRouter>
+        <StartPeer>10.0.0.56</StartPeer>
+        <EndRouter>ARISTA01T1</EndRouter>
+        <EndPeer>10.0.0.57</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>180</HoldTime>
+        <KeepAliveTime>60</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t0</StartRouter>
+        <StartPeer>FC00::71</StartPeer>
+        <EndRouter>ARISTA01T1</EndRouter>
+        <EndPeer>FC00::72</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>180</HoldTime>
+        <KeepAliveTime>60</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>switch-t0</StartRouter>
+        <StartPeer>10.0.0.58</StartPeer>
+        <EndRouter>ARISTA02T1</EndRouter>
+        <EndPeer>10.0.0.59</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>180</HoldTime>
+        <KeepAliveTime>60</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t0</StartRouter>
+        <StartPeer>FC00::75</StartPeer>
+        <EndRouter>ARISTA02T1</EndRouter>
+        <EndPeer>FC00::76</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>180</HoldTime>
+        <KeepAliveTime>60</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>switch-t0</StartRouter>
+        <StartPeer>FC00::75</StartPeer>
+        <EndRouter>ARISTA02T1</EndRouter>
+        <EndPeer>FC00::76</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>180</HoldTime>
+        <KeepAliveTime>60</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>switch-t0</StartRouter>
+        <StartPeer>10.2.0.20</StartPeer>
+        <EndRouter>CHASSIS_PEER</EndRouter>
+        <EndPeer>10.2.0.21</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>180</HoldTime>
+        <KeepAliveTime>60</KeepAliveTime>
+        <ChassisInternal>voq</ChassisInternal>
+      </BGPSession>
+    </PeeringSessions>
+    <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:BGPRouterDeclaration>
+          <a:ASN>1</a:ASN>
+          <a:BgpGroups/>
+          <a:Hostname>BGPMonitor</a:Hostname>
+          <a:Peers>
+              <BGPPeer>
+                  <ElementType>BGPPeer</ElementType>
+                  <Address>10.1.0.32</Address>
+                  <RouteMapIn i:nil="true"/>
+                  <RouteMapOut i:nil="true"/>
+                  <Vrf i:nil="true"/>
+              </BGPPeer>
+          </a:Peers>
+          <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65100</a:ASN>
+        <a:Hostname>switch-t0</a:Hostname>
+        <a:Peers>
+          <BGPPeer>
+            <Address>10.0.0.57</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.59</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.2.0.21</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+        </a:Peers>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA01T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA02T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA03T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA04T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65100</a:ASN>
+        <a:Hostname>CHASSIS_PEER</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+    </Routers>
+  </CpgDec>
+  <DpgDec>
+    <DeviceDataPlaneInfo>
+      <IPSecTunnels/>
+      <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.1.0.32/32</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.1.0.32/32</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FC00:1::32/128</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FC00:1::32/128</a:PrefixStr>
+        </a:LoopbackIPInterface>
+      </LoopbackIPInterfaces>
+      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:ManagementIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.0.0.100/24</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.0.0.100/24</a:PrefixStr>
+        </a:ManagementIPInterface>
+      </ManagementIPInterfaces>
+      <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+      <MplsInterfaces/>
+      <MplsTeInterfaces/>
+      <RsvpInterfaces/>
+      <Hostname>switch-t0</Hostname>
+      <PortChannelInterfaces>
+        <PortChannel>
+          <Name>PortChannel1</Name>
+          <AttachTo>fortyGigE0/4</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+      </PortChannelInterfaces>
+      <VlanInterfaces>
+        <VlanInterface>
+          <Name>ab1</Name>
+          <AttachTo>fortyGigE0/8</AttachTo>
+          <DhcpRelays>192.0.0.1;192.0.0.2</DhcpRelays>
+          <VlanID>1000</VlanID>
+          <Tag>1000</Tag>
+          <Subnets>192.168.0.0/27</Subnets>
+        </VlanInterface>
+        <VlanInterface>
+          <Name>ab4</Name>
+          <AttachTo>fortyGigE0/8</AttachTo>
+          <DhcpRelays>192.0.0.1;192.0.0.2</DhcpRelays>
+          <VlanID>1001</VlanID>
+          <Tag>1001</Tag>
+          <Subnets>192.168.0.32/27</Subnets>
+        </VlanInterface>
+        <VlanInterface>
+          <Name>kk1</Name>
+          <AttachTo>fortyGigE0/12</AttachTo>
+          <DhcpRelays>192.0.0.1;192.0.0.2</DhcpRelays>
+          <VlanID>2020</VlanID>
+          <Tag>2020</Tag>
+          <Type>Tagged</Type>
+          <Subnets>192.168.0.0/28</Subnets>
+        </VlanInterface>
+        <VlanInterface>
+          <Name>ab2</Name>
+          <AttachTo>fortyGigE0/12</AttachTo>
+          <DhcpRelays>192.0.0.1;192.0.0.2</DhcpRelays>
+          <VlanID>2000</VlanID>
+          <Tag>2000</Tag>
+          <Type>Tagged</Type>
+          <Subnets>192.168.0.240/27</Subnets>
+        </VlanInterface>
+        <VlanInterface>
+          <Name>ab3</Name>
+          <AttachTo>fortyGigE0/12</AttachTo>
+          <DhcpRelays>192.0.0.1;192.0.0.2</DhcpRelays>
+          <VlanID>2001</VlanID>
+          <Tag>2001</Tag>
+          <Subnets>192.168.0.240/27</Subnets>
+        </VlanInterface>
+      </VlanInterfaces>
+      <IPInterfaces>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel1</AttachTo>
+          <Prefix>10.0.0.56/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel1</AttachTo>
+          <Prefix>FC00::71/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel1001</AttachTo>
+          <Prefix>10.0.0.57/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel1001</AttachTo>
+          <Prefix>FC00::72/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>fortyGigE0/0</AttachTo>
+          <Prefix>10.0.0.58/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>fortyGigE0/0</AttachTo>
+          <Prefix>FC00::75/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>ab1</AttachTo>
+          <Prefix>192.168.0.1/27</Prefix>
+        </IPInterface>
+      </IPInterfaces>
+      <DataAcls/>
+      <AclInterfaces>
+        <AclInterface>
+          <AttachTo>PortChannel1</AttachTo>
+          <InAcl>DataAcl</InAcl>
+          <Type>DataPlane</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>SNMP</AttachTo>
+          <InAcl>SNMP_ACL</InAcl>
+          <Type>SNMP</Type>
+        </AclInterface>
+        <AclInterface>
+        <AttachTo>Ethernet0;Ethernet1</AttachTo>
+        <InAcl>BMC_ACL_NORTHBOUND</InAcl>
+        <Type>BmcData</Type>
+      </AclInterface>
+      <AclInterface>
+        <AttachTo>Ethernet0;Ethernet1</AttachTo>
+        <InAcl>BMC_ACL_NORTHBOUND_V6</InAcl>
+        <Type>BmcData</Type>
+      </AclInterface>
+      </AclInterfaces>
+      <DownstreamSummaries/>
+      <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    </DeviceDataPlaneInfo>
+  </DpgDec>
+  <PngDec>
+    <DeviceInterfaceLinks>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <Bandwidth>1000</Bandwidth>
+        <EndDevice>ARISTA01T1</EndDevice>
+        <EndPort>et1</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>switch-t0</StartDevice>
+        <StartPort>fortyGigE0/8</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceMgmtLink">
+        <ElementType>DeviceMgmtLink</ElementType>
+        <Bandwidth>1000</Bandwidth>
+        <EndDevice>switch-t0</EndDevice>
+        <EndPort>fortyGigE0/16</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>ChassisMTS1</StartDevice>
+        <StartPort>mgmt0</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceMgmtLink">
+      <ElementType>DeviceMgmtLink</ElementType>
+      <Bandwidth>1000</Bandwidth>
+      <EndDevice>switch-t0</EndDevice>
+      <EndPort>Management1</EndPort>
+      <StartDevice>switch-m0</StartDevice>
+      <StartPort>Management1</StartPort>
+      <Validate>true</Validate>
+      </DeviceLinkBase>
+    </DeviceInterfaceLinks>
+    <Devices>
+      <Device i:type="BmcMgmtToRRouter">
+        <Hostname>switch-mx</Hostname>
+        <HwSku>Arista-720DT-G48S4</HwSku>
+        <ClusterName>AAA00PrdStr00</ClusterName>
+      </Device>
+      <Device i:type="MgmtToRRouter">
+         <Hostname>ARISTA01M0</Hostname>
+         <HwSku>Arista</HwSku>
+      </Device>
+      <Device i:type="MgmtToRRouter">
+         <Hostname>ARISTA02M0</Hostname>
+         <HwSku>Arista</HwSku>
+      </Device>
+    </Devices>
+  </PngDec>
+  <DeviceInfos>
+    <DeviceInfo>
+      <EthernetInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/0</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>10000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet1</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>10000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet2</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>10000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/4</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>25000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/8</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>40000</Speed>
+          <Description>Interface description</Description>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/12</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+          <Description>Interface description</Description>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/16</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/20</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/24</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/28</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/32</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/36</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/40</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/44</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/48</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/52</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/56</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/60</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/64</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/68</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/72</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/76</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/80</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/84</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/88</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/92</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/96</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/100</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/104</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/108</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/112</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/116</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/120</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>fortyGigE0/124</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+      </EthernetInterfaces>
+      <FlowControl>true</FlowControl>
+      <Height>0</Height>
+      <HwSku>Force10-S6000</HwSku>
+      <ManagementInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+	<a:ManagementInterface>
+	  <ElementType>DeviceInterface</ElementType>
+	  <AlternateSpeeds i:nil="true"/>
+	  <Index>1</Index>
+	  <InterfaceName>Management1</InterfaceName>
+	  <MultiPortsInterface>false</MultiPortsInterface>
+	  <PortName>mgmt1</PortName>
+	  <Speed>1000</Speed>
+  	</a:ManagementInterface>
+      </ManagementInterfaces>
+    </DeviceInfo>
+  </DeviceInfos>
+<MetadataDeclaration>
+ <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+  <a:DeviceMetadata>
+   <a:Name>switch-t0</a:Name>
+   <a:Properties>
+    <a:DeviceProperty>
+     <a:Name>DeploymentId</a:Name>
+     <a:Reference i:nil="true"/>
+     <a:Value>1</a:Value>
+    </a:DeviceProperty>
+  </a:Properties>
+  </a:DeviceMetadata>
+ </Devices>
+ <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+</MetadataDeclaration>
+  <Hostname>switch-t0</Hostname>
+  <HwSku>Force10-S6000</HwSku>
+</DeviceMiniGraph>

--- a/src/sonic-config-engine/tests/simple-sample-graph-mx.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-mx.xml
@@ -238,8 +238,8 @@
     </DeviceDataPlaneInfo>
   </DpgDec>
   <PngDec>
-    <DeviceInterfaceLink i:type="DeviceInterfaceLink">
-      <DeviceLinkBase>
+    <DeviceInterfaceLink>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA01M0</EndDevice>
         <EndPort>Ethernet1</EndPort>

--- a/src/sonic-config-engine/tests/simple-sample-graph-mx.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-mx.xml
@@ -238,7 +238,7 @@
     </DeviceDataPlaneInfo>
   </DpgDec>
   <PngDec>
-    <DeviceInterfaceLinks>
+    <DeviceInterfaceLink i:type="DeviceInterfaceLink">
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA01M0</EndDevice>
@@ -247,7 +247,7 @@
         <StartPort>etp47</StartPort>
         <Bandwidth>1000</Bandwidth>
       </DeviceLinkBase>
-      <DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA02M0</EndDevice>
         <EndPort>Ethernet1</EndPort>
@@ -255,14 +255,14 @@
         <StartPort>etp48</StartPort>
         <Bandwidth>1000</Bandwidth>
       </DeviceLinkBase>
-      <DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>switch-mx</EndDevice>
         <EndPort>etp1</EndPort>
         <StartDevice>Servers0</StartDevice>
         <StartPort>eth0</StartPort>
       </DeviceLinkBase>
-      <DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>switch-mx</EndDevice>
         <EndPort>etp2</EndPort>

--- a/src/sonic-config-engine/tests/simple-sample-graph-mx.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-mx.xml
@@ -243,7 +243,7 @@
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA01M0</EndDevice>
         <EndPort>Ethernet1</EndPort>
-        <StartDevice>bjw-can-720dt-2</StartDevice>
+        <StartDevice>switch-mx</StartDevice>
         <StartPort>etp47</StartPort>
         <Bandwidth>1000</Bandwidth>
       </DeviceLinkBase>
@@ -251,20 +251,20 @@
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA02M0</EndDevice>
         <EndPort>Ethernet1</EndPort>
-        <StartDevice>bjw-can-720dt-2</StartDevice>
+        <StartDevice>switch-mx</StartDevice>
         <StartPort>etp48</StartPort>
         <Bandwidth>1000</Bandwidth>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>bjw-can-720dt-2</EndDevice>
+        <EndDevice>switch-mx</EndDevice>
         <EndPort>etp1</EndPort>
         <StartDevice>Servers0</StartDevice>
         <StartPort>eth0</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>bjw-can-720dt-2</EndDevice>
+        <EndDevice>switch-mx</EndDevice>
         <EndPort>etp2</EndPort>
         <StartDevice>Servers1</StartDevice>
         <StartPort>eth0</StartPort>

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -551,6 +551,7 @@ class TestCfgGenCaseInsensitive(TestCase):
 
     def test_mgmt_device_disable_counters(self):
         expected_mgmt_disabled_counters = ["BUFFER_POOL_WATERMARK", "PFCWD", "PG_DROP", "PG_WATERMARK", "PORT_BUFFER_DROP", "QUEUE", "QUEUE_WATERMARK"]
+        expected_mgmt_enabled_counters = ["ACL", "PORT", "RIF"]
         mgmt_graphs = ['simple-sample-graph-mx.xml', 'simple-sample-graph-m0.xml']
         for graph in mgmt_graphs:
             graph_path = os.path.join(self.test_dir, graph)
@@ -559,3 +560,6 @@ class TestCfgGenCaseInsensitive(TestCase):
             for counter in expected_mgmt_disabled_counters:
                 self.assertIn(counter, result['FLEX_COUNTER_TABLE'])
                 self.assertDictEqual(result['FLEX_COUNTER_TABLE'][counter], {'FLEX_COUNTER_STATUS': 'disable'})
+            for counter in expected_mgmt_enabled_counters:
+                if counter in result['FLEX_COUNTER_TABLE']:
+                    self.assertDictEqual(result['FLEX_COUNTER_TABLE'][counter], {'FLEX_COUNTER_STATUS': 'enable'})

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -519,8 +519,8 @@ class TestCfgGenCaseInsensitive(TestCase):
             'type': 'BMCDATAV6',
         }
         # TC1: Minigraph contains acl table type BmcData
-        sample_graph = os.path.join(self.test_dir,'simple-sample-graph-case-acl-type-bmcdata.xml')
-        result = minigraph.parse_xml(sample_graph)
+        sample_mx_graph = os.path.join(self.test_dir,'simple-sample-graph-mx.xml')
+        result = minigraph.parse_xml(sample_mx_graph)
         self.assertIn('ACL_TABLE_TYPE', result)
         self.assertIn('BMCDATA', result['ACL_TABLE_TYPE'])
         self.assertIn('BMCDATAV6', result['ACL_TABLE_TYPE'])
@@ -548,3 +548,14 @@ class TestCfgGenCaseInsensitive(TestCase):
         self.assertEqual(len(mgmt_intf.keys()), 1)
         self.assertTrue(('eth0', 'FC00:1::32/64') in mgmt_intf.keys())
         self.assertTrue(ipaddress.ip_address(u'fc00:1::1') == mgmt_intf[('eth0', 'FC00:1::32/64')]['gwaddr'])
+
+    def test_mgmt_device_disable_counters(self):
+        expected_mgmt_disabled_counters = ["BUFFER_POOL_WATERMARK", "PFCWD", "PG_DROP", "PG_WATERMARK", "PORT_BUFFER_DROP", "QUEUE", "QUEUE_WATERMARK"]
+        mgmt_graphs = ['simple-sample-graph-mx.xml', 'simple-sample-graph-m0.xml']
+        for graph in mgmt_graphs:
+            graph_path = os.path.join(self.test_dir, graph)
+            result = minigraph.parse_xml(graph_path)
+            self.assertIn('FLEX_COUNTER_TABLE', result)
+            for counter in expected_mgmt_disabled_counters:
+                self.assertIn(counter, result['FLEX_COUNTER_TABLE'])
+                self.assertDictEqual(result['FLEX_COUNTER_TABLE'][counter], {'FLEX_COUNTER_STATUS': 'disable'})

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -552,6 +552,7 @@ class TestCfgGenCaseInsensitive(TestCase):
     def test_mgmt_device_disable_counters(self):
         expected_mgmt_disabled_counters = ["BUFFER_POOL_WATERMARK", "PFCWD", "PG_DROP", "PG_WATERMARK", "PORT_BUFFER_DROP", "QUEUE", "QUEUE_WATERMARK"]
         expected_mgmt_enabled_counters = ["ACL", "PORT", "RIF"]
+        # TC1: For M0 and Mx minigraph, counters are configured as expected
         mgmt_graphs = ['simple-sample-graph-mx.xml', 'simple-sample-graph-m0.xml']
         for graph in mgmt_graphs:
             graph_path = os.path.join(self.test_dir, graph)
@@ -563,3 +564,6 @@ class TestCfgGenCaseInsensitive(TestCase):
             for counter in expected_mgmt_enabled_counters:
                 if counter in result['FLEX_COUNTER_TABLE']:
                     self.assertDictEqual(result['FLEX_COUNTER_TABLE'][counter], {'FLEX_COUNTER_STATUS': 'enable'})
+        # TC2: For other minigraph, result should not contain FLEX_COUNTER_TABLE
+        result = minigraph.parse_xml(self.sample_graph)
+        self.assertNotIn('FLEX_COUNTER_TABLE', result)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To avoid orchagent crash issue like sonic-net/sonic-swss#2935, disable unsupported counters on SONiC management devices.

##### Work item tracking
- Microsoft ADO **(number only)**: 25437720

#### How I did it

Update the minigraph parser to disable unsupported counters on management devices.

#### How to verify it

1. Verified by unittest.
```
root@dd14c2cb8789:/sonic/src/sonic-config-engine/tests$ pytest-3 -v test_minigraph_case.py
============================================================== test session starts ==============================================================
platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /sonic/src/sonic-config-engine
plugins: pyfakefs-5.3.0, cov-2.10.1
collected 43 items

test_minigraph_case.py::TestCfgGenCaseInsensitive::test_additional_json_data PASSED                                                       [  2%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_dhcp_table PASSED                                                                 [  4%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_dummy_run PASSED                                                                  [  6%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_jinja_expression PASSED                                                           [  9%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_metadata_kube PASSED                                                              [ 11%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_metadata_ntp PASSED                                                               [ 13%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_metadata_tacacs PASSED                                                            [ 16%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_mgmt_device_disable_counters PASSED                                               [ 18%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_acl_attach_to_ports PASSED                                              [ 20%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_acl_type_bmcdata PASSED                                                 [ 23%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_bgp_mon PASSED                                                          [ 25%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_cluster PASSED                                                          [ 27%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_console_mgmt_feature PASSED                                             [ 30%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_console_port PASSED                                                     [ 32%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_deployment_id PASSED                                                    [ 34%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_dhcp_server_feature PASSED                                              [ 37%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_interfaces PASSED                                                       [ 39%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_mgmt_port PASSED                                                        [ 41%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_mirror_dscp PASSED                                                      [ 44%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_mux_cable_table PASSED                                                  [ 46%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_neighbor_metadata PASSED                                                [ 48%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_peer_switch PASSED                                                      [ 51%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_peer_switch_hostname PASSED                                             [ 53%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_portchannels PASSED                                                     [ 55%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_rack_mgmt_map PASSED                                                    [ 58%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_sku PASSED                                                              [ 60%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_storage_backend_no_resource_type PASSED                                 [ 62%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_storage_backend_resource_type PASSED                                    [ 65%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_storage_backend_subintf PASSED                                          [ 67%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_storage_device PASSED                                                   [ 69%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_subtype PASSED                                                          [ 72%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_tunnel_table PASSED                                                     [ 74%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_vlan_interfaces PASSED                                                  [ 76%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_vlan_interfaces_keys PASSED                                             [ 79%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_vlan_members PASSED                                                     [ 81%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_vlans PASSED                                                            [ 83%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_vnet PASSED                                                             [ 86%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_minigraph_vxlan PASSED                                                            [ 88%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_mux_cable_parsing PASSED                                                          [ 90%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_parse_device_desc_xml_mgmt_interface PASSED                                       [ 93%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_print_data PASSED                                                                 [ 95%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_read_yaml PASSED                                                                  [ 97%]
test_minigraph_case.py::TestCfgGenCaseInsensitive::test_render_template PASSED                                                            [100%]

============================================================== 43 passed in 24.59s ==============================================================
```
2. Manually apply patch to DUT and do `config load_minigraph`. Then confirmed:
    1. `show run all`: the `FLEX_COUNTER_TABLE` section in running-config is shown as expected.
    2. `config save -y`: the `FLEX_COUNTER_TABLE` section in `config_db.json` is shown as expected.
    3. `show int st`: confirm all interface are healthy.
    4. `show ip bgp sum && show ipv6 bgp sum`: confirm BGP session is healthy.
    5. `portstat`: interface counters are shown as expected.
    6. `show int counters rif`: L3 interface counters are shown as expected.
    7. `aclshow -a`: ACL counters are shown as expected.

    Above contents are confirmed on below platforms and branch:
    | Platform | SONiC Image Branch | Device Type| Result |
    | ----------- | ----------- | ----------- | ----------- |
    | Nokia-7215 | 202305 | MgmtToRRouter (M0) | All Passed |
    | Nokia-7215 | 202205 | MgmtToRRouter (M0) | All Passed |
    | Nokia-7215 | 202012 | MgmtToRRouter (M0) | All Passed |
    | Arista-720DT | 202205 | BmcMgmtToRRouter (Mx) | All Passed |
    | Arista-720DT | 202305 | BmcMgmtToRRouter (Mx) | All Passed |

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

