### PR TITLE
[build] fix invalid comparison in onie-mk-demo.sh

### DIFF
--- a/onie-mk-demo.sh
+++ b/onie-mk-demo.sh
@@ -173,7 +173,7 @@ if [ "$SECURE_UPGRADE_MODE" = "dev" -o "$SECURE_UPGRADE_MODE" = "prod" ]; then
     # append signature to binary
     cat ${CMS_SIG} >> ${output_file}
     sudo rm -rf ${CMS_SIG}
-elif [ "$SECURE_UPGRADE_MODE" -ne "no_sign" ]; then
+elif [ "$SECURE_UPGRADE_MODE" != "no_sign" ]; then
     echo "SECURE_UPGRADE_MODE not defined or defined as $SECURE_UPGRADE_MODE - build without signing"
 fi
 


### PR DESCRIPTION
#### Why I did it

I saw an error message in the build logs. `./onie-mk-demo.sh: 176: [: Illegal number: no_sign`.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

In shell the operand `-ne` only works on integers. In this case we are trying to compare two strings, which it fails doing:

```
+ [ no_sign -ne no_sign ]                                                        
./onie-mk-demo.sh: 176: [: Illegal number: no_sign
```

Instead, use the != operand which is made for this type of comparison. Reference: `man test`.

#### How to verify it

Build, when not using signing you should see the message "SECURE_UPGRADE_MODE not defined or defined as no_sign - build without signing".

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

- [x] master

#### Description for the changelog

N/A

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

