### PR TITLE
[smart_switch][dhcp_server] Add related table checkers for smart_switch in dhcp_db_monitor

### DIFF
--- a/src/sonic-dhcp-utilities/dhcp_utilities/common/dhcp_db_monitor.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/common/dhcp_db_monitor.py
@@ -13,6 +13,8 @@ VLAN = "VLAN"
 VLAN_MEMBER = "VLAN_MEMBER"
 VLAN_INTERFACE = "VLAN_INTERFACE"
 FEATURE = "FEATURE"
+MID_PLANE_BRIDGE = "MID_PLANE_BRIDGE"
+DPUS = "DPUS"
 
 
 class ConfigDbEventChecker(object):
@@ -342,6 +344,45 @@ class VlanMemberTableEventChecker(ConfigDbEventChecker):
             self.clear_event()
             return True
         return False
+
+
+class MidPlaneTableEventChecker(ConfigDbEventChecker):
+    """
+    This event checker interested in changes in MID_PLANE_BRIDGE table
+    """
+    table_name = MID_PLANE_BRIDGE
+
+    def __init__(self, sel, db):
+        self.table_name = MID_PLANE_BRIDGE
+        ConfigDbEventChecker.__init__(self, sel, db)
+
+    def _get_parameter(self, db_snapshot):
+        return ConfigDbEventChecker.get_parameter_by_name(db_snapshot, "enabled_dhcp_interfaces")
+
+    def _process_check(self, key, op, entry, enabled_dhcp_interfaces):
+        if op == "DEL":
+            return True
+        for field, value in entry:
+            if field == "bridge" and value in enabled_dhcp_interfaces:
+                return True
+        return False
+
+
+class DpusTableEventChecker(ConfigDbEventChecker):
+    """
+    This event checker interested in changes in DPUS table
+    """
+    table_name = DPUS
+
+    def __init__(self, sel, db):
+        self.table_name = DPUS
+        ConfigDbEventChecker.__init__(self, sel, db)
+
+    def _get_parameter(self, db_snapshot):
+        return True, None
+
+    def _process_check(self, key, op, entry, param):
+        return True
 
 
 class DhcpServerFeatureStateChecker(ConfigDbEventChecker):

--- a/src/sonic-dhcp-utilities/tests/test_data/dhcp_db_monitor_test_data.json
+++ b/src/sonic-dhcp-utilities/tests/test_data/dhcp_db_monitor_test_data.json
@@ -289,5 +289,51 @@
                 "pre_disabled": false
             }
         }
+    ],
+    "test_mid_plane_update": [
+        {
+            "table": [
+                ["GLOBAL", "SET", [["bridge", "bridge_midplane"], ["ip_prefix", "169.254.200.254/24"]]]
+            ],
+            "exp_res": true
+        },
+        {
+            "table": [
+                ["GLOBAL", "SET", [["bridge", "bridge_midplane2"], ["ip_prefix", "169.254.200.254/24"]]]
+            ],
+            "exp_res": false
+        },
+        {
+            "table": [
+                ["GLOBAL", "DEL", []]
+            ],
+            "exp_res": true
+        }
+    ],
+    "test_dpus_update": [
+        {
+            "table": [
+                ["dpu0", "SET", [["midplane_interface", "dpu0"]]]
+            ],
+            "exp_res": true
+        },
+        {
+            "table": [
+                ["dpu1", "SET", [["midplane_interface", "dpu1"]]]
+            ],
+            "exp_res": true
+        },
+        {
+            "table": [
+                ["dpu0", "DEL", []]
+            ],
+            "exp_res": true
+        },
+        {
+            "table": [
+                ["dpu1", "DEL", []]
+            ],
+            "exp_res": true
+        }
     ]
 }

--- a/src/sonic-dhcp-utilities/tests/test_dhcp_db_monitor.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcp_db_monitor.py
@@ -5,7 +5,8 @@ from common_utils import MockSubscribeTable, get_subscribe_table_tested_data, \
 from dhcp_utilities.common.dhcp_db_monitor import DhcpRelaydDbMonitor, DhcpServdDbMonitor, ConfigDbEventChecker, \
     DhcpServerTableIntfEnablementEventChecker, DhcpServerTableCfgChangeEventChecker, \
     DhcpPortTableEventChecker, DhcpRangeTableEventChecker, DhcpOptionTableEventChecker, \
-    VlanTableEventChecker, VlanMemberTableEventChecker, VlanIntfTableEventChecker, DhcpServerFeatureStateChecker
+    VlanTableEventChecker, VlanMemberTableEventChecker, VlanIntfTableEventChecker, DhcpServerFeatureStateChecker, \
+    MidPlaneTableEventChecker, DpusTableEventChecker
 from dhcp_utilities.common.utils import DhcpDbConnector
 from swsscommon import swsscommon
 from unittest.mock import patch, ANY, PropertyMock, MagicMock
