### PR TITLE
[202311] [Mellanox] update asic and module temperature in a thread for CMIS management (#16955)

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -82,6 +82,8 @@ class Chassis(ChassisBase):
     # System UID LED
     _led_uid = None
 
+    chassis_instance = None
+
     def __init__(self):
         super(Chassis, self).__init__()
 
@@ -126,6 +128,8 @@ class Chassis(ChassisBase):
         # Build the RJ45 port list from platform.json and hwsku.json
         self._RJ45_port_inited = False
         self._RJ45_port_list = None
+
+        Chassis.chassis_instance = self
 
         self.modules_mgmt_thread = threading.Thread()
         self.modules_changes_queue = queue.Queue()

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_manager.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_manager.py
@@ -15,9 +15,36 @@
 # limitations under the License.
 #
 from sonic_platform_base.sonic_thermal_control.thermal_manager_base import ThermalManagerBase
+from . import thermal_updater
+from .device_data import DeviceDataManager
 
 
 class ThermalManager(ThermalManagerBase):
+    thermal_updater_task = None
+
     @classmethod
     def run_policy(cls, chassis):
         pass
+
+    @classmethod
+    def initialize(cls):
+        """
+        Initialize thermal manager, including register thermal condition types and thermal action types
+        and any other vendor specific initialization.
+        :return:
+        """
+        if DeviceDataManager.is_independent_mode():
+            from .chassis import Chassis
+            cls.thermal_updater_task = thermal_updater.ThermalUpdater(Chassis.chassis_instance.get_all_sfps())
+            cls.thermal_updater_task.start()
+
+
+    @classmethod
+    def deinitialize(cls):
+        """
+        Destroy thermal manager, including any vendor specific cleanup. The default behavior of this function
+        is a no-op.
+        :return:
+        """
+        if DeviceDataManager.is_independent_mode():
+            cls.thermal_updater_task.stop()

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
@@ -1,0 +1,213 @@
+#
+# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from . import utils
+from sonic_py_common import logger
+
+import sys
+import time
+
+sys.path.append('/run/hw-management/bin')
+
+try:
+    import hw_management_independent_mode_update
+except ImportError:
+    # For unit test only
+    from unittest import mock
+    hw_management_independent_mode_update = mock.MagicMock()
+    hw_management_independent_mode_update.module_data_set_module_counter = mock.MagicMock()
+    hw_management_independent_mode_update.thermal_data_set_asic = mock.MagicMock()
+    hw_management_independent_mode_update.thermal_data_set_module = mock.MagicMock()
+    hw_management_independent_mode_update.thermal_data_clean_asic = mock.MagicMock()
+    hw_management_independent_mode_update.thermal_data_clean_module = mock.MagicMock()
+
+
+SFP_TEMPERATURE_SCALE = 1000
+ASIC_TEMPERATURE_SCALE = 125
+ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD = 105000
+ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD = 120000
+
+ERROR_READ_THERMAL_DATA = 254000
+
+TC_CONFIG_FILE = '/run/hw-management/config/tc_config.json'
+logger = logger.Logger('thermal-updater')
+
+
+class ThermalUpdater:
+    def __init__(self, sfp_list):
+        self._sfp_list = sfp_list
+        self._sfp_status = {}
+        self._timer = utils.Timer()
+
+    def load_tc_config(self):
+        asic_poll_interval = 1
+        sfp_poll_interval = 10
+        data = utils.load_json_file(TC_CONFIG_FILE)
+        if not data:
+            logger.log_notice(f'{TC_CONFIG_FILE} does not exist, use default polling interval')
+
+        if data:
+            dev_parameters = data.get('dev_parameters')
+            if dev_parameters is not None:
+                asic_parameter = dev_parameters.get('asic')
+                if asic_parameter is not None:
+                    asic_poll_interval_config = asic_parameter.get('poll_time')
+                    if asic_poll_interval_config:
+                        asic_poll_interval = int(asic_poll_interval_config) / 2
+                module_parameter = dev_parameters.get('module\\d+')
+                if module_parameter is not None:
+                    sfp_poll_interval_config = module_parameter.get('poll_time')
+                    if sfp_poll_interval_config:
+                        sfp_poll_interval = int(sfp_poll_interval_config) / 2
+
+        logger.log_notice(f'ASIC polling interval: {asic_poll_interval}')
+        self._timer.schedule(asic_poll_interval, self.update_asic)
+        logger.log_notice(f'Module polling interval: {sfp_poll_interval}')
+        self._timer.schedule(sfp_poll_interval, self.update_module)
+
+    def start(self):
+        self.clean_thermal_data()
+        if not self.wait_all_sfp_ready():
+            logger.log_error('Failed to wait for all SFP ready, will put hw-management-tc to suspend')
+            self.control_tc(True)
+            return
+        self.control_tc(False)
+        self.load_tc_config()
+        self._timer.start()
+
+    def stop(self):
+        self._timer.stop()
+        self.control_tc(True)
+
+    def control_tc(self, suspend):
+        logger.log_notice(f'Set hw-management-tc to {"suspend" if suspend else "resume"}')
+        utils.write_file('/run/hw-management/config/suspend', 1 if suspend else 0)
+
+    def clean_thermal_data(self):
+        hw_management_independent_mode_update.module_data_set_module_counter(len(self._sfp_list))
+        hw_management_independent_mode_update.thermal_data_clean_asic(0)
+        for sfp in self._sfp_list:
+            hw_management_independent_mode_update.thermal_data_clean_module(
+                0,
+                sfp.sdk_index + 1
+            )
+
+    def wait_all_sfp_ready(self):
+        logger.log_notice('Waiting for all SFP modules ready...')
+        max_wait_time = 60
+        ready_set = set()
+        while len(ready_set) != len(self._sfp_list):
+            for sfp in self._sfp_list:
+                try:
+                    sfp.is_sw_control()
+                    ready_set.add(sfp)
+                except:
+                    continue
+            max_wait_time -= 1
+            if max_wait_time == 0:
+                return False
+            time.sleep(1)
+
+        logger.log_notice('All SFP modules are ready')
+        return True
+
+    def get_asic_temp(self):
+        temperature = utils.read_int_from_file('/sys/module/sx_core/asic0/temperature/input', default=None)
+        return temperature * ASIC_TEMPERATURE_SCALE if temperature is not None else None
+
+    def get_asic_temp_warning_threashold(self):
+        emergency = utils.read_int_from_file('/sys/module/sx_core/asic0/temperature/emergency', default=None, log_func=None)
+        return emergency * ASIC_TEMPERATURE_SCALE if emergency is not None else ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD
+
+    def get_asic_temp_critical_threashold(self):
+        critical = utils.read_int_from_file('/sys/module/sx_core/asic0/temperature/critical', default=None, log_func=None)
+        return critical * ASIC_TEMPERATURE_SCALE if  critical is not None else ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD
+
+    def update_single_module(self, sfp):
+        try:
+            presence = sfp.get_presence()
+            pre_presence = self._sfp_status.get(sfp.sdk_index)
+            if presence:
+                temperature = sfp.get_temperature()
+                if temperature == 0:
+                    warning_thresh = 0
+                    critical_thresh = 0
+                    fault = 0
+                else:
+                    warning_thresh = sfp.get_temperature_warning_threashold()
+                    critical_thresh = sfp.get_temperature_critical_threashold()
+                    fault = ERROR_READ_THERMAL_DATA if (temperature is None or warning_thresh is None or critical_thresh is None) else 0
+                    temperature = 0 if temperature is None else int(temperature * SFP_TEMPERATURE_SCALE)
+                    warning_thresh = 0 if warning_thresh is None else int(warning_thresh * SFP_TEMPERATURE_SCALE)
+                    critical_thresh = 0 if critical_thresh is None else int(critical_thresh * SFP_TEMPERATURE_SCALE)
+
+                hw_management_independent_mode_update.thermal_data_set_module(
+                    0, # ASIC index always 0 for now
+                    sfp.sdk_index + 1,
+                    temperature,
+                    critical_thresh,
+                    warning_thresh,
+                    fault
+                )
+            else:
+                if pre_presence != presence:
+                    hw_management_independent_mode_update.thermal_data_clean_module(0, sfp.sdk_index + 1)
+
+            if pre_presence != presence:
+                self._sfp_status[sfp.sdk_index] = presence
+        except Exception as e:
+            logger.log_error('Failed to update module {sfp.sdk_index} thermal data - {e}')
+            hw_management_independent_mode_update.thermal_data_set_module(
+                0, # ASIC index always 0 for now
+                sfp.sdk_index + 1,
+                0,
+                0,
+                0,
+                ERROR_READ_THERMAL_DATA
+            )
+
+    def update_module(self):
+        for sfp in self._sfp_list:
+            self.update_single_module(sfp)
+
+    def update_asic(self):
+        try:
+            asic_temp = self.get_asic_temp()
+            warn_threshold = self.get_asic_temp_warning_threashold()
+            critical_threshold = self.get_asic_temp_critical_threashold()
+            fault = 0
+            if asic_temp is None:
+                logger.log_error('Failed to read ASIC temperature, send fault to hw-management-tc')
+                asic_temp = warn_threshold
+                fault = ERROR_READ_THERMAL_DATA
+
+            hw_management_independent_mode_update.thermal_data_set_asic(
+                0, # ASIC index always 0 for now
+                asic_temp,
+                critical_threshold,
+                warn_threshold,
+                fault
+            )
+        except Exception as e:
+            logger.log_error('Failed to update ASIC thermal data - {e}')
+            hw_management_independent_mode_update.thermal_data_set_asic(
+                0, # ASIC index always 0 for now
+                0,
+                0,
+                0,
+                ERROR_READ_THERMAL_DATA
+            )

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -292,6 +292,46 @@ class TestSfp:
         assert sfp.get_transceiver_threshold_info()
         sfp.reinit()
 
+    @mock.patch('os.path.exists')
+    @mock.patch('sonic_platform.utils.read_int_from_file')
+    def test_get_temperature(self, mock_read, mock_exists):
+        sfp = SFP(0)
+        sfp.is_sw_control = mock.MagicMock(return_value=True)
+        mock_exists.return_value = False
+        assert sfp.get_temperature() == None
+
+        mock_exists.return_value = True
+        assert sfp.get_temperature() == None
+
+        mock_read.return_value = None
+        sfp.is_sw_control.return_value = False
+        assert sfp.get_temperature() == None
+
+        mock_read.return_value = 448
+        assert sfp.get_temperature() == 56.0
+
+    def test_get_temperature_threshold(self):
+        sfp = SFP(0)
+        sfp.is_sw_control = mock.MagicMock(return_value=True)
+        assert sfp.get_temperature_warning_threashold() == 70.0
+        assert sfp.get_temperature_critical_threashold() == 80.0
+
+        mock_api = mock.MagicMock()
+        mock_api.get_transceiver_thresholds_support = mock.MagicMock(return_value=False)
+        sfp.get_xcvr_api = mock.MagicMock(return_value=mock_api)
+        assert sfp.get_temperature_warning_threashold() == 70.0
+        assert sfp.get_temperature_critical_threashold() == 80.0
+
+        from sonic_platform_base.sonic_xcvr.fields import consts
+        mock_api.get_transceiver_thresholds_support.return_value = True
+        mock_api.xcvr_eeprom = mock.MagicMock()
+        mock_api.xcvr_eeprom.read = mock.MagicMock(return_value={
+            consts.TEMP_HIGH_ALARM_FIELD: 85.0,
+            consts.TEMP_HIGH_WARNING_FIELD: 75.0
+        })
+        assert sfp.get_temperature_warning_threashold() == 75.0
+        assert sfp.get_temperature_critical_threashold() == 85.0
+
     @mock.patch('sonic_platform.utils.read_int_from_file')
     @mock.patch('sonic_platform.device_data.DeviceDataManager.is_independent_mode')
     @mock.patch('sonic_platform.utils.DbUtils.get_db_instance')

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
@@ -1,0 +1,128 @@
+#
+# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import time
+from unittest import mock
+
+from sonic_platform import utils
+from sonic_platform.thermal_updater import ThermalUpdater, hw_management_independent_mode_update
+from sonic_platform.thermal_updater import ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD, \
+                                           ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD
+
+
+mock_tc_config = """
+{
+    "dev_parameters": {
+        "asic": {
+            "pwm_min": 20,
+            "pwm_max": 100,
+            "val_min": "!70000",
+            "val_max": "!105000",
+            "poll_time": 3
+        },
+        "module\\\\d+": {
+            "pwm_min": 20,
+            "pwm_max": 100,
+            "val_min": 60000,
+            "val_max": 80000,
+            "poll_time": 20
+        }
+    }
+}
+"""
+
+
+class TestThermalUpdater:
+    def test_load_tc_config_non_exists(self):
+        updater = ThermalUpdater(None)
+        updater.load_tc_config()
+        assert updater._timer._timestamp_queue.qsize() == 2
+
+    def test_load_tc_config_mocked(self):
+        updater = ThermalUpdater(None)
+        mock_os_open = mock.mock_open(read_data=mock_tc_config)
+        with mock.patch('sonic_platform.utils.open', mock_os_open):
+            updater.load_tc_config()
+        assert updater._timer._timestamp_queue.qsize() == 2
+
+    @mock.patch('sonic_platform.thermal_updater.ThermalUpdater.update_asic', mock.MagicMock())
+    @mock.patch('sonic_platform.thermal_updater.ThermalUpdater.update_module', mock.MagicMock())
+    @mock.patch('sonic_platform.thermal_updater.ThermalUpdater.wait_all_sfp_ready')
+    @mock.patch('sonic_platform.utils.write_file')
+    def test_start_stop(self, mock_write, mock_wait):
+        mock_wait.return_value = True
+        mock_sfp = mock.MagicMock()
+        mock_sfp.sdk_index = 1
+        updater = ThermalUpdater([mock_sfp])
+        updater.start()
+        mock_write.assert_called_once_with('/run/hw-management/config/suspend', 0)
+        utils.wait_until(updater._timer.is_alive, timeout=5)
+
+        mock_write.reset_mock()
+        updater.stop()
+        assert not updater._timer.is_alive()
+        mock_write.assert_called_once_with('/run/hw-management/config/suspend', 1)
+
+        mock_wait.return_value = False
+        mock_write.reset_mock()
+        updater.start()
+        mock_write.assert_called_once_with('/run/hw-management/config/suspend', 1)
+        updater.stop()
+
+    @mock.patch('sonic_platform.thermal_updater.time.sleep', mock.MagicMock())
+    def test_wait_all_sfp_ready(self):
+        mock_sfp = mock.MagicMock()
+        mock_sfp.is_sw_control = mock.MagicMock(return_value=True)
+        updater = ThermalUpdater([mock_sfp])
+        assert updater.wait_all_sfp_ready()
+        mock_sfp.is_sw_control.side_effect = Exception('')
+        assert not updater.wait_all_sfp_ready()
+
+    @mock.patch('sonic_platform.utils.read_int_from_file')
+    def test_update_asic(self, mock_read):
+        mock_read.return_value = 8
+        updater = ThermalUpdater(None)
+        assert updater.get_asic_temp() == 1000
+        assert updater.get_asic_temp_warning_threashold() == 1000
+        assert updater.get_asic_temp_critical_threashold() == 1000
+        updater.update_asic()
+        hw_management_independent_mode_update.thermal_data_set_asic.assert_called_once()
+
+        mock_read.return_value = None
+        assert updater.get_asic_temp() is None
+        assert updater.get_asic_temp_warning_threashold() == ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD
+        assert updater.get_asic_temp_critical_threashold() == ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD
+
+    def test_update_module(self):
+        mock_sfp = mock.MagicMock()
+        mock_sfp.sdk_index = 10
+        mock_sfp.get_presence = mock.MagicMock(return_value=True)
+        mock_sfp.get_temperature = mock.MagicMock(return_value=55.0)
+        mock_sfp.get_temperature_warning_threashold = mock.MagicMock(return_value=70.0)
+        mock_sfp.get_temperature_critical_threashold = mock.MagicMock(return_value=80.0)
+        updater = ThermalUpdater([mock_sfp])
+        updater.update_module()
+        hw_management_independent_mode_update.thermal_data_set_module.assert_called_once_with(0, 11, 55000, 80000, 70000, 0)
+
+        mock_sfp.get_temperature = mock.MagicMock(return_value=0.0)
+        hw_management_independent_mode_update.reset_mock()
+        updater.update_module()
+        hw_management_independent_mode_update.thermal_data_set_module.assert_called_once_with(0, 11, 0, 0, 0, 0)
+
+        mock_sfp.get_presence = mock.MagicMock(return_value=False)
+        updater.update_module()
+        hw_management_independent_mode_update.thermal_data_clean_module.assert_called_once_with(0, 11)

--- a/platform/mellanox/mlnx-platform-api/tests/test_utils.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_utils.py
@@ -191,6 +191,26 @@ class TestUtils:
         mock_os_open = mock.mock_open(read_data='a:b')
         with mock.patch('sonic_platform.utils.open', mock_os_open):
             assert utils.read_key_value_file('some_file') == {'a':'b'}
+
         mock_os_open = mock.mock_open(read_data='a=b')
         with mock.patch('sonic_platform.utils.open', mock_os_open):
             assert utils.read_key_value_file('some_file', delimeter='=') == {'a':'b'}
+
+    def test_timer(self):
+        timer = utils.Timer()
+        timer.start()
+        mock_cb_1000_run_now = mock.MagicMock()
+        mock_cb_1000_run_future = mock.MagicMock()
+        mock_cb_1_run_future_once = mock.MagicMock()
+        mock_cb_1_run_future_repeat = mock.MagicMock()
+        timer.schedule(1000, cb=mock_cb_1000_run_now, repeat=False, run_now=True)
+        timer.schedule(1000, cb=mock_cb_1000_run_future, repeat=False, run_now=False)
+        timer.schedule(1, cb=mock_cb_1_run_future_once, repeat=False, run_now=False)
+        timer.schedule(1, cb=mock_cb_1_run_future_repeat, repeat=True, run_now=False)
+        time.sleep(3)
+        timer.stop()
+
+        mock_cb_1000_run_now.assert_called_once()
+        mock_cb_1000_run_future.assert_not_called()
+        mock_cb_1_run_future_once.assert_called_once()
+        assert mock_cb_1_run_future_repeat.call_count > 1


### PR DESCRIPTION
Backport PR: https://github.com/sonic-net/sonic-buildimage/pull/16955

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When module is totally under software control, driver cannot get module temperature/temperature threshold from firmware. In this case, sonic needs to get temperature/temperature threshold from EEPROM. In this PR, a thread thermal updater is created to update module temperature/temperature threshold while software control is enabled.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Query ASIC temperature from SDK sysfs and update hw-management-tc periodically
Query Module temperature from EEPROM and update hw-management-tc periodically

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Manual test
New unit tests

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [X] 202311 

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

