### PR TITLE
Do not pass the option "device" in rsyslog.conf by default when syslog server's source address is configured

### DIFF
--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -107,7 +107,7 @@ $RepeatedMsgReduction on
 {% set regex = conf.get('filter_regex') -%}
 
 {% set fmodifier = '!' if filter == 'exclude' else '' %}
-{% set device = 'eth0' if vrf != '' and vrf != 'default' -%}
+{% set device = vrf if vrf != '' and vrf != 'default' -%}
 {% set template = 'WelfRemoteFormat' if format == 'welf' else 'SONiCFileFormat' -%}
 
 {# Server extra options -#}

--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -115,11 +115,16 @@ $RepeatedMsgReduction on
 
 {% if source -%}
     {% set options = options ~ ' Address="' ~ source ~ '"'-%}
+    {% set device = device if device != 'eth0' else '' -%}
+{% endif -%}
+
+{% if device -%}
+    {% set options = options ~ ' Device="' ~ device ~ '"'-%}
 {% endif -%}
 
 {% if filter %}
 :msg, {{ fmodifier }}ereregex, "{{ regex }}"
 {% endif %}
 *.{{ severity }}
-action(type="omfwd" Target="{{ server }}" Port="{{ port }}" Protocol="{{ proto }}" Device="{{ device }}" Template="{{ template }}"{{ options }})
+action(type="omfwd" Target="{{ server }}" Port="{{ port }}" Protocol="{{ proto }}" Template="{{ template }}"{{ options }})
 {% endfor %}

--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -107,7 +107,7 @@ $RepeatedMsgReduction on
 {% set regex = conf.get('filter_regex') -%}
 
 {% set fmodifier = '!' if filter == 'exclude' else '' %}
-{% set device = 'eth0' if vrf == 'default' else vrf -%}
+{% set device = 'eth0' if vrf != '' and vrf != 'default' -%}
 {% set template = 'WelfRemoteFormat' if format == 'welf' else 'SONiCFileFormat' -%}
 
 {# Server extra options -#}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

An in-band syslog server will not receive any syslog if it is configured without a VRF specified, which is because `eth0` is always specified as the `device` of a syslog server and the syslog packets will be sent to `eth0` regardless of its destination IP address.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Pass the option "device" in rsyslog.conf only if when syslog server's source address is configured with a non-default VRF

#### How to verify it

Manually test:
1. Configuring a syslog server without VRF specified or with `default` as the VRF: no `device` passed in `rsyslog.conf`
2. Configuring a syslog server with non-default VRF: the configured VRF passed as `device` in `rsyslog.conf`

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

