### PR TITLE
Update smartmontool version >= v7.4

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -359,9 +359,7 @@ sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/restart_service
 
 # Installed smartmontools version should match installed smartmontools in docker-platform-monitor Dockerfile
 # TODO: are mismatching versions fine for bookworm?
-echo "deb http://deb.debian.org/debian bookworm-backports main" | sudo tee -a $FILESYSTEM_ROOT/etc/apt/sources.list > /dev/null
-sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get update
-sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -t bookworm-backports smartmontools=7.4-2~bpo12+1
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -t bookworm-backports smartmontools
 sudo cp $IMAGE_CONFIGS/smartmontools/smartmontools $FILESYSTEM_ROOT/etc/default/smartmontools
 
 # Install custom-built openssh sshd

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -359,7 +359,10 @@ sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/restart_service
 
 # Installed smartmontools version should match installed smartmontools in docker-platform-monitor Dockerfile
 # TODO: are mismatching versions fine for bookworm?
-sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install smartmontools
+echo "deb http://deb.debian.org/debian bookworm-backports main" | sudo tee -a $FILESYSTEM_ROOT/etc/apt/sources.list > /dev/null
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get update
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -t bookworm-backports smartmontools=7.4-2~bpo12+1
+sudo cp $IMAGE_CONFIGS/smartmontools/smartmontools $FILESYSTEM_ROOT/etc/default/smartmontools
 
 # Install custom-built openssh sshd
 sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/openssh-server_${OPENSSH_VERSION}_*.deb $debs_path/openssh-client_${OPENSSH_VERSION}_*.deb $debs_path/openssh-sftp-server_${OPENSSH_VERSION}_*.deb

--- a/files/image_config/smartmontools/smartmontools
+++ b/files/image_config/smartmontools/smartmontools
@@ -1,0 +1,8 @@
+# Defaults for smartmontools initscript (/etc/init.d/smartmontools)
+# This is a POSIX shell fragment
+
+# List of devices you want to explicitly enable S.M.A.R.T. for
+# Not needed (and not recommended) if the device is monitored by smartd
+#enable_smart="/dev/hda /dev/hdb"
+
+smartd_opts="-q nodev0"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Update smartmontool verson to 7.4. This is done to prevent smartmontools service to exit with non-zero exit status on platform that does not have a SSD/disk to be monitored.

Until Debian Bullseye (which had smartmontools 7.2), Debian had a patch applied that changed the default quit mode to never exit. A [bug report](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fbugs.debian.org%2Fcgi-bin%2Fbugreport.cgi%3Fbug%3D1006630&data=05%7C02%7CPrince.George%40microsoft.com%7C7523d0e755c74ab63a3e08dc034e9d89%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638388883394086156%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=pIRsnZSSc8cWF1SrPKyF47FemdXzWcdBEN95kj4jJA8%3D&reserved=0) was filed on Debian, saying that the source code patch isn't needed and could just be done via command line options, and also that smartmontools 7.3 has a new built-in option to exit with 0 if there are no monitorable devices found (which prevents systemd from treating it as a service failure). Because of that, Debian Bookworm (which also upgraded to 7.3) removed the patch and restored the default behavior of exiting with exit code 17 if there are no devices found.
 
Smartmontools v7.3 has this [issue](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fbugs.debian.org%2Fcgi-bin%2Fbugreport.cgi%3Fbug%3D1029210%2315&data=05%7C02%7CPrince.George%40microsoft.com%7C7523d0e755c74ab63a3e08dc034e9d89%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638388883394092717%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=oBqYYbDIUWbk2PPJLruVfxhWaBpOYqvZ1jmebWqif9Y%3D&reserved=0), because of which smartd exits with non-zero exit status even with "-q" option.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. Update the smartmontools to version 7.4 which has the fix for exiting gracefully if no monitoring device is found
2. Added smartd option "-q nodev0" to allow smartd to exit with status 0 if no monitoring device found

#### How to verify it

smartd running version is now v7.4 (stable on bookworm is v7.3)

![image](https://github.com/sonic-net/sonic-buildimage/assets/45705344/c0d7c691-506d-4efd-bddb-b6e6f1528683)


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Smartd is now exiting successfully (exit status=0) if no SSD device found

![image](https://github.com/sonic-net/sonic-buildimage/assets/45705344/0914880a-ca99-4187-8770-756f1e3b6dcd)


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

