### PR TITLE
[Bookworm] [Secure Boot] Fix the updated path for extract-cert binary

### DIFF
--- a/scripts/signing_kernel_modules.sh
+++ b/scripts/signing_kernel_modules.sh
@@ -66,7 +66,7 @@ if [ ! -f ${LOCAL_SIGN_FILE} ]; then
 fi
 
 if [ -z ${LOCAL_EXTRACT_CERT} ]; then
-    LOCAL_EXTRACT_CERT="/usr/lib/linux-kbuild-${kbuild_ver_major}/scripts/extract-cert"
+    LOCAL_EXTRACT_CERT="/usr/lib/linux-kbuild-${kbuild_ver_major}/certs/extract-cert"
 fi
 
 if [ ! -f ${LOCAL_EXTRACT_CERT} ]; then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

```
ERROR: LOCAL_EXTRACT_CERT=/usr/lib/linux-kbuild-6.1/scripts/extract-cert file does not exist
./scripts/signing_kernel_modules.sh: # Display Help
./scripts/signing_kernel_modules.sh -l <LINUX_KERNEL_VERSION> -c <PEM_CERT> -p <PEM_PRIVATE_KEY> -s <LOCAL_SIGN_FILE> -e <LOCAL_EXTRACT_CERT> -k <KERNEL_MODULES_DIR>
Sign kernel modules in <KERNEL_MODULES_DIR> using private & public keys.
Parameters description:
LINUX_KERNEL_VERSION
PEM_CERT                             public key (pem format)
PEM_PRIVATE_KEY                      private key (pem format)
LOCAL_SIGN_FILE                      path of the sign-file tool for signing Kernel Modules, if the value is empty it will used the sign-file installed in /usr/lib/linux-kbuild-<version>/scripts
LOCAL_EXTRACT_CERT                   path of the extract-cert tool for Extract X.509 certificate, if the value is empty it will used the extract-cert installed in /usr/lib/linux-kbuild-<version>/scripts
KERNEL_MODULES_DIR                   ******** directory of all the kernel modules to be sign by the script, if the value empty it will use the call script location as ********.
Runs examples:
1. ./scripts/signing_kernel_modules.sh -l 5.10.0-8-2 -c cert.pem -p priv-key.pem
2. ./scripts/signing_kernel_modules.sh -l 5.10.0-8-2 -c cert.pem -p priv-key.pem -k fs********-mellanox -e /usr/lib/linux-kbuild-5.10/scripts/extract-cert -s /usr/lib/linux-kbuild-5.10/scripts/sign-file
+ sudo LANG=C ch******** ./fs********-mellanox umount /proc
+ true
[  FAIL LOG END  ] [ target/sonic-mellanox.bin ]
make: *** [slave.mk:1377: target/sonic-mellanox.bin] Error 1
Makefile.work:612: recipe for target 'target/sonic-mellanox.bin' failed
make[1]: *** [target/sonic-mellanox.bin] Error 2
make[1]: Leaving directory '/builds2/sw-r2d2-bot/workspace/sonic_main/sonic'
Makefile:44: recipe for target 'target/sonic-mellanox.bin' failed
make: *** [target/sonic-mellanox.bin] Error 2
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Updated the path according to the kernel version. extract-certs was moved from scripts/ to certs/ from kernel 5.17 https://github.com/gregkh/linux/commit/340a02535ee785c64c62a9c45706597a0139e972


#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

