### PR TITLE
[ARISTA] Adding media_settings.json for Arista-7260CX3-Q64 and Arista-7060CX-32S-Q32 for supporting unreliable LOS

### DIFF
--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/media_settings.json
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/media_settings.json
@@ -1,0 +1,42 @@
+{
+    "GLOBAL_MEDIA_SETTINGS": {
+        "1-6": {
+            "^QSFP+\\.*40G.*LR4.*": {
+                   "interface_type": "sr4",
+                   "unreliable_los": "on"
+
+            },
+            "^QSFP\\+.*40G.*SR4": {
+                   "interface_type": "sr4",
+                   "unreliable_los": "on"
+
+            }
+
+        },
+        "11-22": {
+            "^QSFP+\\.*40G.*LR4.*": {
+                   "interface_type": "sr4",
+                   "unreliable_los": "on"
+
+            },
+            "^QSFP\\+.*40G.*SR4": {
+                   "interface_type": "sr4",
+                   "unreliable_los": "on"
+
+            }
+
+        },
+        "27-30": {
+            "^QSFP+\\.*40G.*LR4.*": {
+                   "interface_type": "sr4",
+                   "unreliable_los": "on"
+
+            },
+            "^QSFP\\+.*40G.*SR4": {
+                   "interface_type": "sr4",
+                   "unreliable_los": "on"
+
+            }
+        }
+    }
+}

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/media_settings.json
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/media_settings.json
@@ -5,7 +5,7 @@
                    "interface_type": "sr4",
                    "unreliable_los": "on"
 
