### PR TITLE
[YANG] update sonic DB version string format

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-versions.yang
+++ b/src/sonic-yang-models/yang-models/sonic-versions.yang
@@ -23,7 +23,7 @@ module sonic-versions {
                 leaf VERSION {
                     type string {
                         length 1..255;
-                        pattern 'version_([1-9]|[1-9]{1}[0-9]{1})_([0-9]{1,2})_([0-9]{1,2})';
+                        pattern 'version_(([1-9]|[1-9]{1}[0-9]{1})_([0-9]{1,2})_([0-9]{1,2})|([1-9]{1}[0-9]{5})_([0-9]{2}))';
                     }
                 }
             }


### PR DESCRIPTION
#### Why I did it
Add support for new DB version format:

Old format: version_a_b_c
New format: version_<branch>_<nn>

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

