### PR TITLE
[docker-nat] limit privileged flag for nat container

### DIFF
--- a/rules/docker-nat.mk
+++ b/rules/docker-nat.mk
@@ -29,7 +29,7 @@ SONIC_INSTALL_DOCKER_DBG_IMAGES += $(DOCKER_NAT_DBG)
 endif
 
 $(DOCKER_NAT)_CONTAINER_NAME = nat
-$(DOCKER_NAT)_RUN_OPT += -t
+$(DOCKER_NAT)_RUN_OPT += -t --cap-add=NET_ADMIN
 $(DOCKER_NAT)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_NAT)_RUN_OPT += -v /etc/timezone:/etc/timezone:ro 
 $(DOCKER_NAT)_RUN_OPT += -v /host/warmboot:/var/warmboot

--- a/rules/docker-nat.mk
+++ b/rules/docker-nat.mk
@@ -29,7 +29,7 @@ SONIC_INSTALL_DOCKER_DBG_IMAGES += $(DOCKER_NAT_DBG)
 endif
 
 $(DOCKER_NAT)_CONTAINER_NAME = nat
-$(DOCKER_NAT)_RUN_OPT += --privileged -t
+$(DOCKER_NAT)_RUN_OPT += -t
 $(DOCKER_NAT)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_NAT)_RUN_OPT += -v /etc/timezone:/etc/timezone:ro 
 $(DOCKER_NAT)_RUN_OPT += -v /host/warmboot:/var/warmboot


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
#### Why I did it
HLD implementation: Container Hardening (https://github.com/sonic-net/SONiC/pull/1364)
##### Work item tracking
- Microsoft ADO **(number only)**: 14807420
#### How I did it
Reduce linux capabilities in privileged flag

#### How to verify it
Check container's settings: Privileged is false and container only has default Linux caps, does not have extended caps.
```
admin@vlab-01:~$ docker inspect nat | grep Privi
            "Privileged": false,


admin@vlab-01:~$ docker exec -it nat bash
root@vlab-01:/# capsh --print
Current: cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_chroot,cap_mknod,cap_audit_write,cap_setfcap=ep
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

