### PR TITLE
[Mellanox]: Disable MFT bash autocompletion.

### DIFF
--- a/platform/mellanox/mft/Makefile
+++ b/platform/mellanox/mft/Makefile
@@ -42,13 +42,27 @@ DERIVED_TARGETS = mft-oem_$(MFT_VERSION)-$(MFT_REVISION)_$(CONFIGURED_ARCH).deb
 DKMS_CTRL = /var/lib/dkms/kernel-mft-dkms/
 DKMS_TMP := $(shell mktemp -u -d -t dkms.XXXXXXXXXX)
 
-MFT_TMP = /tmp/mft_build/
+MFT_DEB_TMP := $(shell mktemp -u -d -t mft.deb.XXXXXXXXXX)
+MFT_TMP := $(shell mktemp -u -d -t mft.XXXXXXXXXX)
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	mkdir -p $(MFT_TMP)
 	pushd $(MFT_TMP)
 	wget -O $(MFT_TGZ) $(MFT_TGZ_URL)
 	tar xzf $(MFT_TGZ)
+
+	# w/a: disable bash autocompletion
+	mkdir -p $(MFT_DEB_TMP)/DEBIAN
+
+	dpkg -e $(MFT_NAME)/DEBS/$(MAIN_TARGET) $(MFT_DEB_TMP)/DEBIAN
+	dpkg -x $(MFT_NAME)/DEBS/$(MAIN_TARGET) $(MFT_DEB_TMP)
+
+	rm -rf $(MFT_DEB_TMP)/etc/bash_completion.d
+	sed -i '/bash_completion.d/d' $(MFT_DEB_TMP)/DEBIAN/conffiles
+
+	dpkg -b $(MFT_DEB_TMP) $(MFT_NAME)/DEBS/$(MAIN_TARGET)
+
+	rm -rf $(MFT_DEB_TMP)
 
 	# fix timestamp
 	touch $(MFT_NAME)/DEBS/*.deb


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

A W/A to overcome delay of about 20 sec on login due to MFT bash autocompletion bug.
Should be reverted once a formal solution will be available in future MFT release.

#### Why I did it
* To overcome SN2700 20 sec delay on login

##### Work item tracking
* N/A

#### How I did it
* Removed MFT bash autocompletion part

#### How to verify it
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
1. make configure PLATFORM=mellanox
2. make target/sonic-mellanox.bin
3. Verify no such links after system boot.

#### Which release branch to backport (provide reason below if selected)
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master <!-- image version 1 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
* N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```