### PR TITLE
NTP long jump is enabled - Fix for 5007

### DIFF
--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -26,7 +26,7 @@ function modify_ntp_default
 sonic-cfggen -d -t /usr/share/sonic/templates/ntp.conf.j2 >/etc/ntp.conf
 
 get_database_reboot_type
-echo "Disabling NTP long jump for reboot type ${reboot_type} ..."
-modify_ntp_default "s/NTPD_OPTS='-g'/NTPD_OPTS='-x'/"
+echo "Enabling NTP long jump for reboot type ${reboot_type} ..."
+modify_ntp_default "s/NTPD_OPTS='-x'/NTPD_OPTS='-g'/"
 
 systemctl --no-block restart ntp


### PR DESCRIPTION
…k time even when NTP is synchronized to it

Root-Cause: NTP long jump is disabled in the NTP daemon
What I did: Enabled NTP longjump so that sonic device clock is synchronized with NTP server

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
As NTP long jump is disabled causing system clock to stay away from actual time even when NTP server is configured
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Reenabled NTP long jump in code
#### How to verify it
```
1. Set the clock away from actual time.
2. Configure NTP server
3. Observe that system clock is synchronized to NTP server. 
```

#### Description for the changelog
NTP long jump is enabled in NTP config file when it is restarted by ntp-config.sh file

**Issue Link:** https://github.com/sonic-net/sonic-buildimage/issues/5007

