### PR TITLE
[rsyslog]: Use RELP instead of UDP for forwarding from container to host

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -371,6 +371,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     squashfs-tools          \
     $bootloader_packages    \
     rsyslog                 \
+    rsyslog-relp            \
     screen                  \
     hping3                  \
     tcptraceroute           \

--- a/dockers/docker-base-bullseye/Dockerfile.j2
+++ b/dockers/docker-base-bullseye/Dockerfile.j2
@@ -62,7 +62,7 @@ RUN apt-get update &&        \
 
 # default rsyslog version is 8.2110.0 which has a bug on log rate limit,
 # use backport version 8.2206.0-1~bpo11+1
-RUN apt-get -t bullseye-backports -y install rsyslog
+RUN apt-get -t bullseye-backports -y install rsyslog rsyslog-relp
 
 # Upgrade pip via PyPI and uninstall the Debian version
 RUN pip3 install --upgrade pip

--- a/dockers/docker-base-bullseye/etc/rsyslog.conf
+++ b/dockers/docker-base-bullseye/etc/rsyslog.conf
@@ -9,24 +9,23 @@
 #### MODULES ####
 #################
 
-$ModLoad imuxsock # provides support for local system logging
-
 #
 # Set a rate limit on messages from the container
 #
 $SystemLogRateLimitInterval 300
 $SystemLogRateLimitBurst 20000
 
-#$ModLoad imklog  # provides kernel logging support
-#$ModLoad immark  # provides --MARK-- message capability
+module(load="imuxsock") # provides support for local system logging
+#module(load="imklog")   # provides kernel logging support
+#module(load="immark")  # provides --MARK-- message capability
 
 # provides UDP syslog reception
-#$ModLoad imudp
-#$UDPServerRun 514
+#module(load="imudp")
+#input(type="imudp" port="514")
 
 # provides TCP syslog reception
-#$ModLoad imtcp
-#$InputTCPServerRun 514
+#module(load="imtcp")
+#input(type="imtcp" port="514")
 
 
 ###########################
