### PR TITLE
add subport to support CMIS breakout

### DIFF
--- a/platform/vs/tests/breakout/sample_output/sample_new_port_config.json
+++ b/platform/vs/tests/breakout/sample_output/sample_new_port_config.json
@@ -4,12 +4,14 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27,28",
 	        "speed": "50000",
+		"subport": "2",
 	        "index": "0"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25,26",
 	        "speed": "50000",
+		"subport": "1",
 	        "index": "0"
 	    }
     },
@@ -18,18 +20,21 @@
                 "alias": "fortyGigE0/12",
                 "lanes": "37,38",
                 "speed": "50000",
+		"subport": "1",
                 "index": "3"
             },
             "Ethernet14": {
                 "alias": "fortyGigE0/14",
                 "lanes": "39",
                 "speed": "25000",
+		"subport": "2",
                 "index": "3"
             },
 	    "Ethernet15": {
                 "alias": "fortyGigE0/15",
                 "lanes": "40",
                 "speed": "25000",
+		"subport": "3",
                 "index": "3"
             }
     },
@@ -38,12 +43,14 @@
                 "alias": "fortyGigE0/2",
                 "lanes": "27,28",
                 "speed": "50000",
+		"subport": "2",
                 "index": "0"
             },
             "Ethernet0": {
                 "alias": "fortyGigE0/0",
                 "lanes": "25,26",
                 "speed": "50000",
+		"subport": "1",
                 "index": "0"
             }
     },
@@ -52,6 +59,7 @@
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25,26,27,28",
 	        "speed": "100000",
+		"subport": "1",
 	        "index": "0"
 	    }
     },
@@ -60,24 +68,28 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27",
 	        "speed": "25000",
+		"subport": "3",
 	        "index": "0"
 	    },
 	    "Ethernet3": {
 	        "alias": "fortyGigE0/3",
 	        "lanes": "28",
 	        "speed": "25000",
+		"subport": "4",
 	        "index": "0"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25",
 	        "speed": "25000",
+		"subport": "1",
 	        "index": "0"
 	    },
 	    "Ethernet1": {
 	        "alias": "fortyGigE0/1",
 	        "lanes": "26",
 	        "speed": "25000",
+		"subport": "2",
 	        "index": "0"
 	    }
     },
@@ -86,18 +98,21 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27,28",
 	        "speed": "50000",
+		"subport": "3",
 	        "index": "0"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25",
 	        "speed": "25000",
+		"subport": "1",
 	        "index": "0"
 	    },
 	    "Ethernet1": {
 	        "alias": "fortyGigE0/1",
 	        "lanes": "26",
 	        "speed": "25000",
+		"subport": "2",
 	        "index": "0"
 	    }
     },
@@ -106,18 +121,21 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27",
 	        "speed": "25000",
+		"subport": "2",
 	        "index": "0"
 	    },
 	    "Ethernet3": {
 	        "alias": "fortyGigE0/3",
 	        "lanes": "28",
 	        "speed": "25000",
+		"subport": "3",
 	        "index": "0"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25,26",
 	        "speed": "50000",
+		"subport": "1",
 	        "index": "0"
 		}
     },
@@ -126,24 +144,28 @@
 		"alias": "fortyGigE0/6",
 		"lanes": "31",
 		"speed": "25000",
+		"subport": "3",
 		"index": "1"
 	},
 	"Ethernet7": {
 		"alias": "fortyGigE0/7",
 		"lanes": "32",
 		"speed": "25000",
+		"subport": "4",
 		"index": "1"
 	},
 	"Ethernet4": {
 		"alias": "fortyGigE0/4",
 		"lanes": "29",
 		"speed": "25000",
+		"subport": "1",
 		"index": "1"
 	},
 	"Ethernet5": {
 		"alias": "fortyGigE0/5",
 		"lanes": "30",
 		"speed": "25000",
+		"subport": "2",
 		"index": "1"
 	}
     },
@@ -152,12 +174,14 @@
 		"alias": "fortyGigE0/6",
 		"lanes": "31,32",
 		"speed": "50000",
+		"subport": "2",
 		"index": "1"
 	},
 	"Ethernet4": {
 		"alias": "fortyGigE0/4",
 		"lanes": "29,30",
 		"speed": "50000",
+		"subport": "1",
 		"index": "1"
 	}
     },
