### PR TITLE
[202311][YANG][sonic-utilities] update sonic DB version string format

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-versions.yang
+++ b/src/sonic-yang-models/yang-models/sonic-versions.yang
@@ -23,7 +23,7 @@ module sonic-versions {
                 leaf VERSION {
                     type string {
                         length 1..255;
-                        pattern 'version_([1-9]|[1-9]{1}[0-9]{1})_([0-9]{1,2})_([0-9]{1,2})';
+                        pattern 'version_(([1-9]|[1-9]{1}[0-9]{1})_([0-9]{1,2})_([0-9]{1,2})|([1-9]{1}[0-9]{5})_([0-9]{2}))';
                     }
                 }
             }


### PR DESCRIPTION
#### Why I did it
To support new sonic DB version format:

Old format: version_a_b_c
New format: version_<branch>_<nn>

* fba4bf0b 2023-12-21 | [202311][db_migrator] add db migrator version space for 202305/202311 branch (#3082) (HEAD -> 202311, github/202311) [Ying Xie]

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
PR test