@@ -37,7 +36,8 @@ set $.CONTAINER_NAME=getenv("CONTAINER_NAME");
 
 # Set remote syslog server
 template (name="ForwardFormatInContainer" type="string" string="<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %$.CONTAINER_NAME%#%syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
-*.* action(type="omfwd" target=`echo $SYSLOG_TARGET_IP` port="514" protocol="udp" Template="ForwardFormatInContainer")
+module(load="omrelp")
+*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" Template="ForwardFormatInContainer")
 
 #
 # Use traditional timestamp format.

--- a/files/image_config/rsyslog/rsyslog-container.conf.j2
+++ b/files/image_config/rsyslog/rsyslog-container.conf.j2
@@ -9,8 +9,6 @@
 #### MODULES ####
 #################
 
-$ModLoad imuxsock # provides support for local system logging
-
 #
 # Set a rate limit on messages from the container
 #
@@ -37,16 +35,17 @@ $SystemLogRateLimitBurst {{ rate_limit_burst }}
 $SystemLogRateLimitBurst 20000
 {% endif %}
 
-#$ModLoad imklog  # provides kernel logging support
-#$ModLoad immark  # provides --MARK-- message capability
+module(load="imuxsock") # provides support for local system logging
+#module(load="imklog")   # provides kernel logging support
+#module(load="immark")  # provides --MARK-- message capability
 
 # provides UDP syslog reception
-#$ModLoad imudp
-#$UDPServerRun 514
+#module(load="imudp")
+#input(type="imudp" port="514")
 
 # provides TCP syslog reception
-#$ModLoad imtcp
-#$InputTCPServerRun 514
+#module(load="imtcp")
+#input(type="imtcp" port="514")
 
 
 ###########################
@@ -71,7 +70,8 @@ if ($.PLATFORM == "x86_64-mlnx_msn2700-r0" or $.PLATFORM == "x86_64-mlnx_msn2700
 
 # Set remote syslog server
 template (name="ForwardFormatInContainer" type="string" string="<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %$.CONTAINER_NAME%#%syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
-*.* action(type="omfwd" target=`echo $SYSLOG_TARGET_IP` port="514" protocol="udp" Template="ForwardFormatInContainer")
+module(load="omrelp")
+*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" Template="ForwardFormatInContainer")
 
 #
 # Use traditional timestamp format.

--- a/files/image_config/rsyslog/rsyslog-container.conf.j2
+++ b/files/image_config/rsyslog/rsyslog-container.conf.j2
@@ -71,17 +71,7 @@ if ($.PLATFORM == "x86_64-mlnx_msn2700-r0" or $.PLATFORM == "x86_64-mlnx_msn2700
 # Set remote syslog server
 template (name="ForwardFormatInContainer" type="string" string="<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %$.CONTAINER_NAME%#%syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
 module(load="omrelp")
-*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" Template="ForwardFormatInContainer")
-
-#
-# Use traditional timestamp format.
-# To enable high precision timestamps, comment out the following line.
-#
-#$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
-
-# Define a custom template
-$template SONiCFileFormat,"%TIMESTAMP%.%timestamp:::date-subseconds% %HOSTNAME% %syslogseverity-text:::uppercase% %$.CONTAINER_NAME%#%syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
-$ActionFileDefaultTemplate SONiCFileFormat
+*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" Template="ForwardFormatInContainer" RepeatedMsgReduction="on")
 
 #
 # Set the default permissions for all log files.
@@ -101,11 +91,6 @@ $WorkDirectory /var/spool/rsyslog
 # Include all config files in /etc/rsyslog.d/
 #
 $IncludeConfig /etc/rsyslog.d/*.conf
-
-#
-# Suppress duplicate messages and report "message repeated n times"
-#
-$RepeatedMsgReduction on
 
 ###############
 #### RULES ####

--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -13,8 +13,6 @@
 #### MODULES ####
 #################
 
-$ModLoad imuxsock # provides support for local system logging
-
 {% set gconf = (SYSLOG_CONFIG | d({})).get('GLOBAL', {}) -%}
 {% set rate_limit_interval = gconf.get('rate_limit_interval') %}
 {% set rate_limit_burst = gconf.get('rate_limit_burst') %}
@@ -26,17 +24,21 @@ $SystemLogRateLimitInterval {{ rate_limit_interval }}
 $SystemLogRateLimitBurst {{ rate_limit_burst }}
 {% endif %}
 
-$ModLoad imklog   # provides kernel logging support
-#$ModLoad immark  # provides --MARK-- message capability
+module(load="imuxsock") # provides support for local system logging
+module(load="imklog")   # provides kernel logging support
+#module(load="immark")  # provides --MARK-- message capability
 
 # provides UDP syslog reception
-$ModLoad imudp
-$UDPServerAddress {{udp_server_ip}}  #bind to localhost before udp server run
-$UDPServerRun 514
+#module(load="imudp")
+#input(type="imudp" port="514")
 
 # provides TCP syslog reception
-#$ModLoad imtcp
-#$InputTCPServerRun 514
+#module(load="imtcp")
+#input(type="imtcp" port="514")
+
+# provides RELP syslog reception
+module(load="imrelp")
+input(type="imrelp" port="2514")
 
 
 ###########################

--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -53,7 +53,7 @@ input(type="imrelp" port="2514")
 #$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 
 # Define a custom template
-$template SONiCFileFormat,"%timegenerated%.%timegenerated:::date-subseconds% %HOSTNAME% %syslogseverity-text:::uppercase% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
+$template SONiCFileFormat,"%TIMESTAMP:::date-rfc3339% %HOSTNAME% %syslogseverity-text:::uppercase% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
 $ActionFileDefaultTemplate SONiCFileFormat
 
 template(name="WelfRemoteFormat" type="string" string="%TIMESTAMP% id=firewall time=\"%timereported\


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When the host's rsyslog is restarted (for example, to regenerate the config after some changes, or as part of some automated script), there is a chance that some syslog messages from the containers are lost. Most of the time, this isn't an issue. However, if there are test cases that expect all syslogs to be present (such as the advanced-reboot test case), then this can cause a problem. Additionally, this could affect debuggability of issues where a rsyslog restart happens in the middle.

There are two options for reliable message transport in rsyslog: TCP and RELP. With TCP, while the protocol knows whether a syslog message has been delivered or not, the application doesn't know, because there is no feedback from the remote side saying the message was received. This means that there is still a chance that messages could be lost when the connection is broken (if, for example, the host rsyslog gets restarted), because after the connection is established, the sender rsyslog (in the
container) doesn't know if the message has been received or not.

RELP instead adds a feedback mechanism where the remote side notifies the sender whether the message has actually been received or not. This makes it much less likely to lose a message. There is one known possible case where a message (or messages) could be lost: the network is down, and rsyslog gets restarted. This at least requires both the network and rsyslog to have an issue, rather than just one. There is also a slim possibility where a message could get duplicated; this should be mostly fine (hopefully).

RELP does require that both sides are using a recent version of rsyslogd (at least 7.3.16, which looks like it was released more than 10 years ago), but since we use Debian on both the container and the host, it should be fine.

Therefore, switch to using RELP when sending syslog messages from the container to the host.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Modify the rsyslog.conf file on the host and the container to use RELP instead of UDP.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Stop rsyslogd on the host, make sure that the containers generate some syslogs, restart rsyslogd on the host, and verify no logs were lost.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

