### PR TITLE
[202311][dhcp_server][yang] Update supported option type to string (#18029)

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1024,7 +1024,7 @@ IPV4 DHPC Server related configuration are defined in **DHCP_SERVER_IPV4**, **DH
     "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
         "option60": {
             "id": 60,
-            "type": "text",
+            "type": "string",
             "value": "dummy_value"
         }
     },

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1924,7 +1924,7 @@
         "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
             "option60": {
                 "id": "60",
-                "type": "text",
+                "type": "string",
                 "value": "dummy_value"
             }
         },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/dhcp_server_ipv4.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/dhcp_server_ipv4.json
@@ -35,8 +35,8 @@
         "eStrKey": "InvalidValue",
         "eStr": ["type"]
     },
-    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_TEXT": {
-        "desc": "Add text type of DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS."
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_STRING": {
+        "desc": "Add string type of DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS."
     },
     "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_IPV4_ADDRESS": {
         "desc": "Add ipv4-address type of DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS."

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcp_server_ipv4.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcp_server_ipv4.json
@@ -46,7 +46,7 @@
                     {
                         "name": "option60",
                         "id": 60,
-                        "type": "text",
+                        "type": "string",
                         "value": "dummy_value"
                     }
                 ]
@@ -171,7 +171,7 @@
                     {
                         "name": "option60",
                         "id": 60,
-                        "type": "text",
+                        "type": "string",
                         "value": "dummy_value"
                     }
                 ]
@@ -230,7 +230,7 @@
                     {
                         "name": "option60",
                         "id": 60,
-                        "type": "text",
+                        "type": "string",
                         "value": "dummy_value"
                     }
                 ]
@@ -248,14 +248,14 @@
             }
         }
     },
-    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_TEXT": {
+    "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_STRING": {
         "sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4": {
             "sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS": {
                 "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
                     {
                         "name": "option60",
                         "id": 60,
-                        "type": "text",
+                        "type": "string",
                         "value": "dummy_value"
                     }
                 ]
@@ -325,7 +325,7 @@
                     {
                         "name": "option60",
                         "id": 60,
-                        "type": "texts",
+                        "type": "text",
                         "value": "dummy_value"
                     }
                 ]
@@ -448,7 +448,7 @@
                     {
                         "name": "option60",
                         "id": 60,
-                        "type": "text",
+                        "type": "string",
                         "value": "dummy_value"
                     }
                 ]
@@ -529,7 +529,7 @@
                     {
                         "name": "option60",
                         "id": 60,
-                        "type": "text",
+                        "type": "string",
                         "value": "dummy_value"
                     }
                 ]
@@ -610,7 +610,7 @@
                     {
                         "name": "option60",
                         "id": 60,
-                        "type": "text",
+                        "type": "string",
                         "value": "dummy_value"
                     }
                 ]
@@ -691,7 +691,7 @@
                     {
                         "name": "option60",
                         "id": 60,
-                        "type": "text",
+                        "type": "string",
                         "value": "dummy_value"
                     }
                 ]
@@ -772,7 +772,7 @@
                     {
                         "name": "option60",
                         "id": 60,
-                        "type": "text",
+                        "type": "string",
                         "value": "dummy_value"
                     }
                 ]
@@ -814,7 +814,7 @@
                 "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST": [
                     {
                         "name": "option60",
-                        "type": "text",
+                        "type": "string",
                         "value": "dummy_value"
                     }
                 ]
@@ -828,7 +828,7 @@
                     {
                         "name": "option60",
                         "id": 60,
-                        "type": "text"
+                        "type": "string"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-dhcp-server-ipv4.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dhcp-server-ipv4.yang
@@ -130,7 +130,7 @@ module sonic-dhcp-server-ipv4 {
                 leaf type {
                     description "Type of customized option, for standard DHCP option, this field is invalid";
                     type enumeration {
-                        enum text;
+                        enum string;
                         enum ipv4-address;
                         enum uint8;
                         enum uint16;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Manually cherry-pick and resolve conflicts of this PR: https://github.com/sonic-net/sonic-buildimage/pull/18029
Changes in current PR is totally same as master PR: https://github.com/sonic-net/sonic-buildimage/pull/18029. Conflicts generated because smart switch support in master branch which shouldn't be backported to 202311

Align yang model with implementation and KEA doc https://kea.readthedocs.io/en/latest/arm/dhcp4-srv.html#standard-dhcpv4-options, change type text to string

##### Work item tracking
- Microsoft ADO **(number only)**: 26685449

#### How I did it
Update supported option type to string

#### How to verify it
Image build successfully

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

