### PR TITLE
Fix frrcfgd high CPU utilzation issue caused by small pubsub timeout.

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1486,7 +1486,7 @@ class ExtConfigDBConnector(ConfigDBConnector):
         """Start listen Redis keyspace events and will trigger corresponding handlers when content of a table changes.
         """
         self.pubsub = self.get_redis_client(self.db_name).pubsub()
-        self.sub_thread = threading.Thread(target=self.listen_thread, args=(0.01,))
+        self.sub_thread = threading.Thread(target=self.listen_thread, args=(10,))
         self.sub_thread.start()
 
     def stop_listen(self):


### PR DESCRIPTION
Fix frrcfgd high CPU utilization issue caused by small pubsub timeout.

#### Why I did it
Fix frrcfgd high CPU utilization issue caused by small pubsub timeout.

##### Work item tracking
- Microsoft ADO: 27002941

#### How I did it
Increase pubsub timeout to 10seconds.

#### How to verify it
Pass all UT.
Manually check CPU utilization back to normal.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
Fix frrcfgd high CPU utilization issue caused by small pubsub timeout.

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

