### PR TITLE
[bookworm] Fix docker gid mismatch with host 

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -69,6 +69,7 @@ USER := $(shell id -un)
 PWD := $(shell pwd)
 USER_LC := $(shell echo $(USER) | tr A-Z a-z)
 DOCKER_MACHINE := $(shell docker run --rm debian:buster uname -m)
+HOST_DOCKERD_GID := $(shell getent group docker | cut -d : -f3)
 
 comma := ,
 
@@ -231,6 +232,7 @@ $(shell CONFIGURED_ARCH=$(CONFIGURED_ARCH) \
 $(shell CONFIGURED_ARCH=$(CONFIGURED_ARCH) \
 	MULTIARCH_QEMU_ENVIRON=$(MULTIARCH_QEMU_ENVIRON) \
 	CROSS_BUILD_ENVIRON=$(CROSS_BUILD_ENVIRON) \
+	DOCKERD_GID=$(HOST_DOCKERD_GID) \
 	j2 $(SLAVE_DIR)/Dockerfile.user.j2 > $(SLAVE_DIR)/Dockerfile.user)
 
 ifeq ($(CROSS_BUILD_ENVIRON), y)

--- a/Makefile.work
+++ b/Makefile.work
@@ -232,7 +232,6 @@ $(shell CONFIGURED_ARCH=$(CONFIGURED_ARCH) \
 $(shell CONFIGURED_ARCH=$(CONFIGURED_ARCH) \
 	MULTIARCH_QEMU_ENVIRON=$(MULTIARCH_QEMU_ENVIRON) \
 	CROSS_BUILD_ENVIRON=$(CROSS_BUILD_ENVIRON) \
-	DOCKERD_GID=$(HOST_DOCKERD_GID) \
 	j2 $(SLAVE_DIR)/Dockerfile.user.j2 > $(SLAVE_DIR)/Dockerfile.user)
 
 ifeq ($(CROSS_BUILD_ENVIRON), y)
@@ -389,7 +388,7 @@ endif
 
 ifeq ($(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD), y)
 ifneq ($(MULTIARCH_QEMU_ENVIRON), y)
-    DOCKER_RUN += -v /var/run/docker.sock:/var/run/docker.sock
+    DOCKER_RUN += -v /var/run/docker.sock:/var/run/docker.sock --group-add $(HOST_DOCKERD_GID)
 endif
 endif
 

--- a/sonic-slave-bookworm/Dockerfile.user.j2
+++ b/sonic-slave-bookworm/Dockerfile.user.j2
@@ -20,6 +20,10 @@ RUN useradd $user -l -u $uid -g $guid -d /var/$user -m -s /bin/bash
 
 RUN gpasswd -a $user docker
 
+{% if DOCKERD_GID is defined and DOCKERD_GID|length %}
+RUN usermod -aG {{ DOCKERD_GID }} $user
+{%- endif %}
+
 # Config git for stg
 RUN su $user -c "git config --global user.name $user"
 RUN su $user -c "git config --global user.email $user@contoso.com"

--- a/sonic-slave-bookworm/Dockerfile.user.j2
+++ b/sonic-slave-bookworm/Dockerfile.user.j2
@@ -20,10 +20,6 @@ RUN useradd $user -l -u $uid -g $guid -d /var/$user -m -s /bin/bash
 
 RUN gpasswd -a $user docker
 
-{% if DOCKERD_GID is defined and DOCKERD_GID|length %}
-RUN usermod -aG {{ DOCKERD_GID }} $user
-{%- endif %}
-
 # Config git for stg
 RUN su $user -c "git config --global user.name $user"
 RUN su $user -c "git config --global user.email $user@contoso.com"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix https://github.com/sonic-net/sonic-buildimage/issues/17155

Check the ticket for more details

#### How I did it

#### How to verify it


```
vkarri@build-server:/sonic-buildimage$ NOBUSTER=1 NOBULLSEYE=1 make SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD=y sonic-slave-bash

vkarri@0fdfd946d5a7:/sonic$ cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"

vkarri@0fdfd946d5a7:/sonic$ docker ps -a
CONTAINER ID   IMAGE                                             COMMAND                  CREATED          STATUS                      PORTS     NAMES
0fdfd946d5a7   sonic-slave-bookworm-vkarri:969180aefd            "bash"                   3 minutes ago    Up 3 minutes                22/tcp    admiring_swirles
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

