### PR TITLE
[202205][ebtables] Add multicast drop rule to ebtables

### DIFF
--- a/files/image_config/ebtables/ebtables.filter.cfg
+++ b/files/image_config/ebtables/ebtables.filter.cfg
@@ -8,4 +8,5 @@
 -A FORWARD -d BGA -j DROP
 -A FORWARD -p ARP -j DROP
 -A FORWARD -p 802_1Q --vlan-encap ARP -j DROP
+-A FORWARD -d Multicast -j DROP
 


### PR DESCRIPTION
Adding rule to ebtables to drop multicast packets in kernel. This was done to address a bug where NS packets were flooding ports with duplicate packets.

#### Why I did it
ADO: 26395578
Fixes bug where NS packets were flooding ports with duplicate packets

##### Work item tracking
- Microsoft ADO **(number only)**: 26395578

#### How I did it
Added ebtables rule to drop multicast packets

#### How to verify it
1. set up testbed with ebtables rule:  -A FORWARD -d Multicast -j DROP
2. tcpdump from eth4
3. send NS packet from eth8

before this fix, we saw 2 packets received on the tcpdump port. After this fix, we will only see one coming from the basic forwarding

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

Back-porting to 202205 for bug-fix

#### Tested branch (Please provide the tested image version)

- [x] 202311
- [x] 202205

#### Description for the changelog

Adding ebtables rule to drop multicast packets.

#### A picture of a cute animal (not mandatory but encouraged)

![IMG_3777](https://github.com/sonic-net/sonic-buildimage/assets/26731235/81a3bc1b-fd28-499d-94a7-67b526ec6fd7)
