### PR TITLE
Adding a new field to CONFIG DB: "subport"

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/hwsku.json
@@ -1,100 +1,132 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet8": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet16": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet24": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet32": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet40": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet48": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet56": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet64": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet72": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet80": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet88": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet96": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet104": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet112": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet120": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet128": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet136": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet144": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet152": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet160": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet168": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet176": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet184": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet192": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet200": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet208": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet216": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet224": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet232": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet240": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet248": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         }
     }
 }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/hwsku.json
@@ -1,132 +1,100 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet8": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet16": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet24": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet32": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet40": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet48": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet56": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet64": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet72": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet80": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet88": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet96": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet104": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet112": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet120": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet128": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet136": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet144": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet152": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet160": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet168": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet176": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet184": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet192": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet200": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet208": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet216": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet224": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet232": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet240": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet248": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         }
     }
 }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-C128/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-C128/hwsku.json
@@ -1,388 +1,516 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet2": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet4": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet6": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet8": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet10": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet12": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet14": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet16": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet18": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet20": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet22": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet24": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet26": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet28": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet30": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet32": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet34": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet36": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet38": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet40": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet42": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet44": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet46": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet48": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet50": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet52": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet54": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet56": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet58": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet60": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet62": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet64": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet66": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet68": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet70": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet72": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet74": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet76": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet78": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet80": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet82": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet84": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet86": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet88": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet90": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet92": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet94": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet96": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet98": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet100": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet102": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet104": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet106": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet108": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet110": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet112": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet114": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet116": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet118": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet120": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet122": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet124": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet126": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet128": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet130": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet132": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet134": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet136": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet138": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet140": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet142": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet144": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet146": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet148": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet150": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet152": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet154": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet156": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet158": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet160": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet162": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet164": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet166": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet168": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet170": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet172": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet174": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet176": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet178": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet180": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet182": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet184": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet186": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet188": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet190": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet192": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet194": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet196": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet198": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet200": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet202": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet204": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet206": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet208": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet210": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet212": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet214": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet216": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet218": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet220": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet222": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet224": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet226": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet228": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet230": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet232": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet234": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet236": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet238": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet240": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet242": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet244": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet246": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet248": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet250": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet252": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet254": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         }
     }
 }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O28/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O28/hwsku.json
@@ -1,100 +1,132 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet8": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet16": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet24": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet32": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet40": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet48": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet56": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet64": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet72": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet80": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet88": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet96": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet104": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet112": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet120": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet128": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet136": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet144": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet152": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet160": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet168": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet176": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet184": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet192": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet200": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet208": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet216": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet224": {
-	    "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]"
+	     "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet232": {
-	    "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]"
+	     "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet240": {
-	    "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]"
+	     "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet248": {
-	    "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]"
+	     "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         }
     }
 }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/hwsku.json
@@ -1,172 +1,228 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet4": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet8": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet12": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet16": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet20": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet24": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet28": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet32": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet36": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet40": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet44": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet48": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet52": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet56": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet60": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet64": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet68": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet72": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet76": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet80": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet84": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet88": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet92": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet96": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet104": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet112": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet120": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet128": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet136": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet144": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet152": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet160": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet164": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet168": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet172": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet176": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet180": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet184": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet188": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet192": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet196": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet200": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet204": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet208": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet212": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet216": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet220": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet224": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet228": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet232": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet236": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet240": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet244": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet248": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet252": {
-            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         }
     }
 }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/hwsku.json
@@ -1,172 +1,228 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet4": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet8": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet12": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet16": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet20": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet24": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet28": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet32": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet36": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet40": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet44": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet48": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet52": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet56": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet60": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet64": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet68": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet72": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet76": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet80": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet84": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet88": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet92": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet96": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet104": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet112": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet120": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet128": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet136": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet144": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet152": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet160": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet164": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet168": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet172": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet176": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet180": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet184": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet188": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet192": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet196": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet200": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet204": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet208": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet212": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet216": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet220": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet224": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet228": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet232": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet236": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet240": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet244": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet248": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet252": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         }
     }
 }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V48C32/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V48C32/hwsku.json
@@ -1,244 +1,324 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet4": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet8": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet12": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet16": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet20": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet24": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet28": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet32": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet36": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet40": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet44": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet48": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet52": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet56": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet60": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet64": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet68": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet72": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet76": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet80": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet84": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet88": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet92": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet96": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet100": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet104": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet108": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet112": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet116": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet120": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet124": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet128": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet132": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet136": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet140": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet144": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet148": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet152": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet156": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet160": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet164": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet168": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet172": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet176": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet180": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet184": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet188": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet192": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet194": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet196": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet198": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet200": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet202": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet204": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet206": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet208": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet210": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet212": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet214": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet216": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet218": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet220": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet222": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet224": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet226": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet228": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet230": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet232": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet234": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet236": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet238": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet240": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet242": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet244": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet246": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         },
         "Ethernet248": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "1"
         },
         "Ethernet250": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "2"
         },
         "Ethernet252": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "3"
         },
         "Ethernet254": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
