### PR TITLE
[Mellanox] Disable SSD NCQ on Mellanox platforms

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2010-r0/installer.conf
+++ b/device/mellanox/x86_64-mlnx_msn2010-r0/installer.conf
@@ -1,1 +1,1 @@
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="acpi_enforce_resources=lax acpi=noirq"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="acpi_enforce_resources=lax acpi=noirq libata.force=noncq"

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/installer.conf
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/installer.conf
@@ -1,1 +1,1 @@
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="acpi_enforce_resources=lax acpi=noirq"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="acpi_enforce_resources=lax acpi=noirq libata.force=noncq"

--- a/device/mellanox/x86_64-mlnx_msn2700a1-r0/installer.conf
+++ b/device/mellanox/x86_64-mlnx_msn2700a1-r0/installer.conf
@@ -1,0 +1,1 @@
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq"

--- a/device/mellanox/x86_64-mlnx_msn3420-r0/installer.conf
+++ b/device/mellanox/x86_64-mlnx_msn3420-r0/installer.conf
@@ -1,0 +1,1 @@
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq"

--- a/device/mellanox/x86_64-mlnx_msn3700-r0/installer.conf
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/installer.conf
@@ -1,0 +1,1 @@
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq"

--- a/device/mellanox/x86_64-mlnx_msn3700c-r0/installer.conf
+++ b/device/mellanox/x86_64-mlnx_msn3700c-r0/installer.conf
@@ -1,0 +1,1 @@
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq"

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/installer.conf
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/installer.conf
@@ -1,0 +1,1 @@
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq"

--- a/device/mellanox/x86_64-mlnx_msn4410-r0/installer.conf
+++ b/device/mellanox/x86_64-mlnx_msn4410-r0/installer.conf
@@ -1,0 +1,1 @@
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq"

--- a/device/mellanox/x86_64-mlnx_msn4600-r0/installer.conf
+++ b/device/mellanox/x86_64-mlnx_msn4600-r0/installer.conf
@@ -1,0 +1,1 @@
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq"

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/installer.conf
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/installer.conf
@@ -1,0 +1,1 @@
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq"

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/installer.conf
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/installer.conf
@@ -1,0 +1,1 @@
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq"

--- a/device/mellanox/x86_64-nvidia_sn2201-r0/installer.conf
+++ b/device/mellanox/x86_64-nvidia_sn2201-r0/installer.conf
@@ -1,1 +1,1 @@
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="acpi_enforce_resources=lax"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="acpi_enforce_resources=lax libata.force=noncq"

--- a/device/mellanox/x86_64-nvidia_sn4800-r0/installer.conf
+++ b/device/mellanox/x86_64-nvidia_sn4800-r0/installer.conf
@@ -1,0 +1,1 @@
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq"

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/installer.conf
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/installer.conf
@@ -1,0 +1,1 @@
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Based on some research some products might experience an occasional IO failures in the communication between CPU and SSD because of NCQ.
There seems to be a problem between some kernel versions and some SATA controllers.

Syslog error message examples:
- Error "ata1: SError: { UnrecovData Handshk }" - "failed command: WRITE FPDMA QUEUED".
- Error "ata1: SError: { RecovComm HostInt PHYRdyChg CommWake 10B8B DevExch }" - "failed command: READ FPDMA QUEUED".

Some vendors already disabled NCQ on their platforms in SONiC due to similar issue:
- https://github.com/sonic-net/sonic-buildimage/pull/13739 [Arista] Disable ATA NCQ for a few products
- https://github.com/sonic-net/sonic-buildimage/pull/13964 [Arista] Disable SSD NCQ on DCS-7050CX3-32S

Also there are other discussions on Debian/Ubuntu forums about similar issues and it was suggested to disable NCQ:
- https://askubuntu.com/questions/133946/are-these-sata-errors-dangerous




##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add a kernel parameter to tell libata to disable NCQ

#### How to verify it
Use FIO tool - `fio --direct=1 --rw=randrw --bs=64k --ioengine=libaio --iodepth=64 --runtime=120 --numjobs=4`

**Test results with NCQ enabled:**
```
 READ: bw=128MiB/s (135MB/s), 128MiB/s-128MiB/s (135MB/s-135MB/s), io=247MiB (259MB), run=1924-1924msec
WRITE: bw=131MiB/s (138MB/s), 131MiB/s-131MiB/s (138MB/s-138MB/s), io=253MiB (265MB), run=1924-1924msec
…
 READ: bw=130MiB/s (136MB/s), 130MiB/s-130MiB/s (136MB/s-136MB/s), io=247MiB (259MB), run=1902-1902msec
WRITE: bw=133MiB/s (139MB/s), 133MiB/s-133MiB/s (139MB/s-139MB/s), io=253MiB (265MB), run=1902-1902msec
…
 READ: bw=129MiB/s (135MB/s), 129MiB/s-129MiB/s (135MB/s-135MB/s), io=247MiB (259MB), run=1919-1919msec
WRITE: bw=132MiB/s (138MB/s), 132MiB/s-132MiB/s (138MB/s-138MB/s), io=253MiB (265MB), run=1919-1919msec
```

**Test results with NCQ disabled:**
```
 READ: bw=105MiB/s (110MB/s), 105MiB/s-105MiB/s (110MB/s-110MB/s), io=247MiB (259MB), run=2354-2354msec
WRITE: bw=107MiB/s (113MB/s), 107MiB/s-107MiB/s (113MB/s-113MB/s), io=253MiB (265MB), run=2354-2354msec
…
 READ: bw=105MiB/s (110MB/s), 105MiB/s-105MiB/s (110MB/s-110MB/s), io=247MiB (259MB), run=2349-2349msec
WRITE: bw=108MiB/s (113MB/s), 108MiB/s-108MiB/s (113MB/s-113MB/s), io=253MiB (265MB), run=2349-2349msec
…
 READ: bw=105MiB/s (110MB/s), 105MiB/s-105MiB/s (110MB/s-110MB/s), io=247MiB (259MB), run=2349-2349msec
WRITE: bw=108MiB/s (113MB/s), 108MiB/s-108MiB/s (113MB/s-113MB/s), io=253MiB (265MB), run=2349-2349msec
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305
- [x] 202311 

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

