### PR TITLE
Fix missing gnupg package issue during installing k8s gpg file process

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -271,11 +271,9 @@ sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install docker-ce=${DOCKER_VERSIO
 
 install_kubernetes () {
     local ver="$1"
-    sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install gnupg
     sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT curl -fsSL \
         https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
-        sudo LANG=C chroot $FILESYSTEM_ROOT apt-key add -
-    sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y purge gnupg
+        sudo LANG=C chroot $FILESYSTEM_ROOT tee /etc/apt/trusted.gpg.d/kubernetes.asc
     ## Check out the sources list update matches current Debian version
     sudo cp files/image_config/kubernetes/kubernetes.list $FILESYSTEM_ROOT/etc/apt/sources.list.d/
     sudo LANG=C chroot $FILESYSTEM_ROOT apt-get update

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -271,9 +271,11 @@ sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install docker-ce=${DOCKER_VERSIO
 
 install_kubernetes () {
     local ver="$1"
+    sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install gnupg
     sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT curl -fsSL \
         https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
         sudo LANG=C chroot $FILESYSTEM_ROOT apt-key add -
+    sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y purge gnupg
     ## Check out the sources list update matches current Debian version
     sudo cp files/image_config/kubernetes/kubernetes.list $FILESYSTEM_ROOT/etc/apt/sources.list.d/
     sudo LANG=C chroot $FILESYSTEM_ROOT apt-get update

--- a/rules/config
+++ b/rules/config
@@ -185,7 +185,7 @@ INCLUDE_ROUTER_ADVERTISER ?= y
 
 # INCLUDE_KUBERNETES - if set to y kubernetes packages are installed to be able to
 # run as worker node in kubernetes cluster.
-INCLUDE_KUBERNETES ?= n
+INCLUDE_KUBERNETES ?= y
 
 KUBE_DOCKER_PROXY = http://172.16.1.1:3128/
 

--- a/rules/config
+++ b/rules/config
@@ -185,7 +185,7 @@ INCLUDE_ROUTER_ADVERTISER ?= y
 
 # INCLUDE_KUBERNETES - if set to y kubernetes packages are installed to be able to
 # run as worker node in kubernetes cluster.
-INCLUDE_KUBERNETES ?= y
+INCLUDE_KUBERNETES ?= n
 
 KUBE_DOCKER_PROXY = http://172.16.1.1:3128/
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When try to install k8s gpg file, there reports an error.
- "E: gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation   curl: (23) Failed writing body". 

To fix error we need to install gunpg package. But apt-key add is going to be deprecated, mv the gpg file to /etc/apt/trusted.gpg.d/ directly
##### Work item tracking
- Microsoft ADO **(number only)**: 26901718

#### How I did it
Download k8s gpg file and put it in /etc/apt/trusted.gpg.d/
#### How to verify it
We can install k8s gpg file successfully, but no gnupg package installed inside sonic image.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

