### PR TITLE
Adding support of common security cipher module for encryption and decryption of a passkey

### DIFF
--- a/src/sonic-py-common/sonic_py_common/security_cipher.py
+++ b/src/sonic-py-common/sonic_py_common/security_cipher.py
@@ -1,0 +1,120 @@
+'''
+
+A common module for handling the encryption and
+decryption of the feature passkey. It also takes
+care of storying the secure cipher at root 
+protected file system
+
+'''
+
+import subprocess
+import threading
+import syslog
+import os
+from swsscommon.swsscommon import ConfigDBConnector
+
+class security_cipher:
+    _instance = None
+    _lock = threading.Lock()
+
+    def __new__(cls):
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super(security_cipher, cls).__new__(cls)
+                cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self):
+        if not self._initialized:
+            self._file_path = "/etc/cipher_pass"
+            self._config_db = ConfigDBConnector()
+            self._config_db.connect()
+            # Note: Kept 1st index NA intentionally to map it with the cipher_pass file
+            # contents. The file has a comment at the 1st row / line
+            self._feature_list = ["NA", "TACPLUS", "RADIUS", "LDAP"]
+            if not os.path.exists(self._file_path):
+                with open(self._file_path, 'w') as file:
+                    file.writelines("#Auto generated file for storing the encryption passwords\n")
+                    file.writelines("TACPLUS : \nRADIUS : \nLDAP :\n")
+                    #os.chmod(self._file_path, 0o644)
+            self._initialized = True
+
+    # Write cipher_pass file
+    def __write_passwd_file(self, feature_type, passwd):
+        if feature_type == 'NA':
+            syslog.syslog(syslog.LOG_ERR, "__write_passwd_file: Invalid feature type: {}".format(feature_type))
+            return
+
+        if feature_type in self._feature_list:
+            try:
+                with open(self._file_path, 'r') as file:
+                    lines = file.readlines()
+                    # Update the password for given feature
+                    lines[self._feature_list.index(feature_type)] = feature_type + ' : ' + passwd + '\n'
+
+                    #os.chmod(self._file_path, 0o777)
+                    with open(self._file_path, 'w') as file:
+                        file.writelines(lines)
+                    #os.chmod(self._file_path, 0o644)
+            except FileNotFoundError:
+                syslog.syslog(syslog.LOG_ERR, "__write_passwd_file: File {} no found".format(self._file_path))
+            except PermissionError:
+                syslog.syslog(syslog.LOG_ERR, "__write_passwd_file: Read permission denied: {}".format(self._file_path))
+
+    # Read cipher pass file and return the feature specifc
+    # password
+    def __read_passwd_file(self, feature_type):
+        passwd = None
+        if feature_type == 'NA':
+            syslog.syslog(syslog.LOG_ERR, "__read_passwd_file: Invalid feature type: {}".format(feature_type))
+            return passwd 
+
+        if feature_type in self._feature_list:
+           try:
+               with open(self._file_path, "r") as file:
+                   lines = file.readlines()
+                   for line in lines:
+                       if feature_type in line:
+                           passwd = line.split(' : ')[1]
+
+           except FileNotFoundError:
+                syslog.syslog(syslog.LOG_ERR, "__read_passwd_file: File {} no found".format(self._file_path))
+           except PermissionError:
+                syslog.syslog(syslog.LOG_ERR, "__read_passwd_file: Read permission denied: {}".format(self._file_path))
+
+        syslog.syslog(syslog.LOG_ERR, "NIKHIL PASSWORD {}".format(passwd))
+        return passwd
+    
+    # Encrypt the passkey
+    def encrypt_passkey(self, feature_type, secret, passwd):
+        cmd = [ 'openssl', 'enc', '-aes-128-cbc', '-A',  '-a', '-salt', '-pbkdf2', '-pass', 'pass:' + passwd ]
+        p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        outsecret, errs = p.communicate(input=secret)
+        if not errs:
+            self.__write_passwd_file(feature_type, passwd)
+
+        return outsecret,errs
+
+    # Decrypt the passkey
+    def decrypt_passkey(self, feature_type, secret):
+        errs = "Passkey Decryption failed"
+        passwd = self.__read_passwd_file(feature_type)
+        if passwd is not None:
+            cmd = "echo " + format(secret) + " | openssl enc -aes-128-cbc -a -d -salt -pbkdf2 -pass pass:" + passwd
+            proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+            output, errs = proc.communicate()
+
+            if not errs:
+                output = output.decode('utf-8')
+
+        return output, errs
+
+    # Check if the encryption is enabled 
+    def is_key_encrypt_enabled(self, table, entry):
+        key = 'key_encrypt'
+        data = self._config_db.get_entry(table, entry)
+        if data:
+            if key in data:
+                return data[key]
+        return False
+


### PR DESCRIPTION

#### Why I did it
This module is created to handle the passkey encryption, decryption and the cipher storage. It's a common module which will be used for feature like TACACS, RADIUS, LDAP etc.
This implementation is aligned with [HLD](https://github.com/sonic-net/SONiC/pull/1471)

#### How I did it
This module will expose following APIs.
1. Passkey encryption for a given feature
2. Passkey decryption for a given feature
3. Check whether encryption feature is enabled for a given feature

#### How to verify it
`
Cipher / password used for the encryption:
root@sonic:/tmp# cat /etc/cipher_pass 
#Auto generated file for storing the encryption passwords
TACPLUS : TEST1
RADIUS : TEST2
LDAP : TEST3


Is encryption enabled for TACACS: False
Encrypted passkey for Feature: TACPLUS - U2FsdGVkX1/frdwl4GGD7bTKyzLi+lr2K76v0IECzkQ=
Passkey post decryption:TACPLUS - passkey1
Encrypted passkey for Feature: RADIUS - U2FsdGVkX1/fdiBo3RWWxIIPFJYCy1CF/ZQeLt8N96Q=
Passkey post decryption: RADIUS - passkey2
Encrypted passkey for Feature: LDAP - U2FsdGVkX1/o0UkHtWgOjr46UzLQRhXKAHngctey9TE=
Passkey post decryption: LDAP - passkey3
`
#### Which release branch to backport (provide reason below if selected)
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111
- [ ] 202205
- [x] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
Master

#### Link to config_db schema for YANG module changes
[Schema](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#tacplus-server)

