### PR TITLE
[Arista] Update config.bcm of 7060_cx32s for handling 40g optics with unreliable los settings

### DIFF
--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
@@ -449,4 +449,3 @@ serdes_preemphasis_109=0x145c00
 
 mmu_init_config="MSFT-TH-Tier0"
 phy_an_lt_msft=1
-phy_unlos_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
@@ -449,3 +449,4 @@ serdes_preemphasis_109=0x145c00
 
 mmu_init_config="MSFT-TH-Tier0"
 phy_an_lt_msft=1
+phy_unlos_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
@@ -449,3 +449,4 @@ serdes_preemphasis_109=0x145c00
 
 mmu_init_config="MSFT-TH-Tier1"
 phy_an_lt_msft=1
+phy_unlos_msft=1

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -326,6 +326,7 @@ phy_pcs_repeater
 l3_alpm_hit_skip
 sai_verify_incoming_chksum
 phy_an_lt_msft
+phy_unlos_msft
 system_ref_core_clock_khz
 xflow_macsec_secure_chan_to_num_secure_assoc_encrypt
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt


### PR DESCRIPTION
… 
For 40G optics there is SAI handling of T0 facing ports to be set with SR4 type and unreliable los set for a fixed set of ports. For this property to be invoked the requirement is set 
`phy_unlos_msft=1` in config.bcm. 
This change is to meet the requirement and once this property is set, the los/interface type settings is applied by SAI on the required ports. 


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For Arista-7060CX-32S-Q32 T1, 40G ports RX_ERR minimalization during connected device reboot
can be achieved by turning on Unreliable LOS and SR4 media_type for all ports which are connected to T0.
 
The property `phy_unlos_msft=1` is to exclusively enable this property. 

##### Work item tracking
- Microsoft ADO **(number only)**:
25941176
#### How I did it
Changes in SAI and turning on property
#### How to verify it
Ran the changes on a testbed and verified configurations are as intended. 

with property
```
admin@sonic2:~$ bcmcmd "phy diag xe8 dsc config" | grep -C 2 "LOS"
Brdfe_on                    = 0
Media Type                  = 2
Unreliable LOS              = 1
Scrambling Disable          = 0
Lane Config from PCS        = 0

without property

admin@sonic:~$ bcmcmd "phy diag xe8 dsc config" | grep -C 2 "LOS"
Brdfe_on                    = 0
Media Type                  = 0
Unreliable LOS              = 0
Scrambling Disable          = 0
Lane Config from PCS        = 0
```
--

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

