### PR TITLE
[dhcp_server] add dhcp server show option

### DIFF
--- a/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
@@ -149,3 +149,28 @@ Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled  option6
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
         assert result.stdout == expected_stdout
 
+    def test_show_dhcp_server_ipv4_option_without_name(self, mock_db):
+        expected_stdout = """\
+Option Name      Option ID  Value        Type
+-------------  -----------  -----------  ------
+option60                60  dummy_value  string
+"""
+        runner = CliRunner()
+        db = clicommon.Db()
+        db.db = mock_db
+        result = runner.invoke(show_dhcp_server.dhcp_server.commands["ipv4"].commands["option"], [], obj=db)
+        assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+        assert result.stdout == expected_stdout
+
+    def test_show_dhcp_server_ipv4_option_with_name(self, mock_db):
+        expected_stdout = """\
+Option Name      Option ID  Value        Type
+-------------  -----------  -----------  ------
+option60                60  dummy_value  string
+"""
+        runner = CliRunner()
+        db = clicommon.Db()
+        db.db = mock_db
+        result = runner.invoke(show_dhcp_server.dhcp_server.commands["ipv4"].commands["option"], ["option60"], obj=db)
+        assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+        assert result.stdout == expected_stdout

--- a/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
@@ -100,5 +100,21 @@ def info(db, dhcp_interface, with_customized_options):
     click.echo(tabulate(table, headers=headers))
 
 
+@ipv4.command()
+@click.argument("option_name", required=False)
+@clicommon.pass_db
+def option(db, option_name):
+    if not option_name:
+        option_name = "*"
+    headers = ["Option Name", "Option", "Value", "Type"]
+    table = []
+    dbconn = db.db
+    for key in dbconn.keys("CONFIG_DB", "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS|" + option_name):
+        entry = dbconn.get_all("CONFIG_DB", key)
+        name = key.split("|")[1]
+        table.append([name, entry["id"], entry["value"], entry["type"]])
+    click.echo(tabulate(table, headers=headers))
+
+
 def register(cli):
     cli.add_command(dhcp_server)

--- a/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
@@ -106,7 +106,7 @@ def info(db, dhcp_interface, with_customized_options):
 def option(db, option_name):
     if not option_name:
         option_name = "*"
-    headers = ["Option Name", "Option", "Value", "Type"]
+    headers = ["Option Name", "Option ID", "Value", "Type"]
     table = []
     dbconn = db.db
     for key in dbconn.keys("CONFIG_DB", "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS|" + option_name):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add show dhcp_server option

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add show dhcp_server option command to plugin

#### How to verify it
Add unittest and manually run on latest image.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)
Latest master branch

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