@@ -166,12 +190,14 @@
 	        "alias": "fortyGigE0/8",
 	        "lanes": "33,34",
 	        "speed": "50000",
+		"subport": "1",
 	        "index": "2"
 	    },
 	    "Ethernet10": {
 	        "alias": "fortyGigE0/10",
 	        "lanes": "35,36",
 	        "speed": "50000",
+		"subport": "2",
 	        "index": "2"
 	    }
     },
@@ -180,12 +206,14 @@
 	        "alias": "fortyGigE0/10",
 	        "lanes": "35",
 	        "speed": "25000",
+		"subport": "2",
 	        "index": "2"
 	    },
 	    "Ethernet11": {
 	        "alias": "fortyGigE0/11",
 	        "lanes": "36",
 	        "speed": "25000",
+		"subport": "3",
 	        "index": "2"
 	    }
     },
@@ -194,18 +222,21 @@
 	        "alias": "fortyGigE0/8",
 	        "lanes": "33",
 	        "speed": "25000",
+		"subport": "1",
 	        "index": "2"
 	    },
 	    "Ethernet9": {
 	        "alias": "fortyGigE0/9",
 	        "lanes": "34",
 	        "speed": "25000",
+		"subport": "2",
 	        "index": "2"
 	    },
 	    "Ethernet10": {
 	        "alias": "fortyGigE0/10",
 	        "lanes": "35,36",
 	        "speed": "50000",
+		"subport": "3",
 	        "index": "2"
 	    }
     },
@@ -214,6 +245,7 @@
 	        "alias": "fortyGigE0/8",
 	        "lanes": "33,34,35,36",
 	        "speed": "100000",
+		"subport": "1",
 	        "index": "2"
 	    }
     }

--- a/platform/vs/tests/breakout/sample_output/sample_new_port_config.json
+++ b/platform/vs/tests/breakout/sample_output/sample_new_port_config.json
@@ -4,15 +4,15 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27,28",
 	        "speed": "50000",
-		"subport": "2",
-	        "index": "0"
+	        "index": "0",
+		"subport": "2"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25,26",
 	        "speed": "50000",
