### PR TITLE
Revert "[pmon] update gRPC version to 1.57.0 (#16257)"

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -35,8 +35,8 @@ RUN apt-get update &&   \
 # doesn't ensure all dependencies are installed in the container. So here we
 # install any dependencies required by the Arista sonic_platform package.
 # TODO: eliminate the need to install these explicitly.
-RUN pip3 install grpcio==1.57.0 \
-        grpcio-tools==1.57.0
+RUN pip3 install grpcio==1.39.0 \
+        grpcio-tools==1.39.0
 
 # Barefoot platform vendors' sonic_platform packages import these Python libraries
 RUN pip3 install thrift==0.13.0 netifaces

--- a/files/build/versions/dockers/docker-platform-monitor/versions-py3
+++ b/files/build/versions/dockers/docker-platform-monitor/versions-py3
@@ -1,8 +1,8 @@
 attrs==20.3.0
 certifi==2023.5.7
 charset-normalizer==3.1.0
-grpcio==1.57.0
-grpcio-tools==1.57.0
+grpcio==1.39.0
+grpcio-tools==1.39.0
 guacamole==0.9.2
 idna==3.4
 importlib-metadata==1.6.0


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#17219

On Nov 30, a new [PR16257](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fsonic-net%2Fsonic-buildimage%2Fpull%2F16257&data=05%7C02%7Cstormliang%40microsoft.com%7C1ba374bffd314363977008dbf46135a8%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638372470636102546%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=crrZPgqmiQiOXXcBZ0nidoA9QM8cVuE%2B0lUSmRyEpUw%3D&reserved=0) was introduced to sonic-buildimage that changed the grpcio version (from 1.39 to 1.57)  within the pmon docker.  This PR was then merged to 202205 as [PR17218](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fsonic-net%2Fsonic-buildimage%2Fpull%2F17218&data=05%7C02%7Cstormliang%40microsoft.com%7C1ba374bffd314363977008dbf46135a8%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638372470636112064%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=g3esPcuH%2Bnmt4SrbIbwV2vVB1%2FbXEqUUmJfKQ3h7ZjM%3D&reserved=0).  We believe that this change in version caused the issue shown below within our NDK during pmon init.  Below is a traceback of the errors within the pmon at runtime: