### PR TITLE
[202205] [Mellanox] Revert LPM implementation to the old way

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -481,6 +481,80 @@ class SFP(NvidiaSFPCommon):
 
         return rc == SX_STATUS_SUCCESS
 
+
+    @classmethod
+    def is_nve(cls, port):
+        return (port & NVE_MASK) != 0
+
+
+    @classmethod
+    def is_cpu(cls, port):
+        return (port & CPU_MASK) != 0
+
+
+    @classmethod
+    def _fetch_port_status(cls, sdk_handle, log_port):
+        oper_state_p = new_sx_port_oper_state_t_p()
+        admin_state_p = new_sx_port_admin_state_t_p()
+        module_state_p = new_sx_port_module_state_t_p()
+        rc = sx_api_port_state_get(sdk_handle, log_port, oper_state_p, admin_state_p, module_state_p)
+        assert rc == SXD_STATUS_SUCCESS, "sx_api_port_state_get failed, rc = %d" % rc
+
+        admin_state = sx_port_admin_state_t_p_value(admin_state_p)
+        oper_state = sx_port_oper_state_t_p_value(oper_state_p)
+
+        delete_sx_port_oper_state_t_p(oper_state_p)
+        delete_sx_port_admin_state_t_p(admin_state_p)
+        delete_sx_port_module_state_t_p(module_state_p)
+
+        return oper_state, admin_state
+
+
+    @classmethod
+    def is_port_admin_status_up(cls, sdk_handle, log_port):
+        _, admin_state = cls._fetch_port_status(sdk_handle, log_port);
+        return admin_state == SX_PORT_ADMIN_STATUS_UP
+
+
+    @classmethod
+    def set_port_admin_status_by_log_port(cls, sdk_handle, log_port, admin_status):
+        rc = sx_api_port_state_set(sdk_handle, log_port, admin_status)
+        if SX_STATUS_SUCCESS != rc:
+            logger.log_error("sx_api_port_state_set failed, rc = %d" % rc)
+
+        return SX_STATUS_SUCCESS == rc
+
+
+    @classmethod
+    def get_logical_ports(cls, sdk_handle, sdk_index, slot_id):
+        # Get all the ports related to the sfp, if port admin status is up, put it to list
+        port_cnt_p = new_uint32_t_p()
+        uint32_t_p_assign(port_cnt_p, 0)
+        rc = sx_api_port_device_get(sdk_handle, DEVICE_ID, SWITCH_ID, None,  port_cnt_p)
+
+        assert rc == SX_STATUS_SUCCESS, "sx_api_port_device_get failed, rc = %d" % rc
+        port_cnt = uint32_t_p_value(port_cnt_p)
+        port_attributes_list = new_sx_port_attributes_t_arr(port_cnt)
+
+        rc = sx_api_port_device_get(sdk_handle, DEVICE_ID , SWITCH_ID, port_attributes_list,  port_cnt_p)
+        assert rc == SX_STATUS_SUCCESS, "sx_api_port_device_get failed, rc = %d" % rc
+
+        port_cnt = uint32_t_p_value(port_cnt_p)
+        log_port_list = []
+        for i in range(0, port_cnt):
+            port_attributes = sx_port_attributes_t_arr_getitem(port_attributes_list, i)
+            if not cls.is_nve(int(port_attributes.log_port)) \
+               and not cls.is_cpu(int(port_attributes.log_port)) \
+               and port_attributes.port_mapping.module_port == sdk_index \
+               and port_attributes.port_mapping.slot == slot_id \
+               and cls.is_port_admin_status_up(sdk_handle, port_attributes.log_port):
+                log_port_list.append(port_attributes.log_port)
+
+        delete_sx_port_attributes_t_arr(port_attributes_list)
+        delete_uint32_t_p(port_cnt_p)
+        return log_port_list
+
+
     @classmethod
     def mgmt_phy_mod_pwr_attr_set(cls, sdk_handle, sdk_index, slot_id, power_attr_type, admin_pwr_mode):
         result = False
@@ -506,14 +580,27 @@ class SFP(NvidiaSFPCommon):
 
         return result
 
+
     @classmethod
