### PR TITLE
Wait till CHASIS_APP_DB PING is successful,  host_name and asic_name are valid in CONIFG_DB before starting chassis-db-cleanup

### DIFF
--- a/files/build_templates/per_namespace/swss.service.j2
+++ b/files/build_templates/per_namespace/swss.service.j2
@@ -11,7 +11,6 @@ Requires=opennsl-modules.service
 {% endif %}
 Requires=updategraph.service
 After=updategraph.service
-After=hostname-config.service
 BindsTo=sonic.target
 After=sonic.target
 Before=ntp-config.service

--- a/files/build_templates/per_namespace/swss.service.j2
+++ b/files/build_templates/per_namespace/swss.service.j2
@@ -11,6 +11,7 @@ Requires=opennsl-modules.service
 {% endif %}
 Requires=updategraph.service
 After=updategraph.service
+After=hostname-config.service
 BindsTo=sonic.target
 After=sonic.target
 Before=ntp-config.service

--- a/files/image_config/hostname/hostname-config.sh
+++ b/files/image_config/hostname/hostname-config.sh
@@ -11,10 +11,16 @@ fi
 echo $HOSTNAME > /etc/hostname
 hostname -F /etc/hostname
 
+#Don't update the /etc/hosts if hostname is not changed
+#This is to prevent intermittent redis_chassis.server reachability issue
+if [ $CURRENT_HOSTNAME == $HOSTNAME ] ;  then
+    exit 0
+fi
+
 # Remove the old hostname entry from hosts file.
 # But, 'localhost' entry is used by multiple applications. Don't remove it altogether.
 # Edit contents of /etc/hosts and put in /etc/hosts.new
-if [ $CURRENT_HOSTNAME  != "localhost" ] || [ $CURRENT_HOSTNAME == $HOSTNAME ] ;  then
+if [ $CURRENT_HOSTNAME  != "localhost" ] ;  then
     sed "/\s$CURRENT_HOSTNAME$/d" /etc/hosts > /etc/hosts.new
 else
     cp -f /etc/hosts /etc/hosts.new

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -132,12 +132,23 @@ function clean_up_chassis_db_tables()
         return
     fi
 
-    if [[ !($($SONIC_DB_CLI CHASSIS_APP_DB PING | grep -c True) -gt 0) ]]; then
-        return
-    fi
+    until [[ $($SONIC_DB_CLI CHASSIS_APP_DB PING | grep -c True) -gt 0 ]]; do
+        sleep 1
+    done
 
     lc=`$SONIC_DB_CLI CONFIG_DB  hget 'DEVICE_METADATA|localhost' 'hostname'`
+    until [[ -n "${lc}" ]]; do
+        lc=`$SONIC_DB_CLI CONFIG_DB  hget 'DEVICE_METADATA|localhost' 'hostname'`
+        sleep 1
+    done
+    debug "Chassis db clean up for ${SERVICE}$DEV. hostname=$lc"
+
     asic=`$SONIC_DB_CLI CONFIG_DB  hget 'DEVICE_METADATA|localhost' 'asic_name'`
+    until [[ -n "${asic}" ]]; do
+        asic=`$SONIC_DB_CLI CONFIG_DB  hget 'DEVICE_METADATA|localhost' 'asic_name'`
+        sleep 1
+    done
+    debug "Chassis db clean up for ${SERVICE}$DEV. asic=$asic"
 
     # First, delete SYSTEM_NEIGH entries
     num_neigh=`$SONIC_DB_CLI CHASSIS_APP_DB EVAL "


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR fixes the issue reported in Issu #17945 
We noticed that chassis db clean up is skipped sometimes when the CHASSIS_APP_DB PING fails. Also if host_name and asic_name are not written to CONIG_DB, it could pass the empty strings to CHASSIS_APP_DB EVAL commands.
The service hostname-config.service is restarted whenever the config-reload or load-minigraph is done and this services renames the file /etc/hosts to updates it with the new file. This interferes with swss@.service and when swss.sh script CHASSIS_APP_DPP when the /etc/hosts file is renamed, the error "Unable to connect to redis: Cannot assign requested address" is seen and the CHASSIS_APP_DB EVAL command fails. This causes the chassis db entries not getting cleaned up and causes orchagent crash in  remote LC's.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
 Wait till CHASS_APP_DB PING is successful before checking for entries in CHASSIS_APP_DB table. Also wait till host_name and asic_name are valis in CONFIG_DB. 
Modified swss@.service to start after hostname-config.service

#### How to verify it
Ran a script with 200 times config reload & load-minigraph and verified that chassis db cleanup is done every time and the orchagent crash is not seen .
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

