### PR TITLE
[dhcp_server] Add support for smart switch in dhcprelayd

### DIFF
--- a/src/sonic-dhcp-utilities/tests/test_data/mock_config_db.json
+++ b/src/sonic-dhcp-utilities/tests/test_data/mock_config_db.json
@@ -46,6 +46,12 @@
             "tagging_mode": "untagged"
         }
     },
+    "MID_PLANE_BRIDGE": {
+        "GLOBAL": {
+            "bridge": "bridge_midplane",
+            "address": "169.254.200.254/24"
+        }
+    },
     "DHCP_SERVER_IPV4": {
         "Vlan1000": {
             "customized_options": [
@@ -53,6 +59,17 @@
                 "option223"
             ],
             "gateway": "192.168.0.1",
+            "lease_time": "900",
+            "mode": "PORT",
+            "netmask": "255.255.255.0",
+            "state": "enabled"
+        },
+        "bridge_midplane": {
+            "customized_options": [
+                "option60",
+                "option223"
+            ],
+            "gateway": "169.254.200.254",
             "lease_time": "900",
             "mode": "PORT",
             "netmask": "255.255.255.0",

--- a/src/sonic-dhcp-utilities/tests/test_data/mock_config_db.json
+++ b/src/sonic-dhcp-utilities/tests/test_data/mock_config_db.json
@@ -46,12 +46,6 @@
             "tagging_mode": "untagged"
         }
     },
-    "MID_PLANE_BRIDGE": {
-        "GLOBAL": {
-            "bridge": "bridge_midplane",
-            "address": "169.254.200.254/24"
-        }
-    },
     "DHCP_SERVER_IPV4": {
         "Vlan1000": {
             "customized_options": [
@@ -59,17 +53,6 @@
                 "option223"
             ],
             "gateway": "192.168.0.1",
-            "lease_time": "900",
-            "mode": "PORT",
-            "netmask": "255.255.255.0",
-            "state": "enabled"
-        },
-        "bridge_midplane": {
-            "customized_options": [
-                "option60",
-                "option223"
-            ],
-            "gateway": "169.254.200.254",
             "lease_time": "900",
             "mode": "PORT",
             "netmask": "255.255.255.0",

--- a/src/sonic-dhcp-utilities/tests/test_data/mock_config_db_smart_switch.json
+++ b/src/sonic-dhcp-utilities/tests/test_data/mock_config_db_smart_switch.json
@@ -1,0 +1,27 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "hostname": "sonic-host",
+            "subtype": "SmartSwitch"
+        }
+    },
+    "MID_PLANE_BRIDGE": {
+        "GLOBAL": {
+            "bridge": "bridge_midplane",
+            "address": "169.254.200.254/24"
+        }
+    },
+    "DHCP_SERVER_IPV4": {
+        "bridge_midplane": {
+            "customized_options": [
+                "option60",
+                "option223"
+            ],
+            "gateway": "169.254.200.254",
+            "lease_time": "900",
+            "mode": "PORT",
+            "netmask": "255.255.255.0",
+            "state": "enabled"
+        }
+    }
+}

