### PR TITLE
Add enable_xcvrd_sff_mgr flag support for xcvrd startup command

### DIFF
--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -95,13 +95,23 @@ dependent_startup_wait_for=rsyslogd:running
 
 {% if not skip_xcvrd %}
 [program:xcvrd]
+{% set base_command = "python3 /usr/local/bin/xcvrd" %}
+{% set options = "" -%}
+
+{% if skip_xcvrd_cmis_mgr %}
+    {%- set options = options + " --skip_cmis_mgr" %}
+{% endif -%}
+
+{% if enable_xcvrd_sff_mgr %}
+    {%- set options = options + " --enable_sff_mgr" %}
+{% endif -%}
+
 {% if delay_xcvrd %}
-command={% if skip_xcvrd_cmis_mgr %} bash -c "sleep 30 && python3 /usr/local/bin/xcvrd --skip_cmis_mgr" {% else %} bash -c "sleep 30 && python3 /usr/local/bin/xcvrd" {% endif %}
-
+    {%- set command = "bash -c \"sleep 30 && " ~ base_command ~ options ~ "\"" %}
 {% else %}
-command={% if skip_xcvrd_cmis_mgr %} python3 /usr/local/bin/xcvrd --skip_cmis_mgr {% else %} python3 /usr/local/bin/xcvrd {% endif %}
-
-{% endif %}
+    {%- set command = base_command ~ options %}
+{% endif -%}
+command={{ command }}
 priority=6
 autostart=false
 autorestart=unexpected


### PR DESCRIPTION
This PR is a dependency of https://github.com/sonic-net/sonic-platform-daemons/pull/383
HLD of sff_mgr: https://github.com/sonic-net/SONiC/pull/1371

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Add enable_xcvrd_sff_mgr flag support for sff_mgr

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

In docker-pmon.supervisord.conf.j2 file, add logic to append enable_sff_mgr flag to xcvrd startup command based on the enable_xcvrd_sff_mgr flag defined in  pmon_daemon_control.json

Also did clean-up on the corresponding j2 logic to make it more read-able and easier to extend.

#### How to verify it

Verified with different combinations of flags for the output of j2, matched with the original and correct output.
```
sonic-cfggen -a '{"skip_xcvrd_cmis_mgr": false, "enable_xcvrd_sff_mgr": false, "delay_xcvrd": false}' -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 | grep "program:xcvrd" -A 1
[program:xcvrd]
command=python3 /usr/local/bin/xcvrd

sonic-cfggen -a '{"skip_xcvrd_cmis_mgr": true, "enable_xcvrd_sff_mgr": false, "delay_xcvrd": false}' -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 | grep "program:xcvrd" -A 1
[program:xcvrd]
command=python3 /usr/local/bin/xcvrd --skip_cmis_mgr

sonic-cfggen -a '{"skip_xcvrd_cmis_mgr": false, "enable_xcvrd_sff_mgr": true, "delay_xcvrd": false}' -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 | grep "program:xcvrd" -A 1
[program:xcvrd]
command=python3 /usr/local/bin/xcvrd --enable_sff_mgr

sonic-cfggen -a '{"skip_xcvrd_cmis_mgr": false, "enable_xcvrd_sff_mgr": false, "delay_xcvrd": true}' -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 | grep "program:xcvrd" -A 1
[program:xcvrd]
command=bash -c "sleep 30 && python3 /usr/local/bin/xcvrd"

sonic-cfggen -a '{"skip_xcvrd_cmis_mgr": true, "enable_xcvrd_sff_mgr": true, "delay_xcvrd": false}' -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 | grep "program:xcvrd" -A 1
[program:xcvrd]
command=python3 /usr/local/bin/xcvrd --skip_cmis_mgr --enable_sff_mgr

sonic-cfggen -a '{"skip_xcvrd_cmis_mgr": true, "enable_xcvrd_sff_mgr": false, "delay_xcvrd": true}' -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 | grep "program:xcvrd" -A 1
[program:xcvrd]
command=bash -c "sleep 30 && python3 /usr/local/bin/xcvrd --skip_cmis_mgr"

sonic-cfggen -a '{"skip_xcvrd_cmis_mgr": false, "enable_xcvrd_sff_mgr": true, "delay_xcvrd": true}' -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 | grep "program:xcvrd" -A 1
[program:xcvrd]
command=bash -c "sleep 30 && python3 /usr/local/bin/xcvrd --enable_sff_mgr"

sonic-cfggen -a '{"skip_xcvrd_cmis_mgr": true, "enable_xcvrd_sff_mgr": true, "delay_xcvrd": true}' -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 | grep "program:xcvrd" -A 1
[program:xcvrd]
command=bash -c "sleep 30 && python3 /usr/local/bin/xcvrd --skip_cmis_mgr --enable_sff_mgr"
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202305

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

