### PR TITLE
[lldp][hostname-config] Optimize: the “RemoteDevice” displayed in "show lldp tables" does not match the remote device's default hostname.

### DIFF
--- a/files/image_config/hostname/hostname-config.sh
+++ b/files/image_config/hostname/hostname-config.sh
@@ -6,6 +6,7 @@ HOSTNAME=`sonic-cfggen -d -v DEVICE_METADATA[\'localhost\'][\'hostname\']`
 if [ -z "$HOSTNAME" ] ; then
        echo "Missing hostname in the config file, setting to default 'sonic'"
        HOSTNAME='sonic'
+       sonic-cfggen -a '{"DEVICE_METADATA":{"localhost":{"hostname":"sonic"}}}' -w
 fi
 
 echo $HOSTNAME > /etc/hostname


### PR DESCRIPTION
hostname-config/lldp: Optimize

* Fixing the “RemoteDevice” displayed in "show lldp tables" does not match the remote device's hostname.

  Signed-off-by: qu.pinghao@h3c.com

#### Why I did it

When the user does not provide a configured hostname for the device, the default value is "sonic"， but this hostname is not saved in the config_db. However, the LLDP protocol message's “System Name” needs to obtain the hostname from the config_db. If it cannot be obtained, it will be filled with “None”. This results in the device's hostname being displayed as "sonic," but the remote device indeed receives “None”.

![image](https://github.com/sonic-net/sonic-buildimage/assets/123941348/9e367856-f2e4-4da4-bb41-e71d7ce07c93)


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Write the default hostname ‘sonic’ into config_db

#### How to verify it
Do not configure the hostname
Establish an LLDP neighbor relationship between the two devices.
Check the information displayed using the "show lldp tables" command

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)
- [x ] 202205

#### A picture of a cute animal (not mandatory but encouraged)
![image](https://github.com/sonic-net/sonic-buildimage/assets/123941348/2cad1622-6502-49b9-a4d4-692e16371fab)

