### PR TITLE
[202311][FRR] Fix zebra memory leak when bgp fib suppress pending is enabled

### DIFF
--- a/src/sonic-frr/patch/0033-zebra-The-dplane_fpm_nl-return-path-leaks-memory.patch
+++ b/src/sonic-frr/patch/0033-zebra-The-dplane_fpm_nl-return-path-leaks-memory.patch
@@ -1,0 +1,57 @@
+From c13964525dae96299dc54daf635609971576a09e Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Mon, 11 Dec 2023 13:41:36 -0500
+Subject: [PATCH] zebra: The dplane_fpm_nl return path leaks memory
+
+The route entry created when using a ctx to pass route
+entry data backup to the master pthread in zebra is
+being leaked.  Prevent this from happening.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+
+diff --git a/zebra/rib.h b/zebra/rib.h
+index 016106312..e99eee67c 100644
+--- a/zebra/rib.h
++++ b/zebra/rib.h
+@@ -352,6 +352,8 @@ extern void _route_entry_dump(const char *func, union prefixconstptr pp,
+ 			      union prefixconstptr src_pp,
+ 			      const struct route_entry *re);
+ 
++void zebra_rib_route_entry_free(struct route_entry *re);
++
+ struct route_entry *
+ zebra_rib_route_entry_new(vrf_id_t vrf_id, int type, uint8_t instance,
+ 			  uint32_t flags, uint32_t nhe_id, uint32_t table_id,
+diff --git a/zebra/rt_netlink.c b/zebra/rt_netlink.c
+index 6bdc15592..fc9e8c457 100644
+--- a/zebra/rt_netlink.c
++++ b/zebra/rt_netlink.c
+@@ -1001,6 +1001,8 @@ int netlink_route_change_read_unicast_internal(struct nlmsghdr *h,
+ 						 re, ng, startup, ctx);
+ 			if (ng)
+ 				nexthop_group_delete(&ng);
++			if (ctx)
++				zebra_rib_route_entry_free(re);
+ 		} else {
+ 			/*
+ 			 * I really don't see how this is possible
+diff --git a/zebra/zebra_rib.c b/zebra/zebra_rib.c
+index f2f20bcf7..1cefdfae7 100644
+--- a/zebra/zebra_rib.c
++++ b/zebra/zebra_rib.c
+@@ -4136,6 +4136,12 @@ struct route_entry *zebra_rib_route_entry_new(vrf_id_t vrf_id, int type,
+ 
+ 	return re;
+ }
++
++void zebra_rib_route_entry_free(struct route_entry *re)
++{
++	XFREE(MTYPE_RE, re);
++}
++
+ /*
+  * Internal route-add implementation; there are a couple of different public
+  * signatures. Callers in this path are responsible for the memory they
+-- 
+2.17.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -29,6 +29,7 @@ cross-compile-changes.patch
 0030-bgpd-Treat-EOR-as-withdrawn-to-avoid-unwanted-handli.patch
 0031-bgpd-Ignore-handling-NLRIs-if-we-received-MP_UNREACH.patch
 0032-zebra-Fix-fpm-multipath-encap-addition.patch
+0033-zebra-The-dplane_fpm_nl-return-path-leaks-memory.patch
 0034-fpm-Use-vrf_id-for-vrf-not-tabled_id.patch
 0035-fpm-ignore-route-from-default-table.patch
 0036-Add-support-of-bgp-l3vni-evpn.patch


### PR DESCRIPTION
Manual cherry-pick of https://github.com/sonic-net/sonic-buildimage/pull/17484



<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix zebra leaking memory with fib suppress enabled. Porting the fix from FRRouting/frr#14983

While running test_stress_route.py, systems with lower memory started to throw low memory logs. On further investigation, a memory leak has been found in zebra which was fixed in the FRR community.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Creating patch for with the fix


#### How to verify it
Running test_stress_route.py and confirming that there is no memory leak in zebra after the completion of the test


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

