### PR TITLE
Disable NETIF_F_HW_CSUM in KNET

### DIFF
--- a/platform/broadcom/saibcm-modules/sdklt/linux/knet/ngknet_main.c
+++ b/platform/broadcom/saibcm-modules/sdklt/linux/knet/ngknet_main.c
@@ -1705,8 +1705,9 @@ ngknet_ndev_init(ngknet_netif_t *netif, struct net_device **nd)
     memcpy(ndev->dev_addr, ma, ETH_ALEN);
 
     /* Initialize the device features */
-    ndev->hw_features = NETIF_F_RXCSUM | NETIF_F_HW_CSUM |
-                        NETIF_F_HW_VLAN_CTAG_RX | NETIF_F_HW_VLAN_CTAG_TX;
+    ndev->hw_features = NETIF_F_RXCSUM |
+                        NETIF_F_HW_VLAN_CTAG_RX |
+                        NETIF_F_HW_VLAN_CTAG_TX;
     ndev->features = ndev->hw_features | NETIF_F_HIGHDMA;
 
     /* Register the kernel network device */


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is CSP CS00012280996.
The issue to fix is that the checksum was incorrect for all TCP packets leaving the system so that the BGP connection cannot be established.  We found the issue on BCM56993, and it is possible to affect all platforms using linux_ngknet.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Remove NETIF_F_HW_CSUM

#### How to verify it
We verified that the BGP connection is established according to 'show ip bgp summary'.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

