### PR TITLE
[202311] Fix IPV6 forced-mgmt-route not work issue

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -86,7 +86,7 @@ iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev {{ name }} table {{ vrf_table }}
     up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add pref {{ force_mgmt_route_priority + 1 }} from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
-    up ip rule add pref {{ force_mgmt_route_priority }} to {{ route }} table {{ vrf_table }}
+    up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add pref {{ force_mgmt_route_priority }} to {{ route }} table {{ vrf_table }}
 {% endfor %}
 {% if prefix | ipv6 and vrf_table == 'default'%}
     # IPV6 default table not add to lookup by default, management server need this to access IPV6 address when BGP shutdown
@@ -97,7 +97,7 @@ iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev {{ name }} table {{ vrf_table }}
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete pref {{ force_mgmt_route_priority + 1 }} from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
-    pre-down ip rule delete pref {{ force_mgmt_route_priority }} to {{ route }} table {{ vrf_table }}
+    pre-down ip {{ '-4' if route | ipv4 else '-6' }} rule delete pref {{ force_mgmt_route_priority }} to {{ route }} table {{ vrf_table }}
 {% endfor %}
 {% if prefix | ipv6 and vrf_table == 'default'%}
     pre-down ip -6 rule delete pref {{ force_mgmt_route_priority + 3 }} lookup {{ vrf_table }}

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
@@ -34,14 +34,14 @@ iface eth0 inet static
     up ip -4 route add default via 10.0.0.1 dev eth0 table 5000 metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table 5000
     up ip -4 rule add pref 32765 from 10.0.0.100/32 table 5000
-    up ip rule add pref 32764 to 11.11.11.11 table 5000
-    up ip rule add pref 32764 to 22.22.22.0/23 table 5000
+    up ip -4 rule add pref 32764 to 11.11.11.11 table 5000
+    up ip -4 rule add pref 32764 to 22.22.22.0/23 table 5000
     # management port down rules
     pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table 5000
     pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table 5000
     pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table 5000
-    pre-down ip rule delete pref 32764 to 11.11.11.11 table 5000
-    pre-down ip rule delete pref 32764 to 22.22.22.0/23 table 5000
+    pre-down ip -4 rule delete pref 32764 to 11.11.11.11 table 5000
+    pre-down ip -4 rule delete pref 32764 to 22.22.22.0/23 table 5000
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
@@ -53,10 +53,12 @@ iface eth0 inet6 static
     up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 5000 metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 5000
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 5000
+    up ip -6 rule add pref 32764 to 33:33:33::0/64 table 5000
     # management port down rules
     pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 5000
     pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 5000
     pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table 5000
+    pre-down ip -6 rule delete pref 32764 to 33:33:33::0/64 table 5000
 #
 source /etc/network/interfaces.d/*
 #

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
@@ -34,14 +34,14 @@ iface eth0 inet static
     up ip -4 route add default via 10.0.0.1 dev eth0 table 5000 metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table 5000
     up ip -4 rule add pref 32765 from 10.0.0.100/32 table 5000
-    up ip rule add pref 32764 to 11.11.11.11 table 5000
-    up ip rule add pref 32764 to 22.22.22.0/23 table 5000
+    up ip -4 rule add pref 32764 to 11.11.11.11 table 5000
+    up ip -4 rule add pref 32764 to 22.22.22.0/23 table 5000
     # management port down rules
     pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table 5000
     pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table 5000
     pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table 5000
-    pre-down ip rule delete pref 32764 to 11.11.11.11 table 5000
-    pre-down ip rule delete pref 32764 to 22.22.22.0/23 table 5000
+    pre-down ip -4 rule delete pref 32764 to 11.11.11.11 table 5000
+    pre-down ip -4 rule delete pref 32764 to 22.22.22.0/23 table 5000
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
@@ -53,10 +53,12 @@ iface eth0 inet6 static
     up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 5000 metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 5000
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 5000
+    up ip -6 rule add pref 32764 to 33:33:33::0/64 table 5000
     # management port down rules
     pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 5000
     pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 5000
     pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table 5000
+    pre-down ip -6 rule delete pref 32764 to 33:33:33::0/64 table 5000
 #
 source /etc/network/interfaces.d/*
 #

--- a/src/sonic-config-engine/tests/t0-sample-graph-mvrf.xml
+++ b/src/sonic-config-engine/tests/t0-sample-graph-mvrf.xml
@@ -787,7 +787,7 @@
           <a:DeviceProperty>
             <a:Name>ForcedMgmtRoutes</a:Name>
             <a:Reference i:nil="true"/>
-            <a:Value>11.11.11.11;22.22.22.0/23</a:Value>
+            <a:Value>11.11.11.11;22.22.22.0/23;33:33:33::0/64</a:Value>
           </a:DeviceProperty>
           <a:DeviceProperty>
             <a:Name>ErspanDestinationIpv4</a:Name>


### PR DESCRIPTION
Fix IPV6 forced-mgmt-route not work issue
This is cherry-pick PR for #17299

#### Why I did it
IPV6 forced-mgmt-route not work

When add a IPV6 route, should use 'ip -6 rule add pref 32764 address' command, but currently in the template the '-6' parameter are missing, so the IPV6 route been add to IPV4 route table.

Also this PR depends on https://github.com/sonic-net/sonic-buildimage/pull/17281 , which will fix the IPV6 'default' route table missing in IPV6 route lookup issue. 

##### Work item tracking
- Microsoft ADO **(number only)**:24719238

#### How I did it
Add IPV6 route with 'ip -6' command


#### How to verify it
Pass all UT
Manually verify:

// setup forced mgmt routes
admin@vlab-01:~$ sonic-db-cli  CONFIG_DB HSET "MGMT_INTERFACE|eth0|fec0::ffff:afa:1/64" forced_mgmt_routes@ "1110::ffff:afa:1/64"
1
admin@vlab-01:~$ sudo config save -y
Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
admin@vlab-01:~$ sudo config reload -y
Disabling container monitoring ...
Stopping SONiC target ...


// check interface config update correctly
admin@vlab-01:~$ cat /etc/network/interfaces

...

iface eth0 inet6 static
    address fec0::ffff:afa:1
    netmask 64
    network fec0::
    broadcast fec0::ffff:ffff:ffff:ffff
    ########## management network policy routing rules
    # management port up rules
    up ip -6 route add default via fec0::1 dev eth0 table default metric 201
    up ip -6 route add fec0::/64 dev eth0 table default
    up ip -6 rule add pref 32765 from fec0::ffff:afa:1/128 table default
    up ip **-6** rule add pref 32764 to 1110::ffff:afa:1/64 table default <== force mgmt route added correctly with 'ip -6'

// check route tables:
admin@vlab-01:~$ ip -6 rule list
1001:   from all lookup local
32764:  from all to 1110::ffff:afa:1/64 lookup default
32765:  from fec0::ffff:afa:1 lookup default <== force mgmt route been add to IPV6 table
32766:  from all lookup main
admin@vlab-01:~$


// traceroute command can find route
admin@vlab-01:~$ traceroute 1110::ffff:afa:1
traceroute to 1110::ffff:afa:1 (1110::ffff:afa:1), 30 hops max, 80 byte packets
 1  * * *
 2  * * *


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] master-17299.420743-d31987daa

#### Description for the changelog
Fix IPV6 forced-mgmt-route not work issue

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

