### PR TITLE
[iccpd] Fix bufferAccessOutOfBounds err

### DIFF
--- a/src/iccpd/src/iccp_cli.c
+++ b/src/iccpd/src/iccp_cli.c
@@ -117,7 +117,7 @@ int set_peer_link(int mid, const char* ifname)
                        csm->mlag_id, ifname);
     }
 
-    memset(csm->peer_itf_name, 0, MAX_L_PORT_NAME);
+    memset(csm->peer_itf_name, 0, IFNAMSIZ);
     memcpy(csm->peer_itf_name, ifname, len);
 
     /* update peer-link link handler*/
@@ -162,7 +162,7 @@ int unset_peer_link(int mid)
     scheduler_session_disconnect_handler(csm);
 
     /* clean peer-link*/
-    memset(csm->peer_itf_name, 0, MAX_L_PORT_NAME);
+    memset(csm->peer_itf_name, 0, IFNAMSIZ);
     if (csm->peer_link_if)
     {
         csm->peer_link_if->is_peer_link = 0;


### PR DESCRIPTION
Change-Id: I64370c663bd5b9c6133d605988980f69027c0083


#### Why I did it

struct CSM has char peer_itf_name[IFNAMSIZ];
and IFNAMSIZ is 16, but iccp_cli.c use MAX_L_PORT_NAME which value is 20.

##### Work item tracking


#### How I did it

use IFNAMSIZ

#### How to verify it

no bufferAccessOutOfBounds

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)


#### Description for the changelog


#### Link to config_db schema for YANG module changes


#### A picture of a cute animal (not mandatory but encouraged)

