### PR TITLE
Revert "[pmon] update gRPC library and gRPC IO tools version to 1.57.0"

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -36,8 +36,8 @@ RUN apt-get update &&   \
 # doesn't ensure all dependencies are installed in the container. So here we
 # install any dependencies required by the Arista sonic_platform package.
 # TODO: eliminate the need to install these explicitly.
-RUN pip3 install grpcio==1.57.0 \
-        grpcio-tools==1.57.0
+RUN pip3 install grpcio==1.39.0 \
+        grpcio-tools==1.39.0
 
 # Barefoot platform vendors' sonic_platform packages import these Python libraries
 RUN pip3 install thrift==0.13.0 netifaces

--- a/files/build/versions/dockers/docker-platform-monitor/versions-py3
+++ b/files/build/versions/dockers/docker-platform-monitor/versions-py3
@@ -1,8 +1,8 @@
 attrs==20.3.0
 certifi==2023.7.22
 charset-normalizer==3.2.0
-grpcio==1.57.0
-grpcio-tools==1.57.0
+grpcio==1.39.0
+grpcio-tools==1.39.0
 guacamole==0.9.2
 idna==3.4
 importlib-metadata==1.6.0


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#16257

The version upgraded in #16257 is beyond (newer than) the supported version in bookworm. This new package caused some issues on some platform. Reverting to keep the version within the Debian distribution supported range.