### PR TITLE
Workaround to fix ECMP hash polarization

### DIFF
--- a/platform/broadcom/docker-syncd-brcm/start_led.sh
+++ b/platform/broadcom/docker-syncd-brcm/start_led.sh
@@ -36,3 +36,11 @@ if [[ -r "$LED_PROC_INIT_SOC" && ! -f /var/warmboot/warm-starting ]]; then
     /usr/bin/bcmcmd -t 60 "rcload $LED_PROC_INIT_SOC"
 fi
 
+
+# Run the command and store the output in a variable, ignoring errors
+output=$(/usr/bin/bcmcmd -t 1 "show unit" 2>/dev/null | grep BCM)
+
+# Check if the output contains either "BCM56960" or "BCM56970" or "BCM56971"
+if [[ $output == *"BCM56960"* || $output == *"BCM56970"* || $output == *"BCM56971"* ]]; then
+    /usr/bin/bcmcmd "mod RTAG7_PORT_BASED_HASH 0 391 OFFSET_ECMP=0xa" >/dev/null 2>&1
+fi

--- a/platform/broadcom/docker-syncd-brcm/start_led.sh
+++ b/platform/broadcom/docker-syncd-brcm/start_led.sh
@@ -36,7 +36,7 @@ if [[ -r "$LED_PROC_INIT_SOC" && ! -f /var/warmboot/warm-starting ]]; then
     /usr/bin/bcmcmd -t 60 "rcload $LED_PROC_INIT_SOC"
 fi
 
-
+wait_syncd
 # Run the command and store the output in a variable, ignoring errors
 output=$(/usr/bin/bcmcmd -t 1 "show unit" 2>/dev/null | grep BCM)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Now it has ECMP hash polarization issue, this workaround set OFFSET_ECMP=0xa can fix this issue.
For the final fix from SAI could be longer, we could use this workaround to fix hash polarization issue for now.

##### Work item tracking
- Microsoft ADO **25665344**:

#### How I did it
During syncd bootup, use `/usr/bin/bmccmd "mod RTAG7_PORT_BASED_HASH 0 391 OFFSET_ECMP=0xa" `to set OFFSET_ECMP in registor.

#### How to verify it
After syncd started, check OFFSET_ECMP value with:
`/usr/bin/bcmcmd  "dump RTAG7_PORT_BASED_HASH 0 391 OFFSET_ECMP" `


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

