### PR TITLE
[Nokia-IXER7250E] Modify the Supervisor device data to keep SFM alive while ungraceful reboot

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_ndk.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_ndk.json
@@ -31,6 +31,38 @@
     {
       "key": "sonic_log_level",
       "stringval": "debug"
+    },
+    {
+      "key": "ungraceful_reboot_keep_sfm_alive",
+      "stringval": "yes"
+    },
+    {
+      "key": "ungraceful_reboot_log_interval",
+      "intval": 10
+    },
+    {
+      "key": "ungraceful_reboot_sfm_online",
+      "stringval": "no"
+    },
+    {
+      "key": "thermal_low_margin_threshold",
+      "intval": 10
+    },
+    {
+      "key": "thermal_log_current_threshold",
+      "intval": 3
+    },
+    {
+      "key": "thermal_log_margin_threshold",
+      "intval": 3
+    },
+    {
+      "key": "thermal_log_min_threshold",
+      "intval": 5
+    },
+    {
+      "key": "thermal_log_max_threshold",
+      "intval": 1
     }
     ]
 }


### PR DESCRIPTION
#### Why I did it
On Nokia-IXR7250E chassis,  Fabrics Cards need to be up and running to keep the iBGP traffic intact while Supervisor is reboot ungracefully.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modify the Supervsor platform_ndk.json to enable ungraceful_reboot_keep_sfm_alive flag  to notify the device-manager not to powercycle the SFMs.  And set the ungraceful_reboot_log_interval to 10 seconds to periodically notify users by logging that that system is ungraceful reboot,  need to reboot the whole chassis to recover to a good state.  Also set ungraceful_reboot_sfm_online to "no" to avoid the related swss/syncd to reinitialize the SFMs which trigger the SFMs down/up.

#### How to verify it
1) On supervisor, execute the "sudo /sbin/reboot"
2) after Supervisor is up,  check the syslog, the following message will be logged in every 10 seconds
```
Dec  8 19:04:21.428535 Supervisor ERR sr_device_mgr: debug|16648|16648|00244|E: common    device_mgr.cc:1958       CpmLogWarmRestartMsg  Supervisor card has been ungracefully rebooted. Require to 'sudo reboot' the whole chassis to recover to a good state

```
3)  docker -ps  to verify swss/syncd should not be up.
```
admin@ixre-cpm-chassis14:~$ docker ps
CONTAINER ID   IMAGE                                COMMAND                  CREATED      STATUS         PORTS     NAMES
18824d15c6c3   docker-snmp:latest                   "/usr/local/bin/supe\u2026"   3 days ago   Up 3 minutes             snmp
b84500428805   docker-sonic-telemetry:latest        "/usr/local/bin/supe\u2026"   3 days ago   Up 3 minutes             telemetry
08909b4b0571   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe\u2026"   3 days ago   Up 3 minutes             mgmt-framework
fdf151c7fde0   docker-lldp:latest                   "/usr/bin/docker-lld\u2026"   3 days ago   Up 5 minutes             lldp
219d3eafa864   docker-platform-monitor:latest       "/usr/bin/docker_ini\u2026"   3 days ago   Up 5 minutes             pmon
e6ca3c20a3e7   docker-router-advertiser:latest      "/usr/bin/docker-ini\u2026"   3 days ago   Up 5 minutes             radv
0adca1fd2cdb   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database13
dbd33f387b24   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database10
6e30004405c5   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database3
61dfda55f836   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database2
ae462ee9cbdf   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database4
7c8303c14b12   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database8
2457f156ad8c   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database7
014acd8cbecf   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database1
517a520718ca   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database6
8c8f14b1b006   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database12
a12d42f1e6fd   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database9
aceb87084a95   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database5
6b90bd8913f2   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database15
07490dc19eb2   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database14
dbce0be9146f   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database11
72f05cdd7030   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database0
dcfa638f3c47   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database
0294d839df01   docker-database:latest               "/usr/local/bin/dock\u2026"   3 days ago   Up 5 minutes             database-chassis

```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

