### PR TITLE
[installer]: Create a blank grubenv if doesn't exist

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -264,14 +264,6 @@ demo_install_grub()
         exit 1
     }
 
-    # Create a blank environment block file.
-    if [ ! -f "$onie_initrd_tmp/$demo_mnt/grub/grubenv" ]; then
-        grub-editenv "$onie_initrd_tmp/$demo_mnt/grub/grubenv" create || {
-            echo "ERROR: grub-editenv failed on: $blk_dev"
-            exit 1
-        }
-    fi
-
     if [ "$demo_type" = "DIAG" ] ; then
         # Install GRUB in the partition also.  This allows for
         # chainloading the DIAG image from another OS.
@@ -353,14 +345,6 @@ demo_install_uefi_grub()
         exit 1
     }
     rm -f $grub_install_log
-
-    # Create a blank environment block file.
-    if [ ! -f "$demo_mnt/grub/grubenv" ]; then
-        grub-editenv "$demo_mnt/grub/grubenv" create || {
-            echo "ERROR: grub-editenv failed on: $blk_dev"
-            exit 1
-        }
-    fi
 
     # Configure EFI NVRAM Boot variables.  --create also sets the
     # new boot number as active.
@@ -631,6 +615,14 @@ EOF
         umount $demo_mnt
     else
         cp $grub_cfg $onie_initrd_tmp/$demo_mnt/grub/grub.cfg
+
+        # Create a blank environment block file.
+        if [ ! -f "$onie_initrd_tmp/$demo_mnt/grub/grubenv" ]; then
+            grub-editenv "$onie_initrd_tmp/$demo_mnt/grub/grubenv" create || {
+                echo "ERROR: grub-editenv failed on: $blk_dev"
+                exit 1
+            }
+        fi
     fi
 
     cd /


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

GRUB environment file is neither generated when SONiC is installed from ONiE nor when GRUB starts boot chain sequence
```
https://github.com/sonic-net/sonic-buildimage/blob/202305/installer/default_platform.conf#L506

    cat <<EOF >> $grub_cfg
if [ -s \$prefix/grubenv ]; then
    load_env
fi
if [ "\${saved_entry}" ]; then
    set default="\${saved_entry}"
fi
if [ "\${next_entry}" ]; then
    set default="\${next_entry}"
    unset next_entry
    save_env next_entry
fi
if [ "\${onie_entry}" ]; then
    set next_entry="\${default}"
    set default="\${onie_entry}"
    unset onie_entry
    save_env onie_entry next_entry
fi
EOF
```

The GRUB environment file is being regenerated (if not present) each time after system cold reboot, when SONiC reboot script is being called
```
https://github.com/sonic-net/sonic-utilities/blob/202305/scripts/reboot#L152

# Verify the next image by sonic-installer
local message=$(sonic-installer verify-next-image 2>&1)
if [ $? -ne 0 ]; then
    VERBOSE=yes debug "Failed to verify next image: ${message}"
    exit ${EXIT_SONIC_INSTALLER_VERIFY_REBOOT}
fi
```

In fact, GRUB environment list command is responsible for regeneration
```
root@r-anaconda-15:/home/admin# ls /host/grub/
fonts  grub.cfg  grubenv  i386-pc  locale
root@r-anaconda-15:/home/admin# rm -f /host/grub/grubenv
root@r-anaconda-15:/home/admin# ls /host/grub/
fonts  grub.cfg  i386-pc  locale
root@r-anaconda-15:/home/admin# grub-editenv /host/grub/grubenv list
root@r-anaconda-15:/home/admin# ls /host/grub/
fonts  grub.cfg  grubenv  i386-pc  locale
```

#### Why I did it
* To fix BIOS firmware update after fresh image installation from ONiE

##### Work item tracking
* N/A

#### How I did it
* Initialized empty GRUB environment file after ONiE installation

#### How to verify it
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
1. Install image from ONiE
2. Run BIOS firmware upgrade

#### Which release branch to backport (provide reason below if selected)
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202305 commit https://github.com/sonic-net/sonic-buildimage/commit/688245a724e7462765530fd8ec3a745d7372dd5e

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
* N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```