### PR TITLE
[Bookworm] Upgrade Dell platforms to Bookworm

### DIFF
--- a/platform/broadcom/rules.mk
+++ b/platform/broadcom/rules.mk
@@ -9,7 +9,7 @@ include $(PLATFORM_PATH)/sai.mk
 # * Ragile
 # * Ufispace
 #include $(PLATFORM_PATH)/platform-modules-nokia.mk
-#include $(PLATFORM_PATH)/platform-modules-dell.mk
+include $(PLATFORM_PATH)/platform-modules-dell.mk
 include $(PLATFORM_PATH)/platform-modules-arista.mk
 #include $(PLATFORM_PATH)/platform-modules-ingrasys.mk
 #include $(PLATFORM_PATH)/platform-modules-accton.mk

--- a/platform/broadcom/sonic-platform-modules-dell/common/dell_fpga_ocores.c
+++ b/platform/broadcom/sonic-platform-modules-dell/common/dell_fpga_ocores.c
@@ -1531,5 +1531,4 @@ module_exit (fpgapci_exit);
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("joyce_yu@dell.com");
 MODULE_DESCRIPTION ("Driver for FPGA Logic I2C bus");
-MODULE_SUPPORTED_DEVICE ("FPGA Logic I2C bus");
 MODULE_VERSION ("01.01");

--- a/platform/broadcom/sonic-platform-modules-dell/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/rules
@@ -18,76 +18,76 @@ override_dh_auto_build:
 			cp $(COMMON_DIR)/dell_pmc.c $(MOD_SRC_DIR)/$${mod}/modules/dell_s6100_lpc.c; \
 			cp $(COMMON_DIR)/dell_ich.c $(MOD_SRC_DIR)/$${mod}/modules/dell_ich.c; \
 			cd $(MOD_SRC_DIR)/$${mod}; \
-			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			python3 -m build --wheel --no-isolation --outdir $(MOD_SRC_DIR)/$${mod}/modules; \
 			cd $(MOD_SRC_DIR); \
 		elif [ $$mod = "z9100" ]; then \
 			cp $(COMMON_DIR)/dell_pmc.c $(MOD_SRC_DIR)/$${mod}/modules/dell_mailbox.c; \
 			cp $(COMMON_DIR)/dell_ich.c $(MOD_SRC_DIR)/$${mod}/modules/dell_ich.c; \
 			cd $(MOD_SRC_DIR)/$${mod}; \
-			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			python3 -m build --wheel --no-isolation --outdir $(MOD_SRC_DIR)/$${mod}/modules; \
 			cd $(MOD_SRC_DIR); \
 		elif [ $$mod = "s6000" ]; then \
 			cd $(MOD_SRC_DIR)/$${mod}; \
-			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			python3 -m build --wheel --no-isolation --outdir $(MOD_SRC_DIR)/$${mod}/modules; \
 			cd $(MOD_SRC_DIR); \
 		elif [ $$mod = "z9264f" ]; then \
 		        cp $(COMMON_DIR)/dell_fpga_ocores.c $(MOD_SRC_DIR)/$${mod}/modules/dell_z9264f_fpga_ocores.c; \
 			cp $(COMMON_DIR)/ipmihelper.py $(MOD_SRC_DIR)/$${mod}/sonic_platform/ipmihelper.py; \
 			cd $(MOD_SRC_DIR)/$${mod}; \
-			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			python3 -m build --wheel --no-isolation --outdir $(MOD_SRC_DIR)/$${mod}/modules; \
 			cd $(MOD_SRC_DIR); \
 		elif [ $$mod = "s5212f" ]; then \
 		        cp $(COMMON_DIR)/dell_fpga_ocores.c $(MOD_SRC_DIR)/$${mod}/modules/dell_s5212f_fpga_ocores.c; \
 			cp $(COMMON_DIR)/ipmihelper.py $(MOD_SRC_DIR)/$${mod}/sonic_platform/ipmihelper.py; \
 			cd $(MOD_SRC_DIR)/$${mod}; \
