### PR TITLE
[arp_update]: Flush neighbors with incorrect MAC info

### DIFF
--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -9,6 +9,11 @@
 
 ARP_UPDATE_VARS_FILE="/usr/share/sonic/templates/arp_update_vars.j2"
 
+# Overload `logger` command to include arp_update tag
+logger () {
+    command logger -t "arp_update" "$@"
+}
+
 while /bin/true; do
   # find L3 interfaces which are UP, send ipv6 multicast pings
   ARP_UPDATE_VARS=$(sonic-cfggen -d -t ${ARP_UPDATE_VARS_FILE})
@@ -68,6 +73,19 @@ while /bin/true; do
       if [[ -n "$intf_up" ]]; then
           eval $ping6cmd
       fi
+  done
+
+  # Flush neighbor entries with MAC mismatch between kernel and APPL_DB
+  KERNEL_NEIGH=$(ip neigh show | grep -v "FAILED\|INCOMPLETE" | cut -d ' ' -f 1,3,5 --output-delimiter=',' | tr -d ' ')
+  for neigh in $KERNEL_NEIGH; do
+        ip="$( cut -d ',' -f 1 <<< "$neigh" )"
+        intf="$( cut -d ',' -f 2 <<< "$neigh" )"
+        kernel_mac="$( cut -d ',' -f 3 <<< "$neigh" )"
+        appl_db_mac="$(sonic-db-cli APPL_DB hget NEIGH_TABLE:$intf:$ip neigh)"
+        if [[ $kernel_mac != $appl_db_mac ]]; then
+            logger -p warning "MAC mismatch for ${ip} on ${intf} - kernel: ${kernel_mac}, APPL_DB: ${appl_db_mac}"
+            ip neigh flush $ip
+        fi
   done
 
   VLAN=$(echo $ARP_UPDATE_VARS | jq -r '.vlan')

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -86,7 +86,7 @@ while /bin/true; do
   done
 
   # Flush neighbor entries with MAC mismatch between kernel and APPL_DB
-  KERNEL_NEIGH=$(ip neigh show | grep -v "FAILED\|INCOMPLETE" | cut -d ' ' -f 1,3,5 --output-delimiter=',' | tr -d ' ')
+  KERNEL_NEIGH=$(ip neigh show | grep -v "fe80" | grep -v "FAILED\|INCOMPLETE" | cut -d ' ' -f 1,3,5 --output-delimiter=',' | tr -d ' ')
   for neigh in $KERNEL_NEIGH; do
         ip="$( cut -d ',' -f 1 <<< "$neigh" )"
         intf="$( cut -d ',' -f 2 <<< "$neigh" )"

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -75,6 +75,16 @@ while /bin/true; do
       fi
   done
 
+  # find neighbor entries with aged MAC and flush/relearn them
+  STALE_NEIGHS=$(ip neigh show | grep -v "fe80" | grep "STALE" | awk '{print $1 "," $5}' | tr [:lower:] [:upper:])
+  for neigh in $STALE_NEIGHS; do
+        ip="$( cut -d ',' -f 1 <<< "$neigh" )"
+        mac="$( cut -d ',' -f 2 <<< "$neigh" )"
+        if [[ -z $(sonic-db-cli ASIC_DB keys "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY*${mac}*") ]]; then
+            timeout 1 ping -c1 -w1 $ip > /dev/null
+        fi
+  done
+
   # Flush neighbor entries with MAC mismatch between kernel and APPL_DB
   KERNEL_NEIGH=$(ip neigh show | grep -v "FAILED\|INCOMPLETE" | cut -d ' ' -f 1,3,5 --output-delimiter=',' | tr -d ' ')
   for neigh in $KERNEL_NEIGH; do

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -81,7 +81,7 @@ while /bin/true; do
         ip="$( cut -d ',' -f 1 <<< "$neigh" )"
         mac="$( cut -d ',' -f 2 <<< "$neigh" )"
         if [[ -z $(sonic-db-cli ASIC_DB keys "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY*${mac}*") ]]; then
