### PR TITLE
[Cherry-pick to 202305] Fix device type and add cluster in DEVICE_NEIGHBOR_METADATA yang model

### DIFF
--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -348,6 +348,7 @@
           <a:IPPrefix>10.7.0.196/26</a:IPPrefix>
         </ManagementAddress>
         <Hostname>switch2-t0</Hostname>
+        <ClusterName>DB5PrdApp11</ClusterName>
         <HwSku>Force10-S6000</HwSku>
       </Device>
       <Device i:type="LeafRouter">
@@ -360,6 +361,7 @@
         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
           <a:IPPrefix>10.7.0.196/26</a:IPPrefix>
         </ManagementAddress>
+        <ClusterName>DB5PrdApp11</ClusterName>
         <HwSku>Force10-S6000</HwSku>
       </Device>
       <Device i:type="SmartCable">

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -208,6 +208,7 @@ class TestCfgGenCaseInsensitive(TestCase):
 
         expected_table = {
             'switch2-t0': {
+                'cluster': 'DB5PrdApp11',
                 'lo_addr': '25.1.1.10/32',
                 'mgmt_addr': '10.7.0.196/26',
                 'hwsku': 'Force10-S6000',
@@ -228,6 +229,7 @@ class TestCfgGenCaseInsensitive(TestCase):
                 'type': 'Server'
             },
             'switch-01t1': {
+                'cluster': 'DB5PrdApp11',
                 'lo_addr': '10.1.0.186/32',
                 'deployment_id': '2',
                 'hwsku': 'Force10-S6000',

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -945,12 +945,14 @@ instance is supported in SONiC.
 {
 "DEVICE_NEIGHBOR_METADATA": {
     "ARISTA01T1": {
+        "cluster": "AAA00PrdStr00",
         "lo_addr": "None",
         "mgmt_addr": "10.11.150.45",
         "hwsku": "Arista-VM",
         "type": "LeafRouter"
     },
     "ARISTA02T1": {
+        "cluster": "AAA00PrdStr00",
         "lo_addr": "None",
         "mgmt_addr": "10.11.150.46",
         "hwsku": "Arista-VM",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_neighbor_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_neighbor_metadata.json
@@ -2,17 +2,6 @@
     "DEVICE_NEIGHBOR_METADATA_TABLE": {
         "desc": "DEVICE_NEIGHBOR_METADATA_TABLE config pattern."
     },
-    "DEVICE_NEIGHBOR_METADATA_TYPE_INCORRECT_PATTERN": {
-        "desc": "DEVICE_NEIGHBOR_METADATA_TYPE_INCORRECT_PATTERN pattern failure.",
-        "eStrKey" : "Pattern"
-    },
-    "DEVICE_NEIGHBOR_METADATA_TYPE_CORRECT_PATTERN": {
-        "desc": "DEVICE_NEIGHBOR_METADATA correct value for Type field"
-    },
-    "DEVICE_NEIGHBOR_METADATA_TYPE_INCORRECT_PATTERN_BMC": {
-        "desc": "DEVICE_NEIGHBOR_METADATA_TYPE_INCORRECT_PATTERN pattern failure with IncorrectTypeBmc.",
-        "eStrKey" : "Pattern"
-    },
     "DEVICE_NEIGHBOR_METADATA_TYPE_CORRECT_PATTERN_BMC": {
         "desc": "DEVICE_NEIGHBOR_METADATA correct value for type field for Bmc"
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_neighbor_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_neighbor_metadata.json
@@ -1,43 +1,4 @@
 {
-    "DEVICE_NEIGHBOR_METADATA_TYPE_INCORRECT_PATTERN": {
-        "sonic-device_neighbor_metadata:sonic-device_neighbor_metadata": {
-            "sonic-device_neighbor_metadata:DEVICE_NEIGHBOR_METADATA": {
-                "DEVICE_NEIGHBOR_METADATA_LIST": [
-                    {
-                        "name": "Ethernet116",
-                        "hwsku": "Arista",
-                        "type": "ToRrouter"
-                    }
-                ]
-            }
-        }
-    },
-    "DEVICE_NEIGHBOR_METADATA_TYPE_CORRECT_PATTERN": {
-        "sonic-device_neighbor_metadata:sonic-device_neighbor_metadata": {
-            "sonic-device_neighbor_metadata:DEVICE_NEIGHBOR_METADATA": {
-                "DEVICE_NEIGHBOR_METADATA_LIST": [
-                    {
-                        "name": "Ethernet116",
-                        "hwsku": "Arista",
-                        "type": "BackEndToRRouter"
-                    }
-                ]
-            }
-        }
-    },
-    "DEVICE_NEIGHBOR_METADATA_TYPE_INCORRECT_PATTERN_BMC": {
-        "sonic-device_neighbor_metadata:sonic-device_neighbor_metadata": {
-            "sonic-device_neighbor_metadata:DEVICE_NEIGHBOR_METADATA": {
-                "DEVICE_NEIGHBOR_METADATA_LIST": [
-                    {
-                        "name": "Ethernet116",
-                        "hwsku": "DUMMY_BMC_SKU",
-                        "type": "IncorrectTypeBmc"
-                    }
-                ]
-            }
-        }
-    },
     "DEVICE_NEIGHBOR_METADATA_TYPE_CORRECT_PATTERN_BMC": {
         "sonic-device_neighbor_metadata:sonic-device_neighbor_metadata": {
             "sonic-device_neighbor_metadata:DEVICE_NEIGHBOR_METADATA": {
@@ -69,6 +30,7 @@
             "sonic-device_neighbor_metadata:DEVICE_NEIGHBOR_METADATA": {
                 "DEVICE_NEIGHBOR_METADATA_LIST": [
                     {
+                        "cluster": "AAA00PrdStr00",
                         "lo_addr": "25.77.193.11/32",
                         "mgmt_addr": "0.0.0.0/0",
                         "name": "dccsw01.nw",
@@ -77,6 +39,7 @@
                         "deployment_id": "1"
                     },
                     {
+                        "cluster": "AAA00PrdStr00",
                         "lo_addr": "0.0.0.0/0",
                         "mgmt_addr": "10.11.150.46/26",
                         "name": "dccsw02.nw",
@@ -85,6 +48,7 @@
                         "deployment_id": "1"
                     },
                     {
+                        "cluster": "AAA00PrdStr00",
                         "lo_addr_v6": "2a04:5555:40:a709::2/126",
                         "mgmt_addr": "10.11.150.47/26",
                         "name": "dccsw03.nw",
@@ -93,6 +57,7 @@
                         "deployment_id": "1"
                     },
                     {
+                        "cluster": "AAA00PrdStr00",
                         "name": "dccsw04.nw",
                         "mgmt_addr_v6": "2a04:5555:40:a708::2/126",
                         "hwsku": "Arista",
@@ -100,12 +65,14 @@
                         "deployment_id": "1"
                     },
                     {
+                        "cluster": "AAA00PrdStr00",
                         "name": "dccsw05.nw",
                         "hwsku": "Arista",
                         "type": "LeafRouter",
                         "deployment_id": "1"
                     },
                     {
+                        "cluster": "AAA00PrdStr00",
                         "lo_addr_v6": "2a04:5555:40:a710::2/126",
                         "name": "dccsw06.nw",
                         "hwsku": "Arista",
@@ -113,6 +80,7 @@
                         "deployment_id": "1"
                     },
                     {
+                        "cluster": "AAA00PrdStr00",
                         "lo_addr": "25.77.193.11/32",
                         "name": "dccsw07.nw",
                         "hwsku": "Arista",
@@ -120,6 +88,7 @@
                         "deployment_id": "1"
                     },
                     {
+                        "cluster": "AAA00PrdStr00",
                         "mgmt_addr": "10.11.150.48/26",
                         "name": "dccsw08.nw",
                         "hwsku": "Arista",

--- a/src/sonic-yang-models/yang-models/sonic-device_neighbor_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_neighbor_metadata.yang
@@ -40,6 +40,11 @@ module sonic-device_neighbor_metadata {
                     }
                 }
 
+                leaf cluster {
+                    description "The switch is a member of this cluster";
+                    type string;
+                }
+
                 leaf hwsku {
                     type stypes:hwsku;
                 }
@@ -82,9 +87,7 @@ module sonic-device_neighbor_metadata {
 
                 leaf type {
                     description "Network element type";
-                    type string {
-                        pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC|Asic|Supervior|MgmtToRRouter|MgmtLeafRouter|SpineRouter|BackEndToRRouter|BackEndLeafRouter|EPMS|MgmtTsToR|BmcMgmtToRRouter|Server|Bmc|MiniPower|SmartCable|Ixia|not-provisioned";
-                    }
+                    type string;
                 }
 
                 leaf deployment_id {


### PR DESCRIPTION
Fix device type and add cluster in DEVICE_NEIGHBOR_METADATA yang model (Cherry-pick of #17049)


#### Why I did it
The current DEVICE_NEIGHBOR_METADATA yang model has two issues that would block GCU operation when it checks if the current config aligns with the YANG model：
1. Missing cluster field in YANG
2. Incomplete set of device type. The device type in YANG model doesn't include all the device types
##### Work item tracking
- Microsoft ADO **(number only)**: 25577813

#### How I did it
Add cluster field in DEVICE_NEIGHBOR_METADATA YANG model. Change device type to string.
#### How to verify it
Build the image and verify the unit tests passed.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