-		"subport": "1",
-	        "index": "0"
+	        "index": "0",
+		"subport": "1"
 	    }
     },
     "Ethernet12_1x50G_2x25G": {
@@ -20,22 +20,22 @@
                 "alias": "fortyGigE0/12",
                 "lanes": "37,38",
                 "speed": "50000",
-		"subport": "1",
-                "index": "3"
+                "index": "3",
+                "subport": "1"
             },
             "Ethernet14": {
                 "alias": "fortyGigE0/14",
                 "lanes": "39",
                 "speed": "25000",
-		"subport": "2",
-                "index": "3"
+                "index": "3",
+                "subport": "2"
             },
 	    "Ethernet15": {
                 "alias": "fortyGigE0/15",
                 "lanes": "40",
                 "speed": "25000",
-		"subport": "3",
-                "index": "3"
+                "index": "3",
+                "subport": "3"
             }
     },
     "Ethernet0_2x50G": {
@@ -43,15 +43,15 @@
                 "alias": "fortyGigE0/2",
                 "lanes": "27,28",
                 "speed": "50000",
-		"subport": "2",
-                "index": "0"
+                "index": "0",
+                "subport": "2"
             },
             "Ethernet0": {
                 "alias": "fortyGigE0/0",
                 "lanes": "25,26",
                 "speed": "50000",
-		"subport": "1",
-                "index": "0"
+                "index": "0",
+                "subport": "1"
             }
     },
     "Ethernet0_1x100G": {
@@ -59,8 +59,8 @@
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25,26,27,28",
 	        "speed": "100000",
-		"subport": "1",
-	        "index": "0"
+	        "index": "0",
+		"subport": "1"
 	    }
     },
     "Ethernet0_4x25G":	{
@@ -68,29 +68,29 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27",
 	        "speed": "25000",
-		"subport": "3",
-	        "index": "0"
+	        "index": "0",
+		"subport": "3"
 	    },
 	    "Ethernet3": {
 	        "alias": "fortyGigE0/3",
 	        "lanes": "28",
 	        "speed": "25000",
-		"subport": "4",
-	        "index": "0"
+	        "index": "0",
+		"subport": "4"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25",
 	        "speed": "25000",
-		"subport": "1",
-	        "index": "0"
+	        "index": "0",
+		"subport": "1"
 	    },
 	    "Ethernet1": {
 	        "alias": "fortyGigE0/1",
 	        "lanes": "26",
 	        "speed": "25000",
-		"subport": "2",
-	        "index": "0"
+	        "index": "0",
+		"subport": "2"
 	    }
     },
     "Ethernet0_2x25G_1x50G": {
@@ -98,22 +98,22 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27,28",
 	        "speed": "50000",
-		"subport": "3",
-	        "index": "0"
+	        "index": "0",
+		"subport": "3"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25",
 	        "speed": "25000",
-		"subport": "1",
-	        "index": "0"
+	        "index": "0",
+		"subport": "1"
 	    },
 	    "Ethernet1": {
 	        "alias": "fortyGigE0/1",
 	        "lanes": "26",
 	        "speed": "25000",
-		"subport": "2",
-	        "index": "0"
+	        "index": "0",
+		"subport": "2"
 	    }
     },
     "Ethernet0_1x50G_2x25G": {
@@ -121,22 +121,22 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27",
 	        "speed": "25000",
-		"subport": "2",
-	        "index": "0"
+	        "index": "0",
+		"subport": "2"
 	    },
 	    "Ethernet3": {
 	        "alias": "fortyGigE0/3",
 	        "lanes": "28",
 	        "speed": "25000",
-		"subport": "3",
-	        "index": "0"
+	        "index": "0",
+		"subport": "3"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25,26",
 	        "speed": "50000",
-		"subport": "1",
-	        "index": "0"
+	        "index": "0",
+		"subport": "1"
 		}
     },
     "Ethernet4_4x25G": {
@@ -144,29 +144,29 @@
 		"alias": "fortyGigE0/6",
 		"lanes": "31",
 		"speed": "25000",
-		"subport": "3",
-		"index": "1"
+		"index": "1",
+		"subport": "3"
 	},
 	"Ethernet7": {
 		"alias": "fortyGigE0/7",
 		"lanes": "32",
 		"speed": "25000",
-		"subport": "4",
-		"index": "1"
+		"index": "1",
+		"subport": "4"
 	},
 	"Ethernet4": {
 		"alias": "fortyGigE0/4",
 		"lanes": "29",
 		"speed": "25000",
-		"subport": "1",
-		"index": "1"
+		"index": "1",
+		"subport": "1"
 	},
 	"Ethernet5": {
 		"alias": "fortyGigE0/5",
 		"lanes": "30",
 		"speed": "25000",
-		"subport": "2",
-		"index": "1"
+		"index": "1",
+		"subport": "2"
 	}
     },
     "Ethernet4_2x50G": {
@@ -174,15 +174,15 @@
 		"alias": "fortyGigE0/6",
 		"lanes": "31,32",
 		"speed": "50000",
-		"subport": "2",
-		"index": "1"
+		"index": "1",
+		"subport": "2"
 	},
 	"Ethernet4": {
 		"alias": "fortyGigE0/4",
 		"lanes": "29,30",
 		"speed": "50000",
-		"subport": "1",
-		"index": "1"
+		"index": "1",
+		"subport": "1"
 	}
     },
     "Ethernet8_2x50G": {
@@ -190,15 +190,15 @@
 	        "alias": "fortyGigE0/8",
 	        "lanes": "33,34",
 	        "speed": "50000",
-		"subport": "1",
-	        "index": "2"
+	        "index": "2",
+		"subport": "1"
 	    },
 	    "Ethernet10": {
 	        "alias": "fortyGigE0/10",
 	        "lanes": "35,36",
 	        "speed": "50000",
-		"subport": "2",
-	        "index": "2"
+	        "index": "2",
+		"subport": "2"
 	    }
     },
     "Ethernet8_1x50G_2x25G": {
@@ -206,15 +206,15 @@
 	        "alias": "fortyGigE0/10",
 	        "lanes": "35",
 	        "speed": "25000",
-		"subport": "2",
-	        "index": "2"
+	        "index": "2",
+		"subport": "2"
 	    },
 	    "Ethernet11": {
 	        "alias": "fortyGigE0/11",
 	        "lanes": "36",
 	        "speed": "25000",
-		"subport": "3",
-	        "index": "2"
+	        "index": "2",
+		"subport": "3"
 	    }
     },
     "Ethernet8_2x25G_1x50G": {
@@ -222,22 +222,22 @@
 	        "alias": "fortyGigE0/8",
 	        "lanes": "33",
 	        "speed": "25000",
-		"subport": "1",
-	        "index": "2"
+	        "index": "2",
+		"subport": "1"
 	    },
 	    "Ethernet9": {
 	        "alias": "fortyGigE0/9",
 	        "lanes": "34",
 	        "speed": "25000",
-		"subport": "2",
-	        "index": "2"
+	        "index": "2",
+		"subport": "2"
 	    },
 	    "Ethernet10": {
 	        "alias": "fortyGigE0/10",
 	        "lanes": "35,36",
 	        "speed": "50000",
-		"subport": "3",
-	        "index": "2"
+	        "index": "2",
+		"subport": "3"
 	    }
     },
     "Ethernet8_1x100G": {
@@ -245,8 +245,8 @@
 	        "alias": "fortyGigE0/8",
 	        "lanes": "33,34,35,36",
 	        "speed": "100000",
-		"subport": "1",
-	        "index": "2"
+	        "index": "2",
+		"subport": "1"
 	    }
     }
 }

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -363,6 +363,7 @@ class BreakoutCfg(object):
 
         lane_id = 0
         alias_id = 0
