### PR TITLE
[dhcp_server] improve show dhcp server output

### DIFF
--- a/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
@@ -16,11 +16,15 @@ class TestShowDHCPServer(object):
 
     def test_show_dhcp_server_ipv4_lease_without_dhcpintf(self, mock_db):
         expected_stdout = """\
-Interface            MAC Address        IP           Lease Start          Lease End
--------------------  -----------------  -----------  -------------------  -------------------
-Vlan1000|Ethernet10  10:70:fd:b6:13:00  192.168.0.1  2023-03-01 03:16:21  2023-03-01 03:31:21
-Vlan1000|Ethernet11  10:70:fd:b6:13:01  192.168.0.2  2023-03-01 03:16:21  2023-03-01 03:31:21
-Vlan1001|<Unknown>   10:70:fd:b6:13:02  192.168.0.3  2023-03-01 03:16:21  2023-03-01 03:31:21
++---------------------+-------------------+-------------+---------------------+---------------------+
+| Interface           | MAC Address       | IP          | Lease Start         | Lease End           |
++=====================+===================+=============+=====================+=====================+
+| Vlan1000|Ethernet10 | 10:70:fd:b6:13:00 | 192.168.0.1 | 2023-03-01 03:16:21 | 2023-03-01 03:31:21 |
++---------------------+-------------------+-------------+---------------------+---------------------+
+| Vlan1000|Ethernet11 | 10:70:fd:b6:13:01 | 192.168.0.2 | 2023-03-01 03:16:21 | 2023-03-01 03:31:21 |
++---------------------+-------------------+-------------+---------------------+---------------------+
+| Vlan1001|<Unknown>  | 10:70:fd:b6:13:02 | 192.168.0.3 | 2023-03-01 03:16:21 | 2023-03-01 03:31:21 |
++---------------------+-------------------+-------------+---------------------+---------------------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -31,10 +35,13 @@ Vlan1001|<Unknown>   10:70:fd:b6:13:02  192.168.0.3  2023-03-01 03:16:21  2023-0
 
     def test_show_dhcp_server_ipv4_lease_with_dhcpintf(self, mock_db):
         expected_stdout = """\
-Interface            MAC Address        IP           Lease Start          Lease End
--------------------  -----------------  -----------  -------------------  -------------------
-Vlan1000|Ethernet10  10:70:fd:b6:13:00  192.168.0.1  2023-03-01 03:16:21  2023-03-01 03:31:21
-Vlan1000|Ethernet11  10:70:fd:b6:13:01  192.168.0.2  2023-03-01 03:16:21  2023-03-01 03:31:21
++---------------------+-------------------+-------------+---------------------+---------------------+
+| Interface           | MAC Address       | IP          | Lease Start         | Lease End           |
++=====================+===================+=============+=====================+=====================+
+| Vlan1000|Ethernet10 | 10:70:fd:b6:13:00 | 192.168.0.1 | 2023-03-01 03:16:21 | 2023-03-01 03:31:21 |
++---------------------+-------------------+-------------+---------------------+---------------------+
+| Vlan1000|Ethernet11 | 10:70:fd:b6:13:01 | 192.168.0.2 | 2023-03-01 03:16:21 | 2023-03-01 03:31:21 |
++---------------------+-------------------+-------------+---------------------+---------------------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -45,9 +52,11 @@ Vlan1000|Ethernet11  10:70:fd:b6:13:01  192.168.0.2  2023-03-01 03:16:21  2023-0
 
     def test_show_dhcp_server_ipv4_lease_client_not_in_fdb(self, mock_db):
         expected_stdout = """\
-Interface           MAC Address        IP           Lease Start          Lease End
-------------------  -----------------  -----------  -------------------  -------------------
-Vlan1001|<Unknown>  10:70:fd:b6:13:02  192.168.0.3  2023-03-01 03:16:21  2023-03-01 03:31:21
++--------------------+-------------------+-------------+---------------------+---------------------+
+| Interface          | MAC Address       | IP          | Lease Start         | Lease End           |
++====================+===================+=============+=====================+=====================+
+| Vlan1001|<Unknown> | 10:70:fd:b6:13:02 | 192.168.0.3 | 2023-03-01 03:16:21 | 2023-03-01 03:31:21 |
++--------------------+-------------------+-------------+---------------------+---------------------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -58,11 +67,15 @@ Vlan1001|<Unknown>  10:70:fd:b6:13:02  192.168.0.3  2023-03-01 03:16:21  2023-03
 
     def test_show_dhcp_server_ipv4_range_without_name(self, mock_db):
         expected_stdout = """\
