### PR TITLE
[config-chassisdb] use cached variables

### DIFF
--- a/files/image_config/config-chassisdb/config-chassisdb
+++ b/files/image_config/config-chassisdb/config-chassisdb
@@ -27,7 +27,7 @@
 config_chassis_db() {
     startdb_file="/etc/sonic/chassisdb.conf"
     [ ! -e $startdb_file ] || rm $startdb_file
-    platform=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
+    platform=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
     # database-chassis services will start when $chassis_config file exists
     chassis_config="/usr/share/sonic/device/$platform/chassisdb.conf"
     if [ ! -e $chassis_config ]; then
@@ -53,6 +53,9 @@ config_chassis_db() {
        fi
     fi
 }
+
+# read SONiC immutable variables
+[ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
 
 config_chassis_db
 


### PR DESCRIPTION
No cache:

```
root@arc-switch1004:/home/admin# time bash -x /usr/bin/config-chassisdb
+ config_chassis_db
+ startdb_file=/etc/sonic/chassisdb.conf
+ '[' '!' -e /etc/sonic/chassisdb.conf ']'
++ sonic-cfggen -H -v DEVICE_METADATA.localhost.platform
+ platform=x86_64-mlnx_msn2700-r0
+ chassis_config=/usr/share/sonic/device/x86_64-mlnx_msn2700-r0/chassisdb.conf
+ '[' '!' -e /usr/share/sonic/device/x86_64-mlnx_msn2700-r0/chassisdb.conf ']'
+ echo 'no chassisdb.conf found, bypass config-chassisdb service'
no chassisdb.conf found, bypass config-chassisdb service
+ exit 0

real    0m0.512s
user    0m0.429s
sys     0m0.058s
```

With cache:

```
root@arc-switch1004:/home/admin# time bash -x /usr/bin/config-chassisdb
+ '[' -f /etc/sonic/sonic-environment ']'
+ . /etc/sonic/sonic-environment
++ SONIC_VERSION=202305_RC.32-da745b71d_Internal
++ PLATFORM=x86_64-mlnx_msn2700-r0
++ HWSKU=Mellanox-SN2700-D48C8
++ DEVICE_TYPE=ToRRouter
++ ASIC_TYPE=mellanox
+ config_chassis_db
+ startdb_file=/etc/sonic/chassisdb.conf
+ '[' '!' -e /etc/sonic/chassisdb.conf ']'
+ platform=x86_64-mlnx_msn2700-r0
+ chassis_config=/usr/share/sonic/device/x86_64-mlnx_msn2700-r0/chassisdb.conf
+ '[' '!' -e /usr/share/sonic/device/x86_64-mlnx_msn2700-r0/chassisdb.conf ']'
+ echo 'no chassisdb.conf found, bypass config-chassisdb service'
no chassisdb.conf found, bypass config-chassisdb service
+ exit 0

real    0m0.017s
user    0m0.005s
sys     0m0.008s
```

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
#### Why I did it
Improve  boot performance mostly needed for fast and warmboot

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Use cached variable.

#### How to verify it
Boot the system. Simply do "systemd-analyze blame" and look at service start time.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

