### PR TITLE
[dhcp_server] Fix UT issues in test_utils and test_dhcp_db_monitor

### DIFF
--- a/src/sonic-dhcp-utilities/tests/test_dhcp_db_monitor.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcp_db_monitor.py
@@ -211,15 +211,12 @@ def test_db_event_checker_subscribe_table(mock_swsscommon_dbconnector_init, enab
             mock_sub.assert_called_once_with(ANY, "")
 
 
-@pytest.mark.parametrize("tested_db_snapshot", [{"enabled_dhcp_interfaces": "Vlan1000"}, {}])
+@pytest.mark.parametrize("tested_db_snapshot", [{"enabled_dhcp_interfaces": {"Vlan1000"}}, {}])
 @pytest.mark.parametrize("tested_data", get_subscribe_table_tested_data("test_dhcp_server_update"))
-@pytest.mark.parametrize("enabled", [True, False])
-def test_dhcp_server_table_cfg_change_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot,
-                                              enabled):
+def test_dhcp_server_table_cfg_change_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot):
     with patch.object(ConfigDbEventChecker, "enable"), \
          patch.object(ConfigDbEventChecker, "subscriber_state_table",
                       return_value=MockSubscribeTable(tested_data["table"]), new_callable=PropertyMock), \
-         patch.object(ConfigDbEventChecker, "enabled", return_value=enabled, new_callable=PropertyMock), \
          patch.object(sys, "exit"):
         sel = swsscommon.Select()
         db_event_checker = DhcpServerTableCfgChangeEventChecker(sel, MagicMock())
@@ -232,15 +229,12 @@ def test_dhcp_server_table_cfg_change_checker(mock_swsscommon_dbconnector_init, 
             assert expected_res == check_res
 
 
-@pytest.mark.parametrize("tested_db_snapshot", [{"enabled_dhcp_interfaces": "Vlan1000"}, {}])
+@pytest.mark.parametrize("tested_db_snapshot", [{"enabled_dhcp_interfaces": {"Vlan1000"}}, {}])
 @pytest.mark.parametrize("tested_data", get_subscribe_table_tested_data("test_dhcp_server_update"))
-@pytest.mark.parametrize("enabled", [True, False])
-def test_dhcp_server_table_enablement_change_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot,
-                                                     enabled):
+def test_dhcp_server_table_enablement_change_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot):
     with patch.object(ConfigDbEventChecker, "enable"), \
          patch.object(ConfigDbEventChecker, "subscriber_state_table",
                       return_value=MockSubscribeTable(tested_data["table"]), new_callable=PropertyMock), \
-         patch.object(ConfigDbEventChecker, "enabled", return_value=enabled, new_callable=PropertyMock), \
          patch.object(sys, "exit"):
         sel = swsscommon.Select()
         db_event_checker = DhcpServerTableIntfEnablementEventChecker(sel, MagicMock())
@@ -253,14 +247,12 @@ def test_dhcp_server_table_enablement_change_checker(mock_swsscommon_dbconnector
             assert expected_res == check_res
 
 
-@pytest.mark.parametrize("tested_db_snapshot", [{"enabled_dhcp_interfaces": "Vlan1000"}, {}])
+@pytest.mark.parametrize("tested_db_snapshot", [{"enabled_dhcp_interfaces": {"Vlan1000"}}, {}])
 @pytest.mark.parametrize("tested_data", get_subscribe_table_tested_data("test_port_update"))
-@pytest.mark.parametrize("enabled", [True, False])
-def test_dhcp_port_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot, enabled):
+def test_dhcp_port_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot):
     with patch.object(ConfigDbEventChecker, "enable"), \
          patch.object(ConfigDbEventChecker, "subscriber_state_table",
                       return_value=MockSubscribeTable(tested_data["table"]), new_callable=PropertyMock), \
-         patch.object(ConfigDbEventChecker, "enabled", return_value=enabled, new_callable=PropertyMock), \
          patch.object(sys, "exit"):
         sel = swsscommon.Select()
         db_event_checker = DhcpPortTableEventChecker(sel, MagicMock())