+        subport_id = 1
 
         for entry in self._breakout_mode_entry:
             lanes_per_port = entry.num_assigned_lanes // entry.num_ports
@@ -376,11 +377,13 @@ class BreakoutCfg(object):
                     'alias': self._breakout_capabilities[alias_id],
                     'lanes': ','.join(lanes),
                     'speed': str(entry.default_speed),
-                    'index': self._indexes[lane_id]
+                    'index': self._indexes[lane_id],
+                    'subport': subport_id
                 }
 
                 lane_id += lanes_per_port
                 alias_id += 1
+                subport_id += 1
 
         return ports
 

--- a/src/sonic-config-engine/tests/sample_output/platform_output.json
+++ b/src/sonic-config-engine/tests/sample_output/platform_output.json
@@ -5,6 +5,7 @@
     "description": "Eth3/1",
     "mtu": "9100",
     "alias": "Eth3/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -15,6 +16,7 @@
     "description": "Eth3/2",
     "mtu": "9100",
     "alias": "Eth3/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -25,6 +27,7 @@
     "description": "Eth10/1",
     "mtu": "9100",
     "alias": "Eth10/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -35,6 +38,7 @@
     "description": "Eth25/2",
     "mtu": "9100",
     "alias": "Eth25/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -47,6 +51,7 @@
     "admin_status": "up",
     "mtu": "9100",
     "alias": "Eth1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "100000",
     "tpid": "0x8100"
@@ -58,6 +63,7 @@
     "admin_status": "up",
     "mtu": "9100",
     "alias": "Eth2/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -69,6 +75,7 @@
     "admin_status": "up",
     "mtu": "9100",
     "alias": "Eth2/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -79,6 +86,7 @@
     "description": "Eth28/2",
     "mtu": "9100",
     "alias": "Eth28/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -89,6 +97,7 @@
     "description": "Eth28/1",
     "mtu": "9100",
     "alias": "Eth28/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -99,6 +108,7 @@
     "description": "Eth5/2",
     "mtu": "9100",
     "alias": "Eth5/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -110,6 +120,7 @@
     "description": "Eth26",
     "mtu": "9100",
     "alias": "Eth26",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "100000",
     "tpid": "0x8100"
@@ -120,6 +131,7 @@
     "description": "Eth9/3",
     "mtu": "9100",
     "alias": "Eth9/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -130,6 +142,7 @@
     "description": "Eth27/1",
     "mtu": "9100",
     "alias": "Eth27/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -140,6 +153,7 @@
     "description": "Eth27/2",
     "mtu": "9100",
     "alias": "Eth27/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -150,6 +164,7 @@
     "description": "Eth24/3",
     "mtu": "9100",
     "alias": "Eth24/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -160,6 +175,7 @@
     "description": "Eth32/2",
     "mtu": "9100",
     "alias": "Eth32/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -170,6 +186,7 @@
     "description": "Eth25/1",
     "mtu": "9100",
     "alias": "Eth25/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -180,6 +197,7 @@
     "description": "Eth32/1",
     "mtu": "9100",
     "alias": "Eth32/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -188,6 +206,7 @@
     "index": "23",
     "lanes": "90",
     "description": "Eth23/3",
