### PR TITLE
eliminate dmidecode in component.py because it requires root privileges

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/n3248te/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/n3248te/sonic_platform/component.py
@@ -16,7 +16,7 @@ try:
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 def get_bios_version():
-    return subprocess.check_output(['dmidecode', '-s', 'system-version']).strip().decode()
+    return subprocess.check_output(['cat', '/sys/class/dmi/id/bios_version']).strip().decode()
 
 def get_cpld_version(cpld):
     mjr_ver_path = '/sys/devices/platform/dell-n3248te-cpld.0/' + cpld + '_mjr_ver'


### PR DESCRIPTION
#### Why I did it

As described in https://github.com/sonic-net/sonic-buildimage/issues/16878, every `show` command on the N3248TE-ON results in an error about `dmidecode` not being found. This is because that command is called in the `get_bios_version` function of `component.py`, which is used in a lot of places (many which should not require privileged access).

The error message prior to this change:

```
jdt@sonic:~$ show system-health
failed to import plugin show.plugins.cisco-8000: [Errno 2] No such file or directory: 'dmidecode'
Usage: show system-health [OPTIONS] COMMAND [ARGS]...

  Show system-health information

```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

On this platform, at least, the BIOS version can be obtained from `/sys/class/dmi/id/bios_version`without requiring `root` privileges. I adjusted `component.py` to use that instead of `dmidecode`.

#### How to verify it

With that change in place, you can see that commands no longer complain about `dmidecode`:

```
jdt@sonic:~$ show system-health
Usage: show system-health [OPTIONS] COMMAND [ARGS]...

  Show system-health information

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  detail           Show system-health detail information
  monitor-list     Show system-health monitored services and devices name...
  summary          Show system-health summary information
  sysready-status  Show system-health system ready status
```

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

master

#### Description for the changelog

Removed call to `dmidecode` for every component command on the N3248TE-ON platform.