### PR TITLE
[pmon] update gRPC version to 1.57.0 (#16257)

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -36,8 +36,8 @@ RUN apt-get update &&   \
 # doesn't ensure all dependencies are installed in the container. So here we
 # install any dependencies required by the Arista sonic_platform package.
 # TODO: eliminate the need to install these explicitly.
-RUN pip3 install grpcio==1.39.0 \
-        grpcio-tools==1.39.0
+RUN pip3 install grpcio==1.57.0 \
+        grpcio-tools==1.57.0
 
 # Barefoot platform vendors' sonic_platform packages import the Python 'thrift' library
 RUN pip3 install thrift==0.13.0

--- a/files/build/versions/dockers/docker-platform-monitor/versions-py3
+++ b/files/build/versions/dockers/docker-platform-monitor/versions-py3
@@ -1,6 +1,4 @@
 attrs==20.3.0
-certifi==2023.7.22
-charset-normalizer==3.2.0
 grpcio==1.57.0
 grpcio-tools==1.57.0
 guacamole==0.9.2

--- a/files/build/versions/dockers/docker-platform-monitor/versions-py3
+++ b/files/build/versions/dockers/docker-platform-monitor/versions-py3
@@ -1,6 +1,8 @@
 attrs==20.3.0
-grpcio==1.39.0
-grpcio-tools==1.39.0
+certifi==2023.7.22
+charset-normalizer==3.2.0
+grpcio==1.57.0
+grpcio-tools==1.57.0
 guacamole==0.9.2
 importlib-metadata==1.6.0
 jsonschema==2.6.0


### PR DESCRIPTION
Cherry-pick conflict 

https://github.com/sonic-net/sonic-buildimage/pull/16257

#16257 

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

