### PR TITLE
[Mellanox] Change the default breakout mode for internal ports of the Mellanox-SN4700-O28 SKU.

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O28/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O28/hwsku.json
@@ -85,16 +85,16 @@
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet224": {
-            "default_brkout_mode": "1x200G"
+	    "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet232": {
-            "default_brkout_mode": "1x200G"
+	    "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet240": {
-            "default_brkout_mode": "1x200G"
+	    "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet248": {
-            "default_brkout_mode": "1x200G"
+	    "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]"
         }
     }
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the issue with configuration generation from the minigrapth:
```
root@sonic:/home/admin# config load_minigraph -y
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
Traceback (most recent call last):
  File "/usr/local/bin/sonic-cfggen", line 452, in <module>
    main()
  File "/usr/local/bin/sonic-cfggen", line 342, in main
    deep_update(data, parse_xml(minigraph, platform, asic_name=asic_name))
  File "/usr/local/lib/python3.9/dist-packages/minigraph.py", line 1542, in parse_xml
    (ports, alias_map, alias_asic_map) = get_port_config(hwsku=hwsku, platform=platform, port_config_file=port_config_file, asic_name=asic_name, hwsku_config_file=hwsku_config_file)
  File "/usr/local/lib/python3.9/dist-packages/portconfig.py", line 207, in get_port_config
    return parse_platform_json_file(hwsku_json_file, port_config_file)
  File "/usr/local/lib/python3.9/dist-packages/portconfig.py", line 422, in parse_platform_json_file
    child_ports = get_child_ports(intf, brkout_mode, platform_json_file)
  File "/usr/local/lib/python3.9/dist-packages/portconfig.py", line 395, in get_child_ports
    mode_handler = BreakoutCfg(interface, breakout_mode, port_dict[INTF_KEY][interface])
  File "/usr/local/lib/python3.9/dist-packages/portconfig.py", line 323, in __init__
    raise RuntimeError("Unsupported breakout mode {}!".format(bmode))
RuntimeError: Unsupported breakout mode 1x200G!
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Change the default breakout mode for internal ports to the mode that corresponds platfom.json configuration.

#### How to verify it
- Deploy minigraph
- Run `config load_minigraph -y` command

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)