### PR TITLE
[dhcp_relay] Optimize j2 file in dhcp_relay container

### DIFF
--- a/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
@@ -1,9 +1,7 @@
 [group:dhcp-relay]
-programs=dhcprelayd,
+programs=dhcprelayd
 {%- set relay_for_ipv6 = { 'flag': False } %}
-{%- set add_preceding_comma = { 'flag': False } %}
-{% if dhcp_server_ipv4_enabled %}
-{%- endif %}
+{%- set add_preceding_comma = { 'flag': True } %}
 {% for vlan_name in VLAN_INTERFACE %}
 {% if DHCP_RELAY and vlan_name in DHCP_RELAY and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
 {% set _dummy = relay_for_ipv6.update({'flag': True})  %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Comma after dhcprelayd would cause error when dhcpv6relay doesn't exist.

##### Work item tracking
- Microsoft ADO **(number only)**: 26164305

#### How I did it
Add comma via dhcp6relay

#### How to verify it
UT passed and build image success

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

