### PR TITLE
[yang]: Add yang model for dpu database service

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1801,6 +1801,7 @@
                 "auto_restart": "always_enabled",
                 "has_global_scope": "true",
                 "has_per_asic_scope": "true",
+                "has_per_dpu_scope": "true",
                 "delayed": "false",
                 "high_mem_alert": "disabled",
                 "state": "always_enabled",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/feature.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/feature.json
@@ -10,6 +10,7 @@
                         "delayed": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
+                        "has_per_dpu_scope": "True",
                         "set_owner": "local",
                         "check_up_status": "False",
                         "support_syslog_rate_limit": "true"

--- a/src/sonic-yang-models/yang-models/sonic-feature.yang
+++ b/src/sonic-yang-models/yang-models/sonic-feature.yang
@@ -78,6 +78,13 @@ module sonic-feature{
                     default "false";
                 }
 
+                leaf has_per_dpu_scope {
+                    description "This configuration identicates there will only one service
+                                spawned per DPU";
+                    type feature-scope-status;
+                    default "false";
+                }
+
                 leaf high_mem_alert {
                     description "This configuration controls the trigger to generate
                                 alert on high memory utilization";


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
According to the design, the database instances of DPU will be kept in the NPU host.

##### Work item tracking
- Microsoft ADO **(number only)**:25072889

#### How I did it
Declare a new field, `has_per_dpu_scope`, in the config_db for database feature.

#### How to verify it
Check Azp


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