-			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			python3  -m build --wheel --no-isolation --outdir $(MOD_SRC_DIR)/$${mod}/modules; \
 			cd $(MOD_SRC_DIR); \
 		elif [ $$mod = "s5224f" ]; then \
 		        cp $(COMMON_DIR)/dell_fpga_ocores.c $(MOD_SRC_DIR)/$${mod}/modules/dell_s5224f_fpga_ocores.c; \
 			cp $(COMMON_DIR)/ipmihelper.py $(MOD_SRC_DIR)/$${mod}/sonic_platform/ipmihelper.py; \
 			cd $(MOD_SRC_DIR)/$${mod}; \
-			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			python3  -m build --wheel --no-isolation --outdir $(MOD_SRC_DIR)/$${mod}/modules; \
 			cd $(MOD_SRC_DIR); \
 		elif [ $$mod = "s5232f" ]; then \
 		        cp $(COMMON_DIR)/dell_fpga_ocores.c $(MOD_SRC_DIR)/$${mod}/modules/dell_s5232f_fpga_ocores.c; \
 			cp $(COMMON_DIR)/ipmihelper.py $(MOD_SRC_DIR)/$${mod}/sonic_platform/ipmihelper.py; \
 			cd $(MOD_SRC_DIR)/$${mod}; \
-			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			python3 -m build --wheel --no-isolation --outdir $(MOD_SRC_DIR)/$${mod}/modules; \
 			cd $(MOD_SRC_DIR); \
 		elif [ $$mod = "s5248f" ]; then \
 		        cp $(COMMON_DIR)/dell_fpga_ocores.c $(MOD_SRC_DIR)/$${mod}/modules/dell_s5248f_fpga_ocores.c; \
 			cp $(COMMON_DIR)/ipmihelper.py $(MOD_SRC_DIR)/$${mod}/sonic_platform/ipmihelper.py; \
 			cd $(MOD_SRC_DIR)/$${mod}; \
-			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			python3 -m build --wheel --no-isolation --outdir $(MOD_SRC_DIR)/$${mod}/modules; \
 			cd $(MOD_SRC_DIR); \
 		elif [ $$mod = "s5296f" ]; then \
 		        cp $(COMMON_DIR)/dell_fpga_ocores.c $(MOD_SRC_DIR)/$${mod}/modules/dell_s5296f_fpga_ocores.c; \
 			cp $(COMMON_DIR)/ipmihelper.py $(MOD_SRC_DIR)/$${mod}/sonic_platform/ipmihelper.py; \
 			cd $(MOD_SRC_DIR)/$${mod}; \
-			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			python3 -m build --wheel --no-isolation --outdir $(MOD_SRC_DIR)/$${mod}/modules; \
 			cd $(MOD_SRC_DIR); \
 		elif [ $$mod = "n3248te" ]; then \
 			cd $(MOD_SRC_DIR)/$${mod}; \
-			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			python3 -m build --wheel --no-isolation --outdir $(MOD_SRC_DIR)/$${mod}/modules; \
 			cd $(MOD_SRC_DIR); \
 		elif [ $$mod = "z9332f" ]; then \
 			cp $(COMMON_DIR)/ipmihelper.py $(MOD_SRC_DIR)/$${mod}/sonic_platform/ipmihelper.py; \
 			cd $(MOD_SRC_DIR)/$${mod}; \
-			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			python3 -m build --wheel --no-isolation --outdir $(MOD_SRC_DIR)/$${mod}/modules; \
 			cd $(MOD_SRC_DIR); \
 		elif [ $$mod = "z9432f" ]; then \
 		        cp $(COMMON_DIR)/dell_fpga_ocores.c $(MOD_SRC_DIR)/$${mod}/modules/dell_z9432f_fpga_ocores.c; \
 			cp $(COMMON_DIR)/ipmihelper.py $(MOD_SRC_DIR)/$${mod}/sonic_platform/ipmihelper.py; \
 			cd $(MOD_SRC_DIR)/$${mod}; \