+            "subport": "4"
         }
     }
 }

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -37,7 +37,7 @@ PORT_STR = "Ethernet"
 BRKOUT_MODE = "default_brkout_mode"
 CUR_BRKOUT_MODE = "brkout_mode"
 INTF_KEY = "interfaces"
-OPTIONAL_HWSKU_ATTRIBUTES = ["fec", "autoneg"]
+OPTIONAL_HWSKU_ATTRIBUTES = ["fec", "autoneg", "subport"]
 
 BRKOUT_PATTERN = r'(\d{1,6})x(\d{1,6}G?)(\[(\d{1,6}G?,?)*\])?(\((\d{1,6})\))?'
 BRKOUT_PATTERN_GROUPS = 6
@@ -422,9 +422,10 @@ def parse_platform_json_file(hwsku_json_file, platform_json_file):
         child_ports = get_child_ports(intf, brkout_mode, platform_json_file)
 
         # take optional fields from hwsku.json
-        for key, item in hwsku_dict[INTF_KEY][intf].items():
-            if key in OPTIONAL_HWSKU_ATTRIBUTES:
-                child_ports.get(intf)[key] = item
+        for child_port in child_ports:
+            for key, item in hwsku_dict[INTF_KEY][child_port].items():
+                if key in OPTIONAL_HWSKU_ATTRIBUTES:
+                    child_ports.get(child_port)[key] = item
 
         ports.update(child_ports)
 

--- a/src/sonic-config-engine/tests/sample_hwsku.json
+++ b/src/sonic-config-engine/tests/sample_hwsku.json
@@ -6,13 +6,37 @@
         "Ethernet4": {
             "default_brkout_mode": "2x50G"
         },
+        "Ethernet6": {
+            "default_brkout_mode": "2x50G"
+        },
         "Ethernet8": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet9": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet10": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet11": {
             "default_brkout_mode": "4x25G[10G]"
         },
         "Ethernet12": {
             "default_brkout_mode": "2x25G(2)+1x50G(2)"
         },
+        "Ethernet13": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
+        "Ethernet14": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
         "Ethernet16": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet18": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet19": {
             "default_brkout_mode": "1x50G(2)+2x25G(2)"
         },
         "Ethernet20": {
@@ -21,13 +45,37 @@
         "Ethernet24": {
             "default_brkout_mode": "2x50G"
         },
+        "Ethernet26": {
+            "default_brkout_mode": "2x50G"
+        },
         "Ethernet28": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet29": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet30": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet31": {
             "default_brkout_mode": "4x25G[10G]"
         },
         "Ethernet32": {
             "default_brkout_mode": "2x25G(2)+1x50G(2)"
         },
+        "Ethernet33": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
+        "Ethernet34": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
         "Ethernet36": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet38": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet39": {
             "default_brkout_mode": "1x50G(2)+2x25G(2)"
         },
         "Ethernet40": {
@@ -36,13 +84,37 @@
         "Ethernet44": {
             "default_brkout_mode": "2x50G[40G,25G,10G,1G]"
         },
+        "Ethernet46": {
+            "default_brkout_mode": "2x50G[40G,25G,10G,1G]"
+        },
         "Ethernet48": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet49": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet50": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet51": {
             "default_brkout_mode": "4x25G[10G]"
         },
         "Ethernet52": {
             "default_brkout_mode": "2x25G(2)+1x50G(2)"
         },
+        "Ethernet53": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
+        "Ethernet54": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
         "Ethernet56": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet58": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet59": {
             "default_brkout_mode": "1x50G(2)+2x25G(2)"
         },
         "Ethernet60": {
@@ -51,13 +123,37 @@
         "Ethernet64": {
             "default_brkout_mode": "2x50G"
         },
+        "Ethernet66": {
+            "default_brkout_mode": "2x50G"
+        },
         "Ethernet68": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet69": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet70": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet71": {
             "default_brkout_mode": "4x25G[10G]"
         },
         "Ethernet72": {
             "default_brkout_mode": "2x25G(2)+1x50G(2)"
         },
