### PR TITLE
Don't restart ntpsec if the mgmt address gets a DHCP response

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -377,6 +377,7 @@ echo "ntp-config.service" | sudo tee -a $GENERATED_SERVICE_FILE
 sudo cp $IMAGE_CONFIGS/ntp/ntp-config.sh $FILESYSTEM_ROOT/usr/bin/
 sudo cp $IMAGE_CONFIGS/ntp/ntp.conf.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
 sudo cp $IMAGE_CONFIGS/ntp/ntp-systemd-wrapper $FILESYSTEM_ROOT/usr/libexec/ntpsec/
+sudo cp $IMAGE_CONFIGS/ntp/ntpsec.default $FILESYSTEM_ROOT_ETC/default/ntpsec
 sudo mkdir $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/ntpsec.service.d
 sudo cp $IMAGE_CONFIGS/ntp/sonic-target.conf $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/ntpsec.service.d/
 echo "ntpsec.service" | sudo tee -a $GENERATED_SERVICE_FILE

--- a/files/image_config/ntp/ntpsec.default
+++ b/files/image_config/ntp/ntpsec.default
@@ -1,0 +1,10 @@
+NTPD_OPTS="-x -N"
+
+# Set to "yes" to ignore DHCP servers returned by DHCP.
+# For SONiC, NTP configuration is separate from DHCP responses on the mgmt port.
+IGNORE_DHCP="yes"
+
+# If you use certbot to obtain a certificate for ntpd, provide its name here.
+# The ntpsec deploy hook for certbot will handle copying and permissioning the
+# certificate and key files.
+NTPSEC_CERTBOT_CERT_NAME=""


### PR DESCRIPTION


Fixes #17114.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

For setups where the mgmt interface address is assigned by a DHCP server, don't restart ntpsec in those cases with any NTP information received by the DHCP server. For SONiC, NTP configuration is (currently) separate from any information received from DHCP. In addition, if this happens at bootup time, there's a chance of a deadlock within systemctl happening.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

