### PR TITLE
[dhcp_server] add config dhcp server enable

### DIFF
--- a/dockers/docker-dhcp-server/cli-plugin-tests/conftest.py
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/conftest.py
@@ -69,6 +69,12 @@ def mock_db():
         if table == "STATE_DB":
             del mock_state_db[key]
 
+    def set_(table, key, k, v):
+        assert table == "CONFIG_DB" or table == "STATE_DB"
+        if table == "CONFIG_DB":
+            mock_config_db[key][k] = v
+        if table == "STATE_DB":
+            mock_state_db[key][k] = v
 
     db.keys = mock.Mock(side_effect=keys)
     db.get_all = mock.Mock(side_effect=get_all)
@@ -76,5 +82,6 @@ def mock_db():
     db.hmset = mock.Mock(side_effect=hmset)
     db.exists = mock.Mock(side_effect=exists)
     db.delete = mock.Mock(side_effect=delete)
+    db.set = mock.Mock(side_effect=set_)
 
     yield db

--- a/dockers/docker-dhcp-server/cli-plugin-tests/mock_config_db.json
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/mock_config_db.json
@@ -20,6 +20,14 @@
         "customized_options": "option60",
         "state": "enabled"
     },
+    "DHCP_SERVER_IPV4|Vlan200": {
+        "gateway": "100.1.1.1",
+        "lease_time": "3600",
+        "mode": "PORT",
+        "netmask": "255.255.255.0",
+        "customized_options": "option60",
+        "state": "disabled"
+    },
     "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS|option60": {
         "id": "60",
         "type": "string",

--- a/dockers/docker-dhcp-server/cli-plugin-tests/mock_config_db.json
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/mock_config_db.json
@@ -20,7 +20,7 @@
         "customized_options": "option60",
         "state": "enabled"
     },
-    "DHCP_SERVER_IPV4|Vlan200": {
+    "DHCP_SERVER_IPV4|Vlan300": {
         "gateway": "100.1.1.1",
         "lease_time": "3600",
         "mode": "PORT",

--- a/dockers/docker-dhcp-server/cli-plugin-tests/test_config_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/test_config_dhcp_server.py
@@ -128,3 +128,18 @@ class TestConfigDHCPServer(object):
         result = runner.invoke(dhcp_server.dhcp_server.commands["ipv4"].commands["del"], ["Vlan200"], obj=db)
         assert result.exit_code == 2, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
 
+    def test_config_dhcp_server_ipv4_enable_already_exist(self, mock_db):
+        runner = CliRunner()
+        db = clicommon.Db()
+        db.db = mock_db
+        result = runner.invoke(dhcp_server.dhcp_server.commands["ipv4"].commands["enable"], ["Vlan200"], obj=db)
+        assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+        assert mock_db.get("CONFIG_DB", "DHCP_SERVER_IPV4|Vlan200") == "enabled"
+
+    def test_config_dhcp_server_ipv4_enable_does_not_exist(self, mock_db):
+        runner = CliRunner()
+        db = clicommon.Db()
+        db.db = mock_db
+        result = runner.invoke(dhcp_server.dhcp_server.commands["ipv4"].commands["enable"], ["Vlan300"], obj=db)
+        assert result.exit_code == 2, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+

--- a/dockers/docker-dhcp-server/cli-plugin-tests/test_config_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/test_config_dhcp_server.py
@@ -132,14 +132,14 @@ class TestConfigDHCPServer(object):
         runner = CliRunner()
         db = clicommon.Db()
         db.db = mock_db
-        result = runner.invoke(dhcp_server.dhcp_server.commands["ipv4"].commands["enable"], ["Vlan200"], obj=db)
+        result = runner.invoke(dhcp_server.dhcp_server.commands["ipv4"].commands["enable"], ["Vlan300"], obj=db)
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
-        assert mock_db.get("CONFIG_DB", "DHCP_SERVER_IPV4|Vlan200") == "enabled"
+        assert mock_db.get("CONFIG_DB", "DHCP_SERVER_IPV4|Vlan300") == "enabled"
 
     def test_config_dhcp_server_ipv4_enable_does_not_exist(self, mock_db):
         runner = CliRunner()
         db = clicommon.Db()
         db.db = mock_db
-        result = runner.invoke(dhcp_server.dhcp_server.commands["ipv4"].commands["enable"], ["Vlan300"], obj=db)
+        result = runner.invoke(dhcp_server.dhcp_server.commands["ipv4"].commands["enable"], ["Vlan200"], obj=db)
         assert result.exit_code == 2, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
 

--- a/dockers/docker-dhcp-server/cli-plugin-tests/test_config_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/test_config_dhcp_server.py
@@ -134,7 +134,7 @@ class TestConfigDHCPServer(object):
         db.db = mock_db
         result = runner.invoke(dhcp_server.dhcp_server.commands["ipv4"].commands["enable"], ["Vlan300"], obj=db)
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
-        assert mock_db.get("CONFIG_DB", "DHCP_SERVER_IPV4|Vlan300") == "enabled"
+        assert mock_db.get("CONFIG_DB", "DHCP_SERVER_IPV4|Vlan300", "state") == "enabled"
 
     def test_config_dhcp_server_ipv4_enable_does_not_exist(self, mock_db):
         runner = CliRunner()

--- a/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
@@ -113,8 +113,9 @@ range3   100.1.1.10  100.1.1.10           1
     def test_show_dhcp_server_ipv4_info_without_intf(self, mock_db):
         expected_stdout = """\
 Interface    Mode    Gateway    Netmask          Lease Time(s)  State
------------  ------  ---------  -------------  ---------------  -------
+-----------  ------  ---------  -------------  ---------------  --------
 Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled
+Vlan300      PORT    100.1.1.1  255.255.255.0             3600  disabled
 """
         runner = CliRunner()
         db = clicommon.Db()

--- a/dockers/docker-dhcp-server/cli/config/plugins/dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli/config/plugins/dhcp_server.py
@@ -116,6 +116,19 @@ def dhcp_server_ipv4_del(db, dhcp_interface):
         ctx.fail("Dhcp interface %s does not exist in config db".format(dhcp_interface))
 
 
+@dhcp_server_ipv4.command(name="enable")
+@click.argument("dhcp_interface", required=True)
+@clicommon.pass_db
+def dhcp_server_ipv4_enable(db, dhcp_interface):
+    ctx = click.get_current_context()
+    dbconn = db.db
+    key = "DHCP_SERVER_IPV4|" + dhcp_interface
+    if dbconn.exists("CONFIG_DB", key):
+        dbconn.set("CONFIG_DB", key, "state", "enabled")
+    else:
+        ctx.fail("Failed to enable, dhcp interface %s does not exist".format(dhcp_interface))
+
+
 def register(cli):
     # cli.add_command(dhcp_server)
     pass


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add config dhcp server enable

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
run unittest and manually run on latest image.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add config dhcp_server enable

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

