### PR TITLE
[sonic-dash-api]: Fix wrong path in sonic-dash-api.dep

### DIFF
--- a/rules/sonic-dash-api.dep
+++ b/rules/sonic-dash-api.dep
@@ -3,7 +3,7 @@ SPATH       := $($(LIB_SONIC_DASH_API)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/sonic-dash-api.mk rules/sonic-dash-api.dep   
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(SPATH) | grep -v sonic-dash-api)
-SMDEP_FILES := $(addprefix $(SPATH)/sonic-dash-api/,$(shell cd $(SPATH)/sonic-dash-api && git ls-files))
+SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH)/ && git ls-files))
 
 $(LIB_SONIC_DASH_API)_CACHE_MODE  := GIT_CONTENT_SHA 
 $(LIB_SONIC_DASH_API)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In some local buildings, an error `/bin/bash: line 0: cd: src/sonic-dash-api/sonic-dash-api: No such file or directory` will be raised due to the directory structure of sonic-dash-api has been changed.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Revised the old path variable in sonic-dash-api.deb

#### How to verify it

Check Azp and local building

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

