### PR TITLE
Adds a bind mount from host to /usr/share/stormond/ directory on pmon container

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -91,6 +91,7 @@ COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 COPY ["etc/rsyslog.conf", "/etc/rsyslog.conf"]
 
+RUN mkdir -p /host/storagemon
 RUN sonic-cfggen -a "{\"CONFIGURED_PLATFORM\":\"{{CONFIGURED_PLATFORM}}\"}" -t /usr/share/sonic/templates/docker_init.j2 > /usr/bin/docker_init.sh
 RUN rm -f /usr/share/sonic/templates/docker_init.j2
 RUN chmod 755 /usr/bin/docker_init.sh

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -49,7 +49,7 @@ RUN pip3 install requests
 RUN pip3 install libpci
 
 # Install psutil for process and system monitoring operations
-RUN pip3 install psutil==5.9.8
+RUN pip3 install psutil
 
 {% if docker_platform_monitor_debs.strip() -%}
 # Copy locally-built Debian package dependencies

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -48,6 +48,9 @@ RUN pip3 install requests
 # We install the libpci module in order to be able to do PCI transactions
 RUN pip3 install libpci
 
+# Install psutil for process and system monitoring operations
+RUN pip3 install psutil==5.9.8
+
 {% if docker_platform_monitor_debs.strip() -%}
 # Copy locally-built Debian package dependencies
 {{ copy_files("debs/", docker_platform_monitor_debs.split(' '), "/debs/") }}

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -91,7 +91,7 @@ COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 COPY ["etc/rsyslog.conf", "/etc/rsyslog.conf"]
 
-RUN mkdir -p /usr/share/storagemon
+RUN mkdir -p /usr/share/stormond
 RUN sonic-cfggen -a "{\"CONFIGURED_PLATFORM\":\"{{CONFIGURED_PLATFORM}}\"}" -t /usr/share/sonic/templates/docker_init.j2 > /usr/bin/docker_init.sh
 RUN rm -f /usr/share/sonic/templates/docker_init.j2
 RUN chmod 755 /usr/bin/docker_init.sh

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -91,7 +91,7 @@ COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 COPY ["etc/rsyslog.conf", "/etc/rsyslog.conf"]
 
-RUN mkdir -p /host/storagemon
+RUN mkdir -p /usr/share/storagemon
 RUN sonic-cfggen -a "{\"CONFIGURED_PLATFORM\":\"{{CONFIGURED_PLATFORM}}\"}" -t /usr/share/sonic/templates/docker_init.j2 > /usr/bin/docker_init.sh
 RUN rm -f /usr/share/sonic/templates/docker_init.j2
 RUN chmod 755 /usr/bin/docker_init.sh

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -54,7 +54,6 @@ FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES="$FILESYSTEM_ROOT_USR_SHARE_SONIC/temp
 FILESYSTEM_ROOT_USR_SHARE_SONIC_FIRMWARE="$FILESYSTEM_ROOT_USR_SHARE_SONIC/firmware"
 FILESYSTEM_ROOT_ETC="$FILESYSTEM_ROOT/etc"
 FILESYSTEM_ROOT_ETC_SONIC="$FILESYSTEM_ROOT_ETC/sonic"
-#FILESYSTEM_ROOT_HOST_PMON_STORAGEMON="$FILESYSTEM_ROOT/host/pmon/storagemon"
 
 GENERATED_SERVICE_FILE="$FILESYSTEM_ROOT/etc/sonic/generated_services.conf"
 
@@ -97,9 +96,6 @@ sudo mkdir -p $FILESYSTEM_ROOT_USR_SHARE_SONIC_FIRMWARE/
 # This is needed for Stretch and might not be needed for Buster where Linux create this directory by default.
 # Keeping it generic. It should not harm anyways.
 sudo mkdir -p $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
-
-# This is to create a bind mount on the platform-monitor container
-#sudo mkdir -p $FILESYSTEM_ROOT_HOST_PMON_STORAGEMON
 
 # Install a patched version of ifupdown2  (and its dependencies via 'apt-get -y install -f')
 sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/ifupdown2_*.deb || \

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -54,6 +54,7 @@ FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES="$FILESYSTEM_ROOT_USR_SHARE_SONIC/temp
 FILESYSTEM_ROOT_USR_SHARE_SONIC_FIRMWARE="$FILESYSTEM_ROOT_USR_SHARE_SONIC/firmware"
 FILESYSTEM_ROOT_ETC="$FILESYSTEM_ROOT/etc"
 FILESYSTEM_ROOT_ETC_SONIC="$FILESYSTEM_ROOT_ETC/sonic"
