### PR TITLE
[build_debian] libgrpc++ installation for bookworm debian image build

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -387,8 +387,8 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     python-is-python3       \
     cron                    \
     libprotobuf32           \
-    libgrpc++1              \
     libgrpc29               \
+    libgrpc++1.51           \
     haveged                 \
     fdisk                   \
     gpg                     \


### PR DESCRIPTION
#### Why I did it
Fix libgrpc++ bookworm debian installation issue.  Fix #18033  
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modified the build_debian.sh to change the libgrpc++1 to libgrcp++1.51 for debian bookworm image build 

#### How to verify it
After the image is built in the workspace, verify the libgrpc++.so.1.51 is installed in fsroot-broadcom-dnx/lib/x86_64-linux-gnu diretcory
```
~/data/master/sonic-buildimage/fsroot-broadcom-dnx/lib/x86_64-linux-gnu (master)$ ls libgrpc++.so.1.51
libgrpc++.so.1.51
~/data/master/sonic-buildimage/fsroot-broadcom-dnx/lib/x86_64-linux-gnu (master)$ 
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] master
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

