### PR TITLE
[dhcp_server] add show dhcp server info

### DIFF
--- a/dockers/docker-dhcp-server/cli-plugin-tests/mock_config_db.json
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/mock_config_db.json
@@ -7,9 +7,7 @@
         "lease_time": "3600",
         "mode": "PORT",
         "netmask": "255.255.255.0",
-        "customized_options": [
-            "option60"
-        ],
+        "customized_options": "option60",
         "state": "enabled"
     },
     "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS|option60": {

--- a/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
@@ -112,8 +112,8 @@ range3   100.1.1.10  100.1.1.10           1
 
     def test_show_dhcp_server_ipv4_info_without_intf(self, mock_db):
         expected_stdout = """\
-Interface    Mode    Gateway    Netmask          Lease Time(s)  IP Bind
------------  ------  ---------  -------------  ---------------  ---------
+Interface    Mode    Gateway    Netmask          Lease Time(s)  State
+-----------  ------  ---------  -------------  ---------------  -------
 Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled
 """
         runner = CliRunner()
@@ -125,8 +125,8 @@ Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled
 
     def test_show_dhcp_server_ipv4_info_with_intf(self, mock_db):
         expected_stdout = """\
-Interface    Mode    Gateway    Netmask          Lease Time(s)  IP Bind
------------  ------  ---------  -------------  ---------------  ---------
+Interface    Mode    Gateway    Netmask          Lease Time(s)  State
+-----------  ------  ---------  -------------  ---------------  -------
 Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled
 """
         runner = CliRunner()
@@ -138,9 +138,9 @@ Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled
 
     def test_show_dhcp_server_ipv4_info_with_customized_options(self, mock_db):
         expected_stdout = """\
-Interface    Mode    Gateway    Netmask          Lease Time(s)  IP Bind    Customized Options
------------  ------  ---------  -------------  ---------------  ---------  --------------------
-Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled    option60
+Interface    Mode    Gateway    Netmask          Lease Time(s)  State    Customized Options
+-----------  ------  ---------  -------------  ---------------  -------  --------------------
+Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled  option60
 """
         runner = CliRunner()
         db = clicommon.Db()

--- a/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
@@ -112,9 +112,9 @@ range3   100.1.1.10  100.1.1.10           1
 
     def test_show_dhcp_server_ipv4_info_without_intf(self, mock_db):
         expected_stdout = """\
-Range    IP Start    IP End        IP Count
--------  ----------  ----------  ----------
-range3   100.1.1.10  100.1.1.10           1
+Interface    Mode    Gateway    Netmask          Lease Time(s)  IP Bind
+-----------  ------  ---------  -------------  ---------------  ---------
+Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -125,9 +125,9 @@ range3   100.1.1.10  100.1.1.10           1
 
     def test_show_dhcp_server_ipv4_info_with_intf(self, mock_db):
         expected_stdout = """\
-Range    IP Start    IP End        IP Count
--------  ----------  ----------  ----------
-range3   100.1.1.10  100.1.1.10           1
+Interface    Mode    Gateway    Netmask          Lease Time(s)  IP Bind    Customized Options
+-----------  ------  ---------  -------------  ---------------  ---------  --------------------
+Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled    ['option60']
 """
         runner = CliRunner()
         db = clicommon.Db()

--- a/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
@@ -110,3 +110,42 @@ range3   100.1.1.10  100.1.1.10           1
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
         assert result.stdout == expected_stdout
 
+    def test_show_dhcp_server_ipv4_info_without_intf(self, mock_db):
+        expected_stdout = """\
+Range    IP Start    IP End        IP Count
+-------  ----------  ----------  ----------
+range3   100.1.1.10  100.1.1.10           1
+"""
+        runner = CliRunner()
+        db = clicommon.Db()
+        db.db = mock_db
+        result = runner.invoke(show_dhcp_server.dhcp_server.commands["ipv4"].commands["info"], [], obj=db)
+        assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+        assert result.stdout == expected_stdout
+
+    def test_show_dhcp_server_ipv4_info_with_intf(self, mock_db):
+        expected_stdout = """\
+Range    IP Start    IP End        IP Count
+-------  ----------  ----------  ----------
+range3   100.1.1.10  100.1.1.10           1
+"""
+        runner = CliRunner()
+        db = clicommon.Db()
+        db.db = mock_db
+        result = runner.invoke(show_dhcp_server.dhcp_server.commands["ipv4"].commands["info"], ["Vlan100"], obj=db)
+        assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+        assert result.stdout == expected_stdout
+
+    def test_show_dhcp_server_ipv4_info_with_customized_options(self, mock_db):
+        expected_stdout = """\
+Range    IP Start    IP End        IP Count
+-------  ----------  ----------  ----------
+range3   100.1.1.10  100.1.1.10           1
+"""
+        runner = CliRunner()
+        db = clicommon.Db()
+        db.db = mock_db
+        result = runner.invoke(show_dhcp_server.dhcp_server.commands["ipv4"].commands["info"], ["Vlan100", "--with_customized_options"], obj=db)
+        assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+        assert result.stdout == expected_stdout
+

--- a/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
@@ -125,9 +125,9 @@ Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled
 
     def test_show_dhcp_server_ipv4_info_with_intf(self, mock_db):
         expected_stdout = """\
-Interface    Mode    Gateway    Netmask          Lease Time(s)  IP Bind    Customized Options
------------  ------  ---------  -------------  ---------------  ---------  --------------------
-Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled    ['option60']
+Interface    Mode    Gateway    Netmask          Lease Time(s)  IP Bind
+-----------  ------  ---------  -------------  ---------------  ---------
+Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -138,9 +138,9 @@ Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled    ['opt
 
     def test_show_dhcp_server_ipv4_info_with_customized_options(self, mock_db):
         expected_stdout = """\
-Range    IP Start    IP End        IP Count
--------  ----------  ----------  ----------
-range3   100.1.1.10  100.1.1.10           1
+Interface    Mode    Gateway    Netmask          Lease Time(s)  IP Bind    Customized Options
+-----------  ------  ---------  -------------  ---------------  ---------  --------------------
+Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled    option60
 """
         runner = CliRunner()
         db = clicommon.Db()

--- a/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
@@ -79,5 +79,26 @@ def range(db, range_name):
     click.echo(tabulate(table, headers=headers))
 
 
+@ipv4.command()
+@click.argument('dhcp_interface', required=False)
+@click.option('--with_customized_options', default=False, is_flag=True)
+@clicommon.pass_db
+def info(db, dhcp_interface, with_customized_options):
+    if not dhcp_interface:
+        dhcp_interface = "*"
+    headers = ["Interface", "Mode", "Gateway", "Netmask", "Lease Time(s)", "IP Bind"]
+    if with_customized_options:
+        headers.append("Customized Options")
+    table = []
+    dbconn = db.db
+    for key in dbconn.keys("CONFIG_DB", "DHCP_SERVER_IPV4|" + dhcp_interface):
+        entry = dbconn.get_all("CONFIG_DB", key)
+        interface = key.split("|")[1]
+        table.append([interface, entry["mode"], entry["gateway"], entry["netmask"], entry["lease_time"], entry["state"]])
+        if with_customized_options:
+            table[-1].append(entry["customized_options"])
+    click.echo(tabulate(table, headers=headers))
+
+
 def register(cli):
     cli.add_command(dhcp_server)

--- a/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
@@ -86,7 +86,7 @@ def range(db, range_name):
 def info(db, dhcp_interface, with_customized_options):
     if not dhcp_interface:
         dhcp_interface = "*"
-    headers = ["Interface", "Mode", "Gateway", "Netmask", "Lease Time(s)", "IP Bind"]
+    headers = ["Interface", "Mode", "Gateway", "Netmask", "Lease Time(s)", "State"]
     if with_customized_options:
         headers.append("Customized Options")
     table = []


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add show dhcp_server info

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add new subcommand to show dhcp_server command.

#### How to verify it
Add unit tests for compile time testing. Manually run command in latest master image.


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
Latest master image

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add show dhcp_server info

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

