### PR TITLE
[Marvell-arm64]: Fix SYNCD_RPC build

### DIFF
--- a/platform/marvell-arm64/docker-syncd-mrvl-rpc.mk
+++ b/platform/marvell-arm64/docker-syncd-mrvl-rpc.mk
@@ -23,3 +23,5 @@ $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /host/warmboot:/var/warmboot
+
+SONIC_BULLSEYE_DOCKERS += $(DOCKER_SYNCD_MRVL_RPC)


### PR DESCRIPTION
Change-Id: I0bd4932d03141f3f7bc523b49a1bf3d1809817a8

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
With 'ENABLE_SYNCD_RPC' flag enabled, compilation for marvell-arm64 was failing. Failure was due to bookworm now being default docker and absence of python2 support in it.

dh: error: unable to load addon python2: Can't locate Debian/Debhelper/Sequence/python2.pm in @INC (you may need to install the Debian::Debhelper::Sequence::python2 module) (@INC contains: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/aarch64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at (eval 11) line 1.
BEGIN failed--compilation aborted at (eval 11) line 1.
make[2]: *** [debian/rules:91: clean] Error 25
make[2]: Leaving directory '/sonic/src/thrift/thrift-0.11.0'
dpkg-buildpackage: error: fakeroot debian/rules clean subprocess returned exit status 2
make[1]: *** [Makefile:16: /sonic/target/debs/bookworm/libthrift-0.11.0_0.11.0-4_arm64.deb] Error 2
make[1]: Leaving directory '/sonic/src/thrift'
 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Marking syncd_rpc components also to be built with bullsyeye.

#### How to verify it
Completion of build with 'ENABLE_SYNCD_RPC' flag enabled and checked for "show interface up" by loading the image.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

