### PR TITLE
fix python logger enhancement runtime error with traceback when warm-reboot takes place

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2023 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@
 import os
 import subprocess
 
-from sonic_py_common.logger import Logger
+from .logger import logger
 try:
     from sonic_platform_base.sonic_eeprom import eeprom_tlvinfo
 except ImportError as e:
@@ -32,8 +32,6 @@ except ImportError as e:
 
 from .device_data import DeviceDataManager
 from .utils import default_return, is_host, wait_until
-
-logger = Logger()
 
 #
 # this is mlnx-specific

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2023 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,16 +27,13 @@ import subprocess
 
 try:
     from sonic_platform_base.fan_base import FanBase
-    from sonic_py_common.logger import Logger
+    from .logger import logger
     from .led import ComponentFaultyIndicator
     from . import utils
     from .thermal import Thermal
     from .fan_drawer import VirtualDrawer
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
-
-# Global logger class instance
-logger = Logger()
 
 PWM_MAX = 255
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan_drawer.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan_drawer.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,14 +27,11 @@ import os
 try:
     from sonic_platform_base.fan_drawer_base import FanDrawerBase
     from sonic_platform_base.fan_base import FanBase
-    from sonic_py_common.logger import Logger
+    from .logger import logger
     from .led import FanLed, SharedLed
     from . import utils
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
-
-# Global logger class instance
-logger = Logger()
 
 
 class MellanoxFanDrawer(FanDrawerBase):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,11 +17,9 @@
 import os
 import time
 
-from sonic_py_common.logger import Logger
+from .logger import logger
 from . import utils
 from . import device_data
-
-logger = Logger()
 
 
 class Led(object):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/logger.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/logger.py
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+from sonic_py_common.logger import Logger
+
+# Global logger instance for nvidia platform API, the argument "enable_set_log_level_on_fly"
+# will start a thread to detect CONFIG DB LOGGER table change. The logger instance 
+# allow user to set log level via swssloglevel command at real time. This instance 
+# should be shared by all modules of platform API to avoid starting too many logger thread.
+if os.environ.get("PLATFORM_API_UNIT_TESTING") != "1":
+    # platform API is a lib, let caller set the log identifier
+    logger = Logger(enable_set_log_level_on_fly=True)
+else:
+    # for unit test, there is no redis, don't set enable_set_log_level_on_fly=True
+    logger = Logger()
+

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/logger_for_watchdog.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/logger_for_watchdog.py
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+from sonic_py_common.logger import Logger
+
+# Global logger instance for nvidia platform API, the argument "enable_set_log_level_on_fly"
+# will start a thread to detect CONFIG DB LOGGER table change. The logger instance 
+# allow user to set log level via swssloglevel command at real time. This instance 
+# should be shared by all modules of platform API to avoid starting too many logger thread.
+class LoggerForWatchdog(object):
+
+    def __init__(self, enable_set_log_level_on_fly=True):
+
+        if os.environ.get("PLATFORM_API_UNIT_TESTING") != "1":
+            self.logger = Logger(enable_set_log_level_on_fly=enable_set_log_level_on_fly, db_name='nvidia-platform-api')
+        else:
+            # for unit test, there is no redis, don't set enable_set_log_level_on_fly=True
+            self.logger = Logger()
+
+    def get_logger(self):
+        return self.logger
+

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,14 +18,11 @@
 import redis
 import threading
 from sonic_platform_base.module_base import ModuleBase
-from sonic_py_common.logger import Logger
+from .logger import logger
 
 from . import utils
 from .device_data import DeviceDataManager
 from .vpd_parser import VpdParser
-
-# Global logger class instance
-logger = Logger()
 
 
 class Module(ModuleBase):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,9 +28,9 @@ except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 class Platform(PlatformBase):
-    def __init__(self):
+    def __init__(self, enable_set_log_level_on_fly=True):
         PlatformBase.__init__(self)
         if DeviceDataManager.get_linecard_count() == 0:
-            self._chassis = Chassis()
+            self._chassis = Chassis(enable_set_log_level_on_fly)
         else:
             self._chassis = ModularChassis()

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2023 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@ try:
     import os
     import time
     from sonic_platform_base.psu_base import PsuBase
-    from sonic_py_common.logger import Logger
+    from .logger import logger
     from .device_data import DeviceDataManager
     from .led import PsuLed, SharedLed, ComponentFaultyIndicator
     from . import utils
