### PR TITLE
[dhcp_server] Add field not exist checks in dhcp_cfggen

### DIFF
--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
@@ -149,12 +149,13 @@ class DhcpServCfgGenerator(object):
                                   .format(dhcp_interface_name))
                     continue
                 curr_options = {}
-                for option in dhcp_config["customized_options"]:
-                    if option in customized_options.keys():
-                        curr_options[option] = {
-                            "always_send": customized_options[option]["always_send"],
-                            "value": customized_options[option]["value"]
-                        }
+                if "customized_options" in dhcp_config:
+                    for option in dhcp_config["customized_options"]:
+                        if option in customized_options.keys():
+                            curr_options[option] = {
+                                "always_send": customized_options[option]["always_send"],
+                                "value": customized_options[option]["value"]
+                            }
                 for dhcp_interface_ip, port_config in port_ips[dhcp_interface_name].items():
                     pools = []
                     for port_name, ip_ranges in port_config.items():
@@ -354,6 +355,9 @@ class DhcpServCfgGenerator(object):
                 syslog.syslog(syslog.LOG_WARNING, f"Cannot find {splits[1]} in port_alias_map")
                 continue
             port = self.port_alias_map[splits[1]]
+            if dhcp_interface_name not in vlan_interfaces:
+                syslog.syslog(syslog.LOG_WARNING, f"Interface {dhcp_interface_name} doesn't have IPv4 address")
+                continue
             if dhcp_interface_name not in port_ips:
                 port_ips[dhcp_interface_name] = {}
             # Get ip information of Vlan

--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
@@ -136,6 +136,7 @@ class DhcpServCfgGenerator(object):
         client_classes = []
         enabled_dhcp_interfaces = set()
         used_options = set()
+        customized_option_keys = customized_options.keys()
         # Different mode would subscribe different table, always subscribe DHCP_SERVER_IPV4
         subscribe_table = set(["DhcpServerTableCfgChangeEventChecker"])
         for dhcp_interface_name, dhcp_config in dhcp_server_ipv4.items():
@@ -151,11 +152,14 @@ class DhcpServCfgGenerator(object):
                 curr_options = {}
                 if "customized_options" in dhcp_config:
                     for option in dhcp_config["customized_options"]:
-                        if option in customized_options.keys():
-                            curr_options[option] = {
-                                "always_send": customized_options[option]["always_send"],
-                                "value": customized_options[option]["value"]
-                            }
+                        if option not in customized_option_keys:
+                            syslog.syslog(syslog.LOG_WARNING, "Customized option {} configured for {} is not defined"
+                                          .format(option, dhcp_interface_name))
+                            continue
+                        curr_options[option] = {
+                            "always_send": customized_options[option]["always_send"],
+                            "value": customized_options[option]["value"]
+                        }
                 for dhcp_interface_ip, port_config in port_ips[dhcp_interface_name].items():
                     pools = []
                     for port_name, ip_ranges in port_config.items():

--- a/src/sonic-dhcp-utilities/tests/conftest.py
+++ b/src/sonic-dhcp-utilities/tests/conftest.py
@@ -35,7 +35,8 @@ def mock_get_render_template():
 def mock_parse_port_map_alias(scope="function"):
     with patch("dhcp_utilities.dhcpservd.dhcp_cfggen.DhcpServCfgGenerator._parse_port_map_alias",
                return_value=None) as mock_map, \
-         patch.object(DhcpServCfgGenerator, "port_alias_map", return_value={"Ethernet24": "etp7", "Ethernet28": "etp8"},
+         patch.object(DhcpServCfgGenerator, "port_alias_map", return_value={"Ethernet24": "etp7", "Ethernet28": "etp8",
+                                                                            "Ethernet44": "etp12"},
                       new_callable=PropertyMock), \
          patch.object(DhcpServCfgGenerator, "lease_update_script_path", return_value="/etc/kea/lease_update.sh",
                       new_callable=PropertyMock), \

--- a/src/sonic-dhcp-utilities/tests/test_data/mock_config_db.json
+++ b/src/sonic-dhcp-utilities/tests/test_data/mock_config_db.json
@@ -6,7 +6,8 @@
     },
     "VLAN": {
         "Vlan1000": {},
-        "Vlan2000": {}
+        "Vlan2000": {},
+        "Vlan3000": {}
     },
     "VLAN_INTERFACE": {
         "Vlan1000|192.168.0.1/21": {
@@ -26,6 +27,9 @@
         },
         "Vlan2000": {
             "NULL": "NULL"
+        },
+        "Vlan3000": {
+            "NULL": "NULL"
         }
     },
     "VLAN_MEMBER": {
@@ -36,6 +40,9 @@
             "tagging_mode": "untagged"
         },
         "Vlan1000|Ethernet40": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan3000|Ethernet44": {
             "tagging_mode": "untagged"
         }
     },
