### PR TITLE
Update backend_acl.py to specify ACL table name

### DIFF
--- a/files/image_config/backend_acl/backend_acl.py
+++ b/files/image_config/backend_acl/backend_acl.py
@@ -78,7 +78,7 @@ def load_backend_acl(device_type):
         if os.path.isfile(BACKEND_ACL_TEMPLATE_FILE):
             run_command(['sudo', SONIC_CFGGEN_PATH, '-d', '-t', '{},{}'.format(BACKEND_ACL_TEMPLATE_FILE, BACKEND_ACL_FILE)])
         if os.path.isfile(BACKEND_ACL_FILE):
-            run_command(['acl-loader', 'update', 'incremental', BACKEND_ACL_FILE])
+            run_command(['acl-loader', 'update', 'full', BACKEND_ACL_FILE, '--table_name', 'DATAACL'])
     else:
         log_info("Skipping backend acl load - conditions not met")
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix #17552 .

PR #14229 added a service for loading backend ACL rules. There is an issue in below code in `backend_acl.py`.
https://github.com/sonic-net/sonic-buildimage/blob/2ba3c90ad4ac5c03299b86795418702bba26900d/files/image_config/backend_acl/backend_acl.py#L80-L81

Because `table_name` is not specified when calling `acl-loader`, the ACL rules loaded previously will be cleared.

##### Work item tracking
- Microsoft ADO **26167588**:

#### How I did it
Specify the ACL table name `DATAACL` when calling `acl-loader`.

#### How to verify it
The change is verified by running on a physical testbed. The previously loaded ACL rules are not cleared after this change.
```
admin@str2-7050qx-32s-acs-02:/usr/share/sonic/templates$ show acl rule
Table     Rule          Priority    Action    Match
--------  ------------  ----------  --------  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
SNMP_ACL  RULE_1        9999        ACCEPT    SRC_IP: 10.20.0.0/16
DATAACL   RULE_1        9999        FORWARD   ETHER_TYPE: 2048
                                              IN_PORTS: Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet4,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet8
                                              VLAN_ID: 1000
SNMP_ACL  RULE_2        9998        ACCEPT    SRC_IP: 10.154.232.0/21
SNMP_ACL  RULE_3        9997        ACCEPT    SRC_IP: 25.65.16.0/20
SNMP_ACL  RULE_4        9996        ACCEPT    SRC_IP: 25.66.128.0/17
SNMP_ACL  RULE_5        9995        ACCEPT    SRC_IP: 100.126.0.0/16
SNMP_ACL  RULE_6        9994        ACCEPT    SRC_IP: 100.127.64.0/18
......
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 20201231.118


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->
Update backend_acl.py to specify ACL table name.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
No schema change.
 
#### A picture of a cute animal (not mandatory but encouraged)

