### PR TITLE
[dhcp_server] Remove dependency in port-name-alias-map.txt.j2

### DIFF
--- a/dockers/docker-dhcp-server/Dockerfile.j2
+++ b/dockers/docker-dhcp-server/Dockerfile.j2
@@ -86,7 +86,7 @@ RUN apt-get clean -y        && \
 COPY ["docker_init.sh", "start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
-COPY ["port-name-alias-map.txt.j2", "rsyslog/rsyslog.conf.j2", "kea-dhcp4.conf.j2", "/usr/share/sonic/templates/"]
+COPY ["rsyslog/rsyslog.conf.j2", "kea-dhcp4.conf.j2", "/usr/share/sonic/templates/"]
 COPY ["critical_processes", "/etc/supervisor/"]
 COPY ["lease_update.sh", "/etc/kea/"]
 COPY ["kea-dhcp4-init.conf", "/etc/kea/kea-dhcp4.conf"]

--- a/dockers/docker-dhcp-server/docker_init.sh
+++ b/dockers/docker-dhcp-server/docker_init.sh
@@ -12,7 +12,6 @@ hostname=$(hostname)
 sonic-cfggen -d -t /usr/share/sonic/templates/rsyslog.conf.j2 \
     -a "{\"udp_server_ip\": \"$udp_server_ip\", \"hostname\": \"$hostname\"}" \
     > /etc/rsyslog.conf
-sonic-cfggen -d -t /usr/share/sonic/templates/port-name-alias-map.txt.j2,/tmp/port-name-alias-map.txt
 
 # Make the script that waits for all interfaces to come up executable
 chmod +x /etc/kea/lease_update.sh /usr/bin/start.sh

--- a/dockers/docker-dhcp-server/port-name-alias-map.txt.j2
+++ b/dockers/docker-dhcp-server/port-name-alias-map.txt.j2
@@ -1,8 +1,0 @@
-{# Generate port name-alias map for isc-dhcp-relay to parse. Each line contains one #}
-{#  name-alias pair of the form "<name> <alias>" #}
-{% for port, config in PORT.items() %}
-    {{- port }} {% if "alias" in config %}{{ config["alias"] }}{% else %}{{ port }}{% endif %} {{- "\n" -}}
-{% endfor -%}
-{% for pc, config in PORTCHANNEL.items() %}
-    {{- pc }} {{ pc }} {{- "\n" -}}
-{% endfor -%}

--- a/rules/config
+++ b/rules/config
@@ -153,7 +153,7 @@ INCLUDE_NAT = y
 INCLUDE_DHCP_RELAY = y
 
 # INCLUDE_DHCP_SERVER - build and install dhcp-server package
-INCLUDE_DHCP_SERVER ?= n
+INCLUDE_DHCP_SERVER ?= y
 
 # INCLUDE_P4RT - build docker-p4rt for P4RT support
 INCLUDE_P4RT = n

--- a/rules/config
+++ b/rules/config
@@ -153,7 +153,7 @@ INCLUDE_NAT = y
 INCLUDE_DHCP_RELAY = y
 
 # INCLUDE_DHCP_SERVER - build and install dhcp-server package
-INCLUDE_DHCP_SERVER ?= y
+INCLUDE_DHCP_SERVER ?= n
 
 # INCLUDE_P4RT - build docker-p4rt for P4RT support
 INCLUDE_P4RT = n

--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
@@ -7,7 +7,6 @@ import syslog
 from jinja2 import Environment, FileSystemLoader
 from dhcp_utilities.common.utils import merge_intervals, validate_str_type, is_smart_switch
 
-PORT_MAP_PATH = "/tmp/port-name-alias-map.txt"
 UNICODE_TYPE = str
 DHCP_SERVER_IPV4 = "DHCP_SERVER_IPV4"
 DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS = "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS"
@@ -35,14 +34,14 @@ class DhcpServCfgGenerator(object):
     lease_update_script_path = ""
     lease_path = ""
 
-    def __init__(self, dhcp_db_connector, lease_path=DEFAULT_LEASE_PATH, port_map_path=PORT_MAP_PATH,
+    def __init__(self, dhcp_db_connector, lease_path=DEFAULT_LEASE_PATH,
                  lease_update_script_path=LEASE_UPDATE_SCRIPT_PATH, dhcp_option_path=DHCP_OPTION_FILE,
                  kea_conf_template_path=KEA_DHCP4_CONF_TEMPLATE_PATH):
         self.db_connector = dhcp_db_connector
         self.lease_path = lease_path
         self.lease_update_script_path = lease_update_script_path
         # Read port alias map file, this file is render after container start, so it would not change any more
-        self._parse_port_map_alias(port_map_path)
+        self._parse_port_map_alias()
         # Get kea config template
         self._get_render_template(kea_conf_template_path)
         self._read_dhcp_option(dhcp_option_path)
@@ -166,14 +165,13 @@ class DhcpServCfgGenerator(object):
         env = Environment(loader=FileSystemLoader(os.path.dirname(kea_conf_template_path)))  # nosemgrep
         self.kea_template = env.get_template(os.path.basename(kea_conf_template_path))
 
-    def _parse_port_map_alias(self, port_map_path):
-        with open(port_map_path, "r") as file:
-            lines = file.readlines()
-            for line in lines:
-                splits = line.strip().split(" ")
-                if len(splits) != 2:
-                    continue
-                self.port_alias_map[splits[0]] = splits[1]
+    def _parse_port_map_alias(self):
+        port_table = self.db_connector.get_config_db_table("PORT")
+        pc_table = self.db_connector.get_config_db_table("PORTCHANNEL")
+        for port_name, item in port_table.items():
+            self.port_alias_map[port_name] = item.get("alias", port_name)
+        for pc_name in pc_table.keys():
+            self.port_alias_map[pc_name] = pc_name
 
     def _construct_obj_for_template(self, dhcp_server_ipv4, port_ips, hostname, customized_options):
         subnets = []

--- a/src/sonic-dhcp-utilities/tests/test_data/mock_config_db.json
+++ b/src/sonic-dhcp-utilities/tests/test_data/mock_config_db.json
@@ -180,5 +180,38 @@
                 "192.168.0.10"
             ]
         }
+    },
+    "PORT": {
+        "Ethernet0": {
+            "admin_status": "up",
+            "alias": "etp1",
+            "description": "Servers0:eth0",
+            "index": "1",
+            "lanes": "25",
+            "mtu": "9100",
+            "pfc_asym": "off",
+            "speed": "1000",
+            "tpid": "0x8100"
+        },
+        "Ethernet1": {
+            "admin_status": "up",
+            "alias": "etp2",
+            "description": "Servers1:eth0",
+            "index": "2",
+            "lanes": "26",
+            "mtu": "9100",
+            "pfc_asym": "off",
+            "speed": "1000",
+            "tpid": "0x8100"
+        }
+    },
+    "PORTCHANNEL": {
+        "PortChannel101": {
+            "admin_status": "up",
+            "lacp_key": "auto",
+            "min_links": "1",
+            "mtu": "9100",
+            "tpid": "0x8100"
+        }
     }
 }