@@ -92,6 +99,13 @@
             "mode": "PORT",
             "netmask": "255.255.255.0",
             "state": "disabled"
+        },
+        "Vlan6000": {
+            "gateway": "192.168.2.1",
+            "lease_time": "900",
+            "mode": "PORT",
+            "netmask": "255.255.255.0",
+            "state": "enabled"
         }
     },
     "DHCP_SERVER_IPV4_RANGE": {
@@ -157,6 +171,11 @@
             ]
         },
         "Vlan1000|Ethernet40": {
+            "ips": [
+                "192.168.0.10"
+            ]
+        },
+        "Vlan3000|Ethernet44": {
             "ips": [
                 "192.168.0.10"
             ]

--- a/src/sonic-dhcp-utilities/tests/test_dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcp_cfggen.py
@@ -302,7 +302,8 @@ def test_parse_vlan(mock_swsscommon_dbconnector_init, mock_parse_port_map_alias,
     vlan_interfaces, vlan_members = dhcp_cfg_generator._parse_vlan(mock_config_db.config_db.get("VLAN_INTERFACE"),
                                                                    mock_config_db.config_db.get("VLAN_MEMBER"))
     assert vlan_interfaces == expected_vlan_ipv4_interface
-    assert list(vlan_members) == ["Vlan1000|Ethernet24", "Vlan1000|Ethernet28", "Vlan1000|Ethernet40"]
+    expeceted_members = ["Vlan1000|Ethernet24", "Vlan1000|Ethernet28", "Vlan1000|Ethernet40", "Vlan3000|Ethernet44"]
+    assert list(vlan_members) == expeceted_members
 
 
 @pytest.mark.parametrize("test_config_db", ["mock_config_db.json", "mock_config_db_without_port_config.json"])
@@ -351,11 +352,22 @@ def test_construct_obj_for_template(mock_swsscommon_dbconnector_init, mock_parse
     customized_options = {"option223": {"id": "223", "value": "dummy_value", "type": "string", "always_send": "true"}}
     dhcp_cfg_generator = DhcpServCfgGenerator(dhcp_db_connector)
     tested_hostname = "sonic-host"
+    port_ips = {
+        "Vlan1000": {
+            "192.168.0.1/21": {
+                "etp8": [["192.168.0.2", "192.168.0.6"], ["192.168.0.10", "192.168.0.10"]],
+                "etp7": [["192.168.0.7", "192.168.0.7"]],
+                "etp9": []
+            }
+        },
+        "Vlan6000": {
+        }
+    }
     render_obj, enabled_dhcp_interfaces, used_options, subscribe_table = \
         dhcp_cfg_generator._construct_obj_for_template(mock_config_db.config_db.get("DHCP_SERVER_IPV4"),
-                                                       tested_parsed_port, tested_hostname, customized_options)
+                                                       port_ips, tested_hostname, customized_options)
     assert render_obj == expected_render_obj
-    assert enabled_dhcp_interfaces == {"Vlan1000", "Vlan4000", "Vlan3000"}
+    assert enabled_dhcp_interfaces == {"Vlan1000", "Vlan4000", "Vlan3000", "Vlan6000"}
     assert used_options == set(["option223"])
     assert subscribe_table == set(PORT_MODE_CHECKER)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add boundary condition checks in below scenarios when generating DHCP server configuration:
- `customized_options` is not given
- Interfaces configured in `DHCP_SERVER_IPV4` table doesn't have IPv4 address

##### Work item tracking
- Microsoft ADO **(number only)**: 26297130

#### How I did it
- Add boundary condition checks.
- Add related UTs

#### How to verify it
UTs passed

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

