### PR TITLE
lldp timer will be negative when we modify the system

### DIFF
--- a/src/lldpd/patch/0014-modify-lldp-show-timer-will-be-negative.patch
+++ b/src/lldpd/patch/0014-modify-lldp-show-timer-will-be-negative.patch
@@ -1,0 +1,32 @@
+diff -Naurp lldpd-1.0.4/src/client/display.c lldpd-1.0.4_new/src/client/display.c
+--- lldpd-1.0.4/src/client/display.c	2019-04-06 23:03:01.000000000 +0800
++++ lldpd-1.0.4_new/src/client/display.c	2023-07-06 15:41:39.354369756 +0800
+@@ -584,6 +584,11 @@ display_age(time_t lastchange)
+ {
+ 	static char sage[30];
+ 	int age = (int)(time(NULL) - lastchange);
++	// [ISU2023063070054] Change the age to zero if age is less than 0
++	// If age is less than 0, the parse_time function in lldb_syncd will get wrong
++	if (age < 0) {
++		age = 0;
++	}
+ 	if (snprintf(sage, sizeof(sage),
+ 		"%d day%s, %02d:%02d:%02d",
+ 		age / (60*60*24),
+diff -Naurp lldpd-1.0.4/src/daemon/lldpd.c lldpd-1.0.4_new/src/daemon/lldpd.c
+--- lldpd-1.0.4/src/daemon/lldpd.c	2023-07-06 15:48:38.854924058 +0800
++++ lldpd-1.0.4_new/src/daemon/lldpd.c	2023-07-06 15:44:59.268540595 +0800
+@@ -573,6 +573,13 @@ lldpd_decode(struct lldpd *cfg, char *fr
+ 	}
+ 
+ 	TAILQ_FOREACH(oport, &hardware->h_rports, p_entries) {
++		// [ISU2023063070054] If the packets are all the same,the node of last change time won't be changed.
++		// Calculate the difference between the current time and the last lldp packet update time
++		// If the time is negative or larger than TTL, set the node of lastchange = 0.
++		time_t interval_time = time(NULL) - oport->p_lastchange;
++		if (interval_time > oport->p_ttl || interval_time < 0) {
++			oport->p_lastchange = time(NULL);
++		}
+ 		if ((oport->p_lastframe != NULL) &&
+ 		    (oport->p_lastframe->size == s) &&
+ 		    (memcmp(oport->p_lastframe->frame, frame, s) == 0)) {

--- a/src/lldpd/patch/series
+++ b/src/lldpd/patch/series
@@ -6,3 +6,4 @@
 0010-Ported-fix-for-length-exceeded-from-lldp-community.patch
 0011-fix-med-location-len.patch
 0012-fix-recreate-socket-on-ifindex-change.patch
+0014-modify-lldp-show-timer-will-be-negative.patch


### PR DESCRIPTION
    Root cause:
        lldp use the last change packet time to calculate the age time, but if the packets are all the same,the node of last change time won't be changed.
    Solution:
        Calculate the difference between the current time and the last lldp packet update time, if the time is negative or larger than TTL, set the node of last packet change = 0.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