+    "subport": 3,
     "mtu": "9100",
     "alias": "Eth23/3",
     "pfc_asym": "off",
@@ -200,6 +219,7 @@
     "description": "Eth23/4",
     "mtu": "9100",
     "alias": "Eth23/4",
+    "subport": 4,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -210,6 +230,7 @@
     "description": "Eth24/1",
     "mtu": "9100",
     "alias": "Eth24/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -220,6 +241,7 @@
     "description": "Eth24/2",
     "mtu": "9100",
     "alias": "Eth24/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -230,6 +252,7 @@
     "description": "Eth13/3",
     "mtu": "9100",
     "alias": "Eth13/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -240,6 +263,7 @@
     "description": "Eth13/4",
     "mtu": "9100",
     "alias": "Eth13/4",
+    "subport": 4,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -250,6 +274,7 @@
     "description": "Eth14/1",
     "mtu": "9100",
     "alias": "Eth14/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -260,6 +285,7 @@
     "description": "Eth14/2",
     "mtu": "9100",
     "alias": "Eth14/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -270,6 +296,7 @@
     "description": "Eth14/3",
     "mtu": "9100",
     "alias": "Eth14/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -280,6 +307,7 @@
     "description": "Eth25/3",
     "mtu": "9100",
     "alias": "Eth25/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -290,6 +318,7 @@
     "description": "Eth15/1",
     "mtu": "9100",
     "alias": "Eth15/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -300,6 +329,7 @@
     "description": "Eth29/2",
     "mtu": "9100",
     "alias": "Eth29/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -310,6 +340,7 @@
     "description": "Eth20/1",
     "mtu": "9100",
     "alias": "Eth20/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -320,6 +351,7 @@
     "description": "Eth19/3",
     "mtu": "9100",
     "alias": "Eth19/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -330,6 +362,7 @@
     "description": "Eth10/3",
     "mtu": "9100",
     "alias": "Eth10/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -340,6 +373,7 @@
     "description": "Eth19/1",
     "mtu": "9100",
     "alias": "Eth19/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -350,6 +384,7 @@
     "description": "Eth19/2",
     "mtu": "9100",
     "alias": "Eth19/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -360,6 +395,7 @@
     "description": "Eth18/3",
     "mtu": "9100",
     "alias": "Eth18/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -370,6 +406,7 @@
     "description": "Eth18/4",
     "mtu": "9100",
     "alias": "Eth18/4",
+    "subport": 4,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -380,6 +417,7 @@
     "description": "Eth9/1",
     "mtu": "9100",
     "alias": "Eth9/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -390,6 +428,7 @@
     "description": "Eth9/2",
     "mtu": "9100",
     "alias": "Eth9/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -400,6 +439,7 @@
     "description": "Eth5/1",
     "mtu": "9100",
     "alias": "Eth5/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -410,6 +450,7 @@
     "description": "Eth28/4",
     "mtu": "9100",
     "alias": "Eth28/4",
+    "subport": 4,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -420,6 +461,7 @@
     "description": "Eth3/3",
     "mtu": "9100",
     "alias": "Eth3/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -430,6 +472,7 @@
     "description": "Eth3/4",
     "mtu": "9100",
     "alias": "Eth3/4",
