### PR TITLE
Disable SA_EQUALS_DA trap on DNX LC SKUs

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -861,3 +861,4 @@ dma_desc_aggregator_enable_specific_MDB_LPM.BCM8869X=1
 dma_desc_aggregator_enable_specific_MDB_FEC.BCM8869X=1
 sai_pfc_dlr_init_capability=0 
 sai_default_cpu_tx_tc=7
+sai_disable_srcmacqedstmac_ctrl=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1015,3 +1015,4 @@ xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=2
 sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
+sai_disable_srcmacqedstmac_ctrl=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1015,3 +1015,4 @@ xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=2
 sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
+sai_disable_srcmacqedstmac_ctrl=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1032,3 +1032,4 @@ xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
 sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
+sai_disable_srcmacqedstmac_ctrl=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1032,3 +1032,4 @@ xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
 sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
+sai_disable_srcmacqedstmac_ctrl=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1052,3 +1052,4 @@ xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
 sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
+sai_disable_srcmacqedstmac_ctrl=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1052,3 +1052,4 @@ xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
 sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
+sai_disable_srcmacqedstmac_ctrl=1

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -340,3 +340,4 @@ sai_nbr_bcast_ifp_optimized
 sai_pfc_defaults_disable
 sai_optimized_mmu
 sai_default_cpu_tx_tc
+sai_disable_srcmacqedstmac_ctrl


### PR DESCRIPTION
This change was submitted directly to `202205` but it's also needed in `master` and `202305` with SAI9.x
https://github.com/sonic-net/sonic-buildimage/pull/13346

There has been a couple CSPs for this as well:
CS00012273013 - [7.1][J2, J2c+] Disable SA Equals DA trap on DNX
CS00012320965 - SAI9.2: iBGP doesn't work due to SA_EQUALS_DA trap

If SA_EQUALS_DA trap is enabled iBGP won't work as the `Ethernet-IB0` ports are expected to get packets with SA==DA.
E.G. iBGP not working:
```
nfc405-3# show ip bgp summary -d all

IPv4 Unicast Summary:
BGP router identifier 8.0.0.1, local AS number 65100 vrf-id 0
BGP table version 136206
RIB entries 101651, using 19516992 bytes of memory
Peers 5, using 3709880 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  65200       1915       2054         0      0       0  01:22:11   34050           ARISTA01T3
10.0.0.5       4  65200       1924       2060         0      0       0  01:22:39   34050           ARISTA03T3
10.0.0.7       4  65200       1914       2051         0      0       0  01:22:08   34050           ARISTA04T3
10.0.0.11      4  65200       1914       2051         0      0       0  01:22:07   34050           ARISTA06T3
10.0.254.3     4  65100          0          0         0      0       0  never      Connect         nfc405-7
```


Backport:
- [x] 202305