### PR TITLE
[image_config]: Update DHCP rate-limit for mgmt TOR devices

### DIFF
--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -34,8 +34,13 @@
 		    "queue": "4",
 		    "meter_type":"packets",
 		    "mode":"sr_tcm",
+{% if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] is in ['MgmtToRRouter', 'BmcMgmtToRRouter'] %}
+		    "cir":"300",
+		    "cbs":"300",
+{% else %}
 		    "cir":"100",
 		    "cbs":"100",
+{% endif %}
 		    "red_action":"drop"
 	    },
 	    "queue1_group1": {

--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -34,7 +34,7 @@
 		    "queue": "4",
 		    "meter_type":"packets",
 		    "mode":"sr_tcm",
-{% if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] is in ['MgmtToRRouter', 'BmcMgmtToRRouter'] %}
+{% if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and 'Mgmt' in DEVICE_METADATA['localhost']['type'] %}
 		    "cir":"300",
 		    "cbs":"300",
 {% else %}


### PR DESCRIPTION
    Change DHCP rate limit(queue4,group3) in SONiC copp configuration to 300 PPS
    for mgmt TORs while keeping the rate limit at 100 PPS for other topologies.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
    Some mgmt TORs based on Marvell ASIC do not support 100 PPS CIR, so that led
    to these devices silently dropping DHCP packets.
##### Work item tracking
- Microsoft ADO **25820076**:

#### How I did it
    Updated copp_cfg.j2 to set queue4_group3 rate-limit to 300 PPS for mgmt TOR devices and 100 PPS for other device 
    topologies.
#### How to verify it
    Send DHCP broadcast packets to an M0 DUT and verify that they are trapped to
    CPU at 300 PPS. On non-mgmt devices, the packets should be trapped at CIR of
    100 PPS. Also ran sonic-mgmt dhcp_relay test and confirmed that it passes.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->
- [x] 20230531.14
- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