+        "Ethernet73": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
+        "Ethernet74": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
         "Ethernet76": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet78": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet79": {
             "default_brkout_mode": "1x50G(2)+2x25G(2)"
         },
         "Ethernet80": {
@@ -66,13 +162,37 @@
         "Ethernet84": {
             "default_brkout_mode": "2x50G"
         },
+        "Ethernet86": {
+            "default_brkout_mode": "2x50G"
+        },
         "Ethernet88": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet89": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet90": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet91": {
             "default_brkout_mode": "4x25G[10G]"
         },
         "Ethernet92": {
             "default_brkout_mode": "2x25G(2)+1x50G(2)"
         },
+        "Ethernet93": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
+        "Ethernet94": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
         "Ethernet96": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet98": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet99": {
             "default_brkout_mode": "1x50G(2)+2x25G(2)"
         },
         "Ethernet100": {
@@ -81,19 +201,46 @@
         "Ethernet104": {
             "default_brkout_mode": "2x50G"
         },
+        "Ethernet106": {
+            "default_brkout_mode": "2x50G"
+        },
         "Ethernet108": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet109": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet110": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet111": {
             "default_brkout_mode": "4x25G[10G]"
         },
         "Ethernet112": {
             "default_brkout_mode": "2x25G(2)+1x50G(2)"
         },
+        "Ethernet113": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
+        "Ethernet114": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
         "Ethernet116": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet118": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet119": {
             "default_brkout_mode": "1x50G(2)+2x25G(2)"
         },
         "Ethernet120": {
             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet124": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet126": {
             "default_brkout_mode": "2x50G"
         },
         "Ethernet128": {
@@ -105,7 +252,22 @@
         "Ethernet136": {
             "default_brkout_mode": "4x10G[25G]"
         },
+        "Ethernet137": {
+            "default_brkout_mode": "4x10G[25G]"
+        },
+        "Ethernet138": {
+            "default_brkout_mode": "4x10G[25G]"
+        },
+        "Ethernet139": {
+            "default_brkout_mode": "4x10G[25G]"
+        },
         "Ethernet140": {
+            "default_brkout_mode": "2x25G(2)+1x50000(2)"
+        },
+        "Ethernet141": {
+            "default_brkout_mode": "2x25G(2)+1x50000(2)"
+        },
+        "Ethernet142": {
             "default_brkout_mode": "2x25G(2)+1x50000(2)"
         },
         "Ethernet144": {
@@ -113,3 +275,4 @@
         }
     }
 }
+

--- a/src/sonic-device-data/tests/hwsku_json_checker
+++ b/src/sonic-device-data/tests/hwsku_json_checker
@@ -7,7 +7,7 @@ import sys
 
 # Global variable
 PORT_ATTRIBUTES = ["default_brkout_mode"]
-OPTIONAL_PORT_ATTRIBUTES = ["fec", "autoneg", "port_type"]
+OPTIONAL_PORT_ATTRIBUTES = ["fec", "autoneg", "port_type", "subport"]
 PORT_REG = "Ethernet(\d+)"
 HWSKU_JSON = '*hwsku.json'
 INTF_KEY = "interfaces"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The field 'subport' represents the index of the split port within a physical port. For example, if a port is split into 4, the subport of the first logical port is 1, the subport of the second logical port is 2, and so on.
In xcvrd, the CMIS manager uses the subport to calculate the lane mask, which is used to control the data path per lane. In Nvidia platform, the subport is missing and is always set to 0. According to the xcvrd code, when subport=0, it will always correspond to the first logical port. Therefore, if we shut down any logical port that is not the first one, we will see the operational status of the first logical port also becomes down.
This PR aims to add the subport field to CONFIG DB and prevent such scenarios. This is applicable only for static default breakout mode. For DPB, subport calculation will happen on the fly (changes are not in Sonic yet).
(Subport HLD: HLD of subport: [link to the HLD document])

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
I have added the 'subport' field to all relevant Nvidia hwsku.json files (minigraph generation is based on them). Additionally, I introduced the new 'subport' field to portconfig.py, so that sonic-cfggen will be able to generate the minigraph with it. In this file, I also fixed an error that caused all attributes from hwsku.json to be applied only to the first logical ports associated with a physical port.
Furthermore, I updated hwsku_json_checker to include the new field and applied a fix to the sample_hwsku.json file. sample_hwsku.json is the file that sonic-config-engine's unit tests rely on for its tests. Previously, it only included attributes for the first logical port of a split physical port. For example, if Ethernet4, a 4-lane port, was split into 2 ports, then sample_hwsku.json included only the entry for Ethernet4, with no entry for Ethernet6. This misalignment with the structure of other hwsku.json files has been corrected as well.

#### How to verify it
Ensure that each logical port has the correct value of 'subport' in CONFIG DB, and that shutting down a logical port affects only that port and not other ports in the split.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

