### PR TITLE
[ebtables] Add multicast drop rule to ebtables

### DIFF
--- a/files/image_config/ebtables/ebtables.filter.cfg
+++ b/files/image_config/ebtables/ebtables.filter.cfg
@@ -8,4 +8,5 @@
 -A FORWARD -d BGA -j DROP
 -A FORWARD -p ARP -j DROP
 -A FORWARD -p 802_1Q --vlan-encap ARP -j DROP
+-A FORWARD -d Multicast -j DROP
 


### PR DESCRIPTION
Adding rule to ebtables to drop multicast packets in kernel. This was done to address a bug where NS packets were flooding ports with duplicate packets.

#### Why I did it
ADO: 26395587
Fixes bug where NS packets were flooding ports with duplicate packets

##### Work item tracking
- Microsoft ADO **(number only)**: 26395587

#### How I did it
Added ebtables rule to drop multicast packets

#### How to verify it
1. set up testbed with ebtables rule:  -A FORWARD -d Multicast -j DROP
2. tcpdump from eth4
3. send NS packet from eth8

before this fix, we saw 2 packets received on the tcpdump port. After this fix, we will only see one coming from the basic forwarding

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202311

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Adding ebtables rule to drop multicast packets.

#### A picture of a cute animal (not mandatory but encouraged)

![IMG_3777](https://github.com/sonic-net/sonic-buildimage/assets/26731235/81a3bc1b-fd28-499d-94a7-67b526ec6fd7)