@@ -385,4 +386,38 @@ def test_feature_table_checker(mock_swsscommon_dbconnector_init, tested_data, te
         else:
             expected_res = tested_data["exp_res"]["pre_enabled"] if tested_db_snapshot["dhcp_server_feature_enabled"] \
                 else tested_data["exp_res"]["pre_disabled"]
+            assert expected_res == check_res
+
+
+@pytest.mark.parametrize("tested_db_snapshot", [{"enabled_dhcp_interfaces": {"bridge_midplane": ["dpu0"]}}, {}])
+@pytest.mark.parametrize("tested_data", get_subscribe_table_tested_data("test_mid_plane_update"))
+def test_mid_plane_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot):
+    with patch.object(ConfigDbEventChecker, "enable"), \
+         patch.object(ConfigDbEventChecker, "subscriber_state_table",
+                      return_value=MockSubscribeTable(tested_data["table"]), new_callable=PropertyMock), \
+         patch.object(sys, "exit"):
+        sel = swsscommon.Select()
+        db_event_checker = MidPlaneTableEventChecker(sel, MagicMock())
+        expected_res = tested_data["exp_res"]
+        check_res = db_event_checker.check_update_event(tested_db_snapshot)
+        if "enabled_dhcp_interfaces" not in tested_db_snapshot:
+            assert check_res
+        else:
+            assert expected_res == check_res
+
+
+@pytest.mark.parametrize("tested_db_snapshot", [{"enabled_dhcp_interfaces": {"bridge_midplane": ["dpu0"]}}, {}])
+@pytest.mark.parametrize("tested_data", get_subscribe_table_tested_data("test_dpus_update"))
+def test_dpus_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot):
+    with patch.object(ConfigDbEventChecker, "enable"), \
+         patch.object(ConfigDbEventChecker, "subscriber_state_table",
+                      return_value=MockSubscribeTable(tested_data["table"]), new_callable=PropertyMock), \
+         patch.object(sys, "exit"):
+        sel = swsscommon.Select()
+        db_event_checker = DpusTableEventChecker(sel, MagicMock())
+        expected_res = tested_data["exp_res"]
+        check_res = db_event_checker.check_update_event(tested_db_snapshot)
+        if "enabled_dhcp_interfaces" not in tested_db_snapshot:
+            assert check_res
+        else:
             assert expected_res == check_res


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

**Depends on https://github.com/sonic-net/sonic-buildimage/pull/17311**
#### Why I did it
Add table checker for `DPUS` and `MID_PLANE_BRIDGE` tables for smart switch ip assigning, HLD: https://github.com/sonic-net/SONiC/pull/1504/files

##### Work item tracking
- Microsoft ADO **(number only)**: 25973272

#### How I did it
Add `DpusTableEventChecker` and `MidPlaneTableEventChecker` and related unit tests.

#### How to verify it
All UTs passed
```
================================================================================================================================== test session starts ===================================================================================================================================
platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
rootdir: /sonic/src/sonic-dhcp-utilities, configfile: setup.cfg, testpaths: tests
plugins: pyfakefs-5.3.1, cov-2.10.1
collected 436 items                                                                                                                                                                                                                                                                      

tests/test_dhcp_cfggen.py ..................                                                                                                                                                                                                                                       [  4%]
tests/test_dhcp_db_monitor.py .................................................................................................................................................................................................................................................... [ 60%]
........................                                                                                                                                                                                                                                                           [ 65%]
tests/test_dhcp_lease.py .....                                                                                                                                                                                                                                                     [ 66%]
tests/test_dhcprelayd.py ......................................................................................................                                                                                                                                                    [ 90%]
tests/test_dhcpservd.py .......                                                                                                                                                                                                                                                    [ 91%]
tests/test_utils.py ....................................                                                                                                                                                                                                                           [100%]

----------- coverage: platform linux, python 3.9.2-final-0 -----------
Name                                      Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------------------------
dhcp_utilities/dhcprelayd/dhcprelayd.py     179     21     68      0    86.64%   94-133
dhcp_utilities/dhcpservd/dhcpservd.py        67      4     14      0    92.59%   91-98
dhcp_utilities/dhcpservd/dhcp_lease.py       95      3     30      4    94.40%   57->59, 59, 60->61, 61, 74->76, 112->134, 153
dhcp_utilities/dhcpservd/dhcp_cfggen.py     219      6     94      1    97.76%   201-205, 293->295, 295
dhcp_utilities/common/utils.py               76      1     42      1    98.31%   129->134, 134
----------------------------------------------------------------------------------------
TOTAL                                       929     35    344      6    95.68%

2 files skipped due to complete coverage.

Required test coverage of 80.0% reached. Total coverage: 95.68%
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