-Range    IP Start    IP End      IP Count
--------  ----------  ----------  ----------------------
-range1   100.1.1.3   100.1.1.5   3
-range2   100.1.1.9   100.1.1.8   range value is illegal
-range3   100.1.1.10  100.1.1.10  1
++---------+------------+------------+------------------------+
+| Range   | IP Start   | IP End     | IP Count               |
++=========+============+============+========================+
+| range1  | 100.1.1.3  | 100.1.1.5  | 3                      |
++---------+------------+------------+------------------------+
+| range2  | 100.1.1.9  | 100.1.1.8  | range value is illegal |
++---------+------------+------------+------------------------+
+| range3  | 100.1.1.10 | 100.1.1.10 | 1                      |
++---------+------------+------------+------------------------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -73,9 +86,11 @@ range3   100.1.1.10  100.1.1.10  1
 
     def test_show_dhcp_server_ipv4_range_with_name(self, mock_db):
         expected_stdout = """\
-Range    IP Start    IP End       IP Count
--------  ----------  ---------  ----------
-range1   100.1.1.3   100.1.1.5           3
++---------+------------+-----------+------------+
+| Range   | IP Start   | IP End    |   IP Count |
++=========+============+===========+============+
+| range1  | 100.1.1.3  | 100.1.1.5 |          3 |
++---------+------------+-----------+------------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -86,9 +101,11 @@ range1   100.1.1.3   100.1.1.5           3
 
     def test_show_dhcp_server_ipv4_range_wrong_data(self, mock_db):
         expected_stdout = """\
-Range    IP Start    IP End     IP Count
--------  ----------  ---------  ----------------------
-range2   100.1.1.9   100.1.1.8  range value is illegal
++---------+------------+-----------+------------------------+
+| Range   | IP Start   | IP End    | IP Count               |
++=========+============+===========+========================+
+| range2  | 100.1.1.9  | 100.1.1.8 | range value is illegal |
++---------+------------+-----------+------------------------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -99,9 +116,11 @@ range2   100.1.1.9   100.1.1.8  range value is illegal
 
     def test_show_dhcp_server_ipv4_range_single_ip(self, mock_db):
         expected_stdout = """\
-Range    IP Start    IP End        IP Count
--------  ----------  ----------  ----------
-range3   100.1.1.10  100.1.1.10           1
++---------+------------+------------+------------+
+| Range   | IP Start   | IP End     |   IP Count |
++=========+============+============+============+
+| range3  | 100.1.1.10 | 100.1.1.10 |          1 |
++---------+------------+------------+------------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -112,10 +131,13 @@ range3   100.1.1.10  100.1.1.10           1
 
     def test_show_dhcp_server_ipv4_info_without_intf(self, mock_db):
         expected_stdout = """\
-Interface    Mode    Gateway    Netmask          Lease Time(s)  State
------------  ------  ---------  -------------  ---------------  --------
-Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled
-Vlan300      PORT    100.1.1.1  255.255.255.0             3600  disabled
++-------------+--------+-----------+---------------+-----------------+----------+
+| Interface   | Mode   | Gateway   | Netmask       |   Lease Time(s) | State    |
++=============+========+===========+===============+=================+==========+
+| Vlan100     | PORT   | 100.1.1.1 | 255.255.255.0 |            3600 | enabled  |
++-------------+--------+-----------+---------------+-----------------+----------+
+| Vlan300     | PORT   | 100.1.1.1 | 255.255.255.0 |            3600 | disabled |
++-------------+--------+-----------+---------------+-----------------+----------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -126,9 +148,11 @@ Vlan300      PORT    100.1.1.1  255.255.255.0             3600  disabled
 
     def test_show_dhcp_server_ipv4_info_with_intf(self, mock_db):
         expected_stdout = """\
-Interface    Mode    Gateway    Netmask          Lease Time(s)  State
------------  ------  ---------  -------------  ---------------  -------
-Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled
++-------------+--------+-----------+---------------+-----------------+---------+
+| Interface   | Mode   | Gateway   | Netmask       |   Lease Time(s) | State   |
++=============+========+===========+===============+=================+=========+
+| Vlan100     | PORT   | 100.1.1.1 | 255.255.255.0 |            3600 | enabled |
++-------------+--------+-----------+---------------+-----------------+---------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -139,9 +163,11 @@ Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled
 
     def test_show_dhcp_server_ipv4_info_with_customized_options(self, mock_db):
         expected_stdout = """\
