### PR TITLE
[lldp] Clean up service start logic owing to port init start optimization

### DIFF
--- a/files/build_templates/lldp.timer.j2
+++ b/files/build_templates/lldp.timer.j2
@@ -1,1 +1,0 @@
-per_namespace/lldp.timer.j2

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -105,17 +105,6 @@ function waitplatform() {
             debug "Started pmon service"
         fi
     fi
-    if [[ x"$BOOT_TYPE" = @(x"fast"|x"warm"|x"fastfast") ]]; then
-        debug "LLDP service is delayed by a timer for better fast/warm boot performance"
-    else
-        lldp_state=$(systemctl is-enabled lldp.timer)
-        if [[ $lldp_state == "enabled" ]]
-        then
-            debug "Starting lldp service..."
-            /bin/systemctl start lldp
-            debug "Started lldp service"
-        fi
-    fi
 }
 
 function stopplatform1() {


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

As part of service start optimization done, we've removed timer units and used PORT_INIT_DONE as the checkpoint for starting delayed services. Thus this logic is redundant

This fixes the following error log. 
```
Nov  3 14:16:54.281546 r-leopard-44 ERR systemctl[10553]: Failed to get unit file state for lldp.timer: No such file or directory
```

#### How I did it

Redundant lldp timer code is removed from syncd.sh. 

#### How to verify it

Build and test 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

