### PR TITLE
handle json load exception in bgpmon

### DIFF
--- a/src/sonic-bgpcfgd/bgpmon/bgpmon.py
+++ b/src/sonic-bgpcfgd/bgpmon/bgpmon.py
@@ -49,6 +49,7 @@ class BgpStateGet:
         self.db.connect(self.db.STATE_DB, False)
         self.pipe = swsscommon.RedisPipeline(self.db.get_redis_client(self.db.STATE_DB))
         self.db.delete_all_by_pattern(self.db.STATE_DB, "NEIGH_STATE_TABLE|*" )
+        self.MAX_RETRY_ATTEMPTS = 3
 
     # A quick way to check if there are anything happening within BGP is to
     # check its log file has any activities. This is by checking its modified
@@ -77,18 +78,41 @@ class BgpStateGet:
     # Get a new snapshot of BGP neighbors and store them in the "new" location
     def get_all_neigh_states(self):
         cmd = ["vtysh", "-c", 'show bgp summary json']
-        rc, output = getstatusoutput_noshell(cmd)
-        if rc:
-            syslog.syslog(syslog.LOG_ERR, "*ERROR* Failed with rc:{} when execute: {}".format(rc, cmd))
-            return
+        retry_attempt = 0
 
-        peer_info = json.loads(output)
-        # cmd ran successfully, safe to Clean the "new" set/dict for new snapshot
-        self.new_peer_l.clear()
-        self.new_peer_state.clear()
-        for key, value in peer_info.items():
-            if key == "ipv4Unicast" or key == "ipv6Unicast":
-                self.update_new_peer_states(value)
+        while retry_attempt < self.MAX_RETRY_ATTEMPTS:
+            try:
+                rc, output = getstatusoutput_noshell(cmd)
+                if rc:
+                    syslog.syslog(syslog.LOG_ERR, "*ERROR* Failed with rc:{} when execute: {}".format(rc, cmd))
+                    return
+
+                peer_info = json.loads(output)
+                # cmd ran successfully, safe to Clean the "new" set/dict for new snapshot
+                self.new_peer_l.clear()
+                self.new_peer_state.clear()
+                for key, value in peer_info.items():
+                    if key == "ipv4Unicast" or key == "ipv6Unicast":
+                        self.update_new_peer_states(value)
+                return
+
+            except json.JSONDecodeError as decode_error:
+                # Log the exception and retry if within the maximum attempts
+                retry_attempt += 1
+                syslog.syslog(syslog.LOG_WARNING, "*WARNING* JSONDecodeError: {} when execute: {} Retry attempt: {}".format(decode_error, cmd, retry_attempt))
+                time.sleep(1)
+                continue
+            except Exception as e:
+                # Log other exceptions and return failure
+                retry_attempt += 1
+                syslog.syslog(syslog.LOG_WARNING, "*WARNING* An unexpected error occurred: {} when execute: {} Retry attempt: {}".format(e, cmd, retry_attempt))
+                time.sleep(1)
+                continue
+
+        # Log an error if the maximum retry attempts are reached
+        syslog.syslog(syslog.LOG_ERR, "*ERROR* Maximum retry attempts reached. Failed to execute: {} Output: {}".format(cmd, output))
+        sys.exit(1)
+
 
     # This method will take the caller's dictionary which contains the peer state operation
     # That need to be updated in StateDB using Redis pipeline.

--- a/src/sonic-bgpcfgd/bgpmon/bgpmon.py
+++ b/src/sonic-bgpcfgd/bgpmon/bgpmon.py
@@ -86,6 +86,9 @@ class BgpStateGet:
                 if rc:
                     syslog.syslog(syslog.LOG_ERR, "*ERROR* Failed with rc:{} when execute: {}".format(rc, cmd))
                     return
+                if len(output) == 0:
+                    syslog.syslog(syslog.LOG_WARNING, "*WARNING* output none when execute: {}".format(cmd))
+                    return
 
                 peer_info = json.loads(output)
                 # cmd ran successfully, safe to Clean the "new" set/dict for new snapshot


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
ICM reported due to "BGPMon Process exited" which was caused by json load exception.

##### Work item tracking
- Microsoft ADO **(number only)**:
25916773

#### How I did it
Add an exception handle during json load.

#### How to verify it
Verified locally, add debug log to modify the output string of cmd to make it not with json formation, then check the syslog.

