### PR TITLE
sonic-slave-bookworm/Dockerfile.j2 remove sudo

### DIFF
--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -556,7 +556,7 @@ RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs {{ DOCKER_EXTRA_OPTS
 RUN update-alternatives --set iptables /usr/sbin/iptables-legacy
 
 # Install m2crypto package, needed by SWI tools
-RUN sudo apt-get install python3-m2crypto
+RUN apt-get install python3-m2crypto
 
 # Install swi tools
 RUN pip3 install git+https://github.com/aristanetworks/swi-tools.git@bead66bf261770237f7dd21ace3774ba04a017e9


### PR DESCRIPTION
PROXY variables are not available to sudo users during docker build

This patch fixes below error during builds using proxy:

Step 57/63 : RUN sudo apt-get install python3-m2crypto
 ---> Running in ebfa797ebcf8
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  python-m2crypto-doc
The following NEW packages will be installed:
  python3-m2crypto
0 upgraded, 1 newly installed, 0 to remove and 5 not upgraded. Need to get 169 kB of archives.
After this operation, 725 kB of additional disk space will be used. Ign:1 http://deb.debian.org/debian bookworm/main armhf python3-m2crypto armhf 0.38.0-4+b1 Ign:1 http://deb.debian.org/debian bookworm/main armhf python3-m2crypto armhf 0.38.0-4+b1 Ign:1 http://deb.debian.org/debian bookworm/main armhf python3-m2crypto armhf 0.38.0-4+b1 Err:1 http://deb.debian.org/debian bookworm/main armhf python3-m2crypto armhf 0.38.0-4+b1
  Could not connect to debian.map.fastlydns.net:80 (146.75.78.132), connection timed out Unable to connect to deb.debian.org:http:
E: Failed to fetch http://deb.debian.org/debian/pool/main/m/m2crypto/python3-m2crypto_0.38.0-4%2bb1_armhf.deb  Could not connect to debian.map.fastlydns.net:80 (146.75.78.132), connection timed out Unable to connect to deb.debian.org:http: E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

