### PR TITLE
Added current year to all log files

### DIFF
--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -51,7 +51,7 @@ $UDPServerRun 514
 #$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 
 # Define a custom template
-$template SONiCFileFormat,"%timegenerated%.%timegenerated:::date-subseconds% %HOSTNAME% %syslogseverity-text:::uppercase% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
+$template SONiCFileFormat,"%timegenerated:::date-year% %timegenerated%.%timegenerated:::date-subseconds% %HOSTNAME% %syslogseverity-text:::uppercase% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
 $ActionFileDefaultTemplate SONiCFileFormat
 
 template(name="WelfRemoteFormat" type="string" string="%TIMESTAMP% id=firewall time=\"%timereported\


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently SONiC logs do not show the year:

```
root@str2-7050cx3-acs-01:~# tail -f /var/log/teamd.log
Feb 14 00:07:54.856313 str2-7050cx3-acs-01 DEBUG teamd#teamd_PortChannel102[37]: usock: calling method "StateDump"
Feb 14 00:07:54.856795 str2-7050cx3-acs-01 DEBUG teamd#teamd_PortChannel101[29]: usock: calling method "StateDump"
Feb 14 00:07:55.859690 str2-7050cx3-acs-01 DEBUG teamd#teamd_PortChannel104[53]: usock: calling method "StateDump"
```

This PR fixes that issue:

```
2024 Feb 15 02:24:26.091224 str2-7050cx3-acs-01 DEBUG teamd#teamd_PortChannel102[33]: usock: calling method "StateDump"
2024 Feb 15 02:24:26.091224 str2-7050cx3-acs-01 DEBUG teamd#teamd_PortChannel101[25]: usock: calling method "StateDump"
2024 Feb 15 02:24:26.752655 str2-7050cx3-acs-01 DEBUG teamd#teamd_PortChannel103[41]: Ethernet120: Enabling port
2024 Feb 15 02:24:26.752655 str2-7050cx3-acs-01 DEBUG teamd#teamd_PortChannel103[41]: Enable carrier. Number of enabled ports 1 >= configured min_ports 1
2024 Feb 15 02:24:27.094931 str2-7050cx3-acs-01 DEBUG teamd#teamd_PortChannel103[41]: usock: calling method "StateDump"

```

Also added a sonic-mgmt PR [11806](https://github.com/sonic-net/sonic-mgmt/pull/11806) to update the FMT time template in platform_tests/conftest.py to keep up with this image change.

##### Work item tracking
- Microsoft ADO **(number only)**: 26399333

#### How I did it

Added a parameter to rsyslog.conf.j2 that adds the year of the log to the log template.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

1. Flash image with this change on a switch
2. Create list of all log files as below:
```
root@str2-7050cx3-acs-01:~# find /var/log -name *log > logfile-names.txt
root@str2-7050cx3-acs-01:~#
root@str3-msn4600c-acs-08:~# cat logfile-names.txt
/var/log
/var/log/user.log
/var/log/audit/audit.log
/var/log/frr/bgpd.log
/var/log/frr/zebra.log
/var/log/syslog
/var/log/tc_log
/var/log/kern.log
/var/log/lastlog
/var/log/audit.log
/var/log/telemetry.log
/var/log/cron.log
/var/log/daemon.log
/var/log/teamd.log
/var/log/gnmi.log
/var/log/auth.log

```
3. Save the following script as `getlogs.sh`, make it executable (`chmod +x getlogs.sh`) and run it:
```
root@str3-msn4600c-acs-08:~# cat getlogs.sh
#!/usr/bin/bash

mapfile logfiles < logfile-names.txt
for logfile in "${logfiles[@]}"; do
    if [ -f $logfile ]; then
        echo ""
        echo "Processing file: $logfile"
        echo ""
        tail -5 $logfile
    fi
done

```

4. Verify from the output that every log file line that has been updated recently has the current year:
```
root@str2-7050cx3-acs-01:~# ./getlogs.sh

Processing file: /var/log/diagrun.log


Feb 13, 2024; 20:54:04: sdk_diag_run_cfg:(null)
Feb 13, 2024; 20:55:53: platformInit()
Feb 13, 2024; 20:55:54: sdk_diag_run_cfg:(null)
Feb 13, 2024; 21:42:29: platformInit()
Feb 13, 2024; 21:42:29: sdk_diag_run_cfg:(null)

Processing file: /var/log/teamd.log


2024 Feb 15 02:24:26.091224 str2-7050cx3-acs-01 DEBUG teamd#teamd_PortChannel102[33]: usock: calling method "StateDump"
2024 Feb 15 02:24:26.091224 str2-7050cx3-acs-01 DEBUG teamd#teamd_PortChannel101[25]: usock: calling method "StateDump"
2024 Feb 15 02:24:26.752655 str2-7050cx3-acs-01 DEBUG teamd#teamd_PortChannel103[41]: Ethernet120: Enabling port
2024 Feb 15 02:24:26.752655 str2-7050cx3-acs-01 DEBUG teamd#teamd_PortChannel103[41]: Enable carrier. Number of enabled ports 1 >= configured min_ports 1
2024 Feb 15 02:24:27.094931 str2-7050cx3-acs-01 DEBUG teamd#teamd_PortChannel103[41]: usock: calling method "StateDump"

Processing file: /var/log/auth.log


2024 Feb 15 02:51:20.717249 str2-7050cx3-acs-01 INFO sudo: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
2024 Feb 15 02:51:20.736175 str2-7050cx3-acs-01 INFO sudo: pam_unix(sudo:session): session closed for user root
2024 Feb 15 02:53:24.250159 str2-7050cx3-acs-01 NOTICE sudo:     root : PWD=/ ; USER=root ; COMMAND=/usr/bin/openssl engine -vv
2024 Feb 15 02:53:24.250323 str2-7050cx3-acs-01 INFO sudo: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
2024 Feb 15 02:53:24.272462 str2-7050cx3-acs-01 INFO sudo: pam_unix(sudo:session): session closed for user root

Processing file: /var/log/cron.log


2024 Feb 15 02:15:01.872178 str2-7050cx3-acs-01 INFO CRON[1259465]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
2024 Feb 15 02:17:01.915231 str2-7050cx3-acs-01 INFO CRON[1260514]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)
2024 Feb 15 02:25:01.945500 str2-7050cx3-acs-01 INFO CRON[1269190]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
2024 Feb 15 02:35:02.001927 str2-7050cx3-acs-01 INFO CRON[1274943]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
2024 Feb 15 02:45:01.059591 str2-7050cx3-acs-01 INFO CRON[1280611]: (root) CMD (command -v debian-sa1 > /dev/null && debian-sa1 1 1)
.
.
.

```


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 20220531.48
- [x] 20230531.18

#### Description for the changelog

This PR adds the current year to the log files

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

