### PR TITLE
[systemd-sonic-generator] Fix handling service files with additional fields under [Install] section

### DIFF
--- a/src/systemd-sonic-generator/systemd-sonic-generator.c
+++ b/src/systemd-sonic-generator/systemd-sonic-generator.c
@@ -141,6 +141,9 @@ static int get_install_targets_from_line(char* target_string, char* install_type
     char final_target[PATH_MAX];
     int num_targets = 0;
 
+    assert(target_string);
+    assert(install_type);
+
     while ((token = strtok_r(target_string, " ", &target_string))) {
         if (num_targets + existing_targets >= MAX_NUM_TARGETS) {
             fputs("Number of targets found exceeds MAX_NUM_TARGETS\n", stderr);
@@ -269,7 +272,7 @@ int get_install_targets(char* unit_file, char* targets[]) {
     char* token;
     char* line = NULL;
     bool first;
-    char* target_suffix;
+    char* target_suffix = NULL;
     char *instance_name;
     char *dot_ptr;
 
@@ -306,6 +309,8 @@ int get_install_targets(char* unit_file, char* targets[]) {
                 }
                 else if (strstr(token, "WantedBy") != NULL) {
                     target_suffix = ".wants";
+                } else {
+                    break;
                 }
             }
             else {

--- a/src/systemd-sonic-generator/tests/testfiles/test.service
+++ b/src/systemd-sonic-generator/tests/testfiles/test.service
@@ -7,4 +7,5 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/test.sh start
 [Install]
+Alias=test.service
 WantedBy=multi-user.target


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

If encountered a line without RequiredBy or WantedBy the code passes uninitialized pointer to get_install_targets_from_line(). Where it can fail with segfault or silently pass randomly.

#### Why I did it

Uninitialized target_suffix is passed to get_install_targets_from_line() when other fields are present in [Install] section, like this:
```
root@sonic:/home/admin# systemctl cat ntpsec
...
[Install]
Alias=ntp.service
Alias=ntpd.service
WantedBy=multi-user.target
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Initialize target_suffix with NULL, put an assert in get_install_targets_from_line(). Edited test to cover this scenario.

#### How to verify it

UT and on the switch.

Without the change - assert fails:
```
[       OK ] SsgFunctionTest.missing_file (2 ms)
[ RUN      ] SsgFunctionTest.insert_instance_number
[       OK ] SsgFunctionTest.insert_instance_number (2 ms)
[ RUN      ] SsgFunctionTest.get_num_of_asic
[       OK ] SsgFunctionTest.get_num_of_asic (2 ms)
[ RUN      ] SsgFunctionTest.get_unit_files
[       OK ] SsgFunctionTest.get_unit_files (2 ms)
[----------] 4 tests from SsgFunctionTest (8 ms total)

[----------] 4 tests from SsgMainTest
[ RUN      ] SsgMainTest.ssg_main_argv
Installation directory required as argument
[       OK ] SsgMainTest.ssg_main_argv (2 ms)
[ RUN      ] SsgMainTest.ssg_main_single_npu
ssg_test: systemd-sonic-generator.c:145: get_install_targets_from_line: Assertion `install_type' failed.
Aborted (core dumped)
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

