### PR TITLE
Add the hostname field，When device/default_sku is set to l2

### DIFF
--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -36,6 +36,7 @@ def generate_l1_config(data):
 def generate_l3_config(data):
     data['LOOPBACK_INTERFACE'] = {"Loopback0": {},
                                   "Loopback0|10.1.0.1/32": {}}
+    data['DEVICE_METADATA']['localhost']['hostname'] = 'sonic'
     data['BGP_NEIGHBOR'] = {}
     data['DEVICE_NEIGHBOR'] = {}
     data['INTERFACE'] = {}
@@ -144,6 +145,7 @@ def generate_global_dualtor_tables():
     return data
 
 def generate_l2_config(data):
+    data['DEVICE_METADATA']['localhost']['hostname'] = 'sonic'
     # Check if dual ToR configs are needed
     if 'is_dualtor' in data and data['is_dualtor']:
         is_dualtor = True

--- a/src/sonic-config-engine/data/l2switch.j2
+++ b/src/sonic-config-engine/data/l2switch.j2
@@ -1,5 +1,10 @@
 {
-    "DEVICE_METADATA": {{ DEVICE_METADATA | tojson }},
+    "DEVICE_METADATA": {
+        "localhost" : {
+            "hostname": "sonic",
+            "hwsku" : "{{ DEVICE_METADATA.localhost.hwsku }}"
+        }
+    },
     "FLEX_COUNTER_TABLE": {
         "ACL": {
             "FLEX_COUNTER_STATUS": "disable",

--- a/src/sonic-config-engine/data/l3intf.j2
+++ b/src/sonic-config-engine/data/l3intf.j2
@@ -1,6 +1,7 @@
 {
     "DEVICE_METADATA": {
         "localhost" : {
+            "hostname": "sonic",
             "hwsku" : "{{ DEVICE_METADATA.localhost.hwsku }}"
         }
     },

--- a/src/sonic-config-engine/tests/sample_output/py2/l2switch.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/l2switch.json
@@ -1,5 +1,10 @@
 {
-    "DEVICE_METADATA": {"localhost": {"hwsku": "Mellanox-SN2700"}},
+    "DEVICE_METADATA": {
+	"localhost": {
+	    "hostname": "sonic",
+	    "hwsku": "Mellanox-SN2700"
+	}
+    },
     "PORT": {
         "Ethernet8": {
             "alias": "fortyGigE0/8",

--- a/src/sonic-config-engine/tests/sample_output/py2/l2switch_dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/l2switch_dualtor.json
@@ -1,6 +1,7 @@
 {
     "DEVICE_METADATA": {
         "localhost": {
+	    "hostname": "sonic",
             "hwsku": "Arista-7050CX3-32S-D48C8",
             "subtype": "DualToR",
             "peer_switch": "peer_switch_hostname"

--- a/src/sonic-config-engine/tests/sample_output/py2/l3_intfs.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/l3_intfs.json
@@ -1,5 +1,10 @@
 {
-    "DEVICE_METADATA": {"localhost": {"hwsku": "32x1000Gb"}},
+    "DEVICE_METADATA": {
+	"localhost": {
+	    "hostname": "sonic",
+	    "hwsku": "32x1000Gb"
+	}
+    },
     "PORT": {
         "Ethernet0": {
             "admin_status": "up",

--- a/src/sonic-config-engine/tests/sample_output/py3/l2switch.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/l2switch.json
@@ -1,5 +1,10 @@
 {
-    "DEVICE_METADATA": {"localhost": {"hwsku": "Mellanox-SN2700"}},
+    "DEVICE_METADATA": {
+	"localhost": {
+	    "hostname": "sonic",
+            "hwsku": "Mellanox-SN2700"
+	}
+    },
     "PORT": {
         "Ethernet0": {
             "alias": "fortyGigE0/0",

--- a/src/sonic-config-engine/tests/sample_output/py3/l2switch_dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/l2switch_dualtor.json
@@ -1,6 +1,7 @@
 {
     "DEVICE_METADATA": {
         "localhost": {
+	    "hostname": "sonic",
             "hwsku": "Arista-7050CX3-32S-D48C8",
             "subtype": "DualToR",
             "peer_switch": "peer_switch_hostname"

--- a/src/sonic-config-engine/tests/sample_output/py3/l3_intfs.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/l3_intfs.json
@@ -1,5 +1,10 @@
 {
-    "DEVICE_METADATA": {"localhost": {"hwsku": "32x1000Gb"}},
+    "DEVICE_METADATA": {
+	"localhost": {
+	    "hostname": "sonic",
+	    "hwsku": "32x1000Gb"
+	}
+    },
     "PORT": {
         "Ethernet0": {
             "admin_status": "up",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
According to the issue description（https://github.com/sonic-net/sonic-buildimage/issues/17700）, we also add the hostname field to the DEVICE_METADATA|localhost key in the configDB when configuring the l2 l3 mode.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

