### PR TITLE
[SNMP]: Modify minigraph parser to update SNMP_AGENT_ADDRESS_CONFIG

### DIFF
--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -28,7 +28,7 @@
 {% for (agentip, port, vrf) in SNMP_AGENT_ADDRESS_CONFIG %}
 agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% endif %}{% if vrf %}%{{ vrf }}{% endif %}{{ "" }}
 {% endfor %}
-{% if NAMESPACE_COUNT is not defined or NAMESPACE_COUNT|int <= 1 %}
+{% if NAMESPACE_COUNT is defined and NAMESPACE_COUNT|int > 1 %}
 agentAddress udp:[{{ docker0_v4 }}]:161
 agentAddress udp6:[{{ docker0_v6 }}]:161
 {% endif %}

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -26,12 +26,13 @@
 
 {% if SNMP_AGENT_ADDRESS_CONFIG %}
 {% for (agentip, port, vrf) in SNMP_AGENT_ADDRESS_CONFIG %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% endif %}{% if vrf %}%{{ vrf }}{% endif %}{{ "" }}
-{% endfor %}
-{% if NAMESPACE_COUNT is defined and NAMESPACE_COUNT|int > 1 %}
-agentAddress udp:[{{ docker0_v4 }}]:161
-agentAddress udp6:[{{ docker0_v6 }}]:161
+{% set zoneid = '' %}
+{% if agentip.startswith('fe80') %}
+# Use interface as zoneid for link local ipv6
+{% set zoneid = '%' + intf %}
 {% endif %}
+agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]{% if port %}:{{ port }}{% endif %}{% if vrf %}%{{ vrf }}{% endif %}{{ "" }}
+{% endfor %}
 {% else %}
 agentAddress udp:161
 agentAddress udp6:161

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -26,12 +26,7 @@
 
 {% if SNMP_AGENT_ADDRESS_CONFIG %}
 {% for (agentip, port, vrf) in SNMP_AGENT_ADDRESS_CONFIG %}
-{% set zoneid = '' %}
-{% if agentip.startswith('fe80') %}
-# Use interface as zoneid for link local ipv6
-{% set zoneid = '%' + intf %}
-{% endif %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]{% if port %}:{{ port }}{% endif %}{% if vrf %}%{{ vrf }}{% endif %}{{ "" }}
+agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% endif %}{% if vrf %}%{{ vrf }}{% endif %}{{ "" }}
 {% endfor %}
 {% else %}
 agentAddress udp:161

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -28,31 +28,9 @@
 {% for (agentip, port, vrf) in SNMP_AGENT_ADDRESS_CONFIG %}
 agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% endif %}{% if vrf %}%{{ vrf }}{% endif %}{{ "" }}
 {% endfor %}
-{% elif NAMESPACE_COUNT is not defined or NAMESPACE_COUNT|int <= 1 %}
-{% if MGMT_INTERFACE is defined %}
-{% for intf, ip in MGMT_INTERFACE %}
-{% set agentip = ip.split('/')[0]|lower %}
-{% set zoneid = '' %}
-# Use interface as zoneid for link local ipv6
-{% if agentip.startswith('fe80') %}
-{% set zoneid = '%' + intf %}
-{% endif %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
-{% endfor %}
-{% endif %}
-{% if LOOPBACK_INTERFACE is defined %}
-{% for lo in LOOPBACK_INTERFACE %}
-{% if lo | length == 2 %}
-{% set intf = lo[0] %}
-{% set agentip = lo[1].split('/')[0]|lower %}
-{% set zoneid = '' %}
-# Use interface as zoneid for link local ipv6
-{% if agentip.startswith('fe80') %}
-{% set zoneid = '%' + intf %}
-{% endif %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}{{ zoneid }}]:161
-{% endif %}
-{% endfor %}
+{% if NAMESPACE_COUNT is not defined or NAMESPACE_COUNT|int <= 1 %}
+agentAddress udp:[{{ docker0_v4 }}]:161
+agentAddress udp6:[{{ docker0_v6 }}]:161
 {% endif %}
 {% else %}
 agentAddress udp:161

--- a/dockers/docker-snmp/start.sh
+++ b/dockers/docker-snmp/start.sh
@@ -17,6 +17,9 @@ mkdir -p /etc/ssw /etc/snmp
 /usr/bin/snmp_yml_to_configdb.py
 
 ADD_PARAM=$(printf '%s {"NAMESPACE_COUNT":"%s"}' "-a" "$NAMESPACE_COUNT")