+FILESYSTEM_ROOT_HOST_PMON_STORAGEMON="$FILESYSTEM_ROOT/host/pmon/storagemon"
 
 GENERATED_SERVICE_FILE="$FILESYSTEM_ROOT/etc/sonic/generated_services.conf"
 
@@ -96,6 +97,9 @@ sudo mkdir -p $FILESYSTEM_ROOT_USR_SHARE_SONIC_FIRMWARE/
 # This is needed for Stretch and might not be needed for Buster where Linux create this directory by default.
 # Keeping it generic. It should not harm anyways.
 sudo mkdir -p $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
+
+# This is needed so as to create a bind mount on the platform-monitor container
+sudo mkdir -p $FILESYSTEM_ROOT_HOST_PMON_STORAGEMON
 
 # Install a patched version of ifupdown2  (and its dependencies via 'apt-get -y install -f')
 sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/ifupdown2_*.deb || \

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -54,7 +54,7 @@ FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES="$FILESYSTEM_ROOT_USR_SHARE_SONIC/temp
 FILESYSTEM_ROOT_USR_SHARE_SONIC_FIRMWARE="$FILESYSTEM_ROOT_USR_SHARE_SONIC/firmware"
 FILESYSTEM_ROOT_ETC="$FILESYSTEM_ROOT/etc"
 FILESYSTEM_ROOT_ETC_SONIC="$FILESYSTEM_ROOT_ETC/sonic"
-#FILESYSTEM_ROOT_HOST_PMON_STORAGEMON="$FILESYSTEM_ROOT/host/pmon/storagemon"
+FILESYSTEM_ROOT_HOST_PMON_STORAGEMON="$FILESYSTEM_ROOT/host/pmon/storagemon"
 
 GENERATED_SERVICE_FILE="$FILESYSTEM_ROOT/etc/sonic/generated_services.conf"
 
@@ -99,7 +99,7 @@ sudo mkdir -p $FILESYSTEM_ROOT_USR_SHARE_SONIC_FIRMWARE/
 sudo mkdir -p $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
 
 # This is to create a bind mount on the platform-monitor container
-#sudo mkdir -p $FILESYSTEM_ROOT_HOST_PMON_STORAGEMON
+sudo mkdir -p $FILESYSTEM_ROOT_HOST_PMON_STORAGEMON
 
 # Install a patched version of ifupdown2  (and its dependencies via 'apt-get -y install -f')
 sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/ifupdown2_*.deb || \

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -54,7 +54,7 @@ FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES="$FILESYSTEM_ROOT_USR_SHARE_SONIC/temp
 FILESYSTEM_ROOT_USR_SHARE_SONIC_FIRMWARE="$FILESYSTEM_ROOT_USR_SHARE_SONIC/firmware"
 FILESYSTEM_ROOT_ETC="$FILESYSTEM_ROOT/etc"
 FILESYSTEM_ROOT_ETC_SONIC="$FILESYSTEM_ROOT_ETC/sonic"
-FILESYSTEM_ROOT_HOST_PMON_STORAGEMON="$FILESYSTEM_ROOT/host/pmon/storagemon"
+#FILESYSTEM_ROOT_HOST_PMON_STORAGEMON="$FILESYSTEM_ROOT/host/pmon/storagemon"
 
 GENERATED_SERVICE_FILE="$FILESYSTEM_ROOT/etc/sonic/generated_services.conf"
 
@@ -99,7 +99,7 @@ sudo mkdir -p $FILESYSTEM_ROOT_USR_SHARE_SONIC_FIRMWARE/
 sudo mkdir -p $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
 
 # This is to create a bind mount on the platform-monitor container
-sudo mkdir -p $FILESYSTEM_ROOT_HOST_PMON_STORAGEMON
+#sudo mkdir -p $FILESYSTEM_ROOT_HOST_PMON_STORAGEMON
 
 # Install a patched version of ifupdown2  (and its dependencies via 'apt-get -y install -f')
 sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/ifupdown2_*.deb || \

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -54,7 +54,7 @@ FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES="$FILESYSTEM_ROOT_USR_SHARE_SONIC/temp
 FILESYSTEM_ROOT_USR_SHARE_SONIC_FIRMWARE="$FILESYSTEM_ROOT_USR_SHARE_SONIC/firmware"
 FILESYSTEM_ROOT_ETC="$FILESYSTEM_ROOT/etc"
 FILESYSTEM_ROOT_ETC_SONIC="$FILESYSTEM_ROOT_ETC/sonic"
