### PR TITLE
[build] verbose output in wait_for_docker.sh when timing out

### DIFF
--- a/scripts/wait_for_docker.sh
+++ b/scripts/wait_for_docker.sh
@@ -3,7 +3,7 @@
 total_time=$1
 cnt=0
 while [ $cnt -le $total_time ]; do
-    docker info 1>/dev/null
+    docker info &>/dev/null
     rv=$?
     if [ $rv -eq 0 ]; then
         exit 0
@@ -11,5 +11,10 @@ while [ $cnt -le $total_time ]; do
     sleep 1
     cnt=$((cnt+1))
 done
+
+echo 'Timed out waiting for internal docker daemon to start' > /dev/stderr
+echo '==== START OF /var/log/docker.log ===='
+cat /var/log/docker.log
+echo '==== END OF /var/log/docker.log ===='
 
 exit 1


### PR DESCRIPTION
#### Why I did it

If there is some problem starting the internal dockerd currently the only output in the build output is 60x `errors pretty printing info` spread over a minute. This comes from the stderr on the `docker info` invocations and is not helpful to the user. The final error becomes `make: *** [slave.mk:918: docker-start] Error 1`.

![image](https://github.com/sonic-net/sonic-buildimage/assets/149442/904ffc98-2549-4024-a737-702d124485d8)


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Instead, hide the `errors pretty printing info` messages and print the log of dockerd if we time out.

#### How to verify it

You can break the build by e.g. not having support for iptables-legacy, which causes dockerd to fail. With the patch the output will now be:

```
does not exist (do you need to insmod?)\nPerhaps iptables or your kernel needs to be upgraded.`, error: exit status 3"                                                                     
time="2024-01-21T10:23:08.357271920Z" level=info msg="stopping event stream following graceful shutdown" error="<nil>" module=libcontainerd namespace=moby                                 
time="2024-01-21T10:23:08.357830731Z" level=info msg="stopping healthcheck following graceful shutdown" module=libcontainerd                                                               
time="2024-01-21T10:23:08.357857882Z" level=info msg="stopping event stream following graceful shutdown" error="context canceled" module=libcontainerd namespace=plugins.moby             
failed to start daemon: Error initializing network controller: error obtaining controller instance: failed to create NAT chain DOCKER: iptables failed: iptables -t nat -N DOCKER: iptables
 v1.8.7 (legacy): can't initialize iptables table `nat': Table does not exist (do you need to insmod?)
Perhaps iptables or your kernel needs to be upgraded.
 (exit status 3)
=== END OF /var/log/docker.log ====
make: *** [slave.mk:918: docker-start] Error 1 
```

#### Which release branch to backport (provide reason below if selected)

None

#### Tested branch (Please provide the tested image version)

202211 and master

#### Description for the changelog

N/A

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

