### PR TITLE
[pmem] create a emuated persistent memory on RAM for safe warm-reboot

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -494,6 +494,8 @@ write_platform_specific_cmdline() {
     if in_array "$sid" "Upperlake" "UpperlakeES" "UpperlakeElite"; then
         aboot_machine=arista_7060_cx32s
         flash_size=3700
+	cmdline_add memmap=512M!4G
+        cmdline_add mount_pmem=on
     fi
     if [ "$sid" = "UpperlakePlus" ]; then
         aboot_machine=arista_7060cx2_32s

--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -15,6 +15,7 @@ docker_inram=false
 docker_inram_algo=tmpfs
 docker_inram_size={{ DOCKER_RAMFS_SIZE }}
 logs_inram=false
+mount_pmem=false
 secureboot=false
 bootloader=generic
 in_kdump=false
@@ -37,6 +38,9 @@ for x in $(cat /proc/cmdline); do
             ;;
         logs_inram=on)
             logs_inram=true
+            ;;
+        mount_pmem=on)
+            mount_pmem=true
             ;;
         varlog_size=*)
             varlog_size="${x#varlog_size=}"
@@ -232,6 +236,14 @@ else
     if [ -f ${rootmnt}/host/disk-img/var-log.ext4 ]; then
         fsck.ext4 -v -p ${rootmnt}/host/disk-img/var-log.ext4 2>&1 | gzip -c >> /tmp/fsck.log.gz
         mount -t ext4 -o loop,rw ${rootmnt}/host/disk-img/var-log.ext4 ${rootmnt}/var/log
+    fi
+fi
+
+if $mount_pmem; then
+    if [ -f ${rootmnt}/pmem ]; then
+        sudo mkfs.ext4 /dev/pmem0
+        sudo mkdir ${rootmnt}/pmem
+        sudo mount /dev/pmem0 ${rootmnt}/pmem
     fi
 fi
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

