### PR TITLE
[POC] Fix IPV6 mgmt route not work because add to 'defalt' vrf issue

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -81,16 +81,28 @@ iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
 {% endif %}
     ########## management network policy routing rules
     # management port up rules
+{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
     up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev {{ name }} table {{ vrf_table }} metric 201
     up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev {{ name }} table {{ vrf_table }}
     up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add pref 32765 from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
+{% else %}
+    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev {{ name }} metric 201
+    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev {{ name }}
+    up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add pref 32765 from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }}
+{% endif %}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
     up ip rule add pref 32764 to {{ route }} table {{ vrf_table }}
 {% endfor %}
     # management port down rules
+{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev {{ name }} table {{ vrf_table }}
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev {{ name }} table {{ vrf_table }}
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete pref 32765 from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
+{% else %}
+    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev {{ name }}
+    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev {{ name }}
+    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete pref 32765 from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }}
+{% endif %}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
     pre-down ip rule delete pref 32764 to {{ route }} table {{ vrf_table }}
 {% endfor %}

--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -74,37 +74,25 @@ iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     netmask {{ prefix | netmask if prefix | ipv4 else prefix | prefixlen }}
     network {{ prefix | network }}
     broadcast {{ prefix | broadcast }}
-{%     set vrf_table = 'default' %}
+{%     set vrf_table_param = '' %}
 {% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
-{%     set vrf_table = '5000' %}
+{%     set vrf_table_param = 'table 5000' %}
     vrf mgmt
 {% endif %}
     ########## management network policy routing rules
     # management port up rules
-{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
-    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev {{ name }} table {{ vrf_table }} metric 201
-    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev {{ name }} table {{ vrf_table }}
-    up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add pref 32765 from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
-{% else %}
-    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev {{ name }} metric 201
-    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev {{ name }}
-    up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add pref 32765 from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }}
-{% endif %}
+    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev {{ name }} {{ vrf_table_param }} metric 201
+    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev {{ name }} {{ vrf_table_param }}
+    up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add pref 32765 from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} {{ vrf_table_param }}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
-    up ip rule add pref 32764 to {{ route }} table {{ vrf_table }}
+    up ip rule add pref 32764 to {{ route }} {{ vrf_table_param }}
 {% endfor %}
     # management port down rules
