### PR TITLE
Revert "[Mellanox] Align PSU temperature sysfs node name with hw-management change"

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -242,8 +242,8 @@ class Psu(FixedPsu):
 
         self.psu_power_max_capacity = os.path.join(PSU_PATH, "config/psu{}_power_capacity".format(self.index))
 
-        self.psu_temp = os.path.join(PSU_PATH, 'thermal/psu{}_temp1'.format(self.index))
-        self.psu_temp_threshold = os.path.join(PSU_PATH, 'thermal/psu{}_temp1_max'.format(self.index))
+        self.psu_temp = os.path.join(PSU_PATH, 'thermal/psu{}_temp'.format(self.index))
+        self.psu_temp_threshold = os.path.join(PSU_PATH, 'thermal/psu{}_temp_max'.format(self.index))
 
         self.psu_power_slope = os.path.join(PSU_PATH, self.PSU_POWER_SLOPE.format(self.index))
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -65,8 +65,8 @@ THERMAL_NAMING_RULE = {
     "psu thermals":
     {
         "name": "PSU-{} Temp",
-        "temperature": "psu{}_temp1",
-        "high_threshold": "psu{}_temp1_max",
+        "temperature": "psu{}_temp",
+        "high_threshold": "psu{}_temp_max",
         "type": "indexable"
     },
     "chassis thermals": [


### PR DESCRIPTION
This PR depends on new hw-management version 7.0030.2000. Revert it for now and waiting for hw-management upgrading.