### PR TITLE
[Nokia-7215-T1] Disable sysrq-trigger from platform init

### DIFF
--- a/platform/marvell-armhf/sonic-platform-nokia/7215/scripts/nokia-7215init.sh
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/scripts/nokia-7215init.sh
@@ -30,6 +30,9 @@ nokia_7215_profile()
 # Install kernel drivers required for i2c bus access
 load_kernel_drivers
 
+# Disable sysrq-trigger
+echo 0 > /proc/sys/kernel/sysrq
+
 # LOGIC to enumerate SFP eeprom devices - send 0x50 to kernel i2c driver - initialize devices
 # the mux may be enumerated at number 4 or 5 so we check for the mux and skip if needed
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Disable sysrq  invocation by keyboard and terminal server to prevent accidently triggering it under console overload conditions and performing unintentional actions


##### Work item tracking.
- Microsoft ADO **(number only)**:17610243

#### How I did it
Disable sysrq by writing 0 into  "/proc/sys/kernel/sysrq" register


#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
1) Verify the register value is 0. also verify that sysrq cannot be triggered by sending a break character via the terminal server.

```
root@sonic:# cat /proc/sys/kernel/sysrq
0
root@sonic:#
telnet> send brk
hh
-bash: hh: command not found
root@sonic:#
```

2) Verify sysrq can still be triggered from procfs

```
root@sonic:# echo u > /proc/sysrq-trigger 
root@sonic:#  sysrq: EmergeRemount R/O

root@sonic:# echo "hi" > /tmp/abc.txt
-bash: /tmp/abc.txt: Read-only file system
```


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [x] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