+    "subport": 4,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -440,6 +483,7 @@
     "description": "Eth4/1",
     "mtu": "9100",
     "alias": "Eth4/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -450,6 +494,7 @@
     "description": "Eth4/2",
     "mtu": "9100",
     "alias": "Eth4/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -460,6 +505,7 @@
     "description": "Eth15/2",
     "mtu": "9100",
     "alias": "Eth15/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -470,6 +516,7 @@
     "description": "Eth5/3",
     "mtu": "9100",
     "alias": "Eth5/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -480,6 +527,7 @@
     "description": "Eth15/3",
     "mtu": "9100",
     "alias": "Eth15/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -490,6 +538,7 @@
     "description": "Eth10/2",
     "mtu": "9100",
     "alias": "Eth10/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -500,6 +549,7 @@
     "description": "Eth20/2",
     "mtu": "9100",
     "alias": "Eth20/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -510,6 +560,7 @@
     "description": "Eth18/1",
     "mtu": "9100",
     "alias": "Eth18/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -520,6 +571,7 @@
     "description": "Eth4/3",
     "mtu": "9100",
     "alias": "Eth4/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -530,6 +582,7 @@
     "description": "Eth23/2",
     "mtu": "9100",
     "alias": "Eth23/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -540,6 +593,7 @@
     "description": "Eth23/1",
     "mtu": "9100",
     "alias": "Eth23/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -550,6 +604,7 @@
     "description": "Eth30/2",
     "mtu": "9100",
     "alias": "Eth30/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -560,6 +615,7 @@
     "description": "Eth30/3",
     "mtu": "9100",
     "alias": "Eth30/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -570,6 +626,7 @@
     "description": "Eth30/1",
     "mtu": "9100",
     "alias": "Eth30/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -580,6 +637,7 @@
     "description": "Eth29/3",
     "mtu": "9100",
     "alias": "Eth29/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -591,6 +649,7 @@
     "description": "Eth21",
     "mtu": "9100",
     "alias": "Eth21",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "100000",
     "tpid": "0x8100"
@@ -601,6 +660,7 @@
     "description": "Eth29/1",
     "mtu": "9100",
     "alias": "Eth29/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -611,6 +671,7 @@
     "description": "Eth22/2",
     "mtu": "9100",
     "alias": "Eth22/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -621,6 +682,7 @@
     "description": "Eth28/3",
     "mtu": "9100",
     "alias": "Eth28/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -631,6 +693,7 @@
     "description": "Eth22/1",
     "mtu": "9100",
     "alias": "Eth22/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -641,6 +704,7 @@
     "description": "Eth8/4",
     "mtu": "9100",
     "alias": "Eth8/4",
+    "subport": 4,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -651,6 +715,7 @@
     "description": "Eth13/2",
     "mtu": "9100",
     "alias": "Eth13/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -661,6 +726,7 @@
     "description": "Eth13/1",
     "mtu": "9100",
     "alias": "Eth13/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -671,6 +737,7 @@
     "description": "Eth12/2",
     "mtu": "9100",
     "alias": "Eth12/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -681,6 +748,7 @@
     "description": "Eth8/3",
     "mtu": "9100",
     "alias": "Eth8/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -691,6 +759,7 @@
     "description": "Eth8/2",
     "mtu": "9100",
     "alias": "Eth8/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -702,6 +771,7 @@
     "description": "Eth11",
     "mtu": "9100",
     "alias": "Eth11",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "100000",
     "tpid": "0x8100"
@@ -713,6 +783,7 @@
     "description": "Eth31",
     "mtu": "9100",
     "alias": "Eth31",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "100000",
     "tpid": "0x8100"
@@ -723,6 +794,7 @@
     "description": "Eth8/1",
     "mtu": "9100",
     "alias": "Eth8/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -733,6 +805,7 @@
     "description": "Eth17/2",
     "mtu": "9100",
     "alias": "Eth17/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -744,6 +817,7 @@
     "description": "Eth16",
     "mtu": "9100",
     "alias": "Eth16",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "100000",
     "tpid": "0x8100"
@@ -754,6 +828,7 @@
     "description": "Eth17/1",
     "mtu": "9100",
     "alias": "Eth17/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -764,6 +839,7 @@
     "description": "Eth12/1",
     "mtu": "9100",
     "alias": "Eth12/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -776,6 +852,7 @@
     "admin_status": "up",
     "mtu": "9100",
     "alias": "Eth6",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "100000",
     "tpid": "0x8100"
@@ -786,6 +863,7 @@
     "description": "Eth20/3",
     "mtu": "9100",
     "alias": "Eth20/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -796,6 +874,7 @@
     "description": "Eth18/2",
     "mtu": "9100",
     "alias": "Eth18/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000",
     "tpid": "0x8100"
@@ -806,6 +885,7 @@
     "description": "Eth7/1",
     "mtu": "9100",
     "alias": "Eth7/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -816,6 +896,7 @@
     "description": "Eth7/2",
     "mtu": "9100",
     "alias": "Eth7/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "50000",
     "tpid": "0x8100"
@@ -827,6 +908,7 @@
     "tpid": "0x8100",
     "mtu": "9100",
     "alias": "Eth33",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "40000"
   },