+DOCKER0_V4=$(ip -4 addr show docker0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
+DOCKER0_V6=$(ip -6 addr show docker0 scope global | grep -oP '(?<=inet6\s)[0-9a-fA-F:]+')
+ADD_PARAM=$(printf '%s {"docker0_v4":"%s","docker0_v6":"%s","NAMESPACE_COUNT":"%s"}' "-a" "$DOCKER0_V4" "$DOCKER0_V6" "$NAMESPACE_COUNT")
 
 SONIC_CFGGEN_ARGS=" \
     -d \

--- a/dockers/docker-snmp/start.sh
+++ b/dockers/docker-snmp/start.sh
@@ -16,17 +16,11 @@ mkdir -p /etc/ssw /etc/snmp
 # Parse snmp.yml and insert the data in Config DB
 /usr/bin/snmp_yml_to_configdb.py
 
-ADD_PARAM=$(printf '%s {"NAMESPACE_COUNT":"%s"}' "-a" "$NAMESPACE_COUNT")
-DOCKER0_V4=$(ip -4 addr show docker0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
-DOCKER0_V6=$(ip -6 addr show docker0 scope global | grep -oP '(?<=inet6\s)[0-9a-fA-F:]+')
-ADD_PARAM=$(printf '%s {"docker0_v4":"%s","docker0_v6":"%s","NAMESPACE_COUNT":"%s"}' "-a" "$DOCKER0_V4" "$DOCKER0_V6" "$NAMESPACE_COUNT")
-
 SONIC_CFGGEN_ARGS=" \
     -d \
     -y /etc/sonic/sonic_version.yml \
     -t /usr/share/sonic/templates/sysDescription.j2,/etc/ssw/sysDescription \
     -t /usr/share/sonic/templates/snmpd.conf.j2,/etc/snmp/snmpd.conf \
-    $ADD_PARAM \
 "
 
 sonic-cfggen $SONIC_CFGGEN_ARGS

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1723,14 +1723,13 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     if not is_multi_asic() and asic_name is None:
         results['SNMP_AGENT_ADDRESS_CONFIG'] = {}
         port = '161'
-        for mgmt_intf in results['MGMT_INTERFACE'].keys():
+        for mgmt_intf in mgmt_intf.keys():
             snmp_key = mgmt_intf[1].split('/')[0] + '|' + port + '|'
             results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
         # Add Loopback IP as agent address for single asic
-        for loip in results['LOOPBACK_INTERFACE']:
-            if len(loip) == 2:
-                snmp_key = loip[1].split('/')[0] + '|' + port + '|'
-                results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
+        for loip in lo_intfs.keys():
+            snmp_key = loip[1].split('/')[0] + '|' + port + '|'
+            results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
     else:
         results['SNMP_AGENT_ADDRESS_CONFIG'] = {}
 

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -16,6 +16,7 @@ from natsort import natsorted, ns as natsortns
 
 from portconfig import get_port_config, get_fabric_port_config, get_fabric_monitor_config
 from sonic_py_common.interface import backplane_prefix
+from sonic_py_common.multi_asic import is_multi_asic
 
 # TODO: Remove this once we no longer support Python 2
 if sys.version_info.major == 3:
@@ -1719,17 +1720,17 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     results['MGMT_VRF_CONFIG'] = mvrf
     # Update SNMP_AGENT_ADDRESS_CONFIG with Management IP and Loopback0 IP
     # if available.
-    results['SNMP_AGENT_ADDRESS_CONFIG'] = {}
-    port = 161
-    vrf = ''
-    for mgmt_if in results['MGMT_INTERFACE'].keys():
-        snmp_key = mgmt_if[1].split('/')[0] + '|' + str(port)  + '|'
-        results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
-    # Add Loopback0 IP as agent address for single asic
-    for loip in results['LOOPBACK_INTERFACE']:
-        if len(loip) == 2 and loip[0] == 'Loopback0':
-            snmp_key = loip[1].split('/')[0] + '|161|'
+    if not is_multi_asic() and asic_name is None:
+        results['SNMP_AGENT_ADDRESS_CONFIG'] = {}
+        port = 161
+        for mgmt_if in results['MGMT_INTERFACE'].keys():
+            snmp_key = mgmt_if[1].split('/')[0] + '|' + str(port)  + '|'
             results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
+        # Add Loopback0 IP as agent address for single asic
+        for loip in results['LOOPBACK_INTERFACE']:
+            if len(loip) == 2 and loip[0] == 'Loopback0':
+                snmp_key = loip[1].split('/')[0] + '|' + str(port)  + '|'
+                results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
 
     phyport_intfs = {}
     vlan_intfs = {}

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1718,7 +1718,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
             results['LOOPBACK_INTERFACE'][host_lo_intf[0]] = {}
 
     results['MGMT_VRF_CONFIG'] = mvrf
-    # Update SNMP_AGENT_ADDRESS_CONFIG with Management IP and Loopback0 IP
+    # Update SNMP_AGENT_ADDRESS_CONFIG with Management IP and Loopback IP
     # if available.
     if not is_multi_asic() and asic_name is None:
         results['SNMP_AGENT_ADDRESS_CONFIG'] = {}
@@ -1726,9 +1726,9 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         for mgmt_if in results['MGMT_INTERFACE'].keys():
             snmp_key = mgmt_if[1].split('/')[0] + '|' + str(port)  + '|'
             results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
-        # Add Loopback0 IP as agent address for single asic
+        # Add Loopback IP as agent address for single asic
         for loip in results['LOOPBACK_INTERFACE']:
-            if len(loip) == 2 and loip[0] == 'Loopback0':
+            if len(loip) == 2:
                 snmp_key = loip[1].split('/')[0] + '|' + str(port)  + '|'
                 results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
 

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1723,14 +1723,16 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     if not is_multi_asic() and asic_name is None:
         results['SNMP_AGENT_ADDRESS_CONFIG'] = {}
         port = 161
-        for mgmt_if in results['MGMT_INTERFACE'].keys():
-            snmp_key = mgmt_if[1].split('/')[0] + '|' + str(port)  + '|'
+        for mgmt_intf in results['MGMT_INTERFACE'].keys():
+            snmp_key = mgmt_intf[1].split('/')[0] + '|' + str(port)  + '|'
             results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
         # Add Loopback IP as agent address for single asic
         for loip in results['LOOPBACK_INTERFACE']:
             if len(loip) == 2:
                 snmp_key = loip[1].split('/')[0] + '|' + str(port)  + '|'
                 results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
+    else:
+        results['SNMP_AGENT_ADDRESS_CONFIG'] = {}
 
     phyport_intfs = {}
     vlan_intfs = {}

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1717,6 +1717,19 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
             results['LOOPBACK_INTERFACE'][host_lo_intf[0]] = {}
 
     results['MGMT_VRF_CONFIG'] = mvrf
+    # Update SNMP_AGENT_ADDRESS_CONFIG with Management IP and Loopback0 IP
+    # if available.
+    results['SNMP_AGENT_ADDRESS_CONFIG'] = {}
+    port = 161
+    vrf = ''
+    for mgmt_if in results['MGMT_INTERFACE'].keys():
+        snmp_key = mgmt_if[1].split('/')[0] + '|' + str(port)  + '|'
+        results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
+    # Add Loopback0 IP as agent address for single asic
+    for loip in results['LOOPBACK_INTERFACE']:
+        if len(loip) == 2 and loip[0] == 'Loopback0':
+            snmp_key = loip[1].split('/')[0] + '|161|'
+            results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
 
     phyport_intfs = {}
     vlan_intfs = {}

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1722,14 +1722,14 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     # if available.
     if not is_multi_asic() and asic_name is None:
         results['SNMP_AGENT_ADDRESS_CONFIG'] = {}
-        port = 161
+        port = '161'
         for mgmt_intf in results['MGMT_INTERFACE'].keys():
-            snmp_key = mgmt_intf[1].split('/')[0] + '|' + str(port)  + '|'
+            snmp_key = mgmt_intf[1].split('/')[0] + '|' + port + '|'
             results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
         # Add Loopback IP as agent address for single asic
         for loip in results['LOOPBACK_INTERFACE']:
             if len(loip) == 2:
-                snmp_key = loip[1].split('/')[0] + '|' + str(port)  + '|'
+                snmp_key = loip[1].split('/')[0] + '|' + port + '|'
                 results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
     else:
         results['SNMP_AGENT_ADDRESS_CONFIG'] = {}

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1718,6 +1718,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
             results['LOOPBACK_INTERFACE'][host_lo_intf[0]] = {}
 
     results['MGMT_VRF_CONFIG'] = mvrf
+
     # Update SNMP_AGENT_ADDRESS_CONFIG with Management IP and Loopback IP
     # if available.
     if not is_multi_asic() and asic_name is None:

--- a/src/sonic-config-engine/tests/sample_graph.xml
+++ b/src/sonic-config-engine/tests/sample_graph.xml
@@ -63,6 +63,14 @@
           </a:Prefix>
           <a:PrefixStr>100.0.0.6/32</a:PrefixStr>
         </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback1</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+            <b:IPPrefix>100.0.0.7/32</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>100.0.0.7/32</a:PrefixStr>
+        </a:LoopbackIPInterface>
       </LoopbackIPInterfaces>
       <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
         <a:ManagementIPInterface>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -1145,4 +1145,9 @@ class TestCfgGen(TestCase):
             )
         )
 
