### PR TITLE
[yang]Fixing sonic-cfg-help to handle nested container

### DIFF
--- a/src/sonic-yang-mgmt/sonic-cfg-help
+++ b/src/sonic-yang-mgmt/sonic-cfg-help
@@ -54,7 +54,14 @@ class SonicCfgDescriber:
                 self.print_field_desc(table['list'], field)
                 print()
         elif table.get('container') is not None:
-            self.print_field_desc(table.get('container'), field)
+            if isinstance(table['container'], dict):
+                print("key - " + table['container'].get('@name'))
+                self.print_field_desc(table.get('container'), field)
+            elif isinstance(table['container'], list):
+                for c in table['container']:
+                    print("key - " + c.get('@name'))
+                    self.print_field_desc(c, field)
+
             print()
 
     def get_referenced_table_field(self, ref):

--- a/src/sonic-yang-mgmt/tests/test_cfghelp.py
+++ b/src/sonic-yang-mgmt/tests/test_cfghelp.py
@@ -25,6 +25,7 @@ techsupport_table_output="""\
 AUTO_TECHSUPPORT
 Description: AUTO_TECHSUPPORT part of config_db.json
 
+key - GLOBAL
 +-------------------------+----------------------------------------------------+-------------+-----------+-------------+
 | Field                   | Description                                        | Mandatory   | Default   | Reference   |
 +=========================+====================================================+=============+===========+=============+
@@ -62,6 +63,7 @@ techsupport_table_field_output="""\
 AUTO_TECHSUPPORT
 Description: AUTO_TECHSUPPORT part of config_db.json
 
+key - GLOBAL
 +---------+--------------------------------------------------+-------------+-----------+-------------+
 | Field   | Description                                      | Mandatory   | Default   | Reference   |
 +=========+==================================================+=============+===========+=============+
