### PR TITLE
[mlnx-fw-upgrade] Add FW reactivation in case 2 FW upgrades were done without reboot

### DIFF
--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -246,6 +246,7 @@ function RunFwUpdateCmd() {
     ERROR_CODE="$?"
 
     if [[ "${ERROR_CODE}" == "${FW_ALREADY_UPDATED_FAILURE}" ]]; then
+        LogInfo "FW reactivation is required. Reactivating and updating FW ..."
         local -r _MST_DEVICE="$(GetMstDevice)"
         local -r _CMD="flint -d ${_MST_DEVICE} ir"
         output=$(eval "${_CMD}")

--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -30,6 +30,7 @@ declare -r VERBOSE_MIN="${VERBOSE_ERROR}"
 
 declare -r EXIT_SUCCESS="0"
 declare -r EXIT_FAILURE="1"
+declare -r FW_ALREADY_UPDATED_FAILURE="2"
 
 declare -r QUERY_CMD="mlxfwmanager --query"
 declare -r LIST_CONTENT_CMD="mlxfwmanager --list-content"
@@ -243,6 +244,21 @@ function RunFwUpdateCmd() {
     fi
 
     ERROR_CODE="$?"
+
+    if [[ "${ERROR_CODE}" == "${FW_ALREADY_UPDATED_FAILURE}" ]]; then
+        local -r _MST_DEVICE="$(GetMstDevice)"
+        local -r _CMD="flint -d ${_MST_DEVICE} ir"
+        output=$(eval "${_CMD}")
+
+        if [[ "${VERBOSE_LEVEL}" -eq "${VERBOSE_MAX}" ]]; then
+            output=$(eval "${COMMAND}")
+        else
+            output=$(eval "${COMMAND}") >/dev/null 2>&1
+        fi
+    fi
+
+    ERROR_CODE="$?"
+
     if [[ "${ERROR_CODE}" != "${EXIT_SUCCESS}" ]]; then
         echo "${output}"
         failure_msg="${output#*Fail : }"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In order to activate FW after it was upgraded need to perform reboot.
If reboot wasn't performed and user need  to upgrade to another SONiC image then it will fail.
The reason for that is that during SONiC upgrade new FW should be installed but it will fail because previously installed FW wasn't activated.
In order to allow 2nd FW upgrade without reboot in-between need to reactivate FW image.
This change handles such flow.

Example of issue scenario:
- User installed SONiC image on the switch
- Then for some reason FW was upgraded by user or script but reboot was not performed to activate it.
- After that upgrade to new SONiC image will fail because new image need to install FW but it fails due to previous one wasn't activated.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
In "mlnx-fw-upgrade" script check if FW upgrade failed with the error that FW was already installed but reboot was not performed.
If so then perform FW image reactivation and try to upgrade FW again.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
- Install SONiC image on the switch
- Then upgrade FW but don't perform reboot.
- After that upgrade to new SONiC image and check that upgrade was successfull.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->
[mlnx-fw-upgrade] Add FW reactivation in case 2 FW upgrades were done without reboot

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

