### PR TITLE
[staticroutebfd] fix an error in error logging

### DIFF
--- a/src/sonic-bgpcfgd/staticroutebfd/main.py
+++ b/src/sonic-bgpcfgd/staticroutebfd/main.py
@@ -376,7 +376,7 @@ class StaticRouteBfd(object):
 
         valid, is_ipv4, ip = check_ip(ip_prefix)
         if not valid:
-            log_err("invalid ip prefix for static route: ", key)
+            log_err("invalid ip prefix for static route: '%s'"%(key))
             return True
 
         #use lower case if there is letter in IPv6 address string

--- a/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
@@ -171,6 +171,23 @@ def test_set_del_ipv6():
         {'del_default:2603:10e2:400::4/128': { }}
     )
 
+@patch('staticroutebfd.main.log_err')
+def test_invalid_key(mocked_log_err):
+    dut = constructor()
+    intf_setup(dut)
+
+    set_del_test(dut, "srt",
+        "SET",
+        ("2.2.2/24", {
+            "bfd": "true",
+            "nexthop": "192.168.1.2 , 192.168.2.2, 192.168.3.2",
+            "ifname": "if1, if2, if3",
+        }),
+        {},
+        {}
+    )
+    mocked_log_err.assert_called_with("invalid ip prefix for static route: '2.2.2/24'")
+
 def test_set_del():
     dut = constructor()
     intf_setup(dut)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix an error in the log_err call.
this error can be triggered by an invalid static route key. usually the code cannot go here with normal config file. but hit this issue with an invalid key by manual testing with redis-cli directly. the file is scanned by Python lint to prevent such errors.

##### Work item tracking
- Microsoft ADO **()**:26250268

#### How I did it
fix the format error.

#### How to verify it
1, ran pylint to check the design, make sure no such error in the design file.
2, wrote a separate python program to verify the log call.
In the current logging related testing, usually use patch/mock for logging. for this specific error, could not trigger it if we call mock function instead the real function in the design. so need to do lint checking for code change.

 
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