--- a/src/sonic-dhcp-utilities/tests/test_dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcp_cfggen.py
@@ -377,7 +377,7 @@ def test_construct_obj_for_template(mock_swsscommon_dbconnector_init, mock_parse
         dhcp_cfg_generator._construct_obj_for_template(mock_config_db.config_db.get("DHCP_SERVER_IPV4"),
                                                        port_ips, tested_hostname, customized_options)
     assert render_obj == expected_render_obj
-    assert enabled_dhcp_interfaces == {"Vlan1000", "Vlan4000", "Vlan3000", "Vlan6000"}
+    assert enabled_dhcp_interfaces == {"Vlan1000", "Vlan4000", "Vlan3000", "Vlan6000", "bridge_midplane"}
     assert used_options == set(["option223"])
     assert subscribe_table == set(PORT_MODE_CHECKER)
 

--- a/src/sonic-dhcp-utilities/tests/test_dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcp_cfggen.py
@@ -2,10 +2,10 @@ import copy
 import ipaddress
 import json
 import pytest
-from common_utils import MockConfigDb, mock_get_config_db_table, PORT_MODE_CHECKER, SMART_SWITCH_CHECKER
+from common_utils import MockConfigDb, mock_get_config_db_table, PORT_MODE_CHECKER
 from dhcp_utilities.common.utils import DhcpDbConnector
 from dhcp_utilities.dhcpservd.dhcp_cfggen import DhcpServCfgGenerator
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 expected_dhcp_config = {
     "Dhcp4": {
@@ -377,7 +377,7 @@ def test_construct_obj_for_template(mock_swsscommon_dbconnector_init, mock_parse
         dhcp_cfg_generator._construct_obj_for_template(mock_config_db.config_db.get("DHCP_SERVER_IPV4"),
                                                        port_ips, tested_hostname, customized_options)
     assert render_obj == expected_render_obj
-    assert enabled_dhcp_interfaces == {"Vlan1000", "Vlan4000", "Vlan3000", "Vlan6000", "bridge_midplane"}
+    assert enabled_dhcp_interfaces == {"Vlan1000", "Vlan4000", "Vlan3000", "Vlan6000"}
     assert used_options == set(["option223"])
     assert subscribe_table == set(PORT_MODE_CHECKER)
 

--- a/src/sonic-dhcp-utilities/tests/test_dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcprelayd.py
@@ -3,11 +3,12 @@ import pytest
 import subprocess
 import sys
 import time
-from common_utils import mock_get_config_db_table, MockProc, MockPopen, MockSubprocessRes, mock_exit_func
+from common_utils import mock_get_config_db_table, MockProc, MockPopen, MockSubprocessRes, mock_exit_func, \
+    dhcprelayd_refresh_dhcrelay_test, dhcprelayd_proceed_with_check_res_test
 from dhcp_utilities.common.utils import DhcpDbConnector
 from dhcp_utilities.common.dhcp_db_monitor import ConfigDbEventChecker, DhcpRelaydDbMonitor
-from dhcp_utilities.dhcprelayd.dhcprelayd import DhcpRelayd, KILLED_OLD, NOT_KILLED, NOT_FOUND_PROC, FEATURE_CHECKER, \
-    DHCP_SERVER_CHECKER, VLAN_INTF_CHECKER, VLAN_CHECKERS, MID_PLANE_CHECKER
+from dhcp_utilities.dhcprelayd.dhcprelayd import DhcpRelayd, KILLED_OLD, NOT_KILLED, NOT_FOUND_PROC, \
+    DHCP_SERVER_CHECKER, VLAN_CHECKERS
 from swsscommon import swsscommon
 from unittest.mock import patch, call, PropertyMock
 
@@ -34,25 +35,9 @@ def test_start(mock_swsscommon_dbconnector_init, dhcp_server_enabled):
         mock_enabled_checkers.assert_called_once_with(enabled_checkers)
 
 
-@pytest.mark.parametrize("smart_switch", [True, False])
-def test_refresh_dhcrelay(mock_swsscommon_dbconnector_init, smart_switch):
-    with patch.object(DhcpRelayd, "_get_dhcp_server_ip", return_value="240.127.1.2"), \
-         patch.object(DhcpDbConnector, "get_config_db_table", side_effect=mock_get_config_db_table), \
-         patch.object(DhcpRelayd, "_start_dhcrelay_process", return_value=None), \
-         patch.object(DhcpRelayd, "_start_dhcpmon_process", return_value=None), \
-         patch.object(ConfigDbEventChecker, "enable"), \
-         patch.object(DhcpRelayd, "_enable_checkers") as mock_enable_checkers, \
-         patch.object(DhcpRelayd, "_disable_checkers") as mock_disable_checkers, \
-         patch.object(DhcpRelayd, "smart_switch", return_value=smart_switch,
-                      new_callable=PropertyMock):
-        dhcp_db_connector = DhcpDbConnector()
-        dhcprelayd = DhcpRelayd(dhcp_db_connector, None)
-        dhcprelayd.refresh_dhcrelay()
-        expected_checkers = set(["VlanIntfTableEventChecker", "VlanTableEventChecker"])
-        if smart_switch:
-            expected_checkers |= set(["MidPlaneTableEventChecker"])
-        mock_enable_checkers.assert_called_once_with(expected_checkers)
-        mock_disable_checkers.assert_called_once_with(set())
+def test_refresh_dhcrelay(mock_swsscommon_dbconnector_init):
+    expected_checkers = set(["VlanIntfTableEventChecker", "VlanTableEventChecker"])
+    dhcprelayd_refresh_dhcrelay_test(expected_checkers, False, mock_get_config_db_table)
 
 
 @pytest.mark.parametrize("new_dhcp_interfaces", [[], ["Vlan1000"], ["Vlan1000", "Vlan2000"]])
@@ -271,61 +256,9 @@ def test_disable_checkers(mock_swsscommon_dbconnector_init, mock_swsscommon_tabl
 @pytest.mark.parametrize("feature_res", [True, False, None])
 @pytest.mark.parametrize("dhcp_server_res", [True, False, None])
 @pytest.mark.parametrize("vlan_intf_res", [True, False, None])
-@pytest.mark.parametrize("smart_switch", [True, False])
 def test_proceed_with_check_res(mock_swsscommon_dbconnector_init, mock_swsscommon_table_init, feature_enabled,
-                                feature_res, dhcp_server_res, vlan_intf_res, smart_switch):
+                                feature_res, dhcp_server_res, vlan_intf_res):
     enabled_checkers = set([DHCP_SERVER_CHECKER] + VLAN_CHECKERS)
-    if smart_switch:
-        enabled_checkers.add(MID_PLANE_CHECKER)
-    with patch.object(DhcpRelayd, "_enable_checkers") as mock_enable_checkers, \
-         patch.object(DhcpRelayd, "_execute_supervisor_dhcp_relay_process") as mock_execute_process, \
-         patch.object(DhcpRelayd, "refresh_dhcrelay") as mock_refresh_dhcrelay, \
-         patch.object(DhcpRelayd, "_disable_checkers") as mock_disable_checkers, \
-         patch.object(DhcpRelayd, "_kill_exist_relay_releated_process") as mock_kill_process, \
-         patch.object(DhcpRelayd, "_check_dhcp_relay_processes") as mock_check_process, \
-         patch.object(DhcpRelayd, "smart_switch", return_value=smart_switch,
-                      new_callable=PropertyMock), \
-         patch.object(DhcpRelayd, "enabled_checkers", return_value=enabled_checkers, new_callable=PropertyMock):
-        dhcp_db_connector = DhcpDbConnector()
-        dhcprelayd = DhcpRelayd(dhcp_db_connector, DhcpRelaydDbMonitor(None, None, []))
-        dhcprelayd.dhcp_server_feature_enabled = True if feature_enabled else False
-        check_res = {}
-        if feature_res is not None:
-            check_res[FEATURE_CHECKER] = feature_res
-        if dhcp_server_res is not None:
-            check_res[DHCP_SERVER_CHECKER] = dhcp_server_res
-        if vlan_intf_res is not None:
-            check_res[VLAN_INTF_CHECKER] = vlan_intf_res
-        dhcprelayd._proceed_with_check_res(check_res, feature_enabled)
-        if feature_res is None or not feature_res:
-            # Feature status didn't change
-
-            # disabled -> disabled
-            if not feature_enabled:
-                mock_check_process.assert_called_once_with()
-            # enabled-> enabled
-            else:
-                if vlan_intf_res:
-                    mock_refresh_dhcrelay.assert_called_once_with(True)
-                elif dhcp_server_res:
-                    mock_refresh_dhcrelay.assert_called_once_with(False)
-                else:
-                    mock_refresh_dhcrelay.assert_not_called()
-        else:
-            # Feature status changed
-
-            # enabled -> disabled
-            if feature_enabled:
-                expected_checkers = [DHCP_SERVER_CHECKER] + VLAN_CHECKERS
-                if smart_switch:
-                    expected_checkers.append(MID_PLANE_CHECKER)
-                mock_disable_checkers.assert_called_once_with(set(expected_checkers))
-                mock_kill_process.assert_has_calls([
-                    call([], "dhcpmon", True),
-                    call([], "dhcrelay", True)
-                ])
-            # disabled-> enabled
-            else:
-                mock_enable_checkers.assert_called_once_with([DHCP_SERVER_CHECKER])
-                mock_execute_process.assert_called_once_with("stop")
-                mock_refresh_dhcrelay.assert_called_once_with()
+    expected_checkers = set([DHCP_SERVER_CHECKER] + VLAN_CHECKERS)
+    dhcprelayd_proceed_with_check_res_test(enabled_checkers, feature_enabled, feature_res, dhcp_server_res,
+                                           vlan_intf_res, False, expected_checkers)

--- a/src/sonic-dhcp-utilities/tests/test_smart_switch.py
+++ b/src/sonic-dhcp-utilities/tests/test_smart_switch.py
@@ -1,0 +1,26 @@
+import pytest
+from common_utils import MockConfigDb, dhcprelayd_refresh_dhcrelay_test, dhcprelayd_proceed_with_check_res_test
+from dhcp_utilities.dhcprelayd.dhcprelayd import DHCP_SERVER_CHECKER, MID_PLANE_CHECKER
+
+MOCK_CONFIG_DB_PATH_SMART_SWITCH = "tests/test_data/mock_config_db_smart_switch.json"
+
+
+def test_dhcprelayd_refresh_dhcrelay(mock_swsscommon_dbconnector_init):
+    expected_checkers = set(["MidPlaneTableEventChecker"])
+    dhcprelayd_refresh_dhcrelay_test(expected_checkers, True, mock_get_config_db_table)
+
+
+@pytest.mark.parametrize("feature_enabled", [True, False])
+@pytest.mark.parametrize("feature_res", [True, False, None])
+@pytest.mark.parametrize("dhcp_server_res", [True, False, None])
+def test_dhcprelayd_proceed_with_check_res(mock_swsscommon_dbconnector_init, mock_swsscommon_table_init,
+                                           feature_enabled, feature_res, dhcp_server_res):
+    enabled_checkers = set([DHCP_SERVER_CHECKER, MID_PLANE_CHECKER])
+    expected_checkers = set([DHCP_SERVER_CHECKER, MID_PLANE_CHECKER])
+    dhcprelayd_proceed_with_check_res_test(enabled_checkers, feature_enabled, feature_res, dhcp_server_res,
+                                           None, True, expected_checkers)
+
+
+def mock_get_config_db_table(table_name):
+    mock_config_db = MockConfigDb(MOCK_CONFIG_DB_PATH_SMART_SWITCH)
+    return mock_config_db.get_config_db_table(table_name)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add support for smart switch in dhcprelayd

##### Work item tracking
- Microsoft ADO **(number only)**: 26437270

#### How I did it
1. Add checker support for smart switch and add related UTs
1.1 Only enable `FEATURE` table checker when dhcprelayd init
1.2 In function `refresh_dhcrelay`, enable or disable VLAN/MID_PLANE table checkers as needed.
1.3 When dhcp_server feature state change, do changes for checkers:
      * disable -> enabled: Should enable `DHCP_SERVER_IPV4` checker
      * enabled -> enabled: Refer to `refresh_dhcrelay` in 1.2
      * enabled -> disabled: Should disable
      * disabled -> disabled: not need to update

2. Extract function `_proceed_with_check_res` in function `wait` to let UT cover it.

#### How to verify it
UTs passed
```
collected 430 items                                                                                                                                                                                                                                                                      

tests/test_dhcp_cfggen.py ......................                                                                                                                                                                                                                                   [  5%]
tests/test_dhcp_db_monitor.py ...............................................................................................................................................                                                                                                      [ 38%]
tests/test_dhcp_lease.py .....                                                                                                                                                                                                                                                     [ 39%]
tests/test_dhcprelayd.py ................................................................................................................................................................                                                                                          [ 76%]
tests/test_dhcpservd.py .......                                                                                                                                                                                                                                                    [ 78%]
tests/test_smart_switch.py .......................................................                                                                                                                                                                                                 [ 91%]
tests/test_utils.py ......................................                                                                                                                                                                                                                         [100%]

----------- coverage: platform linux, python 3.9.2-final-0 -----------
Name                                      Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------------------------
dhcp_utilities/dhcpservd/dhcpservd.py        67      4     14      0    92.59%   91-98
dhcp_utilities/dhcpservd/dhcp_lease.py       95      3     30      4    94.40%   57->59, 59, 60->61, 61, 74->76, 112->134, 153
dhcp_utilities/dhcpservd/dhcp_cfggen.py     242      6    104      1    97.98%   250-254, 342->344, 344
dhcp_utilities/common/utils.py               78      1     42      1    98.33%   129->134, 134
dhcp_utilities/dhcprelayd/dhcprelayd.py     212      3     74      1    98.60%   102->90, 119-124
----------------------------------------------------------------------------------------
TOTAL                                       984     17    358      7    98.06%

2 files skipped due to complete coverage.

Required test coverage of 80.0% reached. Total coverage: 98.06%
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