--- a/src/sonic-dhcp-utilities/tests/test_data/port-name-alias-map.txt
+++ b/src/sonic-dhcp-utilities/tests/test_data/port-name-alias-map.txt
@@ -1,3 +1,0 @@
-Ethernet24 etp7
-Ethernet28 etp8
-Ethernet32

--- a/src/sonic-dhcp-utilities/tests/test_dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcp_cfggen.py
@@ -268,10 +268,11 @@ tested_options_data = [
 
 
 def test_parse_port_alias(mock_swsscommon_dbconnector_init, mock_get_render_template):
-    dhcp_db_connector = DhcpDbConnector()
-    dhcp_cfg_generator = DhcpServCfgGenerator(dhcp_db_connector,
-                                              port_map_path="tests/test_data/port-name-alias-map.txt")
-    assert dhcp_cfg_generator.port_alias_map == {"Ethernet24": "etp7", "Ethernet28": "etp8"}
+    with patch.object(DhcpDbConnector, "get_config_db_table", side_effect=mock_get_config_db_table):
+        dhcp_db_connector = DhcpDbConnector()
+        dhcp_cfg_generator = DhcpServCfgGenerator(dhcp_db_connector)
+        assert dhcp_cfg_generator.port_alias_map == {"Ethernet0": "etp1", "Ethernet1": "etp2",
+                                                     "PortChannel101": "PortChannel101"}
 
 
 @pytest.mark.parametrize("is_success", [True, False])

--- a/src/sonic-dhcp-utilities/tests/test_dhcpservd.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcpservd.py
@@ -29,10 +29,10 @@ def test_dump_dhcp4_config(mock_swsscommon_dbconnector_init, enabled_checker):
                       new_callable=PropertyMock), \
          patch.object(DhcpServdDbMonitor, "disable_checkers") as mock_unsubscribe, \
          patch.object(DhcpServdDbMonitor, "enable_checkers") as mock_subscribe, \
-         patch.object(DhcpServd, "enabled_checker", return_value=enabled_checker, new_callable=PropertyMock):
+         patch.object(DhcpServd, "enabled_checker", return_value=enabled_checker, new_callable=PropertyMock), \
+         patch.object(DhcpServCfgGenerator, "_parse_port_map_alias"):
         dhcp_db_connector = DhcpDbConnector()
         dhcp_cfg_generator = DhcpServCfgGenerator(dhcp_db_connector,
-                                                  port_map_path="tests/test_data/port-name-alias-map.txt",
                                                   kea_conf_template_path="tests/test_data/kea-dhcp4.conf.j2")
         dhcpservd = DhcpServd(dhcp_cfg_generator, dhcp_db_connector, None,
                               kea_dhcp4_config_path="/tmp/kea-dhcp4.conf")


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently dhcp_cfggen gets port map from file port-name-alias-map.txt, which is actually generated refer to CONFIG_DB. It will encounter error when PORTCHANNEL table or PORT table not exist in CONFIG_DB.

##### Work item tracking
- Microsoft ADO **(number only)**: 26494259

#### How I did it
Modify dhcp_cfggen to get port map from CONFIG_DB directly.

#### How to verify it
- Build successfully.
- UTs passed.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

