### PR TITLE
Change orchagent stuck message from ERR to WARNING

### DIFF
--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -73,7 +73,7 @@ def get_group_and_process_list(process_file):
     return group_list, process_list
 
 
-def generate_alerting_message(process_name, status, dead_minutes):
+def generate_alerting_message(process_name, status, dead_minutes, priority=syslog.LOG_ERR):
     """
     @summary: If a critical process was not running, this function will determine it resides in host
               or in a specific namespace. Then an alerting message will be written into syslog.
@@ -86,7 +86,7 @@ def generate_alerting_message(process_name, status, dead_minutes):
     else:
         namespace = namespace_prefix + namespace_id
 
-    syslog.syslog(syslog.LOG_ERR, "Process '{}' is {} in namespace '{}' ({} minutes)."
+    syslog.syslog(priority, "Process '{}' is {} in namespace '{}' ({} minutes)."
                   .format(process_name, status, namespace, dead_minutes))
 
 
@@ -213,7 +213,7 @@ def main(argv):
             elapsed_secs = epoch_time - process_heart_beat_info[process]["last_heart_beat"]
             if elapsed_secs >= ALERTING_INTERVAL_SECS:
                 elapsed_mins = elapsed_secs // 60
-                generate_alerting_message(process, "stuck", elapsed_mins)
+                generate_alerting_message(process, "stuck", elapsed_mins, syslog.LOG_WARNING)
 
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
Change orchagent stuck message from ERR to WARNING

#### Why I did it
During switch initialization, sometime Orchagent will busy for more than 40seconds and will trigger process stuck workdog error.
To improve this issue, change watchdog error message to warning message.

##### Work item tracking
- Microsoft ADO: 26517622

#### How I did it
Change orchagent stuck message from ERR to WARNING.

#### How to verify it
Pass all UT.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] TODO


#### Description for the changelog
Change orchagent stuck message from ERR to WARNING.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

