### PR TITLE
Correct the aggregation port ID

### DIFF
--- a/src/lldpd/patch/0013-correct-lagid-from-portchannel.patch
+++ b/src/lldpd/patch/0013-correct-lagid-from-portchannel.patch
@@ -1,0 +1,47 @@
+diff -Naurp lldpd-1.0.4/src/daemon/interfaces.c lldpd-1.0.4_new/src/daemon/interfaces.c
+--- lldpd-1.0.4/src/daemon/interfaces.c	2023-06-30 14:31:16.897955818 +0800
++++ lldpd-1.0.4_new/src/daemon/interfaces.c	2023-06-30 13:54:42.025988876 +0800
+@@ -592,6 +592,24 @@ interfaces_helper_add_hardware(struct ll
+ 	TAILQ_INSERT_TAIL(&cfg->g_hardware, hardware, h_entries);
+ }
+ 
++static u_int32_t extractNumber(const char *str) {
++	u_int32_t number = 0;
++	const char *ptr = str;
++
++	// Skip non-number
++	while (*ptr && !isdigit(*ptr)) {
++		ptr++;
++	}
++
++	// Get the portchannel number
++	while (*ptr && isdigit(*ptr)) {
++		number = number * 10 + (*ptr - '0');
++		ptr++;
++	}
++
++	return number;
++}
++
+ void
+ interfaces_helper_physical(struct lldpd *cfg,
+     struct interfaces_device_list *interfaces,
+@@ -666,10 +684,14 @@ interfaces_helper_physical(struct lldpd
+ 		hardware->h_mtu = iface->mtu ? iface->mtu : 1500;
+ 
+ #ifdef ENABLE_DOT3
+-		if (iface->upper && iface->upper->type & IFACE_BOND_T)
+-			hardware->h_lport.p_aggregid = iface->upper->index;
+-		else
++		if (iface->upper && iface->upper->type & IFACE_BOND_T){
++			// Get the iface->upper->name from ip link, we parse the number from the name.
++			u_int32_t aggregationNumber = extractNumber(iface->upper->name);
++			hardware->h_lport.p_aggregid = aggregationNumber;
++		}
++		else{
+ 			hardware->h_lport.p_aggregid = 0;
++		}
+ #endif
+ 	}
+ }
+

--- a/src/lldpd/patch/series
+++ b/src/lldpd/patch/series
@@ -6,3 +6,4 @@
 0010-Ported-fix-for-length-exceeded-from-lldp-community.patch
 0011-fix-med-location-len.patch
 0012-fix-recreate-socket-on-ifindex-change.patch
+0013-correct-lagid-from-portchannel.patch


### PR DESCRIPTION
Description:
    The aggregation port ID is using index of interfaces via ip link.
    So the aggregation port ID is the index number in lldp packet.
    Now we use the number of interface name via ip link.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

