### PR TITLE
[FRR][patch] Add encap type when building packet for FPM

### DIFF
--- a/src/sonic-frr/patch/0026-zebra-Add-encap-type-when-building-packet-for-FPM.patch
+++ b/src/sonic-frr/patch/0026-zebra-Add-encap-type-when-building-packet-for-FPM.patch
@@ -1,0 +1,50 @@
+From b914b0ad506649b5d341b549a37d3cb73e72b494 Mon Sep 17 00:00:00 2001
+From: Stepan Blyschak <stepanb@nvidia.com>
+Date: Mon, 30 Oct 2023 14:31:45 +0200
+Subject: [PATCH] zebra: Add encap type when building packet for FPM
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>
+---
+ zebra/rt_netlink.c | 22 ++++++++++++----------
+ 1 file changed, 12 insertions(+), 10 deletions(-)
+
+diff --git a/zebra/rt_netlink.c b/zebra/rt_netlink.c
+index 6b9b04785..71505e037 100644
+--- a/zebra/rt_netlink.c
++++ b/zebra/rt_netlink.c
+@@ -2269,19 +2269,21 @@ ssize_t netlink_route_multipath_msg_encode(int cmd,
+ 					    p, routedesc, bytelen, nexthop,
+ 					    &req->n, &req->r, datalen, cmd))
+ 					return 0;
++
++				/*
++				 * Add encapsulation information when
++				 * installing via FPM.
++				 */
++				if (fpm) {
++					if (!netlink_route_nexthop_encap(&req->n,
++									 datalen,
++									 nexthop))
++						return 0;
++				}
++
+ 				nexthop_num++;
+ 				break;
+ 			}
+-
+-			/*
+-			 * Add encapsulation information when installing via
+-			 * FPM.
+-			 */
+-			if (fpm) {
+-				if (!netlink_route_nexthop_encap(
+-					    &req->n, datalen, nexthop))
+-					return 0;
+-			}
+ 		}
+ 
+ 		if (setsrc) {
+-- 
+2.17.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -25,3 +25,4 @@ cross-compile-changes.patch
 0023-bgpd-Make-sure-we-have-enough-data-to-read-two-bytes.patch
 0024-bgpd-Do-not-process-NLRIs-if-the-attribute-length-is.patch
 0025-bgpd-Use-treat-as-withdraw-for-tunnel-encapsulation-.patch
+0026-zebra-Add-encap-type-when-building-packet-for-FPM.patch


### PR DESCRIPTION
Back port a patch from upstream FRR - https://github.com/FRRouting/frr/pull/14675

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The EVPN route is not treated correctly and thus leading to messages:

```
Oct 30 11:40:00.494083 r-tigris-22 INFO swss#orchagent: :- addRoute: Failed to get next hop 30.0.0.2@Vlan200 for 20.0.0.2/32, resolving neighbor
Oct 30 11:40:00.494083 r-tigris-22 INFO swss#orchagent: :- addRoute: Failed to get next hop 30.0.0.2@Vlan200 for 200.0.0.0/24, resolving neighbor
Oct 30 11:40:00.494083 r-tigris-22 INFO swss#orchagent: :- addRoute: Failed to get next hop ::ffff:30.0.0.2@Vlan200 for 200::/64, resolving neighbor
Oct 30 11:40:00.494083 r-tigris-22 INFO swss#orchagent: :- addRoute: Failed to get next hop ::ffff:30.0.0.2@Vlan200 for 20::/64, resolving neighbor
Oct 30 11:40:00.494083 r-tigris-22 INFO swss#orchagent: :- addRoute: Failed to get next hop ::ffff:30.0.0.2@Vlan200 for 20::2/128, resolving neighbor
```

This happens because ```fpmsyncd``` does not get encap type field in FPM message.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Backport fix from FRR.

#### How to verify it

EVPN scenario.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