-            },
+            }
 
         },
         "11-22": {

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
@@ -447,6 +447,8 @@ serdes_preemphasis_108=0x145c00
 serdes_driver_current_109=0x4
 serdes_preemphasis_109=0x145c00
 
+sai_interface_type_auto_detect=0
+
 mmu_init_config="MSFT-TH-Tier1"
 phy_an_lt_msft=1
 phy_unlos_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
@@ -451,4 +451,3 @@ sai_interface_type_auto_detect=0
 
 mmu_init_config="MSFT-TH-Tier1"
 phy_an_lt_msft=1
-phy_unlos_msft=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
@@ -1049,5 +1049,6 @@ serdes_preemphasis_117=0x105004
 
 {{ mmu_sock }}
 {{ IPinIP_sock }}
+
+sai_interface_type_auto_detect=0
 phy_an_lt_msft=1
-phy_unlos_msft=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/media_settings.json
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/media_settings.json
@@ -1,6 +1,6 @@
 {
     "GLOBAL_MEDIA_SETTINGS": {
-        "1-6": {
+        "1-12": {
             ".*": {
                    "interface_type": "sr4",
                    "unreliable_los": "on"
@@ -8,15 +8,7 @@
             },
 
         },
-        "11-22": {
-            ".*": {
-                   "interface_type": "sr4",
-                   "unreliable_los": "on"
-
-            }
-
-        },
-        "27-30": {
+        "21-64": {
             ".*": {
                    "interface_type": "sr4",
                    "unreliable_los": "on"

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/media_settings.json
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/media_settings.json
@@ -5,7 +5,7 @@
                    "interface_type": "sr4",
                    "unreliable_los": "on"
 
-            },
+            }
 
         },
         "21-64": {

--- a/src/sonic-device-data/tests/media_checker
+++ b/src/sonic-device-data/tests/media_checker
@@ -11,7 +11,7 @@ si_param_list = ["preemphasis", "idriver", "ipredriver", \
                  "main", "pre1", "pre2", "pre3", \
                  "post1", "post2", "post3", "attn", \
                  "ob_m2lp", "ob_alev_out", "obplev", "obnlev", \
-                 "regn_bfm1p", "regn_bfm1n"]
+                 "regn_bfm1p", "regn_bfm1n", "unreliable_los", "interface_type"]
 lane_speed_key_prefix = 'speed:'
 lane_prefix = "lane"
 comma_separator = ","

--- a/src/sonic-device-data/tests/media_checker
+++ b/src/sonic-device-data/tests/media_checker
@@ -71,9 +71,10 @@ def check_media_dict(vendor_dict):
                     return False
 
                 lane_dict = settings_dict[si_param]
-                for lanes in lane_dict:
-                    if not check_lane_and_value(lanes, lane_dict[lanes]):
-                        return False
+                if isinstance(lane_dict, dict):
+                    for lanes in lane_dict:
+                        if not check_lane_and_value(lanes, lane_dict[lanes]):
+                            return False
     return True
 
 def check_valid_port(port_name):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR adds a media_settings.json file to apply the parameters for arista x86_64-arista_7060_cx32s platform for 
QSFP+ interface of 40G speed and LR4, SR4 types. 
This change will go together with https://github.com/sonic-net/sonic-platform-daemons/pull/471 which has the support for parsing QSFP+ 40G speed regex style keys in media_settings.json and apply the change to interface parameters in APPL DB
This is indented as a part of long term fix repair item to correct RX_ERR on links facing x86_64-arista_7060_cx32s with 40G optical cables. 
##### Work item tracking
32609588
- Microsoft ADO **(number only)**:

#### How I did it
added the meda_settings.json file
#### How to verify it
tested by deploying the change and running it with xcvrd/SAI changes

The following test-scenarios was covered to see unreliable LOS is enabled and param phy_ctrl_unreliable_los is enabled in State DB:

cold reboot 100 times
config reload
xcvrd/pmon restart
cold-reboot/swss restart
apply manual settings in APP DB to ascertain change applies correctly
link shut/unshut 100 times, no effect, link comes up with the required settings.
warm-reboot works as intended, link does not go down as well as settings is maintained
Tested on these hwsku's

Arista-7260CX3-Q44
Arista-7060CX-32S-Q32
```
admin@sonic:~$ sudo redis-cli -n 0 hgetall "PORT_TABLE:Ethernet4"
 1) "admin_status"
 2) "up"
 3) "alias"
 4) "Ethernet2/1"
 5) "description"
 6) "Ethernet2/1"
 7) "index"
 8) "2"
 9) "lanes"
10) "65,66,67,68"
11) "mtu"
12) "9100"
13) "pfc_asym"
14) "off"
15) "speed"
16) "40000"
17) "oper_status"
18) "up"
19) "flap_count"
20) "3"
21) "last_up_time"
22) "Fri Apr 25 03:45:52 2025"
23) "interface_type"
24) "sr4"
25) "unreliable_los"
26) "on"
27) "last_down_time"
28) "Fri Apr 25 03:45:51 2025"
admin@sonic:~$ sudo redis-cli -n 6 hgetall "PORT_TABLE|Ethernet4"
 1) "state"
 2) "ok"
 3) "netdev_oper_status"
 4) "up"
 5) "admin_status"
 6) "up"
 7) "mtu"
 8) "9100"
 9) "supported_speeds"
10) "40000"
11) "supported_fecs"
12) "none,fc"
13) "host_tx_ready"
14) "true"
15) "speed"
16) "40000"
17) "fec"
18) "N/A"
19) "NPU_SI_SETTINGS_SYNC_STATUS"
20) "NPU_SI_SETTINGS_NOTIFIED"
21) "phy_ctrl_unreliable_los"
22) "true"

admin@sonic:~$ bcmcmd "phy diag xe17 dsc config" | grep -C 2 "LOS"
Brdfe_on                    = 0
Media Type                  = 2
Unreliable LOS              = 1
Scrambling Disable          = 0
CL93/72 Training Enable     = 0
--
Brdfe_on                    = 0
Media Type                  = 2
Unreliable LOS              = 1
Scrambling Disable          = 0
CL93/72 Training Enable     = 0
--
Brdfe_on                    = 0
Media Type                  = 2
Unreliable LOS              = 1
Scrambling Disable          = 0
CL93/72 Training Enable     = 0
--
Brdfe_on                    = 0
Media Type                  = 2
Unreliable LOS              = 1
Scrambling Disable          = 0
CL93/72 Training Enable     = 0
admin@str-7260cx3-acs-1:~$
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

