### PR TITLE
Set SYNCD_SHM_SIZE for Arista DNX Devices

### DIFF
--- a/device/arista/x86_64-arista_7280cr3_32p4/platform_env.conf
+++ b/device/arista/x86_64-arista_7280cr3_32p4/platform_env.conf
@@ -1,1 +1,2 @@
+SYNCD_SHM_SIZE=1gb
 usemsi=1

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/platform_env.conf
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/platform_env.conf
@@ -1,2 +1,3 @@
+SYNCD_SHM_SIZE=1gb
 usemsi=1
 dmasize=512M

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/platform_env.conf
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/platform_env.conf
@@ -1,2 +1,3 @@
+SYNCD_SHM_SIZE=1gb
 usemsi=1
 dmasize=512M

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/platform_env.conf
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/platform_env.conf
@@ -1,3 +1,4 @@
+SYNCD_SHM_SIZE=1gb
 usemsi=1
 dmasize=64M
 macsec_enabled=1


### PR DESCRIPTION
SAI 9.x requires a SYNCD_SHM_SIZE specified otherwise it will default to 64mb which is insufficient for syncd.

E.G. of a few failures seen when insufficient shmem was set
```
ha_init:  The file: warmboot_data_0 is of size=762[MB] and is beyond the directory: /dev/shm available storage of size=64[MB]#015
```
```
syncd.sh[26074]: Cannot get SYNCD_SHM_SIZE for chip: [869] in /usr/share/sonic/device/x86_64-broadcom_common/syncd_shm.ini. Skip set SYNCD_SHM_SIZE.
```
Syncd hangs here:
```
syncd#syncd: [none] SAI_API_SWITCH:_brcm_sai_shr_ha_section_resize:536 start=0x7f6e641b4000, end=0x7f6e645b4000, len=302276608, free=0x7f6e641b4000
```

Broadcom recommended using 1gb for DNX devices.

Since currently we don't use SAI9.x on master and 202305 this change won't fix anything until we upgrade the SAI on those branches.

Backport:
- [x] 202305