-{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
-    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev {{ name }} table {{ vrf_table }}
-    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev {{ name }} table {{ vrf_table }}
-    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete pref 32765 from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
-{% else %}
-    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev {{ name }}
-    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev {{ name }}
-    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete pref 32765 from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }}
-{% endif %}
+    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev {{ name }} {{ vrf_table_param }}
+    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev {{ name }} {{ vrf_table_param }}
+    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete pref 32765 from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} {{ vrf_table_param }}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
-    pre-down ip rule delete pref 32764 to {{ route }} table {{ vrf_table }}
+    pre-down ip rule delete pref 32764 to {{ route }} {{ vrf_table_param }}
 {% endfor %}
 {# TODO: COPP policy type rules #}
 {% endfor %}

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces
@@ -21,13 +21,13 @@ iface eth0 inet static
     broadcast 10.0.0.255
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
-    up ip -4 route add 10.0.0.0/24 dev eth0 table default
-    up ip -4 rule add pref 32765 from 10.0.0.100/32 table default
+    up ip -4 route add default via 10.0.0.1 dev eth0  metric 201
+    up ip -4 route add 10.0.0.0/24 dev eth0 
+    up ip -4 rule add pref 32765 from 10.0.0.100/32 
     # management port down rules
-    pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table default
-    pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table default
-    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table default
+    pre-down ip -4 route delete default via 10.0.0.1 dev eth0 
+    pre-down ip -4 route delete 10.0.0.0/24 dev eth0 
+    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
@@ -35,13 +35,13 @@ iface eth0 inet6 static
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
-    up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
-    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table default
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0  metric 201
+    up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 
+    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 
     # management port down rules
-    pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table default
-    pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table default
-    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table default
+    pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 
+    pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 
+    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 
 #
 source /etc/network/interfaces.d/*
 #

--- a/src/sonic-config-engine/tests/sample_output/py2/two_mgmt_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/two_mgmt_interfaces
@@ -22,13 +22,13 @@ iface eth1 inet static
     broadcast 10.0.10.255
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.10.1 dev eth1 table default metric 201
-    up ip -4 route add 10.0.10.0/24 dev eth1 table default
-    up ip -4 rule add pref 32765 from 10.0.10.100/32 table default
+    up ip -4 route add default via 10.0.10.1 dev eth1  metric 201
+    up ip -4 route add 10.0.10.0/24 dev eth1 
+    up ip -4 rule add pref 32765 from 10.0.10.100/32 
     # management port down rules
-    pre-down ip -4 route delete default via 10.0.10.1 dev eth1 table default
-    pre-down ip -4 route delete 10.0.10.0/24 dev eth1 table default
-    pre-down ip -4 rule delete pref 32765 from 10.0.10.100/32 table default
+    pre-down ip -4 route delete default via 10.0.10.1 dev eth1 
+    pre-down ip -4 route delete 10.0.10.0/24 dev eth1 
+    pre-down ip -4 rule delete pref 32765 from 10.0.10.100/32 
 iface eth0 inet static
     address 10.0.0.100
     netmask 255.255.255.0
@@ -36,13 +36,13 @@ iface eth0 inet static
     broadcast 10.0.0.255
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
-    up ip -4 route add 10.0.0.0/24 dev eth0 table default
-    up ip -4 rule add pref 32765 from 10.0.0.100/32 table default
+    up ip -4 route add default via 10.0.0.1 dev eth0  metric 201
+    up ip -4 route add 10.0.0.0/24 dev eth0 
+    up ip -4 rule add pref 32765 from 10.0.0.100/32 
     # management port down rules
-    pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table default
-    pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table default
-    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table default
+    pre-down ip -4 route delete default via 10.0.0.1 dev eth0 
+    pre-down ip -4 route delete 10.0.0.0/24 dev eth0 
+    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 
 iface eth1 inet6 static
     address 2603:10e2:0:abcd::8
     netmask 64
@@ -50,13 +50,13 @@ iface eth1 inet6 static
     broadcast 2603:10e2:0:abcd:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:abcd::1 dev eth1 table default metric 201
-    up ip -6 route add 2603:10e2:0:abcd::/64 dev eth1 table default
-    up ip -6 rule add pref 32765 from 2603:10e2:0:abcd::8/128 table default
+    up ip -6 route add default via 2603:10e2:0:abcd::1 dev eth1  metric 201
+    up ip -6 route add 2603:10e2:0:abcd::/64 dev eth1 
+    up ip -6 rule add pref 32765 from 2603:10e2:0:abcd::8/128 
     # management port down rules
-    pre-down ip -6 route delete default via 2603:10e2:0:abcd::1 dev eth1 table default
-    pre-down ip -6 route delete 2603:10e2:0:abcd::/64 dev eth1 table default
-    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:abcd::8/128 table default
+    pre-down ip -6 route delete default via 2603:10e2:0:abcd::1 dev eth1 
+    pre-down ip -6 route delete 2603:10e2:0:abcd::/64 dev eth1 
+    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:abcd::8/128 
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
@@ -64,13 +64,13 @@ iface eth0 inet6 static
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
-    up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
-    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table default
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0  metric 201
+    up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 
+    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 
     # management port down rules
-    pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table default
-    pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table default
-    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table default
+    pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 
+    pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 
+    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 
 #
 source /etc/network/interfaces.d/*
 #

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces
@@ -21,13 +21,13 @@ iface eth0 inet static
     broadcast 10.0.0.255
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
-    up ip -4 route add 10.0.0.0/24 dev eth0 table default
-    up ip -4 rule add pref 32765 from 10.0.0.100/32 table default
+    up ip -4 route add default via 10.0.0.1 dev eth0  metric 201
+    up ip -4 route add 10.0.0.0/24 dev eth0 
+    up ip -4 rule add pref 32765 from 10.0.0.100/32 
     # management port down rules
-    pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table default
-    pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table default
-    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table default
+    pre-down ip -4 route delete default via 10.0.0.1 dev eth0 
+    pre-down ip -4 route delete 10.0.0.0/24 dev eth0 
+    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
@@ -35,13 +35,13 @@ iface eth0 inet6 static
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
-    up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
-    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table default
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0  metric 201
+    up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 
+    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 
     # management port down rules
-    pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table default
-    pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table default
-    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table default
+    pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 
+    pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 
+    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 
 #
 source /etc/network/interfaces.d/*
 #

--- a/src/sonic-config-engine/tests/sample_output/py3/two_mgmt_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/two_mgmt_interfaces
@@ -22,13 +22,13 @@ iface eth0 inet static
     broadcast 10.0.0.255
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
-    up ip -4 route add 10.0.0.0/24 dev eth0 table default
-    up ip -4 rule add pref 32765 from 10.0.0.100/32 table default
+    up ip -4 route add default via 10.0.0.1 dev eth0  metric 201
+    up ip -4 route add 10.0.0.0/24 dev eth0 
+    up ip -4 rule add pref 32765 from 10.0.0.100/32 
     # management port down rules
-    pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table default
-    pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table default
-    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table default
+    pre-down ip -4 route delete default via 10.0.0.1 dev eth0 
+    pre-down ip -4 route delete 10.0.0.0/24 dev eth0 
+    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
@@ -36,13 +36,13 @@ iface eth0 inet6 static
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
-    up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
-    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table default
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0  metric 201
+    up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 
+    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 
     # management port down rules
-    pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table default
-    pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table default
-    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table default
+    pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 
+    pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 
+    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 
 iface eth1 inet static
     address 10.0.10.100
     netmask 255.255.255.0
@@ -50,13 +50,13 @@ iface eth1 inet static
     broadcast 10.0.10.255
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.10.1 dev eth1 table default metric 201
-    up ip -4 route add 10.0.10.0/24 dev eth1 table default
-    up ip -4 rule add pref 32765 from 10.0.10.100/32 table default
+    up ip -4 route add default via 10.0.10.1 dev eth1  metric 201
+    up ip -4 route add 10.0.10.0/24 dev eth1 
+    up ip -4 rule add pref 32765 from 10.0.10.100/32 
     # management port down rules
-    pre-down ip -4 route delete default via 10.0.10.1 dev eth1 table default
-    pre-down ip -4 route delete 10.0.10.0/24 dev eth1 table default
-    pre-down ip -4 rule delete pref 32765 from 10.0.10.100/32 table default
+    pre-down ip -4 route delete default via 10.0.10.1 dev eth1 
+    pre-down ip -4 route delete 10.0.10.0/24 dev eth1 
+    pre-down ip -4 rule delete pref 32765 from 10.0.10.100/32 
 iface eth1 inet6 static
     address 2603:10e2:0:abcd::8
     netmask 64
@@ -64,13 +64,13 @@ iface eth1 inet6 static
     broadcast 2603:10e2:0:abcd:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:abcd::1 dev eth1 table default metric 201
-    up ip -6 route add 2603:10e2:0:abcd::/64 dev eth1 table default
-    up ip -6 rule add pref 32765 from 2603:10e2:0:abcd::8/128 table default
+    up ip -6 route add default via 2603:10e2:0:abcd::1 dev eth1  metric 201
+    up ip -6 route add 2603:10e2:0:abcd::/64 dev eth1 
+    up ip -6 rule add pref 32765 from 2603:10e2:0:abcd::8/128 
     # management port down rules
-    pre-down ip -6 route delete default via 2603:10e2:0:abcd::1 dev eth1 table default
-    pre-down ip -6 route delete 2603:10e2:0:abcd::/64 dev eth1 table default
-    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:abcd::8/128 table default
+    pre-down ip -6 route delete default via 2603:10e2:0:abcd::1 dev eth1 
+    pre-down ip -6 route delete 2603:10e2:0:abcd::/64 dev eth1 
+    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:abcd::8/128 
 #
 source /etc/network/interfaces.d/*
 #


### PR DESCRIPTION
Please ignore POC PR.


Fix IPV6 mgmt route not work because add to 'defalt' vrf issue.

#### Why I did it
When device set with IPV6 tacacs server address, and shutdown all BGP, device can't connect to TACACS server via mgmt interface.

After investigation, I found when the default IPV6 route of mgmt interface add to 'default' table, the route does not work:

admin@vlab-01:~$ sudo ip route get 1:2:3:4::
RTNETLINK answers: Network is unreachable
admin@vlab-01:~$ sudo route -6 | grep eth0
fec0::/64                      [::]                       U    1024 1     0 eth0
[::]/0                         fec0::1                    UG   201 1     0 eth0
fe80::/64                      [::]                       U    256 1     0 eth0
fec0::/64                      [::]                       U    256 1     0 eth0
fe80::5054:ff:fe37:81fd/128    [::]                       Un   0   6     0 eth0
fec0::ffff:afa:1/128           [::]                       Un   0   2     0 eth0
ff00::/8                       [::]                       U    256 1     0 eth0
admin@vlab-01:~$


##### Work item tracking
- Microsoft ADO: 25798732

#### How I did it
When mgmt vrf not enabled, add mgmt interface route without VRF parameter.

#### How to verify it
Pass all UT.
Manually verify issue fixed:

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [] 202205
- [] 202211
- [] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x]  master-16742.373711-493d8b7bf

#### Description for the changelog
Fix IPV6 mgmt route not work because add to 'defalt' vrf issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

