### PR TITLE
[dhcp_server] add config dhcp_server disable

### DIFF
--- a/dockers/docker-dhcp-server/cli-plugin-tests/test_config_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/test_config_dhcp_server.py
@@ -143,3 +143,18 @@ class TestConfigDHCPServer(object):
         result = runner.invoke(dhcp_server.dhcp_server.commands["ipv4"].commands["enable"], ["Vlan200"], obj=db)
         assert result.exit_code == 2, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
 
+    def test_config_dhcp_server_ipv4_disable_already_exist(self, mock_db):
+        runner = CliRunner()
+        db = clicommon.Db()
+        db.db = mock_db
+        result = runner.invoke(dhcp_server.dhcp_server.commands["ipv4"].commands["disable"], ["Vlan100"], obj=db)
+        assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+        assert mock_db.get("CONFIG_DB", "DHCP_SERVER_IPV4|Vlan300", "state") == "disabled"
+
+    def test_config_dhcp_server_ipv4_disable_does_not_exist(self, mock_db):
+        runner = CliRunner()
+        db = clicommon.Db()
+        db.db = mock_db
+        result = runner.invoke(dhcp_server.dhcp_server.commands["ipv4"].commands["disable"], ["Vlan200"], obj=db)
+        assert result.exit_code == 2, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+

--- a/dockers/docker-dhcp-server/cli/config/plugins/dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli/config/plugins/dhcp_server.py
@@ -91,7 +91,7 @@ def dhcp_server_ipv4_add(db, mode, lease_time, dup_gw_nm, gateway, netmask, dhcp
         ctx.fail("gateway and netmask must be valid ipv4 string")
     key = "DHCP_SERVER_IPV4|" + dhcp_interface
     if dbconn.exists("CONFIG_DB", key):
-        ctx.fail("Dhcp_interface %s already exist".format(dhcp_interface))
+        ctx.fail("Dhcp_interface {} already exist".format(dhcp_interface))
     else:
         dbconn.hmset("CONFIG_DB", key, {
             "mode": mode,
@@ -110,10 +110,10 @@ def dhcp_server_ipv4_del(db, dhcp_interface):
     dbconn = db.db
     key = "DHCP_SERVER_IPV4|" + dhcp_interface
     if dbconn.exists("CONFIG_DB", key):
-        click.echo("Dhcp interface %s exists in config db, proceed to delete".format(dhcp_interface))
+        click.echo("Dhcp interface {} exists in config db, proceed to delete".format(dhcp_interface))
         dbconn.delete("CONFIG_DB", key)
     else:
-        ctx.fail("Dhcp interface %s does not exist in config db".format(dhcp_interface))
+        ctx.fail("Dhcp interface {} does not exist in config db".format(dhcp_interface))
 
 
 @dhcp_server_ipv4.command(name="enable")
@@ -126,7 +126,20 @@ def dhcp_server_ipv4_enable(db, dhcp_interface):
     if dbconn.exists("CONFIG_DB", key):
         dbconn.set("CONFIG_DB", key, "state", "enabled")
     else:
-        ctx.fail("Failed to enable, dhcp interface %s does not exist".format(dhcp_interface))
+        ctx.fail("Failed to enable, dhcp interface {} does not exist".format(dhcp_interface))
+
+
+@dhcp_server_ipv4.command(name="disable")
+@click.argument("dhcp_interface", required=True)
+@clicommon.pass_db
+def dhcp_server_ipv4_disable(db, dhcp_interface):
+    ctx = click.get_current_context()
+    dbconn = db.db
+    key = "DHCP_SERVER_IPV4|" + dhcp_interface
+    if dbconn.exists("CONFIG_DB", key):
+        dbconn.set("CONFIG_DB", key, "state", "disabled")
+    else:
+        ctx.fail("Failed to disable, dhcp interface {} does not exist".format(dhcp_interface))
 
 
 def register(cli):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add config dhcp_server disable

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add dhcp_server disable to config plugin.

#### How to verify it
Run unittest and run manually on latest image.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
Lastest master

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add config dhcp_server disable

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