@@ -272,14 +264,12 @@ def test_dhcp_port_table_checker(mock_swsscommon_dbconnector_init, tested_data, 
             assert expected_res == check_res
 
 
-@pytest.mark.parametrize("tested_db_snapshot", [{"used_range": "range1"}, {}])
+@pytest.mark.parametrize("tested_db_snapshot", [{"used_range": {"range1"}}, {}])
 @pytest.mark.parametrize("tested_data", get_subscribe_table_tested_data("test_range_update"))
-@pytest.mark.parametrize("enabled", [True, False])
-def test_dhcp_range_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot, enabled):
+def test_dhcp_range_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot):
     with patch.object(ConfigDbEventChecker, "enable"), \
          patch.object(ConfigDbEventChecker, "subscriber_state_table",
                       return_value=MockSubscribeTable(tested_data["table"]), new_callable=PropertyMock), \
-         patch.object(ConfigDbEventChecker, "enabled", return_value=enabled, new_callable=PropertyMock), \
          patch.object(sys, "exit"):
         sel = swsscommon.Select()
         db_event_checker = DhcpRangeTableEventChecker(sel, MagicMock())
@@ -291,14 +281,12 @@ def test_dhcp_range_table_checker(mock_swsscommon_dbconnector_init, tested_data,
             assert expected_res == check_res
 
 
-@pytest.mark.parametrize("tested_db_snapshot", [{"used_options": "option223"}, {}])
+@pytest.mark.parametrize("tested_db_snapshot", [{"used_options": {"option223"}}, {}])
 @pytest.mark.parametrize("tested_data", get_subscribe_table_tested_data("test_option_update"))
-@pytest.mark.parametrize("enabled", [True, False])
-def test_dhcp_option_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot, enabled):
+def test_dhcp_option_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot):
     with patch.object(ConfigDbEventChecker, "enable"), \
          patch.object(ConfigDbEventChecker, "subscriber_state_table",
                       return_value=MockSubscribeTable(tested_data["table"]), new_callable=PropertyMock), \
-         patch.object(ConfigDbEventChecker, "enabled", return_value=enabled, new_callable=PropertyMock), \
          patch.object(sys, "exit"):
         sel = swsscommon.Select()
         db_event_checker = DhcpOptionTableEventChecker(sel, MagicMock())
@@ -310,14 +298,12 @@ def test_dhcp_option_table_checker(mock_swsscommon_dbconnector_init, tested_data
             assert expected_res == check_res
 
 
-@pytest.mark.parametrize("tested_db_snapshot", [{"enabled_dhcp_interfaces": "Vlan1000"}, {}])
+@pytest.mark.parametrize("tested_db_snapshot", [{"enabled_dhcp_interfaces": {"Vlan1000"}}, {}])
 @pytest.mark.parametrize("tested_data", get_subscribe_table_tested_data("test_vlan_update"))
-@pytest.mark.parametrize("enabled", [True, False])
-def test_vlan_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot, enabled):
+def test_vlan_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot):
     with patch.object(ConfigDbEventChecker, "enable"), \
          patch.object(ConfigDbEventChecker, "subscriber_state_table",
                       return_value=MockSubscribeTable(tested_data["table"]), new_callable=PropertyMock), \
-         patch.object(ConfigDbEventChecker, "enabled", return_value=enabled, new_callable=PropertyMock), \
          patch.object(sys, "exit"):
         sel = swsscommon.Select()
         db_event_checker = VlanTableEventChecker(sel, MagicMock())
@@ -329,14 +315,12 @@ def test_vlan_table_checker(mock_swsscommon_dbconnector_init, tested_data, teste
             assert expected_res == check_res
 
 
-@pytest.mark.parametrize("tested_db_snapshot", [{"enabled_dhcp_interfaces": "Vlan1000"}, {}])
+@pytest.mark.parametrize("tested_db_snapshot", [{"enabled_dhcp_interfaces": {"Vlan1000"}}, {}])
 @pytest.mark.parametrize("tested_data", get_subscribe_table_tested_data("test_vlan_intf_update"))
-@pytest.mark.parametrize("enabled", [True, False])
-def test_vlan_intf_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot, enabled):
+def test_vlan_intf_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot):
     with patch.object(ConfigDbEventChecker, "enable"), \
          patch.object(ConfigDbEventChecker, "subscriber_state_table",
                       return_value=MockSubscribeTable(tested_data["table"]), new_callable=PropertyMock), \