-
+    def testsnmp_agent_address_config(self):
+        argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', 'SNMP_AGENT_ADDRESS_CONFIG.keys()|list']
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.liststr_to_dict(output.strip()),
+            utils.liststr_to_dict("['192.168.200.15|161|', '100.0.0.6|161|']"))

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -1150,4 +1150,4 @@ class TestCfgGen(TestCase):
         output = self.run_script(argument)
         self.assertEqual(
             utils.liststr_to_dict(output.strip()),
-            utils.liststr_to_dict("['192.168.200.15|161|', '100.0.0.6|161|']"))
+            utils.liststr_to_dict("['192.168.200.15|161|', '100.0.0.6|161|', '100.0.0.7|161|']"))

--- a/src/sonic-config-engine/tests/test_multinpu_cfggen.py
+++ b/src/sonic-config-engine/tests/test_multinpu_cfggen.py
@@ -549,5 +549,12 @@ class TestMultiNpuCfgGen(TestCase):
         output = json.loads(self.run_script(argument, check_stderr=False, validateYang=False))
         self.assertDictEqual(output, {})
 
+    def testsnmp_agent_address_config(self):
+        argument = ['-m', self.sample_graph, '-p', self.sample_port_config, '-v', 'SNMP_AGENT_ADDRESS_CONFIG.keys()|list']
+        output = self.run_script(argument, check_stderr=False, validateYang=False)
+        self.assertEqual(
+            utils.liststr_to_dict(output.strip()),
+            utils.liststr_to_dict("['3.10.147.150|161|', '10.1.0.32|161|', 'FC00:2::32|161|', 'FC00:1::32|161|']"))
+
     def tearDown(self):
         os.environ["CFGGEN_UNIT_TESTING"] = ""