-Interface    Mode    Gateway    Netmask          Lease Time(s)  State    Customized Options
------------  ------  ---------  -------------  ---------------  -------  --------------------
-Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled  option60
++-------------+--------+-----------+---------------+-----------------+---------+----------------------+
+| Interface   | Mode   | Gateway   | Netmask       |   Lease Time(s) | State   | Customized Options   |
++=============+========+===========+===============+=================+=========+======================+
+| Vlan100     | PORT   | 100.1.1.1 | 255.255.255.0 |            3600 | enabled | option60             |
++-------------+--------+-----------+---------------+-----------------+---------+----------------------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -152,9 +178,11 @@ Vlan100      PORT    100.1.1.1  255.255.255.0             3600  enabled  option6
 
     def test_show_dhcp_server_ipv4_option_without_name(self, mock_db):
         expected_stdout = """\
-Option Name      Option ID  Value        Type
--------------  -----------  -----------  ------
-option60                60  dummy_value  string
++---------------+-------------+-------------+--------+
+| Option Name   |   Option ID | Value       | Type   |
++===============+=============+=============+========+
+| option60      |          60 | dummy_value | string |
++---------------+-------------+-------------+--------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -165,9 +193,11 @@ option60                60  dummy_value  string
 
     def test_show_dhcp_server_ipv4_option_with_name(self, mock_db):
         expected_stdout = """\
-Option Name      Option ID  Value        Type
--------------  -----------  -----------  ------
-option60                60  dummy_value  string
++---------------+-------------+-------------+--------+
+| Option Name   |   Option ID | Value       | Type   |
++===============+=============+=============+========+
+| option60      |          60 | dummy_value | string |
++---------------+-------------+-------------+--------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -178,16 +208,21 @@ option60                60  dummy_value  string
 
     def test_show_dhcp_server_ipv4_port_without_intf(self, mock_db):
         expected_stdout = """\
-Interface          Bind
------------------  ----------
-Vlan100|Ethernet4  100.1.1.10
-                   10.1.1.11
-Vlan100|Ethernet7  range1
-                   range2
-Vlan200|Ethernet8  range3
-                   range4
-Ethernet9          range5
-                   range6
++-------------------+------------+
+| Interface         | Bind       |
++===================+============+
+| Vlan100|Ethernet4 | 100.1.1.10 |
+|                   | 10.1.1.11  |
++-------------------+------------+
+| Vlan100|Ethernet7 | range1     |
+|                   | range2     |
++-------------------+------------+
+| Vlan200|Ethernet8 | range3     |
+|                   | range4     |
++-------------------+------------+
+| Ethernet9         | range5     |
+|                   | range6     |
++-------------------+------------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -198,10 +233,12 @@ Ethernet9          range5
 
     def test_show_dhcp_server_ipv4_port_with_port(self, mock_db):
         expected_stdout = """\
-Interface          Bind
------------------  ------
-Vlan100|Ethernet7  range1
-                   range2
++-------------------+--------+
+| Interface         | Bind   |
++===================+========+
+| Vlan100|Ethernet7 | range1 |
+|                   | range2 |
++-------------------+--------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -212,12 +249,15 @@ Vlan100|Ethernet7  range1
 
     def test_show_dhcp_server_ipv4_port_with_vlan(self, mock_db):
         expected_stdout = """\
-Interface          Bind
------------------  ----------
-Vlan100|Ethernet4  100.1.1.10
-                   10.1.1.11
-Vlan100|Ethernet7  range1
-                   range2
++-------------------+------------+
+| Interface         | Bind       |
++===================+============+
+| Vlan100|Ethernet4 | 100.1.1.10 |
+|                   | 10.1.1.11  |
++-------------------+------------+
+| Vlan100|Ethernet7 | range1     |
+|                   | range2     |
++-------------------+------------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -228,10 +268,12 @@ Vlan100|Ethernet7  range1
 
     def test_show_dhcp_server_ipv4_port_with_port_and_vlan(self, mock_db):
         expected_stdout = """\
-Interface          Bind
------------------  ------
-Vlan200|Ethernet8  range3
-                   range4
++-------------------+--------+
+| Interface         | Bind   |
++===================+========+
+| Vlan200|Ethernet8 | range3 |
+|                   | range4 |
++-------------------+--------+
 """
         runner = CliRunner()
         db = clicommon.Db()
@@ -242,10 +284,12 @@ Vlan200|Ethernet8  range3
 
     def test_show_dhcp_server_ipv4_port_with_single_port(self, mock_db):
         expected_stdout = """\