-         patch.object(ConfigDbEventChecker, "enabled", return_value=enabled, new_callable=PropertyMock), \
          patch.object(sys, "exit"):
         sel = swsscommon.Select()
         db_event_checker = VlanIntfTableEventChecker(sel, MagicMock())
@@ -348,14 +332,12 @@ def test_vlan_intf_table_checker(mock_swsscommon_dbconnector_init, tested_data, 
             assert expected_res == check_res
 
 
-@pytest.mark.parametrize("tested_db_snapshot", [{"enabled_dhcp_interfaces": "Vlan1000"}, {}])
+@pytest.mark.parametrize("tested_db_snapshot", [{"enabled_dhcp_interfaces": {"Vlan1000"}}, {}])
 @pytest.mark.parametrize("tested_data", get_subscribe_table_tested_data("test_vlan_member_update"))
-@pytest.mark.parametrize("enabled", [True, False])
-def test_vlan_member_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot, enabled):
+def test_vlan_member_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot):
     with patch.object(ConfigDbEventChecker, "enable"), \
          patch.object(ConfigDbEventChecker, "subscriber_state_table",
                       return_value=MockSubscribeTable(tested_data["table"]), new_callable=PropertyMock), \
-         patch.object(ConfigDbEventChecker, "enabled", return_value=enabled, new_callable=PropertyMock), \
          patch.object(sys, "exit"):
         sel = swsscommon.Select()
         db_event_checker = VlanMemberTableEventChecker(sel, MagicMock())
@@ -370,12 +352,10 @@ def test_vlan_member_table_checker(mock_swsscommon_dbconnector_init, tested_data
 @pytest.mark.parametrize("tested_db_snapshot", [{"dhcp_server_feature_enabled": True},
                                                 {"dhcp_server_feature_enabled": False}, {}])
 @pytest.mark.parametrize("tested_data", get_subscribe_table_tested_data("test_feature_update"))
-@pytest.mark.parametrize("enabled", [True, False])
-def test_feature_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot, enabled):
+def test_feature_table_checker(mock_swsscommon_dbconnector_init, tested_data, tested_db_snapshot):
     with patch.object(ConfigDbEventChecker, "enable"), \
          patch.object(ConfigDbEventChecker, "subscriber_state_table",
                       return_value=MockSubscribeTable(tested_data["table"]), new_callable=PropertyMock), \
-         patch.object(ConfigDbEventChecker, "enabled", return_value=enabled, new_callable=PropertyMock), \
          patch.object(sys, "exit"):
         sel = swsscommon.Select()
         db_event_checker = DhcpServerFeatureStateChecker(sel, MagicMock())

--- a/src/sonic-dhcp-utilities/tests/test_utils.py
+++ b/src/sonic-dhcp-utilities/tests/test_utils.py
@@ -142,5 +142,13 @@ def test_validate_ttr_type(test_data):
 
 
 def test_get_target_process_cmds():
-    with patch.object(psutil, "process_iter", return_value=[MockProc("dhcrelay", 1), MockProc("dhcpmon", 2)], new_callable=PropertyMock):
+    with patch.object(psutil, "process_iter", return_value=[MockProc("dhcrelay", 1), MockProc("dhcpmon", 2)],
+                      new_callable=PropertyMock):
         res = utils.get_target_process_cmds("dhcrelay")
+        expected_res = [
+            [
+                "/usr/sbin/dhcrelay", "-d", "-m", "discard", "-a", "%h:%p", "%P", "--name-alias-map-file",
+                "/tmp/port-name-alias-map.txt", "-id", "Vlan1000", "-iu", "docker0", "240.127.1.2"
+            ]
+        ]
+        assert res == expected_res


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix UT issues in test_utils and test_dhcp_db_monitor 

##### Work item tracking
- Microsoft ADO **(number only)**: 26297134

#### How I did it
- test_dhcp_db_monitor:
1. Remove useless parametrize `enabled`
2. Change params in `tested_db_snapshot` to dict

- test_utils
1. Complete UT `test_get_target_process_cmds`

#### How to verify it
UTs passed

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

