### PR TITLE
Fixed determine/process reboot-cause service dependency

### DIFF
--- a/src/sonic-host-services-data/debian/sonic-host-services-data.process-reboot-cause.service
+++ b/src/sonic-host-services-data/debian/sonic-host-services-data.process-reboot-cause.service
@@ -5,4 +5,5 @@ After=database.service determine-reboot-cause.service
 
 [Service]
 Type=simple
+RemainAfterExit=yes
 ExecStart=/usr/local/bin/process-reboot-cause

--- a/src/sonic-host-services-data/debian/sonic-host-services-data.process-reboot-cause.timer
+++ b/src/sonic-host-services-data/debian/sonic-host-services-data.process-reboot-cause.timer
@@ -1,7 +1,9 @@
 [Unit]
 Description=Delays process-reboot-cause until network is stably connected
+PartOf=process-reboot-cause.service
 
 [Timer]
+OnUnitActiveSec=0 sec
 OnBootSec=1min 30 sec
 Unit=process-reboot-cause.service
 

--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -29,6 +29,8 @@ REBOOT_CAUSE_FILE = os.path.join(REBOOT_CAUSE_DIR, "reboot-cause.txt")
 PREVIOUS_REBOOT_CAUSE_FILE = os.path.join(REBOOT_CAUSE_DIR,  "previous-reboot-cause.json")
 FIRST_BOOT_PLATFORM_FILE = "/tmp/notify_firstboot_to_platform"
 REBOOT_TYPE_KEXEC_FILE = "/proc/cmdline"
+TMP_DIR="/tmp"
+REBOOT_PROCESSED_FILE = os.path.join(TMP_DIR, "previous-reboot-cause-processed")
 # The following SONIC_BOOT_TYPEs come from the warm/fast reboot script which is in sonic-utilities
 # Because the system can be rebooted from some old versions, we have to take all possible BOOT options into consideration.
 # On 201803, 201807 we have
@@ -218,6 +220,10 @@ def main():
         sonic_logger.log_error("User {} does not have permission to execute".format(pwd.getpwuid(os.getuid()).pw_name))
         sys.exit("This utility must be run as root")
 
+    if os.path.exists(REBOOT_PROCESSED_FILE):
+        sonic_logger.log_info("User {} : reboot-cause already processed. Nothing to do. Exiting...".format(pwd.getpwuid(os.getuid()).pw_name))
+        return
+
     # Create REBOOT_CAUSE_DIR if it doesn't exist
     if not os.path.exists(REBOOT_CAUSE_DIR):
         os.makedirs(REBOOT_CAUSE_DIR)
@@ -257,6 +263,10 @@ def main():
     with open(REBOOT_CAUSE_FILE, "w") as cause_file:
         cause_file.write(REBOOT_CAUSE_UNKNOWN)
 
+    # Create tmp reboot processed file to mark processing of last reboot cause during current boot.
+    # This is used to prevent reprocessing of reboot cause if this service restarts.
+    with open(REBOOT_PROCESSED_FILE, "w") as reboot_processed_file:
+        reboot_processed_file.write("processed last reboot cause")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes https://github.com/sonic-net/sonic-buildimage/issues/16990  for 202205 branch

Note: This PR is a 202205 adaptation of https://github.com/sonic-net/sonic-host-services/pull/88 fix for master. The fix in master removes the dependency of determine-reboot-cause on database service. To minimize the effects on the dependency tree, this PR is modified to handle the determine-reboot-cause restart ability with script-side changes.
=====

1. determine-reboot-cause  and process-reboot-cause service does not start If the database service fails to restart in the first attempt. Even if the Database service succeeds in the next attempt, these reboot-cause services do not start.

2. The process-reboot-cause service also does not restart if the docker or database service restarts, which leads to an empty reboot-cause history

3. deploy-mg from sonic-mgmt also triggers the docker service restart. The restart of the docker service caused the issue stated in 2 above. The docker restart also triggers determine-reboot-cause to restart which creates an additional reboot-cause file in history and modifies the last reboot-cause.

This PR fixes these issues by making both processes start again when dependency meets after dependency failure, making both processes restart when the database service restarts, and preventing duplicate processing of the last reboot reason.

##### Work item tracking
- Microsoft ADO **25892856**

#### How I did it
1. Modified systemd unit files to make determine-reboot-cause and process-reboot-cause services restartable when the database service restarts.
2. On the restart, the determine-reboot-cause service should not recreate a new reboot-cause entry in the database. Added check for first start or restart to skip entry for restart case.

#### How to verify it
On single asic pizza box:
1.  Installed the image and check reboot-cause history
2. restart database service and verify that determine-reboot-cause and process-reboot-cause services also restart. Verify that reboot-cause shows correct data and no new entry is created for restart.

On Chassis:
1.  Installed the image and check reboot-cause history
2. restart the database service and verify that determine-reboot-cause and process-reboot-cause services also restart. Verify that reboot-cause shows correct data and no new entry is created for restart.
5. Reboot LC. On Supervicor, stop database-chassis service.
     Let database service on LC fail the first time. determine-reboot-cause and process-reboot-cause  would fail to start due to dependency failure
     start database-chassis on Supervisor. Database service on LC should now start successfully.
     Verify determine-reboot-cause and process-reboot-cause  also starts
     Verify show reboot-cause history output


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