@@ -34,9 +34,6 @@ try:
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
-
-# Global logger class instance
-logger = Logger()
 
 PSU_PATH = '/var/run/hw-management/'
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2023 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +27,7 @@ try:
     import subprocess
     import os
     import threading
-    from sonic_py_common.logger import Logger
+    from .logger import logger
     from sonic_py_common.general import check_output_pipe
     from . import utils
     from .device_data import DeviceDataManager
@@ -182,9 +182,6 @@ limited_eeprom = {
         }
     }
 }
-
-# Global logger class instance
-logger = Logger()
 
 
 # SDK initializing stuff, called from chassis
@@ -365,6 +362,8 @@ class SFP(NvidiaSFPCommon):
                 content = f.read(num_bytes)
                 if ctypes.get_errno() != 0:
                     raise IOError(f'errno = {os.strerror(ctypes.get_errno())}')
+            logger.log_debug(f'read EEPROM sfp={self.sdk_index}, page={page}, page_offset={page_offset}, \
+                    size={num_bytes}, data={content}')
         except (OSError, IOError) as e:
             if log_on_error:
                 logger.log_warning(f'Failed to read sfp={self.sdk_index} EEPROM page={page}, page_offset={page_offset}, \
@@ -403,6 +402,8 @@ class SFP(NvidiaSFPCommon):
                     raise IOError(f'write return code = {ret}')
                 if ctypes.get_errno() != 0:
                     raise IOError(f'errno = {os.strerror(ctypes.get_errno())}')
+            logger.log_debug(f'write EEPROM sfp={self.sdk_index}, page={page}, page_offset={page_offset}, \
+                    size={num_bytes}, data={write_buffer}')
         except (OSError, IOError) as e:
             data = ''.join('{:02x}'.format(x) for x in write_buffer)
             logger.log_error(f'Failed to write EEPROM data sfp={self.sdk_index} EEPROM page={page}, page_offset={page_offset}, size={num_bytes}, \

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp_event.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp_event.py
@@ -36,7 +36,7 @@ try:
         new_sx_user_channel_t_p = MagicMock()
 except KeyError:
     pass
-from sonic_py_common.logger import Logger
+from .logger import logger
 from .sfp import SFP
 
 # SFP status from PMAOS register
@@ -125,8 +125,6 @@ SYSTEM_FAIL = 'system_fail'
 SDK_DAEMON_READY_FILE = '/tmp/sdk_ready'
 
 PMPE_PACKET_SIZE = 2000
-
-logger = Logger()
 
 class sfp_event:
     ''' Listen to plugin/plugout cable events '''

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -24,7 +24,7 @@
 
 try:
     from sonic_platform_base.thermal_base import ThermalBase
-    from sonic_py_common.logger import Logger
+    from .logger import logger
     import copy
     import os
 
@@ -32,9 +32,6 @@ try:
     from . import utils
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
-
-# Global logger class instance
-logger = Logger()
 
 DEFAULT_TEMP_SCALE = 1000
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2023 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,15 +24,13 @@ import threading
 import time
 import os
 from sonic_py_common import device_info
-from sonic_py_common.logger import Logger
+from .logger import logger
 
 HWSKU_JSON = 'hwsku.json'
 
 PORT_INDEX_KEY = "index"
 PORT_TYPE_KEY = "port_type"
 RJ45_PORT_TYPE = "RJ45"
-
-logger = Logger()
 
 
 def read_from_file(file_path, target_type, default='', raise_exception=False, log_func=logger.log_error):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/vpd_parser.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/vpd_parser.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,11 +16,10 @@
 #
 
 import os
-from sonic_py_common.logger import Logger
+from .logger import logger
 
 from . import utils
 
-logger = Logger()
 SN_VPD_FIELD = "SN_VPD_FIELD"
 PN_VPD_FIELD = "PN_VPD_FIELD"
 REV_VPD_FIELD = "REV_VPD_FIELD"


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fix python logger enhancement runtime error with traceback when warm-reboot takes place

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
create another logger file for chassis, which watchdogutil will call through Platform with the flag of set logging level on the fly
set to False

#### How to verify it
run warm-reboot and verify the runtime error with traceback doesn't happen
change logging level of nvidia-platform-api (mlnx-platform-api) to different then default, like info or debug

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

