### PR TITLE
[hsflowd] Fix .gitignore to not ignore patch/

### DIFF
--- a/src/sflow/hsflowd/.gitignore
+++ b/src/sflow/hsflowd/.gitignore
@@ -2,3 +2,4 @@
 !.gitignore
 !Makefile
 !patch/
+!patch/**


### PR DESCRIPTION

#### Why I did it

If you added a patch in the patch/ subdir it would be ignored by default.

#### How I did it

Modify .gitignore

#### How to verify it

Add file in patch/ and see that it is now not ignored in `git status`.

E.g.:

```
$ git status 
On branch 202211
Your branch is up to date with 'origin/202211'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   series

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   ../.gitignore

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        9999-kamel_jumbo-frames.patch
        dropmon/asdasd
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

#### Description for the changelog

N/A

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

![image](https://github.com/sonic-net/sonic-buildimage/assets/149442/fab61d7f-c421-4044-a82d-3373862aea08)