-Interface    Bind
------------  ------
-Ethernet9    range5
-             range6
++-------------+--------+
+| Interface   | Bind   |
++=============+========+
+| Ethernet9   | range5 |
+|             | range6 |
++-------------+--------+
 """
         runner = CliRunner()
         db = clicommon.Db()

--- a/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
@@ -43,7 +43,7 @@ def lease(db, dhcp_interface):
         if not port:
             port = "<Unknown>"
         table.append([interface + "|" + port, mac, entry["ip"], ts_to_str(entry["lease_start"]), ts_to_str(entry["lease_end"])])
-    click.echo(tabulate(table, headers=headers))
+    click.echo(tabulate(table, headers=headers, tablefmt="grid"))
 
 
 def count_ipv4(start, end):
@@ -74,7 +74,7 @@ def range(db, range_name):
         if count < 1:
             count = "range value is illegal"
         table.append([name, start, end, count])
-    click.echo(tabulate(table, headers=headers))
+    click.echo(tabulate(table, headers=headers, tablefmt="grid"))
 
 
 def dhcp_interface_is_match(input_, key):
@@ -104,7 +104,7 @@ def info(db, dhcp_interface, with_customized_options):
         table.append([interface, entry["mode"], entry["gateway"], entry["netmask"], entry["lease_time"], entry["state"]])
         if with_customized_options:
             table[-1].append(entry["customized_options"])
-    click.echo(tabulate(table, headers=headers))
+    click.echo(tabulate(table, headers=headers, tablefmt="grid"))
 
 
 @ipv4.command()
@@ -118,7 +118,7 @@ def option(db, option_name):
         entry = dbconn.get_all("CONFIG_DB", key)
         name = key.split("|")[1]
         table.append([name, entry["id"], entry["value"], entry["type"]])
-    click.echo(tabulate(table, headers=headers))
+    click.echo(tabulate(table, headers=headers, tablefmt="grid"))
 
 
 @ipv4.command()
@@ -136,7 +136,7 @@ def port(db, interface):
                 table.append([intf, entry["ranges"].replace(",", "\n")])
             if "ips" in entry:
                 table.append([intf, entry["ips"].replace(",", "\n")])
-    click.echo(tabulate(table, headers=headers))
+    click.echo(tabulate(table, headers=headers, tablefmt="grid"))
 
 
 def register(cli):

--- a/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
@@ -30,11 +30,9 @@ def ipv4():
 
 
 @ipv4.command()
-@click.argument('dhcp_interface', required=False)
+@click.argument('dhcp_interface', required=False, default="*")
 @clicommon.pass_db
 def lease(db, dhcp_interface):
-    if not dhcp_interface:
-        dhcp_interface = "*"
     headers = ["Interface", "MAC Address", "IP", "Lease Start", "Lease End"]
     table = []
     dbconn = db.db
@@ -55,11 +53,9 @@ def count_ipv4(start, end):
 
 
 @ipv4.command()
-@click.argument('range_name', required=False)
+@click.argument('range_name', required=False, default="*")
 @clicommon.pass_db
 def range(db, range_name):
-    if not range_name:
-        range_name = "*"
     headers = ["Range", "IP Start", "IP End", "IP Count"]
     table = []
     dbconn = db.db
@@ -93,12 +89,10 @@ def dhcp_interface_is_match(input_, key):
 
 
 @ipv4.command()
-@click.argument('dhcp_interface', required=False)
+@click.argument('dhcp_interface', required=False, default="*")
 @click.option('--with_customized_options', default=False, is_flag=True)
 @clicommon.pass_db
 def info(db, dhcp_interface, with_customized_options):
-    if not dhcp_interface:
-        dhcp_interface = "*"
     headers = ["Interface", "Mode", "Gateway", "Netmask", "Lease Time(s)", "State"]
     if with_customized_options:
         headers.append("Customized Options")
@@ -114,11 +108,9 @@ def info(db, dhcp_interface, with_customized_options):
 
 
 @ipv4.command()
-@click.argument("option_name", required=False)
+@click.argument("option_name", required=False, default="*")
 @clicommon.pass_db
 def option(db, option_name):
-    if not option_name:
-        option_name = "*"
     headers = ["Option Name", "Option ID", "Value", "Type"]
     table = []
     dbconn = db.db
@@ -130,11 +122,9 @@ def option(db, option_name):
 
 
 @ipv4.command()
-@click.argument('interface', required=False)
+@click.argument('interface', required=False, default="*")
 @clicommon.pass_db
 def port(db, interface):
-    if not interface:
-        interface = "*"
     headers = ["Interface", "Bind"]
     table = []
     dbconn = db.db


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Current show dhcp_server output format can be a bit messy

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Give show dhcp_server a "grid" format when output with tabulate.

#### How to verify it
Passed unittests

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
Latest master image

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
improve show dhcp_server output

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