-FILESYSTEM_ROOT_HOST_PMON_STORAGEMON="$FILESYSTEM_ROOT/host/pmon/storagemon"
+#FILESYSTEM_ROOT_HOST_PMON_STORAGEMON="$FILESYSTEM_ROOT/host/pmon/storagemon"
 
 GENERATED_SERVICE_FILE="$FILESYSTEM_ROOT/etc/sonic/generated_services.conf"
 
@@ -98,8 +98,8 @@ sudo mkdir -p $FILESYSTEM_ROOT_USR_SHARE_SONIC_FIRMWARE/
 # Keeping it generic. It should not harm anyways.
 sudo mkdir -p $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
 
-# This is needed so as to create a bind mount on the platform-monitor container
-sudo mkdir -p $FILESYSTEM_ROOT_HOST_PMON_STORAGEMON
+# This is to create a bind mount on the platform-monitor container
+#sudo mkdir -p $FILESYSTEM_ROOT_HOST_PMON_STORAGEMON
 
 # Install a patched version of ifupdown2  (and its dependencies via 'apt-get -y install -f')
 sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/ifupdown2_*.deb || \

--- a/rules/docker-platform-monitor.mk
+++ b/rules/docker-platform-monitor.mk
@@ -51,7 +51,7 @@ $(DOCKER_PLATFORM_MONITOR)_CONTAINER_NAME = pmon
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += --privileged -t
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /etc/timezone:/etc/timezone:ro 
-$(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /host/pmon/storagemon:/host/storagemon:rw
+#$(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /host/pmon/storagemon:/host/storagemon:rw
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /var/run/platform_cache:/var/run/platform_cache:ro
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /usr/share/sonic/device/pddf:/usr/share/sonic/device/pddf:ro
 

--- a/rules/docker-platform-monitor.mk
+++ b/rules/docker-platform-monitor.mk
@@ -51,6 +51,7 @@ $(DOCKER_PLATFORM_MONITOR)_CONTAINER_NAME = pmon
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += --privileged -t
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /etc/timezone:/etc/timezone:ro 
+$(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /host/pmon/storagemon:/host/storagemon:rw
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /var/run/platform_cache:/var/run/platform_cache:ro
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /usr/share/sonic/device/pddf:/usr/share/sonic/device/pddf:ro
 

--- a/rules/docker-platform-monitor.mk
+++ b/rules/docker-platform-monitor.mk
@@ -51,7 +51,7 @@ $(DOCKER_PLATFORM_MONITOR)_CONTAINER_NAME = pmon
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += --privileged -t
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /etc/timezone:/etc/timezone:ro 
-#$(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /host/pmon/storagemon:/host/storagemon:rw
+$(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /host/pmon/storagemon:/host/storagemon:rw
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /var/run/platform_cache:/var/run/platform_cache:ro
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /usr/share/sonic/device/pddf:/usr/share/sonic/device/pddf:ro
 

--- a/rules/docker-platform-monitor.mk
+++ b/rules/docker-platform-monitor.mk
@@ -51,7 +51,7 @@ $(DOCKER_PLATFORM_MONITOR)_CONTAINER_NAME = pmon
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += --privileged -t
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /etc/timezone:/etc/timezone:ro 
-$(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /host/pmon/storagemon:/host/storagemon:rw
+$(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /host/pmon/storagemon:/usr/share/storagemon:rw
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /var/run/platform_cache:/var/run/platform_cache:ro
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /usr/share/sonic/device/pddf:/usr/share/sonic/device/pddf:ro
 

--- a/rules/docker-platform-monitor.mk
+++ b/rules/docker-platform-monitor.mk
@@ -51,7 +51,7 @@ $(DOCKER_PLATFORM_MONITOR)_CONTAINER_NAME = pmon
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += --privileged -t
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /etc/timezone:/etc/timezone:ro 
-$(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /host/pmon/storagemon:/usr/share/storagemon:rw
+$(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /host/pmon/stormond:/usr/share/stormond:rw
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /var/run/platform_cache:/var/run/platform_cache:ro
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /usr/share/sonic/device/pddf:/usr/share/sonic/device/pddf:ro
 

--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -500,6 +500,7 @@ RUN pip3 uninstall -y enum34
 
 # For sonic-platform-common testing
 RUN pip3 install redis
+RUN pip3 install psutil
 
 # For sonic-swss-common testing
 RUN pip3 install Pympler==1.0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is a part of a larger commit that adds a storage monitoring daemon to SONiC. This commit is needed to that storagemon daemon can save FS stats JSON file to disk in the event of planned reboots and unintentional powercycles.

[SONiC Storage Monitoring Daemon HLD](https://github.com/sonic-net/SONiC/pull/1481)

Also added `psutil` module to perform process and system monitoring operations pythonically.

##### Work item tracking
- Microsoft ADO **(number only)**: 17468992

#### How I did it
- Added a rule to create the directory on the pmon container
- Added a rule to create a bind-mount

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Flash a switch with image containing the changes. 
Run:

```
root@str2-7050cx3-acs-13:~# docker inspect pmon
```

and verify the following parameters in the "mounts" section:
```
        "Mounts": [
            .
            .
            .
            {
                "Type": "bind",
                "Source": "/host/pmon/stormond",
                "Destination": "/usr/share/stormond",
                "Mode": "rw",
                "RW": true,
                "Propagation": "rprivate"
            },
            .
            .
            .
        ]
```

Additionally, you can run the following steps:

1. Navigate to /host/pmon/stormond directory on the host and create an empty file
2. Enter the pmon container and navigate to /usr/share/stormond
3. Verify that the file created in the host is seen here
4. Add text to this file
5. Exit the docker container
6. `cat` the file on the host and verify that the text you added is seen here

```
root@str2-7050cx3-acs-13:/host# cd pmon/
root@str2-7050cx3-acs-13:/host/pmon# ls
stormond
root@str2-7050cx3-acs-13:/host/pmon# cd stormond/
root@str2-7050cx3-acs-13:/host/pmon/stormond# touch ashwin.txt
root@str2-7050cx3-acs-13:/host/pmon/stormond# docker exec -it pmon bash
root@str2-7050cx3-acs-13:/# cd /usr/share/stormond/
root@str2-7050cx3-acs-13:/usr/share/stormond# ls
ashwin.txt
root@str2-7050cx3-acs-13:/usr/share/stormond# ls -al
total 8
drwxr-xr-x 2 root root 4096 Feb 19 04:06 .
drwxr-xr-x 3 root root 4096 Feb 19 02:04 ..
-rw-r--r-- 1 root root    0 Feb 19 04:06 ashwin.txt
root@str2-7050cx3-acs-13:/usr/share/stormond# echo "Bind mount successful?" > ashwin.txt
root@str2-7050cx3-acs-13:/usr/share/stormond# exit
exit
root@str2-7050cx3-acs-13:/host/pmon/stormond# cat ashwin.txt
Bind mount successful?
root@str2-7050cx3-acs-13:/host/pmon/stormond#
```

As a third test:

Run `ls -alirth` in both the `/host/pmon/stormond` dir on the host and `/usr/share/stormond` dir in the pmon container and verify that the inode numbers match.

```
root@str2-7050cx3-acs-13:/host/pmon/stormond# ls -alirth
total 12K
129546 drwxr-xr-x 3 root root 4.0K Feb 19 04:06 ..
129554 drwxr-xr-x 2 root root 4.0K Feb 19 04:06 .
129555 -rw-r--r-- 1 root root   23 Feb 19 04:07 ashwin.txt

root@str2-7050cx3-acs-13:/host/pmon/stormond# docker exec -it pmon bash
root@str2-7050cx3-acs-13:/# cd /usr/share/stormond/
root@str2-7050cx3-acs-13:/usr/share/stormond# ls -alirth
total 12K
 33618 drwxr-xr-x 3 root root 4.0K Feb 19 02:04 ..
129554 drwxr-xr-x 2 root root 4.0K Feb 19 04:06 .
129555 -rw-r--r-- 1 root root   23 Feb 19 04:07 ashwin.txt
root@str2-7050cx3-acs-13:/usr/share/stormond#

```

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] custom master image

#### Description for the changelog
adds bind mount from `/host/pmon/stormond` on the host to `/usr/share/stormond` on the pmon container as part of the larger stormon daemon feature.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

