### PR TITLE
[UT] Fix eventd zmq code bug and UT flaky issue.

### DIFF
--- a/src/sonic-eventd/src/eventd.cpp
+++ b/src/sonic-eventd/src/eventd.cpp
@@ -382,14 +382,14 @@ capture_service::do_capture()
     cap_sub_sock = zmq_socket(m_ctx, ZMQ_SUB);
     RET_ON_ERR(cap_sub_sock != NULL, "failing to get ZMQ_SUB socket");
 
+    rc = zmq_setsockopt(cap_sub_sock, ZMQ_RCVTIMEO, &block_ms, sizeof (block_ms));
+    RET_ON_ERR(rc == 0, "Failed to ZMQ_RCVTIMEO to %d", block_ms);
+
     rc = zmq_connect(cap_sub_sock, get_config(string(CAPTURE_END_KEY)).c_str());
     RET_ON_ERR(rc == 0, "Failing to bind capture SUB to %s", get_config(string(CAPTURE_END_KEY)).c_str());
 
     rc = zmq_setsockopt(cap_sub_sock, ZMQ_SUBSCRIBE, "", 0);
     RET_ON_ERR(rc == 0, "Failing to ZMQ_SUBSCRIBE");
-
-    rc = zmq_setsockopt(cap_sub_sock, ZMQ_RCVTIMEO, &block_ms, sizeof (block_ms));
-    RET_ON_ERR(rc == 0, "Failed to ZMQ_RCVTIMEO to %d", block_ms);
 
     m_cap_run = true;
 

--- a/src/sonic-eventd/tests/eventd_ut.cpp
+++ b/src/sonic-eventd/tests/eventd_ut.cpp
@@ -162,9 +162,9 @@ void run_cap(void *zctx, bool &term, string &read_source,
     static int proxy_finished_init = false;
 
     EXPECT_TRUE(NULL != mock_cap);
+    EXPECT_EQ(0, zmq_setsockopt(mock_cap, ZMQ_RCVTIMEO, &block_ms, sizeof (block_ms)));
     EXPECT_EQ(0, zmq_connect(mock_cap, get_config(CAPTURE_END_KEY).c_str()));
     EXPECT_EQ(0, zmq_setsockopt(mock_cap, ZMQ_SUBSCRIBE, "", 0));
-    EXPECT_EQ(0, zmq_setsockopt(mock_cap, ZMQ_RCVTIMEO, &block_ms, sizeof (block_ms)));
 
     if(!proxy_finished_init) {
         zmq_msg_t msg;
@@ -193,9 +193,9 @@ void run_sub(void *zctx, bool &term, string &read_source, internal_events_lst_t 
     int block_ms = 200;
 
     EXPECT_TRUE(NULL != mock_sub);
+    EXPECT_EQ(0, zmq_setsockopt(mock_sub, ZMQ_RCVTIMEO, &block_ms, sizeof (block_ms)));
     EXPECT_EQ(0, zmq_connect(mock_sub, get_config(XPUB_END_KEY).c_str()));
     EXPECT_EQ(0, zmq_setsockopt(mock_sub, ZMQ_SUBSCRIBE, "", 0));
-    EXPECT_EQ(0, zmq_setsockopt(mock_sub, ZMQ_RCVTIMEO, &block_ms, sizeof (block_ms)));
 
     while(!term) {
         if (0 == zmq_message_read(mock_sub, 0, source, ev_int)) {

--- a/src/sonic-eventd/tests/eventd_ut.cpp
+++ b/src/sonic-eventd/tests/eventd_ut.cpp
@@ -157,7 +157,7 @@ void run_cap(void *zctx, bool &term, string &read_source,
     void *mock_cap = zmq_socket (zctx, ZMQ_SUB);
     string source;
     internal_event_t ev_int;
-    int block_ms = 200;
+    int block_ms = 400;
     int i=0;
     static int proxy_finished_init = false;
 
@@ -190,7 +190,7 @@ void run_sub(void *zctx, bool &term, string &read_source, internal_events_lst_t 
     void *mock_sub = zmq_socket (zctx, ZMQ_SUB);
     string source;
     internal_event_t ev_int;
-    int block_ms = 200;
+    int block_ms = 400;
 
     EXPECT_TRUE(NULL != mock_sub);
     EXPECT_EQ(0, zmq_setsockopt(mock_sub, ZMQ_RCVTIMEO, &block_ms, sizeof (block_ms)));


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix eventd UT flaky error.  Here is zmq doc:  http://api.zeromq.org/2-1:zmq-setsockopt

int zmq_setsockopt (void *socket, int option_name, const void *option_value, size_t option_len);

Caution: All options, with the exception of ZMQ_SUBSCRIBE, ZMQ_UNSUBSCRIBE and ZMQ_LINGER, only take effect for subsequent socket bind/connects.

Typical use is to set this socket option ahead of each zmq_connect() attempt to a new host. Each connection MUST be assigned a unique name. Assigning a name that is already in use is not allowed.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Put setsockopt before connects.

#### How to verify it

In my local test. 
eventd.proxy passed 10 out of 10
eventd.capture passed 9 out of 10.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

