### PR TITLE
[YANG]: Fix SNMP_AGENT_ADDRESS_CONFIG yang model

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
@@ -506,7 +506,7 @@
     "SNMP_AGENT_ADDRESS_CONFIG": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
-                "SNMP_AGENT_ADDRESS_LIST": [
+                "SNMP_AGENT_ADDRESS_CONFIG_LIST": [
                     {
                        "agent_ip": "10.0.0.1",
                        "port": "161",
@@ -519,7 +519,7 @@
     "SNMP_AGENT_ADDRESS_CONFIG_IPV6": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
-                "SNMP_AGENT_ADDRESS_LIST": [
+                "SNMP_AGENT_ADDRESS_CONFIG_LIST": [
                     {
                        "agent_ip": "fd00::1",
                        "port": "161",
@@ -532,7 +532,7 @@
     "SNMP_AGENT_ADDRESS_CONFIG_EMPTY_PORT_NUMBER": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
-                "SNMP_AGENT_ADDRESS_LIST": [
+                "SNMP_AGENT_ADDRESS_CONFIG_LIST": [
                     {
                        "agent_ip": "10.0.0.1",
                        "port": "",
@@ -545,7 +545,7 @@
     "SNMP_AGENT_ADDRESS_CONFIG_MGMT_VRF": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
-                "SNMP_AGENT_ADDRESS_LIST": [
+                "SNMP_AGENT_ADDRESS_CONFIG_LIST": [
                     {
                        "agent_ip": "10.0.0.1",
                        "port": "161",
@@ -558,7 +558,7 @@
     "SNMP_AGENT_ADDRESS_CONFIG_NO_VRF": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
-                "SNMP_AGENT_ADDRESS_LIST": [
+                "SNMP_AGENT_ADDRESS_CONFIG_LIST": [
                     {
                        "agent_ip": "10.0.0.1",
                        "port": "161"
@@ -570,7 +570,7 @@
     "SNMP_AGENT_ADDRESS_CONFIG_INVALID_PORT": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
-                "SNMP_AGENT_ADDRESS_LIST": [
+                "SNMP_AGENT_ADDRESS_CONFIG_LIST": [
                     {
                        "agent_ip": "10.0.0.1",
 		       "port": "65536",
@@ -583,7 +583,7 @@
     "SNMP_AGENT_ADDRESS_CONFIG_DUPLICATE_IP_PORT": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
-                "SNMP_AGENT_ADDRESS_LIST": [
+                "SNMP_AGENT_ADDRESS_CONFIG_LIST": [
                     {
                        "agent_ip": "10.0.0.1",
                        "port": "161",
@@ -601,7 +601,7 @@
     "SNMP_AGENT_ADDRESS_CONFIG_INVALID_IPV4_ADDRESS": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
-                "SNMP_AGENT_ADDRESS_LIST": [
+                "SNMP_AGENT_ADDRESS_CONFIG_LIST": [
                     {
                        "agent_ip": "340.1.1.10",
                        "port": "161",
@@ -614,7 +614,7 @@
     "SNMP_AGENT_ADDRESS_CONFIG_INVALID_IPV6_ADDRESS": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_AGENT_ADDRESS_CONFIG": {
-                "SNMP_AGENT_ADDRESS_LIST": [
+                "SNMP_AGENT_ADDRESS_CONFIG_LIST": [
                     {
                        "agent_ip": "2001:aa:aa:aa",
                        "port": "161",

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -163,7 +163,7 @@ module sonic-snmp {
       }
     }
     container SNMP_AGENT_ADDRESS_CONFIG {
-      list SNMP_AGENT_ADDRESS_LIST {
+      list SNMP_AGENT_ADDRESS_CONFIG_LIST {
         key "agent_ip port vrf_name";
         unique "agent_ip port";
         description "List of SNMP agent listening IP Addresses and ports.";
@@ -179,7 +179,6 @@ module sonic-snmp {
             }
             type inet:port-number;
           }
-          default "";
           description "SNMP agent listening port number";
         }
         leaf vrf_name {
@@ -194,7 +193,6 @@ module sonic-snmp {
               pattern "Vrf[a-zA-Z0-9_-]+";
             }
           }
-          default "";
           description "VRF name";
         }
       }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
fixes https://github.com/sonic-net/sonic-buildimage/issues/16011
#### Why I did it
1. seeing below warning ,essage:
libyang[1]: Default value "" in the list key "port" is ignored. (/sonic-snmp:sonic-snmp/SNMP_AGENT_ADDRESS_CONFIG/SNMP_AGENT_ADDRESS_LIST)
libyang[1]: Default value "" in the list key "vrf_name" is ignored. (/sonic-snmp:sonic-snmp/SNMP_AGENT_ADDRESS_CONFIG/SNMP_AGENT_ADDRESS_LIST)

2.  name of list is not <model_name>_LIST.

##### Work item tracking
- Microsoft ADO 25646016:

#### How I did it
1. Remove default value provided to key in yang model to avoid seeing below error:
libyang[1]: Default value "" in the list key "port" is ignored. (/sonic-snmp:sonic-snmp/SNMP_AGENT_ADDRESS_CONFIG/SNMP_AGENT_ADDRESS_LIST)
libyang[1]: Default value "" in the list key "vrf_name" is ignored. (/sonic-snmp:sonic-snmp/SNMP_AGENT_ADDRESS_CONFIG/SNMP_AGENT_ADDRESS_LIST)

2. Modify the LIST name to have <model_name>_LIST as this was failing yang validation during unit-tests.
#### How to verify it
unit-tests passing.
Before fix
```
admin@vlab-01:~$ sudo sonic-package-manager list
libyang[1]: Default value "" in the list key "port" is ignored. (/sonic-snmp:sonic-snmp/SNMP_AGENT_ADDRESS_CONFIG/SNMP_AGENT_ADDRESS_LIST)
libyang[1]: Default value "" in the list key "vrf_name" is ignored. (/sonic-snmp:sonic-snmp/SNMP_AGENT_ADDRESS_CONFIG/SNMP_AGENT_ADDRESS_LIST)
Name            Repository                   Description                   Version    Status
--------------  ---------------------------  ----------------------------  ---------  ---------
database        docker-database              SONiC database package        1.0.0      Built-In
dhcp-relay      docker-dhcp-relay            N/A                           1.0.0      Installed
eventd          docker-eventd                SONiC eventd package          1.0.0      Built-In
fpm-frr         docker-fpm-frr               SONiC fpm-frr package         1.0.0      Built-In
gbsyncd         docker-gbsyncd-vs            SONiC gbsyncd package         1.0.0      Built-In
lldp            docker-lldp                  SONiC lldp package            1.0.0      Built-In
macsec          docker-macsec                N/A                           1.0.0      Installed
mgmt-framework  docker-sonic-mgmt-framework  SONiC mgmt-framework package  1.0.0      Built-In
mux             docker-mux                   SONiC mux package             1.0.0      Built-In
nat             docker-nat                   SONiC nat package             1.0.0      Built-In
pmon            docker-platform-monitor      SONiC pmon package            1.0.0      Built-In
radv            docker-router-advertiser     SONiC radv package            1.0.0      Built-In
sflow           docker-sflow                 SONiC sflow package           1.0.0      Built-In
snmp            docker-snmp                  SONiC snmp package            1.0.0      Built-In
swss            docker-orchagent             SONiC swss package            1.0.0      Built-In
syncd           docker-syncd-vs              SONiC syncd package           1.0.0      Built-In
teamd           docker-teamd                 SONiC teamd package           1.0.0      Built-In
telemetry       docker-sonic-telemetry       SONiC telemetry package       1.0.0      Built-In
```
After fix:
```
admin@vlab-01:~$ sudo sonic-package-manager list
Name            Repository                   Description                   Version    Status
--------------  ---------------------------  ----------------------------  ---------  ---------
database        docker-database              SONiC database package        1.0.0      Built-In
dhcp-relay      docker-dhcp-relay            N/A                           1.0.0      Installed
eventd          docker-eventd                SONiC eventd package          1.0.0      Built-In
fpm-frr         docker-fpm-frr               SONiC fpm-frr package         1.0.0      Built-In
gbsyncd         docker-gbsyncd-vs            SONiC gbsyncd package         1.0.0      Built-In
lldp            docker-lldp                  SONiC lldp package            1.0.0      Built-In
macsec          docker-macsec                N/A                           1.0.0      Installed
mgmt-framework  docker-sonic-mgmt-framework  SONiC mgmt-framework package  1.0.0      Built-In
mux             docker-mux                   SONiC mux package             1.0.0      Built-In
nat             docker-nat                   SONiC nat package             1.0.0      Built-In
pmon            docker-platform-monitor      SONiC pmon package            1.0.0      Built-In
radv            docker-router-advertiser     SONiC radv package            1.0.0      Built-In
sflow           docker-sflow                 SONiC sflow package           1.0.0      Built-In
snmp            docker-snmp                  SONiC snmp package            1.0.0      Built-In
swss            docker-orchagent             SONiC swss package            1.0.0      Built-In
syncd           docker-syncd-vs              SONiC syncd package           1.0.0      Built-In
teamd           docker-teamd                 SONiC teamd package           1.0.0      Built-In
telemetry       docker-sonic-telemetry       SONiC telemetry package       1.0.0      Built-In
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

