### PR TITLE
[service-checker] Fix the service-checker issue which is caused by PR 17836

### DIFF
--- a/src/system-health/health_checker/service_checker.py
+++ b/src/system-health/health_checker/service_checker.py
@@ -102,6 +102,7 @@ class ServiceChecker(HealthChecker):
                     
         if device_info.is_supervisor():
             expected_running_containers.add("database-chassis")
+            container_feature_dict["database-chassis"] = "database"
         return expected_running_containers, container_feature_dict
 
     def get_current_running_containers(self):


### PR DESCRIPTION
#### Why I did it
PR https://github.com/sonic-net/sonic-buildimage/pull/17836 added the container checking for database-chassis for Supervisor.  But the related container_feature_dict[] is missing for the database-chassis. This causes the exception failure shows on Supervisor
```
admin@ixre-cpm-chassis13:~$ sudo show system-health sum 
System status summary

  System status LED  red
  Services:
    Status: OK
  Hardware:
    Status: Not OK
    Reasons: PSU 12 is missing or not available
	     PSU 11 is missing or not available
	     PSU 10 is missing or not available
	     PSU 9 is missing or not available
	     PSU 8 is missing or not available
	     Failed to perform health check for ServiceChecker due to exception - KeyError('database-chassis')

``` 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added the database-chassis feature entry to container_feature_dict[] to address this issue
 
#### How to verify it
On Supervisor,  execute the "show system-health summary".  No exception error shown
```
admin@ixre-cpm-chassis13:~$ sudo show system-health sum 
System status summary

  System status LED  red
  Services:
    Status: OK
  Hardware:
    Status: Not OK
    Reasons: PSU 12 is missing or not available
	     PSU 11 is missing or not available
	     PSU 10 is missing or not available
	     PSU 9 is missing or not available
	     PSU 8 is missing or not available
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [x] 202305


#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

