### PR TITLE
[Nokia-IXR7250E] Modify the platform_reboot on the IXR7250E for PMON API reboot and disable all SFPs

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_reboot
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_reboot
@@ -17,6 +17,10 @@ update_reboot_cause()
     sync
 }
 
+echo "Disable all SFPs"
+python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); platform_chassis.tx_disable_all_sfps()'
+sleep 3
+
 # update the reboot_cuase file when reboot is trigger by device-mgr
 update_reboot_cause
 

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_reboot
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_reboot
@@ -1,15 +1,39 @@
 #!/bin/bash
-echo "Rebooting all Linecards"
-python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); platform_chassis.reboot_imms()'
-sleep 3
+
+DEVICE_MGR_REBOOT_FILE="/tmp/device_mgr_reboot"
+
+update_reboot_cause()
+{
+    DEVICE_MGR_REBOOT_FILE=/tmp/device_mgr_reboot
+    REBOOT_CAUSE_FILE=/host/reboot-cause/reboot-cause.txt
+    DEVICE_REBOOT_CAUSE_FILE=/etc/opt/srlinux/reboot-cause.txt
+    if [ -e  $DEVICE_MGR_REBOOT_FILE ]; then
+        if [ -e $DEVICE_REBOOT_CAUSE_FILE ]; then
+            cp -f $DEVICE_REBOOT_CAUSE_FILE $REBOOT_CAUSE_FILE
+        fi
+        rm -f $DEVICE_MGR_REBOOT_FILE
+    else
+        touch /etc/opt/srlinux/devmgr_reboot_cause.done
+        rm -f $DEVICE_REBOOT_CAUSE_FILE &> /dev/null
+    fi
+    sync
+}
+
+if [ ! -e $DEVICE_MGR_REBOOT_FILE ]; then
+    echo "Rebooting all Linecards"
+    python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); platform_chassis.reboot_imms()'
+    sleep 3
+fi
+
+# update the reboot_cuase file when reboot is trigger by device-mgr
+update_reboot_cause
+
 systemctl stop nokia-watchdog.service
 sleep 2
 echo "w" > /dev/watchdog
 kick_date=`date -u`
 echo "last watchdog kick $kick_date" > /var/log/nokia-watchdog-last.log
 rm -f /sys/firmware/efi/efivars/dump-*
-touch /etc/opt/srlinux/devmgr_reboot_cause.done
-rm -f /etc/opt/srlinux/reboot-cause.txt
 echo "Shutdown midplane"
 ifconfig xe0 down
 sync


### PR DESCRIPTION
#### Why I did it
When Supervisor card is rebooted by using PMON API, it takes about 90 seconds to trigger the shutdown in down path.  At this time linecards have been up. This delays linecards database initialization which is trying to PING/PONG the database-chassis. To address this issue, we modified the NDK to use the system call with "sudo reboot"  when the request is from PMON API on Supervisor case.  The NDK version is 22.9.20  and greater.  This new NDK requires this modifcaiton of platform_reboot to work with.   

##### Work item tracking
- Microsoft ADO **(number only)**: 26365734

#### How I did it

Modify the platform_reboot In Supervisor not to reboot all IMMs since it has been done in the function reboot() in module.py.  Also handle the reboot-cause.txt for on the Supervisor when the reboot is request from PMON API. 
Modify the Nokia platform specific platform_reboot in linecard to disable all SPFs. 
This PR works with NDK version 22.9.20 and above
 
#### How to verify it
1) On supervisor card,  execute the reboot() method in module.py to reboot the Supervisor card. 
2) Verify the all linecards have been rebooted successfully. 
3)  Execute the show reboot-cause history command on Supervisor card after it is up.
4) The following entries with cause "reboot from PMON"  should be shown in the table:
```
admin@ixre-cpm-chassis7:~$ show reboot-cause history 
Name                 Cause             Time                             User      Comment
-------------------  ----------------  -------------------------------  --------  ----------------------------------------------------------------------------------------------
2023_12_12_16_19_03  reboot from PMON  Tue 12 Dec 2023 04:17:03 PM UTC  PMON-API  N/A
2023_12_12_15_41_30  reboot            Tue 12 Dec 2023 03:39:08 PM UTC  admin     N/A
2023_12_12_08_42_47  reboot            Tue 12 Dec 2023 08:40:37 AM UTC  admin     N/A
2023_12_12_05_03_57  reboot from PMON  Tue 12 Dec 2023 05:01:48 AM UTC  PMON-API  N/A
2023_12_12_04_45_56  reboot            Tue 12 Dec 2023 04:43:42 AM UTC  admin     N/A
2023_12_12_04_36_48  reboot from PMON  Tue 12 Dec 2023 04:34:27 AM UTC  PMON-API  N/A
2023_12_12_04_33_25  reboot            Tue 12 Dec 2023 04:31:13 AM UTC  admin     N/A

``` 
5) Execute sudo reboot on a Linecard.  Verify the peer ports detect the link down while the platform specific reboot is running.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

