### PR TITLE
Change leaf value of used_cnt of sonic-events-swss:chk_crm_threshold

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/sonic-events-swss.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/sonic-events-swss.json
@@ -180,9 +180,9 @@
     "SONIC_EVENTS_SWSS_CHK_CRM_THRESHOLD_VALID": {
         "sonic-events-swss:sonic-events-swss": {
             "sonic-events-swss:chk_crm_threshold": {
-                "percent": 0,
-                "used_cnt": 0,
-                "free_cnt": 0,
+                "percent": 80,
+                "used_cnt": 6414,
+                "free_cnt": 65300,
                 "timestamp": "1985-04-12T23:20:50.52Z"
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-events-swss.yang
+++ b/src/sonic-yang-models/yang-models/sonic-events-swss.yang
@@ -102,11 +102,11 @@ module sonic-events-swss {
             }
 
             leaf used_cnt {
-                type uint64;
+                type uint32;
             }
 
             leaf free_cnt {
-                type uint64;
+                type uint32;
             }
 
             uses evtcmn:sonic-events-cmn;

--- a/src/sonic-yang-models/yang-models/sonic-events-swss.yang
+++ b/src/sonic-yang-models/yang-models/sonic-events-swss.yang
@@ -102,7 +102,7 @@ module sonic-events-swss {
             }
 
             leaf used_cnt {
-                type uint8;
+                type uint64;
             }
 
             leaf free_cnt {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Current YANG model of sonic-events-swss:chk_crm_threshold has the type uint8 for leaf used_cnt which is too small of a range to hold values of used_cnt which can greatly exceed that. Updating leaf type of used_cnt and free_cnt to match defined definition.

Changed to uint32 as per defined here: https://github.com/sonic-net/sonic-swss/blob/master/orchagent/crmorch.h#L99

##### Work item tracking
- Microsoft ADO **(number only)**:26091912

#### How I did it

Update leaf value

#### How to verify it

UT and sonic-mgmt PR checker

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

