### PR TITLE
Refactor get_num_dpus function.

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -860,21 +860,18 @@ def get_num_dpus():
     if not platform:
         return 0
 
-    (platform_path, hwsku_path) = get_paths_to_platform_and_hwsku_dirs()
+    # Get Platform path.
+    platform_path = get_path_to_platform_dir()
 
-    # Check for 'hwsku.json' file presence first
-    hwsku_json_file = os.path.join(hwsku_path, HWSKU_JSON_FILE)
-
-    if os.path.isfile(hwsku_json_file):
-        if os.path.isfile(os.path.join(platform_path, PLATFORM_JSON_FILE)):
-            json_file = os.path.join(platform_path, PLATFORM_JSON_FILE)
-            platform_data = json.loads(open(json_file).read())
-
-            # Convert to lower case avoid case sensitive.
-            data = {k.lower(): v for k, v in platform_data.items()}
-            DPUs = data.get('dpus', None)
-            if DPUs is not None and len(DPUs) > 0:
-                return len(DPUs)
+    if os.path.isfile(os.path.join(platform_path, PLATFORM_JSON_FILE)):
+        json_file = os.path.join(platform_path, PLATFORM_JSON_FILE)
+        platform_data = json.loads(open(json_file).read())
+        
+        # Convert to lower case avoid case sensitive.
+        data = {k.lower(): v for k, v in platform_data.items()}
+        DPUs = data.get('dpus', None)
+        if DPUs is not None and len(DPUs) > 0:
+            return len(DPUs)
 
     return 0
 

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -865,7 +865,13 @@ def get_num_dpus():
 
     if os.path.isfile(os.path.join(platform_path, PLATFORM_JSON_FILE)):
         json_file = os.path.join(platform_path, PLATFORM_JSON_FILE)
-        platform_data = json.loads(open(json_file).read())
+        
+        try:
+            with open(json_file, 'r') as file:
+                platform_data = json.load(file)
+        except (json.JSONDecodeError, IOError, TypeError, ValueError):
+            # Handle any file reading and JSON parsing errors
+            return 0
         
         # Convert to lower case avoid case sensitive.
         data = {k.lower(): v for k, v in platform_data.items()}


### PR DESCRIPTION
#### Why I did it
Refactor current get_num_dpus function to consuming platform.json which is reliable way to retrieve the number of DPUs.


##### Work item tracking
- Microsoft ADO **number**:

#### How I did it
Read platform.json file to retrieve the number of DPU objects in DPUS section.

```json
"DPUs": [
   {
      "DPU0": {
         "Ethernet244": "Ehternet0",
         "Ethernet248": "Ethernet1"
      }
   },
   {
      "DPU1": {
         "Ethernet252": "Ethernet0",
         "Ethernet256": "Ethernet1"
      },
   }
]
```

#### How to verify it
Create local platform json file which follow the format of [hwsku.json](https://github.com/sonic-net/sonic-buildimage/blob/d4a78665eeba62d597b8a6319dbc1a5ab5cfa775/src/sonic-config-engine/tests/data/smartswitch/SSwitch-32x1000Gb/hwsku.json#L115) then run the function call locally.

```python
import json

def get_num_dpus():
    json_file = "/tmp/hwsku.json"
    if os.path.isfile(os.path.join(platform_path, "hwsku.json")):
        json_file = os.path.join(platform_path, "hwsku.json")

        try:
            with open(json_file, 'r') as file:
                platform_data = json.load(file)
        except (json.JSONDecodeError, IOError, TypeError, ValueError):
            # Handle any file reading and JSON parsing errors
            return 0

        # Convert to lower case avoid case sensitive.
        data = {k.lower(): v for k, v in platform_data.items()}
        DPUs = data.get('dpus', None)
        if DPUs is not None and len(DPUs) > 0:
            return len(DPUs)

    return 0

print(get_num_dpus()) # output is 4, which is expected.
```


#### Which release branch to backport (provide reason below if selected)

- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)


#### Description for the changelog

#### A picture of a cute animal (not mandatory but encouraged)

