### PR TITLE
Add SDK dependent python packages

### DIFF
--- a/platform/innovium/docker-syncd-invm/Dockerfile.j2
+++ b/platform/innovium/docker-syncd-invm/Dockerfile.j2
@@ -17,6 +17,9 @@ debs/
 RUN apt-get install -y net-tools
 RUN apt-get install -y libjansson4
 RUN apt-get install -y libyaml-dev
+RUN apt-get install -y binutils
+RUN pip3 install numpy
+RUN pip3 install yamlordereddictloader
 
 RUN dpkg -i \
 {% for deb in docker_syncd_invm_debs.split(' ') -%}


### PR DESCRIPTION
This change adds dependent python packages required for innovium platform sdk

Why I did it
To fix innovium sdk issue in syncd docker 

Work item tracking
- Microsoft ADO **(number only)**:

How I did it
Added dependent python packages in syncd dockerfile

How to verify it
Verified on innovium platforms

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
Tested branch (Please provide the tested image version)
master


