### PR TITLE
[dhcp_server] Fix parse_dpus error in dhcp_cfggen

### DIFF
--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
@@ -70,7 +70,7 @@ class DhcpServCfgGenerator(object):
         # Parse dpu
         dpus_table = self.db_connector.get_config_db_table(DPUS)
         mid_plane_table = self.db_connector.get_config_db_table(MID_PLANE_BRIDGE)
-        mid_plane, dpus = self._parse_dpu(dpus_table, mid_plane_table) if smart_switch else {}, {}
+        mid_plane, dpus = self._parse_dpu(dpus_table, mid_plane_table) if smart_switch else ({}, {})
 
         dhcp_server_ipv4, customized_options_ipv4, range_ipv4, port_ipv4 = self._get_dhcp_ipv4_tables_from_db()
         # Parse range table

--- a/src/sonic-dhcp-utilities/tests/test_data/mock_config_db_smart_switch.json
+++ b/src/sonic-dhcp-utilities/tests/test_data/mock_config_db_smart_switch.json
@@ -8,7 +8,7 @@
     "MID_PLANE_BRIDGE": {
         "GLOBAL": {
             "bridge": "bridge_midplane",
-            "address": "169.254.200.254/24"
+            "ip_prefix": "169.254.200.254/24"
         }
     },
     "DHCP_SERVER_IPV4": {
@@ -22,6 +22,42 @@
             "mode": "PORT",
             "netmask": "255.255.255.0",
             "state": "enabled"
+        }
+    },
+    "DHCP_SERVER_IPV4_PORT": {
+        "bridge_midplane|dpu0": {
+            "ips": [
+                "169.254.200.1"
+            ]
+        },
+        "bridge_midplane|dpu1": {
+            "ips": [
+                "169.254.200.2"
+            ]
+        },
+        "bridge_midplane|dpu2": {
+            "ips": [
+                "169.254.200.3"
+            ]
+        },
+        "bridge_midplane|dpu3": {
+            "ips": [
+                "169.254.200.4"
+            ]
+        }
+    },
+    "DPUS": {
+        "dpu0": {
+            "midplane_interface": "dpu0"
+        },
+        "dpu1": {
+            "midplane_interface": "dpu1"
+        },
+        "dpu2": {
+            "midplane_interface": "dpu2"
+        },
+        "dpu3": {
+            "midplane_interface": "dpu3"
         }
     }
 }

--- a/src/sonic-dhcp-utilities/tests/test_smart_switch.py
+++ b/src/sonic-dhcp-utilities/tests/test_smart_switch.py
@@ -1,8 +1,106 @@
+import json
 import pytest
 from common_utils import MockConfigDb, dhcprelayd_refresh_dhcrelay_test, dhcprelayd_proceed_with_check_res_test
 from dhcp_utilities.dhcprelayd.dhcprelayd import DHCP_SERVER_CHECKER, MID_PLANE_CHECKER
+from dhcp_utilities.dhcpservd.dhcp_cfggen import DhcpServCfgGenerator
+from dhcp_utilities.common.utils import DhcpDbConnector
+from unittest.mock import patch
 
 MOCK_CONFIG_DB_PATH_SMART_SWITCH = "tests/test_data/mock_config_db_smart_switch.json"