-			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			python3 -m build --wheel --no-isolation --outdir $(MOD_SRC_DIR)/$${mod}/modules; \
 			cd $(MOD_SRC_DIR); \
 		elif [ $$mod = "n3248pxe" ]; then \
 			cd $(MOD_SRC_DIR)/$${mod}; \
-			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			python3 -m build --wheel --no-isolation --outdir $(MOD_SRC_DIR)/$${mod}/modules; \
 			cd $(MOD_SRC_DIR); \
 		elif [ $$mod = "e3224f" ]; then \
 			cd $(MOD_SRC_DIR)/$${mod}; \
-			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			python3 -m build --wheel --no-isolation --outdir $(MOD_SRC_DIR)/$${mod}/modules; \
 			cd $(MOD_SRC_DIR); \
 		fi; \
 		echo "making man page alias $$mod -> $$mod APIs";\

--- a/platform/broadcom/sonic-platform-modules-dell/e3224f/modules/emc2305.c
+++ b/platform/broadcom/sonic-platform-modules-dell/e3224f/modules/emc2305.c
@@ -57,7 +57,6 @@ static const unsigned short i2c_adresses[] = {
     0x4D,
     I2C_CLIENT_END
 };
-
 /*
  * global registers
  */
@@ -854,7 +853,7 @@ static const struct sensor_device_attribute *emc2305_fan_attrs[] = {
  * driver interface
  */
 
-static int emc2305_remove(struct i2c_client *client)
+static void emc2305_remove(struct i2c_client *client)
 {
     struct emc2305_data *data = i2c_get_clientdata(client);
     int fan_idx, i;
@@ -872,7 +871,6 @@ static int emc2305_remove(struct i2c_client *client)
                 &emc2305_attr_common[i].dev_attr);
 
     kfree(data);
-    return 0;
 }
 
 

--- a/platform/broadcom/sonic-platform-modules-dell/n3248pxe/modules/emc2305.c
+++ b/platform/broadcom/sonic-platform-modules-dell/n3248pxe/modules/emc2305.c
@@ -609,7 +609,7 @@ static const struct sensor_device_attribute *emc2305_fan_attrs[] = {
  * driver interface
  */
 
-static int emc2305_remove(struct i2c_client *client)
+static void emc2305_remove(struct i2c_client *client)
 {
 	struct emc2305_data *data = i2c_get_clientdata(client);
 	int fan_idx, i;
@@ -627,7 +627,6 @@ static int emc2305_remove(struct i2c_client *client)
 				   &emc2305_attr_common[i].dev_attr);
 
 	kfree(data);
-	return 0;
 }
 
 

--- a/platform/broadcom/sonic-platform-modules-dell/n3248te/modules/emc2305.c
+++ b/platform/broadcom/sonic-platform-modules-dell/n3248te/modules/emc2305.c
@@ -609,7 +609,7 @@ static const struct sensor_device_attribute *emc2305_fan_attrs[] = {
  * driver interface
  */
 
-static int emc2305_remove(struct i2c_client *client)
+static void emc2305_remove(struct i2c_client *client)
 {
 	struct emc2305_data *data = i2c_get_clientdata(client);
 	int fan_idx, i;
@@ -627,7 +627,6 @@ static int emc2305_remove(struct i2c_client *client)
 				   &emc2305_attr_common[i].dev_attr);
 
 	kfree(data);
-	return 0;
 }
 
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/modules/dell_s6100_iom_cpld.c
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/modules/dell_s6100_iom_cpld.c
@@ -49,7 +49,6 @@ struct cpld_data {
     struct mutex  update_lock;
 };
 
-
 static void dell_s6100_iom_cpld_add_client(struct i2c_client *client)
 {
     struct cpld_data *data = kzalloc(sizeof(struct cpld_data), GFP_KERNEL);
@@ -68,7 +67,6 @@ static void dell_s6100_iom_cpld_remove_client(struct i2c_client *client)
 {
     struct cpld_data *data = i2c_get_clientdata(client);
     kfree(data);
-    return;
 }
 
 int dell_s6100_iom_cpld_read(struct cpld_data *data,unsigned short cpld_addr, u8 reg)
@@ -474,10 +472,9 @@ exit:
     return status;
 }
 
