### PR TITLE
[arm64] Fix qemu arm64 compile failing with NO_PUBKEY

### DIFF
--- a/dockers/docker-base-bullseye/Dockerfile.j2
+++ b/dockers/docker-base-bullseye/Dockerfile.j2
@@ -32,6 +32,10 @@ COPY ["no_install_recommend_suggest", "/etc/apt/apt.conf.d"]
 COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
 COPY ["apt-multiple-retries", "/etc/apt/apt.conf.d"]
 
+{%- if CONFIGURED_ARCH == "arm64" and MULTIARCH_QEMU_ENVIRON == "y" %}
+RUN SKIP_BUILD_HOOK="y" wget -O debian-archive-keyring.deb 'http://ftp.de.debian.org/debian/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb' && dpkg -i debian-archive-keyring.deb && rm debian-archive-keyring.deb && SKIP_BUILD_HOOK="n"
+{%- endif %}
+
 # Update apt cache and
 # pre-install fundamental packages
 RUN apt-get update &&        \

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -55,6 +55,10 @@ ARG CROSS_CXX=${gcc_arch}-g++
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
+{%- if CONFIGURED_ARCH == "arm64" and MULTIARCH_QEMU_ENVIRON == "y" %}
+RUN SKIP_BUILD_HOOK="y" wget -O debian-archive-keyring.deb 'http://ftp.de.debian.org/debian/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb' && dpkg -i debian-archive-keyring.deb && rm debian-archive-keyring.deb && SKIP_BUILD_HOOK="n"
+{%- endif %}
+
 {%- if CROSS_BUILD_ENVIRON == "y" %}
 RUN eatmydata apt-get install -y python3 python3-pip
 RUN apt-get install -y python3-minimal:$arch python3.9:$arch python3:$arch python3-dev:$arch python3-setuptools:$arch


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix qemu arm64 compile failing with NO_PUBKEY. The fail log in sonic-slave-bullseye-march-arm64_44ef87e04db.log:
```
Get:1 http://debian-archive.trafficmanager.net/debian bullseye InRelease [116 kB]
Get:2 http://debian-archive.trafficmanager.net/debian bullseye-updates InRelease [44.1 kB]
Get:3 http://debian-archive.trafficmanager.net/debian bullseye-backports InRelease [49.0 kB]
Get:4 http://debian-archive.trafficmanager.net/debian-security bullseye-security InRelease [48.4 kB]
Err:1 http://debian-archive.trafficmanager.net/debian bullseye InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 0E98404D386FA1D9 NO_PUBKE
Y 6ED0E7B82643E131 NO_PUBKEY 605C66F00D6C9793
Err:2 http://debian-archive.trafficmanager.net/debian bullseye-updates InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 0E98404D386FA1D9 NO_PUBKE
Y 6ED0E7B82643E131
Err:3 http://debian-archive.trafficmanager.net/debian bullseye-backports InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 0E98404D386FA1D9 NO_PUBKE
Y 6ED0E7B82643E131
Get:5 http://debian-archive.trafficmanager.net/debian-security bullseye-security/main Sources [207 kB]
Get:6 http://debian-archive.trafficmanager.net/debian-security bullseye-security/non-free Sources [716 B]
Get:7 http://debian-archive.trafficmanager.net/debian-security bullseye-security/main arm64 Packages [326 kB]
Reading package lists...
W: GPG error: http://debian-archive.trafficmanager.net/debian bullseye InRelease: The following signatures
 couldn't be verified because the public key is not available: NO_PUBKEY 0E98404D386FA1D9 NO_PUBKEY 6ED0E7B82643E131 NO_PUBK
EY 605C66F00D6C9793
E: The repository 'http://debian-archive.trafficmanager.net/debian bullseye InRelease' is not signed.
W: GPG error: http://debian-archive.trafficmanager.net/debian bullseye-updates InRelease: The following signatures co
uldn't be verified because the public key is not available: NO_PUBKEY 0E98404D386FA1D9 NO_PUBKEY 6ED0E7B82643E131
E: The repository 'http://debian-archive.trafficmanager.net/debian bullseye-updates InRelease' is not signed.
W: GPG error: http://debian-archive.trafficmanager.net/debian bullseye-backports InRelease: The following signatures 
couldn't be verified because the public key is not available: NO_PUBKEY 0E98404D386FA1D9 NO_PUBKEY 6ED0E7B82643E131
E: The repository 'http://debian-archive.trafficmanager.net/debian bullseye-backports InRelease' is not signed.
```
The cause of this problem is a missing bullseye's GPG key in march bullseye docker image.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Install latest bullseye GPG keyring.

#### How to verify it
Compile Centec ARM64 platform on X86 server with qemu march mode:
1. make init
2. make configure PLATFORM=centec-arm64 PLATFORM_ARCH=arm64
3. make all

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