Jan 19 03:09:56.275058 str3-7060-acs-1 INFO tmp.py: bgpmon service started
Jan 19 03:09:56.571696 str3-7060-acs-1 WARNING tmp.py: *WARNING* JSONDecodeError: Expecting ':' delimiter: line 109 column 12 (char 2203) when execute: ['vtysh', '-c', 'show bgp summary json'] Retry attempt: 1
Jan 19 03:09:57.891086 str3-7060-acs-1 WARNING tmp.py: *WARNING* JSONDecodeError: Expecting ':' delimiter: line 109 column 12 (char 2203) when execute: ['vtysh', '-c', 'show bgp summary json'] Retry attempt: 2
Jan 19 03:09:59.229662 str3-7060-acs-1 WARNING tmp.py: *WARNING* JSONDecodeError: Expecting ':' delimiter: line 109 column 12 (char 2203) when execute: ['vtysh', '-c', 'show bgp summary json'] Retry attempt: 3
Jan 19 03:10:00.231532 str3-7060-acs-1 ERR tmp.py: *ERROR* Maximum retry attempts reached. Failed to execute: ['vtysh', '-c', 'show bgp summary json'] Output: {#012"ipv4Unicast":{#012  "routerId":"10.1.0.32{#012"ipv4Unicast":{#012  "routerId":"10.1.0.32",#012  "as":65100,#012  "vrfId":0,#012  "vrfName":"default",#012  "tableVersion":6,#012  "ribCount":3,#012  "ribMemory":576,#012  "peerCount":4,#012  "peerMemory":2967904,#012  "peerGroupCount":4,#012  "peerGroupMemory":256,#012  "peers":{#012    "10.0.0.57":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA01T1",#012      "idType":"ipv4"#012    },#012    "10.0.0.59":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA02T1",#012      "idType":"ipv4"#012    },#012    "10.0.0.61":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA03T1",#012      "idType":"ipv4"#012    },#012    "10.0.0.63":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA04T1",#012      "idType":"ipv4"#012    }#012  },#012  "failedPeers":4,#012  "displayedPeers":4,#012  "totalPeers":4,#012  "dynamicPeers":0,#012  "bestPath":{#012    "multiPathRelax":"true"#012  }#012}#012,#012"ipv6Unicast":{#012  "routerId":"10.1.0.32",#012  "as":65100,#012  "vrfId":0,#012  "vrfName"error"default",#012  "tableVersion":6,#012  "ribCount":3,#012  "ribMemory":576,#012  "peerCount":4,#012  "peerMemory":2967904,#012  "peerGroupCount":4,#012  "peerGroupMemory":256,#012  "peers":{#012    "fc00::72":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA01T1",#012      "idType":"ipv6"#012    },#012    "fc00::76":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA02T1",#012      "idType":"ipv6"#012    },#012    "fc00::7a":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA03T1",#012      "idType":"ipv6"#012    },#012    "fc00::7e":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA04T1",#012      "idType":"ipv6"#012    }#012  },#012  "failedPeers":4,#012  "displayedPeers":4,#012  "totalPeers":4,#012  "dynamicPeers":0,#012  "bestPath":{#012    "multiPathRelax":"true"#012  }#012}#012}",#012  "as":65100,#012  "vrfId":0,#012  "vrfName":"default",#012  "tableVersion":6,#012  "ribCount":3,#012  "ribMemory":576,#012  "peerCount":4,#012  "peerMemory":2967904,#012  "peerGroupCount":4,#012  "peerGroupMemory":256,#012  "peers":{#012    "10.0.0.57":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA01T1",#012      "idType":"ipv4"#012    },#012    "10.0.0.59":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA02T1",#012      "idType":"ipv4"#012    },#012    "10.0.0.61":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA03T1",#012      "idType":"ipv4"#012    },#012    "10.0.0.63":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA04T1",#012      "idType":"ipv4"#012    }#012  },#012  "failedPeers":4,#012  "displayedPeers":4,#012  "totalPeers":4,#012  "dynamicPeers":0,#012  "bestPath":{#012    "multiPathRelax":"true"#012  }#012}#012,#012"ipv6Unicast":{#012  "routerId":"10.1.0.32",#012  "as":65100,#012  "vrfId":0,#012  "vrfName"error"default",#012  "tableVersion":6,#012  "ribCount":3,#012  "ribMemory":576,#012  "peerCount":4,#012  "peerMemory":2967904,#012  "peerGroupCount":4,#012  "peerGroupMemory":256,#012  "peers":{#012    "fc00::72":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA01T1",#012      "idType":"ipv6"#012    },#012    "fc00::76":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA02T1",#012      "idType":"ipv6"#012    },#012    "fc00::7a":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA03T1",#012      "idType":"ipv6"#012    },#012    "fc00::7e":{#012      "remoteAs":64600,#012      "localAs":65100,#012      "version":4,#012      "msgRcvd":0,#012      "msgSent":0,#012      "tableVersion":0,#012      "outq":0,#012      "inq":0,#012      "peerUptime":"never",#012      "peerUptimeMsec":0,#012      "pfxRcd":0,#012      "pfxSnt":0,#012      "state":"Active",#012      "peerState":"OK",#012      "connectionsEstablished":0,#012      "connectionsDropped":0,#012      "desc":"ARISTA04T1",#012      "idType":"ipv6"#012    }#012  },#012  "failedPeers":4,#012  "displayedPeers":4,#012  "totalPeers":4,#012  "dynamicPeers":0,#012  "bestPath":{#012    "multiPathRelax":"true"#012  }#012}#012}

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

