### PR TITLE
[202205] Update OpenSSH to 1:8.4p1-5+deb11u2

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -340,7 +340,7 @@ sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/restart_service
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install smartmontools=7.2-1
 
 # Install custom-built openssh sshd
-sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/openssh-server_${OPENSSH_VERSION}_*.deb
+sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/openssh-server_${OPENSSH_VERSION}_*.deb $debs_path/openssh-client_${OPENSSH_VERSION}_*.deb $debs_path/openssh-sftp-server_${OPENSSH_VERSION}_*.deb
 
 {% if sonic_asic_platform == 'broadcom' %}
 # Install custom-built flashrom

--- a/rules/openssh.mk
+++ b/rules/openssh.mk
@@ -1,6 +1,6 @@
 # openssh package
 
-OPENSSH_VERSION = 8.4p1-5+deb11u1
+OPENSSH_VERSION = 8.4p1-5+deb11u2
 
 export OPENSSH_VERSION
 
@@ -8,6 +8,12 @@ OPENSSH_SERVER = openssh-server_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
 $(OPENSSH_SERVER)_SRC_PATH = $(SRC_PATH)/openssh
 $(OPENSSH_SERVER)_DEPENDS +=  $(LIBNL3_DEV) $(LIBNL_ROUTE3_DEV)
 SONIC_MAKE_DEBS += $(OPENSSH_SERVER)
+
+OPENSSH_CLIENT = openssh-client_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
+#$(eval $(call add_derived_package,$(OPENSSH_SERVER),$(OPENSSH_CLIENT)))
+
+OPENSSH_SFTP_SERVER = openssh-sftp-server_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
+#$(eval $(call add_derived_package,$(OPENSSH_SERVER),$(OPENSSH_SFTP_SERVER)))
 
 # The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
 # are archived into debug one image to facilitate debugging.

--- a/rules/openssh.mk
+++ b/rules/openssh.mk
@@ -10,10 +10,10 @@ $(OPENSSH_SERVER)_DEPENDS +=  $(LIBNL3_DEV) $(LIBNL_ROUTE3_DEV)
 SONIC_MAKE_DEBS += $(OPENSSH_SERVER)
 
 OPENSSH_CLIENT = openssh-client_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
-#$(eval $(call add_derived_package,$(OPENSSH_SERVER),$(OPENSSH_CLIENT)))
+$(eval $(call add_derived_package,$(OPENSSH_SERVER),$(OPENSSH_CLIENT)))
 
 OPENSSH_SFTP_SERVER = openssh-sftp-server_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
-#$(eval $(call add_derived_package,$(OPENSSH_SERVER),$(OPENSSH_SFTP_SERVER)))
+$(eval $(call add_derived_package,$(OPENSSH_SERVER),$(OPENSSH_SFTP_SERVER)))
 
 # The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
 # are archived into debug one image to facilitate debugging.

--- a/slave.mk
+++ b/slave.mk
@@ -654,7 +654,7 @@ SONIC_TARGET_LIST += $(addprefix $(DEBS_PATH)/, $(SONIC_DPKG_DEBS))
 # we depend on it and move our deb to other targets
 # Add new dev package:
 #     $(eval $(call add_derived_package,$(ORIGINAL_DEB),derived_deb_file.deb))
-$(addprefix $(DEBS_PATH)/, $(SONIC_DERIVED_DEBS)) : $(DEBS_PATH)/% : .platform $$(addsuffix -install,$$(addprefix $(DEBS_PATH)/,$$($$*_DEPENDS)))
+$(addprefix $(DEBS_PATH)/, $(SONIC_DERIVED_DEBS)) : $(DEBS_PATH)/% : .platform
 	$(HEADER)
 	# All noise takes place in main deb recipe, so we are just telling that
 	# we depend on it

--- a/slave.mk
+++ b/slave.mk
@@ -654,7 +654,7 @@ SONIC_TARGET_LIST += $(addprefix $(DEBS_PATH)/, $(SONIC_DPKG_DEBS))
 # we depend on it and move our deb to other targets
 # Add new dev package:
 #     $(eval $(call add_derived_package,$(ORIGINAL_DEB),derived_deb_file.deb))
-$(addprefix $(DEBS_PATH)/, $(SONIC_DERIVED_DEBS)) : $(DEBS_PATH)/% : .platform
+$(addprefix $(DEBS_PATH)/, $(SONIC_DERIVED_DEBS)) : $(DEBS_PATH)/% : .platform $$(addprefix $(DEBS_PATH)/,$$($$*_DEPENDS))
 	$(HEADER)
 	# All noise takes place in main deb recipe, so we are just telling that
 	# we depend on it

--- a/src/openssh/Makefile
+++ b/src/openssh/Makefile
@@ -3,7 +3,11 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = openssh-server_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
-DERIVED_TARGETS = openssh-server-dbgsym_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
+DERIVED_TARGETS = openssh-server-dbgsym_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb \
+				  openssh-client_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb \
+				  openssh-client-dbgsym_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb \
+				  openssh-sftp-server_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb \
+				  openssh-sftp-server-dbgsym_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Obtain openssh: https://salsa.debian.org/ssh-team/openssh/-/tree/debian/1%258.4p1-5


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This backports #16826, #16859, and #16896 to the 202205 branch, for updating OpenSSH to 1:8.4p1-5+deb11u2 and for fixing the subsequent build failures. This backport is being done in a single PR to avoid breakages in PR builds introduced by the first two PRs.

##### Work item tracking
- Microsoft ADO **(number only)**: 25436638, 25517845

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