-            timeout 1 ping -c1 -w1 $ip > /dev/null
+            timeout 0.2 ping -c1 -w1 $ip > /dev/null
         fi
   done
 
@@ -95,6 +95,7 @@ while /bin/true; do
         if [[ $kernel_mac != $appl_db_mac ]]; then
             logger -p warning "MAC mismatch for ${ip} on ${intf} - kernel: ${kernel_mac}, APPL_DB: ${appl_db_mac}"
             ip neigh flush $ip
+            timeout 0.2 ping -c1 -w1 $ip > /dev/null
         fi
   done
 

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -24,7 +24,7 @@ while /bin/true; do
       STATIC_ROUTE_IFNAMES=($(echo $ARP_UPDATE_VARS | jq -r '.static_route_ifnames'))
       # on supervisor/rp exit the script gracefully
       if [[ -z "$STATIC_ROUTE_NEXTHOPS" ]] || [[ -z "$STATIC_ROUTE_IFNAMES" ]]; then
-          logger "arp_update: exiting as no static route in packet based chassis"
+          logger "exiting as no static route in packet based chassis"
           exit 0
       fi
       for i in ${!STATIC_ROUTE_NEXTHOPS[@]}; do
@@ -43,7 +43,7 @@ while /bin/true; do
               interface="${STATIC_ROUTE_IFNAMES[i]}"
               if [[ -z "$interface" ]]; then
                   # should never be here, handling just in case
-                  logger "ERR: arp_update: missing interface entry for static route $nexthop"
+                  logger -p error "missing interface entry for static route $nexthop"
                   continue
               fi
               intf_up=$(ip link show $interface | grep "state UP")
@@ -52,7 +52,7 @@ while /bin/true; do
                   eval $pingcmd
                   # STALE entries may appear more often, not logging to prevent periodic syslogs
                   if [[ -z $(echo ${neigh_state} | grep 'STALE') ]]; then
-                      logger "arp_update: static route nexthop not resolved ($neigh_state), pinging $nexthop on $interface"
+                      logger "static route nexthop not resolved ($neigh_state), pinging $nexthop on $interface"
                   fi
               fi
           fi
@@ -176,11 +176,11 @@ while /bin/true; do
           if [[ $ip == *"."* ]] && [[ ! $KERNEIGH4 =~ "${ip},${intf}" ]]; then
               pingcmd="timeout 0.2 ping -I $intf -n -q -i 0 -c 1 -W 1 $ip >/dev/null"
               eval $pingcmd
-              logger "arp_update: mismatch arp entry, pinging ${ip} on ${intf}"
+              logger "mismatch arp entry, pinging ${ip} on ${intf}"
           elif [[ $ip == *":"* ]] && [[ ! $KERNEIGH6 =~ "${ip},${intf}" ]]; then
               ping6cmd="timeout 0.2 ping6 -I $intf -n -q -i 0 -c 1 -W 1 $ip >/dev/null"
               eval $ping6cmd
-              logger "arp_update: mismatch v6 nbr entry, pinging ${ip} on ${intf}"
+              logger "mismatch v6 nbr entry, pinging ${ip} on ${intf}"
           fi
       fi
   done


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- Prevent packet drops due to MAC expiration in hardware
- Mitigate MAC mismatch between kernel and APPL_DB neighbor table

##### Work item tracking
- Microsoft ADO **25135974** and **25647679**:

#### How I did it

#### How to verify it
- Load script onto some DUT, wait for MAC entries to expire (`show arp` will have entries with 'Iface' listed as '-'). Run the arp_update script. After several seconds confirm that the expired entries are no longer present in `show arp`
- For some learned neighbor, manually set the APPL_DB MAC address in the neighbor table to a value different from the MAC address learned in the kernel. Run the arp_update script, confirm that the neighbor is flushed.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ 20220531.38] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

