### PR TITLE
[yang][dhcp_server] Add support for smart switch in sonic-dhcp-server-ipv4.yang

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/dhcp_server_ipv4.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/dhcp_server_ipv4.json
@@ -4,7 +4,7 @@
     },
     "DHCP_SERVER_IPV4_WITH_INVALID_VLAN": {
         "desc": "Configure vlan-id in DHCP_SERVER_IPV4 table which is invalid.",
-        "eStrKey" : "Pattern"
+        "eStrKey" : "InvalidValue"
     },
     "DHCP_SERVER_IPV4_INCORRECT_GATEWAY": {
         "desc": "Add gateway which is not in correct ip-prefix format.",
@@ -22,6 +22,10 @@
         "desc": "Configure wrong value for mode.",
         "eStrKey": "InvalidValue"
     },
+    "DHCP_SERVER_IPV4_WITH_NON_EXIST_BRIDGE": {
+        "desc": "Configure bridge in DHCP_SERVER_IPV4 table which does not exist in MID_PLANE_BRIDGE table.",
+        "eStrKey": "InvalidValue"
+    },
     "DHCP_SREVER_IPV4_NON_EXIST_OPTION": {
         "desc": "Configure option in DHCP_SERVER_IPV4 table which does not exist in DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS table.",
         "eStrKey": "LeafRef"
@@ -34,6 +38,10 @@
         "desc": "Configure wrong value for type.",
         "eStrKey": "InvalidValue",
         "eStr": ["type"]
+    },
+    "DHCP_SERVER_IPV4_PORT_WITH_NO_EXIST_PORT": {
+        "desc": "Configure DHCP port in DHCP_SERVER_IPV4_PORT table which is no exist.",
+        "eStrKey": "InvalidValue"
     },
     "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_TEXT": {
         "desc": "Add text type of DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS."

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcp_server_ipv4.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcp_server_ipv4.json
@@ -1,5 +1,13 @@
 {
     "DHCP_SERVER_IPV4_VALID_FORMAT": {
+        "sonic-smart-switch:sonic-smart-switch": {
+            "sonic-smart-switch:MID_PLANE_BRIDGE": {
+                "GLOBAL": {
+                    "bridge": "bridge_midplane",
+                    "ip_prefix": "169.254.200.254/24"
+                }
+            }
+        },
         "sonic-portchannel:sonic-portchannel": {
             "sonic-portchannel:PORTCHANNEL": {
                 "PORTCHANNEL_LIST": [
@@ -37,6 +45,14 @@
                         "customized_options": [
                             "option60"
                         ],
+                        "state": "enabled"
+                    },
+                    {
+                        "name": "bridge_midplane",
+                        "gateway": "169.254.200.254",
+                        "lease_time": 3600,
+                        "mode": "PORT",
+                        "netmask": "255.255.255.0",
                         "state": "enabled"
                     }
                 ]
@@ -164,6 +180,30 @@
             }
         }
     },
+    "DHCP_SERVER_IPV4_WITH_NON_EXIST_BRIDGE": {
+        "sonic-smart-switch:sonic-smart-switch": {
+            "sonic-smart-switch:MID_PLANE_BRIDGE": {
+                "GLOBAL": {
+                    "bridge": "bridge_midplane",
+                    "ip_prefix": "169.254.200.254/24"
+                }
+            }
+        },
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "non_exist_bridge_midplane",
+                        "gateway": "192.168.0.1",
+                        "lease_time": 3600,
+                        "mode": "PORT",
+                        "netmask": "255.255.255.0",
+                        "state": "enabled"
+                    }
+                ]
+            }
+        }
+    },
     "DHCP_SREVER_IPV4_NON_EXIST_OPTION": {
         "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
             "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
@@ -242,6 +282,41 @@
                         "port": "Ethernet0",
                         "ips": [
                             "192.168.0.4"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "DHCP_SERVER_IPV4_PORT_WITH_NO_EXIST_PORT": {
+        "sonic-smart-switch:sonic-smart-switch": {
+            "sonic-smart-switch:MID_PLANE_BRIDGE": {
+                "GLOBAL": {
+                    "bridge": "bridge_midplane",
+                    "ip_prefix": "169.254.200.254/24"
+                }
+            }
+        },
+        "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4": {
+                "DHCP_SERVER_IPV4_LIST": [
+                    {
+                        "name": "bridge_midplane",
+                        "gateway": "169.254.200.254",
+                        "lease_time": 3600,
+                        "mode": "PORT",
+                        "netmask": "255.255.255.0",
+                        "state": "enabled"
+                    }
+                ]
+            },
+            "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_PORT": {
+                "DHCP_SERVER_IPV4_PORT_LIST": [
+                    {
+                        "name": "bridge_midplane",
+                        "port": "non_exit_dpu",
+                        "ips": [
+                            "169.254.200.1"
                         ]
                     }
                 ]

--- a/src/sonic-yang-models/yang-models/sonic-dhcp-server-ipv4.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dhcp-server-ipv4.yang
@@ -27,6 +27,10 @@ module sonic-dhcp-server-ipv4 {
         prefix lag;
     }
 
+    import sonic-smart-switch {
+        prefix smartswitch;
+    }
+
     description "DHCP_SERVER_IPV4 YANG module for SONiC OS";
 
     revision 2023-07-19 {
@@ -46,12 +50,17 @@ module sonic-dhcp-server-ipv4 {
 
                 leaf name {
                     description "Interface name for DHCP server";
-                    // Comment VLAN leaf reference here until libyang back-links issue is resolved and use VLAN string pattern
-                    // type leafref {
-                    //     path "/vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:name";
-                    // }
-                    type string {
-                        pattern 'Vlan([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
+                    type union {
+                        // Comment VLAN leaf reference here until libyang back-links issue is resolved and use VLAN string pattern
+                        // type leafref {
+                        //     path "/vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:name";
+                        // }
+                        type string {
+                            pattern 'Vlan([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
+                        }
+                        type leafref {
+                            path "/smartswitch:sonic-smart-switch/smartswitch:MID_PLANE_BRIDGE/smartswitch:GLOBAL/smartswitch:bridge";
+                        }
                     }
                 }
 
@@ -204,13 +213,16 @@ module sonic-dhcp-server-ipv4 {
                 }
 
                 leaf port {
-                    description "Interface under vlan";
+                    description "Interface under DHCP interface";
                     type union {
                         type leafref {
                             path "/port:sonic-port/port:PORT/port:PORT_LIST/port:name";
                         }
                         type leafref {
                             path "/lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name";
+                        }
+                        type leafref {
+                            path "/smartswitch:sonic-smart-switch/smartswitch:DPUS/smartswitch:DPUS_LIST/smartswitch:midplane_interface";
                         }
                     }
                 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

**Depends on https://github.com/sonic-net/sonic-buildimage/pull/17311**
#### Why I did it
Add support for smart swith in dhcp-server-ipv4 yang model:
1. "name" in `DHCP_SERVER_IPV4` would refer to "bridge" in `MID_PLANE_BRIDGE`
2. "port" in `DHCP_SERVER_IPV4_PORT` would refer to "midplane_interface" in `DPUS`

##### Work item tracking
- Microsoft ADO **(number only)**:  25975672

#### How I did it
Add support for smart switch in sonic-dhcp-server-ipv4.yang

#### How to verify it
Unit tests in sonic-yang-models all passed.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