-    def _set_lpmode_raw(cls, sdk_handle, sdk_index, slot_id, attr_type, power_mode):
+    def _set_lpmode_raw(cls, sdk_handle, sdk_index, slot_id, ports, attr_type, power_mode):
+        result = False
         # Check if the module already works in the same mode
         admin_pwr_mode, oper_pwr_mode = cls.mgmt_phy_mod_pwr_attr_get(attr_type, sdk_handle, sdk_index, slot_id)
         if (power_mode == SX_MGMT_PHY_MOD_PWR_MODE_LOW_E and oper_pwr_mode == SX_MGMT_PHY_MOD_PWR_MODE_LOW_E) \
            or (power_mode == SX_MGMT_PHY_MOD_PWR_MODE_AUTO_E and admin_pwr_mode == SX_MGMT_PHY_MOD_PWR_MODE_AUTO_E):
             return True
-        return cls.mgmt_phy_mod_pwr_attr_set(sdk_handle, sdk_index, slot_id, attr_type, power_mode)
+        try:
+            # Bring the port down
+            for port in ports:
+                cls.set_port_admin_status_by_log_port(sdk_handle, port, SX_PORT_ADMIN_STATUS_DOWN)
+            # Set the desired power mode
+            result = cls.mgmt_phy_mod_pwr_attr_set(sdk_handle, sdk_index, slot_id, attr_type, power_mode)
+        finally:
+            # Bring the port up
+            for port in ports:
+                cls.set_port_admin_status_by_log_port(sdk_handle, port, SX_PORT_ADMIN_STATUS_UP)
+
+        return result
 
 
     def set_lpmode(self, lpmode):
@@ -539,9 +626,6 @@ class SFP(NvidiaSFPCommon):
             # Set LPM
             try:
                 output = subprocess.check_output(lpm_cmd, shell=True, universal_newlines=True)
-                for line in output.splitlines():
-                    if line.startswith('Error') or line.startswith('Notice'):
-                        print('\n' + line)
                 return 'True' in output
             except subprocess.CalledProcessError as e:
                 print("Error! Unable to set LPM for {}, rc = {}, err msg: {}".format(self.sdk_index, e.returncode, e.output))
@@ -549,13 +633,15 @@ class SFP(NvidiaSFPCommon):
         else:
             return self._set_lpmode(lpmode, self.sdk_handle, self.sdk_index, self.slot_id)
 
+
     @classmethod
     def _set_lpmode(cls, lpmode, sdk_handle, sdk_index, slot_id):
-        print('\nNotice: please set port admin status to down before setting power mode, ignore this message if already set')
+        log_port_list = cls.get_logical_ports(sdk_handle, sdk_index, slot_id)
         sdk_lpmode = SX_MGMT_PHY_MOD_PWR_MODE_LOW_E if lpmode else SX_MGMT_PHY_MOD_PWR_MODE_AUTO_E
         cls._set_lpmode_raw(sdk_handle,
                             sdk_index,
                             slot_id,
+                            log_port_list,
                             SX_MGMT_PHY_MOD_PWR_ATTR_PWR_MODE_E,
                             sdk_lpmode)
         logger.log_info("{} low power mode for module {}, slot {}".format("Enabled" if lpmode else "Disabled", sdk_index, slot_id))

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2019-2023 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2019-2023 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -143,6 +143,14 @@ class TestSfp:
             handle.read.side_effect = OSError('')
             assert sfp.read_eeprom(0, 1) is None
 
+    @mock.patch('sonic_platform.sfp.SFP._fetch_port_status')
+    def test_is_port_admin_status_up(self, mock_port_status):
+        mock_port_status.return_value = (0, True)
+        assert SFP.is_port_admin_status_up(None, None)
+
+        mock_port_status.return_value = (0, False)
+        assert not SFP.is_port_admin_status_up(None, None)
+
     @mock.patch('sonic_platform.sfp.SFP._get_eeprom_path', mock.MagicMock(return_value = None))
     @mock.patch('sonic_platform.sfp.SFP._get_sfp_type_str')
     def test_is_write_protected(self, mock_get_type_str):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
backport https://github.com/sonic-net/sonic-buildimage/pull/17096  because of no clean cherry-pick

The current low power mode setting implementation requests the user to set the port to admin down first before toggling LP mode, this is not backward compatible, now revert it to the old way so that the user can toggle the LP mode regardless of the port admin status.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Reverts commit f74c69e876bdc80c38ae6bd06b414e357d1a63fa.

#### How to verify it

run all sfputil and SFP platform API related tests on all the Mellanox platforms.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

