### PR TITLE
[Nokia-IXR7250E][Devicedata] Update the device data for Nokia IXR7250…

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_ndk.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_ndk.json
@@ -50,11 +50,11 @@
     },
     {
       "key": "thermal_log_current_threshold",
-      "intval": 2
+      "intval": 5
     },
     {
       "key": "thermal_log_margin_threshold",
-      "intval": 2
+      "intval": 5
     },
     {
       "key": "thermal_log_min_threshold",

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_ndk.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_ndk.json
@@ -38,11 +38,11 @@
     },
     {
       "key": "thermal_log_current_threshold",
-      "intval": 3
+      "intval": 5
     },
     {
       "key": "thermal_log_margin_threshold",
-      "intval": 3
+      "intval": 5
     },
     {
       "key": "thermal_log_min_threshold",


### PR DESCRIPTION
These changes adjust Nokia IXR7250 thermal sensor logging thresholds.

#### Why I did it

To modify the thermal sensor logging thresholds used on LC and Supervisor.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Modified the JSON based thermal logging thresholds used to determine when to log current high sensor temperature and hottest sensor margin fluctuations.

#### How to verify it

Verify that syslog messages indicating current (high) temperature and margin values are only logged when these respective values fluctuate by at least 5 degrees.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [X] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

- [X] 202205


#### Description for the changelog

[Nokia-IXR7250E][Devicedata] Update device data for Nokia IXR7250 for the purpose of adjusting default thermal logging thresholds

