### PR TITLE
enable MIRROR_SNAPSHOT if SONIC_VERSION_CONTROL_COMPONENTS includes deb

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -264,6 +264,14 @@ TRUSTED_GPG_URLS = https://packages.trafficmanager.net/debian/public_key.gpg,htt
 #   docker: docker base images
 SONIC_VERSION_CONTROL_COMPONENTS ?= none
 
+ifeq ($(SONIC_VERSION_CONTROL_COMPONENTS),all)
+override MIRROR_SNAPSHOT = y
+endif
+
+ifneq (,$(findstring deb,$(SONIC_VERSION_CONTROL_COMPONENTS)))
+override MIRROR_SNAPSHOT = y
+endif
+
 # MIRROR_SNAPSHOT - support mirror snapshot flag
 MIRROR_SNAPSHOT ?= n
 

--- a/scripts/build_mirror_config.sh
+++ b/scripts/build_mirror_config.sh
@@ -11,7 +11,7 @@ export APT_RETRIES_COUNT
 
 DEFAULT_MIRROR_URL_PREFIX=http://packages.trafficmanager.net
 MIRROR_VERSION_FILE=
-[[ "$SONIC_VERSION_CONTROL_COMPONENTS" == *deb* || $SONIC_VERSION_CONTROL_COMPONENTS == *all* ]] && MIRROR_VERSION_FILE=files/build/versions/default/versions-mirror && MIRROR_SNAPSHOT=y
+[[ "$SONIC_VERSION_CONTROL_COMPONENTS" == *deb* || $SONIC_VERSION_CONTROL_COMPONENTS == *all* ]] && MIRROR_VERSION_FILE=files/build/versions/default/versions-mirror
 [ -f target/versions/default/versions-mirror ] && MIRROR_VERSION_FILE=target/versions/default/versions-mirror
 
 # The default mirror urls


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix #17113
If we set `MIRROR_SNAPSHOT=y` in `build_mirror_config.sh`
then we have incorrect value of `MIRROR_SNAPSHOT` in other places like `buildinfo/config/buildinfo.config`

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Override `MIRROR_SNAPSHOT=y` in `rules/config` if
`SONIC_VERSION_CONTROL_COMPONENTS=all` or
`SONIC_VERSION_CONTROL_COMPONENTS` includes `deb` component.

#### How to verify it

Start to build with different values of `SONIC_VERSION_CONTROL_COMPONENTS` and `MIRROR_SNAPSHOT` in cmdline
and check value of `MIRROR_SNAPSHOT` in `buildinfo.config` and debian mirrors in sources.list files

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