@@ -837,6 +919,7 @@
     "tpid": "0x8100",
     "mtu": "9100",
     "alias": "Eth34",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "25000"
   },
@@ -847,6 +930,7 @@
     "tpid": "0x8100",
     "mtu": "9100",
     "alias": "Eth35/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "10000"
   },
@@ -857,6 +941,7 @@
     "tpid": "0x8100",
     "mtu": "9100",
     "alias": "Eth35/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "10000"
   },
@@ -867,6 +952,7 @@
     "tpid": "0x8100",
     "mtu": "9100",
     "alias": "Eth35/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "10000"
   },
@@ -877,6 +963,7 @@
     "tpid": "0x8100",
     "mtu": "9100",
     "alias": "Eth35/4",
+    "subport": 4,
     "pfc_asym": "off",
     "speed": "10000"
   },
@@ -887,6 +974,7 @@
     "tpid": "0x8100",
     "mtu": "9100",
     "alias": "Eth36/1",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "25000"
   },
@@ -897,6 +985,7 @@
     "tpid": "0x8100",
     "mtu": "9100",
     "alias": "Eth36/2",
+    "subport": 2,
     "pfc_asym": "off",
     "speed": "25000"
   },
@@ -907,6 +996,7 @@
     "tpid": "0x8100",
     "mtu": "9100",
     "alias": "Eth36/3",
+    "subport": 3,
     "pfc_asym": "off",
     "speed": "50000"
   },
@@ -917,6 +1007,7 @@
     "tpid": "0x8100",
     "mtu": "9100",
     "alias": "Eth37",
+    "subport": 1,
     "pfc_asym": "off",
     "speed": "100000",
     "fec": "rs"

--- a/src/sonic-config-engine/tests/test_cfggen_platformJson.py
+++ b/src/sonic-config-engine/tests/test_cfggen_platformJson.py
@@ -79,19 +79,19 @@ class TestCfgGenPlatformJson(TestCase):
         argument = ['-m', self.platform_sample_graph, '-p', self.platform_json, '-S', self.hwsku_json, '-v', "PORT[\'Ethernet8\']"]
         output = self.run_script(argument)
         self.maxDiff = None
-        expected = "{'index': '3', 'lanes': '8', 'description': 'Eth3/1', 'mtu': '9100', 'alias': 'Eth3/1', 'pfc_asym': 'off', 'speed': '25000', 'tpid': '0x8100'}"
+        expected = "{'index': '3', 'lanes': '8', 'description': 'Eth3/1', 'mtu': '9100', 'alias': 'Eth3/1', 'subport': 1, 'pfc_asym': 'off', 'speed': '25000', 'tpid': '0x8100'}"
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict(expected))
 
         argument = ['-m', self.platform_sample_graph, '-p', self.platform_json, '-S', self.hwsku_json, '-v', "PORT[\'Ethernet112\']"]
         output = self.run_script(argument)
         self.maxDiff = None
-        expected = "{'index': '29', 'lanes': '112', 'description': 'Eth29/1', 'mtu': '9100', 'alias': 'Eth29/1', 'pfc_asym': 'off', 'speed': '25000', 'tpid': '0x8100'}"
+        expected = "{'index': '29', 'lanes': '112', 'description': 'Eth29/1', 'mtu': '9100', 'alias': 'Eth29/1', 'subport': 1, 'pfc_asym': 'off', 'speed': '25000', 'tpid': '0x8100'}"
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict(expected))
 
         argument = ['-m', self.platform_sample_graph, '-p', self.platform_json, '-S', self.hwsku_json, '-v', "PORT[\'Ethernet4\']"]
         output = self.run_script(argument)
         self.maxDiff = None
-        expected = "{'index': '2', 'lanes': '4,5', 'description': 'Eth2/1', 'admin_status': 'up', 'mtu': '9100', 'alias': 'Eth2/1', 'pfc_asym': 'off', 'speed': '50000', 'tpid': '0x8100'}"
+        expected = "{'index': '2', 'lanes': '4,5', 'description': 'Eth2/1', 'admin_status': 'up', 'mtu': '9100', 'alias': 'Eth2/1', 'subport': 1, 'pfc_asym': 'off', 'speed': '50000', 'tpid': '0x8100'}"
         print(output.strip())
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict(expected))
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