--- a/src/sonic-config-engine/tests/test_multinpu_cfggen.py
+++ b/src/sonic-config-engine/tests/test_multinpu_cfggen.py
@@ -549,12 +549,5 @@ class TestMultiNpuCfgGen(TestCase):
         output = json.loads(self.run_script(argument, check_stderr=False, validateYang=False))
         self.assertDictEqual(output, {})
 
-    def testsnmp_agent_address_config(self):
-        argument = ['-m', self.sample_graph, '-p', self.sample_port_config, '-v', 'SNMP_AGENT_ADDRESS_CONFIG.keys()|list']
-        output = self.run_script(argument, check_stderr=False, validateYang=False)
-        self.assertEqual(
-            utils.liststr_to_dict(output.strip()),
-            utils.liststr_to_dict("['3.10.147.150|161|', '10.1.0.32|161|', 'FC00:2::32|161|', 'FC00:1::32|161|']"))
-
     def tearDown(self):
         os.environ["CFGGEN_UNIT_TESTING"] = ""


### PR DESCRIPTION
table

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
SNMP query over IPv6 does not work due to issue in net-snmp where IPv6 query does not work on multi-nic environment.
To get around this, if snmpd listens on specific ipv4 or ipv6 address, then the issue is not seen.
We plan to configure Management IP and Loopback IP configured in minigraph.xml as SNMP_AGENT_ADDRESS in config_db., based on changes discussed in https://github.com/sonic-net/SONiC/pull/1457.

##### Work item tracking
- Microsoft ADO **(number only)**:26091228

#### How I did it
Modify minigraph parser to update SNMP_AGENT_ADDRESS_CONFIG with management and Loopback0 IP addresses.
Modify snmpd.conf.j2 to use SNMP_AGENT_ADDRESS_CONFIG table if it is present in config_db, if not listen on any IP.
Main change:
1. if minigraph.xml is used to configure the device, then snmpd will listen on mgmt and loopback IP addresses,
2. if config_db is used to configure the device, snmpd will listen IP present in SNMP_AGENT_ADDRESS_CONFIG  if that table is present, if table is not present snmpd will listen on any IP.
#### How to verify it
config_db.json created from minigraph.xml for single asic VS image with mgmt and Loopback IP addresses.
```
    "SNMP_AGENT_ADDRESS_CONFIG": {
        "10.1.0.32|161|": {},
        "10.250.0.101|161|": {},
        "FC00:1::32|161|": {},
        "fec0::ffff:afa:1|161|": {}
    },
 .....
 
 snmpd listening on the above IP addresses:
 admin@vlab-01:~$ sudo netstat -tulnp | grep 161
tcp        0      0 127.0.0.1:3161          0.0.0.0:*               LISTEN      71522/snmpd         
udp        0      0 10.250.0.101:161        0.0.0.0:*                           71522/snmpd         
udp        0      0 10.1.0.32:161           0.0.0.0:*                           71522/snmpd         
udp6       0      0 fec0::ffff:afa:1:161    :::*                                71522/snmpd         
udp6       0      0 fc00:1::32:161          :::*                                71522/snmpd  
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

