### PR TITLE
[Mellanox] Remove log in RAM kernel option for 2700 A1 platform

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700a1-r0/installer.conf
+++ b/device/mellanox/x86_64-mlnx_msn2700a1-r0/installer.conf
@@ -1,1 +1,0 @@
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="logs_inram=on"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Remove logs_inram kernel option

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Remove logs_inram kernel option

#### How to verify it

Regression test

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202305.c87506217
- [ ] <!-- image version 2 -->

Full sonic-mgmt regression t0/t1-lag passed.

#### Description for the changelog
The change is to prevent log to RAM on 2700 A1 platform. It is to align with 2700 platform.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