-static int dell_s6100_iom_cpld_remove(struct i2c_client *client)
+static void dell_s6100_iom_cpld_remove(struct i2c_client *client)
 {
     dell_s6100_iom_cpld_remove_client(client);
-    return 0;
 }
 
 

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/modules/dell_z9100_cpld.c
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/modules/dell_z9100_cpld.c
@@ -449,10 +449,9 @@ exit:
     return status;
 }
 
-static int dell_z9100_iom_cpld_remove(struct i2c_client *client)
+static void dell_z9100_iom_cpld_remove(struct i2c_client *client)
 {
     dell_z9100_iom_cpld_remove_client(client);
-    return 0;
 }
 
 

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/modules/cls-i2c-mux-pca954x.c
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/modules/cls-i2c-mux-pca954x.c
@@ -50,7 +50,6 @@
 #define PCA954X_MAX_NCHANS 8
 
 #define PCA954X_IRQ_OFFSET 4
-static void pca954x_remove(struct i2c_client *client);
 enum pca_type {
 	pca_9540,
 	pca_9542,

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/modules/cls-i2c-mux-pca954x.c
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/modules/cls-i2c-mux-pca954x.c
@@ -50,7 +50,7 @@
 #define PCA954X_MAX_NCHANS 8
 
 #define PCA954X_IRQ_OFFSET 4
-
+static void pca954x_remove(struct i2c_client *client);
 enum pca_type {
 	pca_9540,
 	pca_9542,
@@ -533,14 +533,13 @@ fail_cleanup:
 	return ret;
 }
 
-static int pca954x_remove(struct i2c_client *client)
+static void pca954x_remove(struct i2c_client *client)
 {
 	struct i2c_mux_core *muxc = i2c_get_clientdata(client);
 
 	device_remove_file(&client->dev, &dev_attr_idle_state);
 
 	pca954x_cleanup(muxc);
-	return 0;
 }
 
 #ifdef CONFIG_PM_SLEEP

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/modules/mc24lc64t.c
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/modules/mc24lc64t.c
@@ -108,15 +108,13 @@ static int mc24lc64t_probe(struct i2c_client *client,
         return err;
 }
 
-static int mc24lc64t_remove(struct i2c_client *client)
+static void mc24lc64t_remove(struct i2c_client *client)
 {
         struct mc24lc64t_data *drvdata = i2c_get_clientdata(client);
 
         i2c_unregister_device(drvdata->fake_client);
 
         sysfs_remove_bin_file(&client->dev.kobj, &mc24lc64t_bit_attr);
-
-        return 0;
 }
 
 static const struct i2c_device_id mc24lc64t_id[] = {

--- a/platform/broadcom/sonic-platform-modules-dell/z9432f/modules/mc24lc64t.c
+++ b/platform/broadcom/sonic-platform-modules-dell/z9432f/modules/mc24lc64t.c
@@ -108,15 +108,13 @@ static int mc24lc64t_probe(struct i2c_client *client,
         return err;
 }
 
-static int mc24lc64t_remove(struct i2c_client *client)
+static void mc24lc64t_remove(struct i2c_client *client)
 {
         struct mc24lc64t_data *drvdata = i2c_get_clientdata(client);
 
         i2c_unregister_device(drvdata->fake_client);
 
         sysfs_remove_bin_file(&client->dev.kobj, &mc24lc64t_bit_attr);
-
-        return 0;
 }
 
 static const struct i2c_device_id mc24lc64t_id[] = {


### PR DESCRIPTION
#### Why I did it

- https://github.com/sonic-net/sonic-buildimage/issues/16735

#### How I did it

- Modified platform driver to comply with bookworm kernel.
- Removed MODULE_SUPPORTED_DEVICE wherever used.
- Modified python build commands for building whl packages.

#### How to verify it

- Verify whether all the platform bookworm debs are built. 
  `make target/debs/bookworm/platform-modules-z9100_1.1_amd64.deb`
- Load the platform debian into the device and install it in bookworm image.
- Verify the platform related CLI and the functionality

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
