### PR TITLE
[sonic-dash-api] fix redundant path in sonic-dash-api build

### DIFF
--- a/rules/sonic-dash-api.dep
+++ b/rules/sonic-dash-api.dep
@@ -3,7 +3,7 @@ SPATH       := $($(LIB_SONIC_DASH_API)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/sonic-dash-api.mk rules/sonic-dash-api.dep   
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(SPATH) | grep -v sonic-dash-api)
-SMDEP_FILES := $(addprefix $(SPATH)/sonic-dash-api/,$(shell cd $(SPATH)/sonic-dash-api && git ls-files))
+SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files))
 
 $(LIB_SONIC_DASH_API)_CACHE_MODE  := GIT_CONTENT_SHA 
 $(LIB_SONIC_DASH_API)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)


### PR DESCRIPTION
#### Why I did it

For the past couple of weeks at least, my builds have been generating an error related to `sonic-dash-api` indicating that component is not defined correctly:

```bash
"GZ_COMPRESS_PROGRAM"             : "gzip"
"LEGACY_SONIC_MGMT_DOCKER"        : "y"
"INCLUDE_EXTERNAL_PATCHES"        : "n"

/bin/bash: line 1: cd: src/sonic-dash-api/sonic-dash-api: No such file or directory
"SONIC_DPKG_CACHE_METHOD"         : "none"

[ 01 ] [ target/debs/bookworm/linux-headers-6.1.0-11-2-common_6.1.38-4_all.deb ]
[ 02 ] [ target/debs/bookworm/libyang_1.0.73_amd64.deb ]
[ 03 ] [ target/debs/bookworm/bash_5.1-2_amd64.deb ]
[ 04 ] [ target/python-wheels/bookworm/redis_dump_load-1.1-py3-none-any.whl ]
```

This change fixes that.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

In `sonic-dash-api.mk` this variable is defined: `$(LIB_SONIC_DASH_API)_SRC_PATH = $(SRC_PATH)/sonic-dash-api`

`sonic-dash-api.dep` forgets that the `sonic-dash-api` bit was added and tries to re-append it:

```makefile
SPATH       := $($(LIB_SONIC_DASH_API)_SRC_PATH)
...
SMDEP_FILES := $(addprefix $(SPATH)/sonic-dash-api/,$(shell cd $(SPATH)/sonic-dash-api && git ls-files))
```

I adjusted the `dep` file to not re-append the `sonic-dash-api` path:

```makefile
SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files))
```

#### How to verify it

I'm re-building now. But so far, the errors are gone:

```bash
"GZ_COMPRESS_PROGRAM"             : "gzip"
"LEGACY_SONIC_MGMT_DOCKER"        : "y"
"INCLUDE_EXTERNAL_PATCHES"        : "n"

"SONIC_DPKG_CACHE_METHOD"         : "none"

[ 01 ] [ target/debs/buster/libyang_1.0.73_amd64.deb ]
[ 02 ] [ target/debs/buster/libnl-3-200_3.5.0-1_amd64.deb ]
[ 03 ] [ target/python-wheels/buster/redis_dump_load-1.1-py2-none-any.whl ]
```

#### Tested branch (Please provide the tested image version)

`master`

#### Description for the changelog

Corrects redundant path for sonic-dash-api in build files
