### PR TITLE
[Dell] S6100 - Update EEPROM API serial_number_str to return service tag instead of serial number

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
@@ -216,7 +216,7 @@ class Chassis(ChassisBase):
         Returns:
             string: Serial number of chassis
         """
-        return self._eeprom.serial_str()
+        return self._eeprom.serial_number_str()
 
     def get_status(self):
         """

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/eeprom.py
@@ -83,8 +83,14 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
                 self.eeprom_tlv_dict[mac_code] = '00:00:00:00:00:00'
 
     def serial_number_str(self):
-        (is_valid, results) = self.get_tlv_field(
-                    self.eeprom_data, self._TLV_CODE_SERIAL_NUMBER)
+        # For Chassis, return service tag instead of serial number
+        if not self.is_module:
+            (is_valid, results) = self.get_tlv_field(
+                        self.eeprom_data, self._TLV_CODE_SERVICE_TAG)
+        else:
+            (is_valid, results) = self.get_tlv_field(
+                        self.eeprom_data, self._TLV_CODE_SERIAL_NUMBER)
+
         if not is_valid:
             return "N/A"
 
@@ -113,14 +119,6 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
     def part_number_str(self):
         (is_valid, results) = self.get_tlv_field(
                     self.eeprom_data, self._TLV_CODE_PART_NUMBER)
-        if not is_valid:
-            return "N/A"
-
-        return results[2].decode('ascii')
-
-    def serial_str(self):
-        (is_valid, results) = self.get_tlv_field(
-                    self.eeprom_data, self._TLV_CODE_SERVICE_TAG)
         if not is_valid:
             return "N/A"
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/module.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/module.py
@@ -139,7 +139,7 @@ class Module(ModuleBase):
         Returns:
             string: Serial number of module
         """
-        return self._eeprom.serial_str()
+        return self._eeprom.serial_number_str()
 
     def get_status(self):
         """


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To modify EEPROM API serial_number_str to return service tag instead of serial number in Dell S6100.
Ref PR: #1239 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Update EEPROM API serial_number_str to return service tag instead of serial number.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Verify `decode-syseeprom -s` returns service tag in Dell S6100.

Logs: [UT_logs.txt](https://github.com/sonic-net/sonic-buildimage/files/13596493/UT_logs.txt)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[Dell] S6100 - Update EEPROM API serial_number_str to return service tag instead of serial number

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