@@ -118,6 +120,25 @@ key - ACL_TABLE_NAME:RULE_NAME
 
 """
 
+snmp_table_output="""\
+
+SNMP
+
+key - CONTACT
++---------+----------------------+-------------+-----------+-------------+
+| Field   | Description          | Mandatory   | Default   | Reference   |
++=========+======================+=============+===========+=============+
+| Contact | SNMP System Contact. |             |           |             |
++---------+----------------------+-------------+-----------+-------------+
+key - LOCATION
++----------+-----------------------+-------------+-----------+-------------+
+| Field    | Description           | Mandatory   | Default   | Reference   |
++==========+=======================+=============+===========+=============+
+| Location | SNMP System Location. |             |           |             |
++----------+-----------------------+-------------+-----------+-------------+
+
+"""
+
 class TestCfgHelp(TestCase):
 
     def setUp(self):
@@ -167,3 +188,8 @@ class TestCfgHelp(TestCase):
         argument = ['-t', 'ACL_RULE', '-f', 'ICMP_TYPE']
         output = self.run_script(argument)
         self.assertEqual(output, acl_rule_table_field_output)
+
+    def test_nested_container(self):
+        argument = ['-t', 'SNMP']
+        output = self.run_script(argument)
+        self.assertEqual(output, snmp_table_output)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixing sonic-cfg-help to handle nested container scenario. In case of nested container, the inner container name acts as key for the table. For e.g. 
```
"AUTO_TECHSUPPORT": {
        "GLOBAL": {
         }
}
```

Previous output

```
AUTO_TECHSUPPORT
Description: AUTO_TECHSUPPORT part of config_db.json

+-------------------------+----------------------------------------------------+-------------+-----------+-------------+
| Field                   | Description                                        | Mandatory   | Default   | Reference   |
+=========================+====================================================+=============+===========+=============+
| state                   | Knob to make techsupport invocation event-driven   |             |           |             |
|                         | based on core-dump generation                      |             |           |             |
+-------------------------+----------------------------------------------------+-------------+-----------+-------------+
| rate_limit_interval     | Minimum time in seconds between two successive     |             |           |             |
|                         | techsupport invocations. Configure 0 to explicitly |             |           |             |
|                         | disable                                            |             |           |             |
+-------------------------+----------------------------------------------------+-------------+-----------+-------------+
| max_techsupport_limit   | Max Limit in percentage for the cummulative size   |             |           |             |
|                         | of ts dumps. No cleanup is performed if the value  |             |           |             |
|                         | isn't configured or is 0.0                         |             |           |             |
+-------------------------+----------------------------------------------------+-------------+-----------+-------------+
| max_core_limit          | Max Limit in percentage for the cummulative size   |             |           |             |
|                         | of core dumps. No cleanup is performed if the      |             |           |             |
|                         | value isn't congiured or is 0.0                    |             |           |             |
+-------------------------+----------------------------------------------------+-------------+-----------+-------------+
| available_mem_threshold | Memory threshold; 0 to disable techsupport         |             | 10.0      |             |
|                         | invocation on memory usage threshold crossing      |             |           |             |
+-------------------------+----------------------------------------------------+-------------+-----------+-------------+
| min_available_mem       | Minimum Free memory (in MB) that should be         |             | 200       |             |
|                         | available for the techsupport execution to start   |             |           |             |
+-------------------------+----------------------------------------------------+-------------+-----------+-------------+
| since                   | Only collect the logs & core-dumps generated since |             |           |             |
|                         | the time provided. A default value of '2 days ago' |             |           |             |
|                         | is used if this value is not set explicitly or a   |             |           |             |
|                         | non-valid string is provided                       |             |           |             |
+-------------------------+----------------------------------------------------+-------------+-----------+-------------+


```

New output

```
AUTO_TECHSUPPORT
Description: AUTO_TECHSUPPORT part of config_db.json

key - GLOBAL
+-------------------------+----------------------------------------------------+-------------+-----------+-------------+
| Field                   | Description                                        | Mandatory   | Default   | Reference   |
+=========================+====================================================+=============+===========+=============+
| state                   | Knob to make techsupport invocation event-driven   |             |           |             |
|                         | based on core-dump generation                      |             |           |             |
+-------------------------+----------------------------------------------------+-------------+-----------+-------------+
| rate_limit_interval     | Minimum time in seconds between two successive     |             |           |             |
|                         | techsupport invocations. Configure 0 to explicitly |             |           |             |
|                         | disable                                            |             |           |             |
+-------------------------+----------------------------------------------------+-------------+-----------+-------------+
| max_techsupport_limit   | Max Limit in percentage for the cummulative size   |             |           |             |
|                         | of ts dumps. No cleanup is performed if the value  |             |           |             |
|                         | isn't configured or is 0.0                         |             |           |             |
+-------------------------+----------------------------------------------------+-------------+-----------+-------------+
| max_core_limit          | Max Limit in percentage for the cummulative size   |             |           |             |
|                         | of core dumps. No cleanup is performed if the      |             |           |             |
|                         | value isn't congiured or is 0.0                    |             |           |             |
+-------------------------+----------------------------------------------------+-------------+-----------+-------------+
| available_mem_threshold | Memory threshold; 0 to disable techsupport         |             | 10.0      |             |
|                         | invocation on memory usage threshold crossing      |             |           |             |
+-------------------------+----------------------------------------------------+-------------+-----------+-------------+
| min_available_mem       | Minimum Free memory (in MB) that should be         |             | 200       |             |
|                         | available for the techsupport execution to start   |             |           |             |
+-------------------------+----------------------------------------------------+-------------+-----------+-------------+
| since                   | Only collect the logs & core-dumps generated since |             |           |             |
|                         | the time provided. A default value of '2 days ago' |             |           |             |
|                         | is used if this value is not set explicitly or a   |             |           |             |
|                         | non-valid string is provided                       |             |           |             |
+-------------------------+----------------------------------------------------+-------------+-----------+-------------+


```
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Fixing sonic-cfg-help tool to handle nested container

#### How to verify it
Added UT to verify it.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202305 commit https://github.com/sonic-net/sonic-buildimage/commit/8dc776bebbd3b8845c628f7bdbfd436539cc43ae
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