+expected_kea_config = {
+    "Dhcp4": {
+        "hooks-libraries": [
+            {
+                "library": "/usr/local/lib/kea/hooks/libdhcp_run_script.so",
+                "parameters": {
+                    "name": "/etc/kea/lease_update.sh",
+                    "sync": False
+                }
+            }
+        ],
+        "interfaces-config": {
+            "interfaces": [
+                "eth0"
+            ]
+        },
+        "control-socket": {
+            "socket-type": "unix",
+            "socket-name": "/run/kea/kea4-ctrl-socket"
+        },
+        "lease-database": {
+            "type": "memfile",
+            "persist": True,
+            "name": "/tmp/kea-lease.csv",
+            "lfc-interval": 3600
+        },
+        "subnet4": [
+            {
+                "subnet": "169.254.200.0/24",
+                "pools": [
+                    {
+                        "pool": "169.254.200.1 - 169.254.200.1",
+                        "client-class": "sonic-host:dpu0"
+                    },
+                    {
+                        "pool": "169.254.200.2 - 169.254.200.2",
+                        "client-class": "sonic-host:dpu1"
+                    },
+                    {
+                        "pool": "169.254.200.3 - 169.254.200.3",
+                        "client-class": "sonic-host:dpu2"
+                    },
+                    {
+                        "pool": "169.254.200.4 - 169.254.200.4",
+                        "client-class": "sonic-host:dpu3"
+                    }
+                ],
+                "option-data": [
+                    {
+                        "name": "routers",
+                        "data": "169.254.200.254"
+                    },
+                    {
+                        "name": "dhcp-server-identifier",
+                        "data": "169.254.200.254"
+                    }
+                ],
+                "valid-lifetime": 900,
+                "reservations": []
+            }
+        ],
+        "loggers": [
+            {
+                "name": "kea-dhcp4",
+                "output_options": [
+                    {
+                        "output": "/var/log/kea-dhcp.log",
+                        "pattern": "%-5p %m\n"
+                    }
+                ],
+                "severity": "INFO",
+                "debuglevel": 0
+            }
+        ],
+        "client-classes": [
+            {
+                "name": "sonic-host:dpu0",
+                "test": "substring(relay4[1].hex, -15, 15) == 'sonic-host:dpu0'"
+            },
+            {
+                "name": "sonic-host:dpu1",
+                "test": "substring(relay4[1].hex, -15, 15) == 'sonic-host:dpu1'"
+            },
+            {
+                "name": "sonic-host:dpu2",
+                "test": "substring(relay4[1].hex, -15, 15) == 'sonic-host:dpu2'"
+            },
+            {
+                "name": "sonic-host:dpu3",
+                "test": "substring(relay4[1].hex, -15, 15) == 'sonic-host:dpu3'"
+            }
+        ]
+    }
+}
 
 
 def test_dhcprelayd_refresh_dhcrelay(mock_swsscommon_dbconnector_init):
@@ -19,6 +117,24 @@ def test_dhcprelayd_proceed_with_check_res(mock_swsscommon_dbconnector_init, moc
     expected_checkers = set([DHCP_SERVER_CHECKER, MID_PLANE_CHECKER])
     dhcprelayd_proceed_with_check_res_test(enabled_checkers, feature_enabled, feature_res, dhcp_server_res,
                                            None, True, expected_checkers)
+
+
+def test_dhcp_dhcp_cfggen_generate(mock_swsscommon_dbconnector_init, mock_parse_port_map_alias):
+    with patch.object(DhcpDbConnector, "get_config_db_table", side_effect=mock_get_config_db_table):
+        dhcp_db_connector = DhcpDbConnector()
+        dhcp_cfg_generator = DhcpServCfgGenerator(dhcp_db_connector,
+                                                  kea_conf_template_path="tests/test_data/kea-dhcp4.conf.j2")
+        kea_dhcp4_config, used_ranges, enabled_dhcp_interfaces, used_options, subscribe_table = \
+            dhcp_cfg_generator.generate()
+        assert json.loads(kea_dhcp4_config) == expected_kea_config
+        assert used_ranges == set()
+        assert enabled_dhcp_interfaces == set(["bridge_midplane"])
+        assert used_options == set()
+        expected_tables = set(["DpusTableEventChecker", "MidPlaneTableEventChecker", "VlanTableEventChecker",
+                               "VlanIntfTableEventChecker", "DhcpRangeTableEventChecker", "VlanMemberTableEventChecker",
+                               "DhcpOptionTableEventChecker", "DhcpPortTableEventChecker",
+                               "DhcpServerTableCfgChangeEventChecker"])
+        assert subscribe_table == expected_tables
 
 
 def mock_get_config_db_table(table_name):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix parse_dpus error in dhcp_cfggen

##### Work item tracking
- Microsoft ADO **(number only)**: 26515431

#### How I did it
* Fix parse_dpus error in dhcp_cfggen
* Add ut for it

#### How to verify it
* UTs passed
* Build python package and install to test

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

