### PR TITLE
[master][Supervisor][datbase-chassis] Fix  redis_chassis FATAL issue in database-chassis on Supervisor

### DIFF
--- a/dockers/docker-database/docker-database-init.sh
+++ b/dockers/docker-database/docker-database-init.sh
@@ -61,12 +61,16 @@ cp $db_cfg_file $db_cfg_file_tmp
 if [[ $DATABASE_TYPE == "chassisdb" ]]; then
     # Docker init for database-chassis
     echo "Init docker-database-chassis..."
+    VAR_LIB_REDIS_CHASSIS_DIR="/var/lib/redis_chassis"
+    mkdir -p $VAR_LIB_REDIS_CHASSIS_DIR   
     update_chassisdb_config -j $db_cfg_file_tmp -k -p $chassis_db_port
     # generate all redis server supervisord configuration file
     sonic-cfggen -j $db_cfg_file_tmp \
     -t /usr/share/sonic/templates/supervisord.conf.j2,/etc/supervisor/conf.d/supervisord.conf \
     -t /usr/share/sonic/templates/critical_processes.j2,/etc/supervisor/critical_processes
     rm $db_cfg_file_tmp
+    chown -R redis:redis $VAR_LIB_REDIS_CHASSIS_DIR
+    chown -R redis:redis $REDIS_DIR
     exec /usr/local/bin/supervisord
     exit 0
 fi


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
redis_chassis process fails to start in the database-chassis on the supervisor card.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
The redis and redis_chassis processes in supervisor.conf has been modified to start with 'redis' as user.  The modification only added redis and redis group for database containers except database-chassis container.  This commit adds code to the docker-database-init.sh to add redis and redis group for the database-chassis to address this issue.

#### How to verify it
Booting the image on Supervisor. And verify the database-chassis container should be in UP state,  and the database-chassis.service is in active(running) state 
```
admin@ixre-cpm-chassis15:~$ docker ps -a
CONTAINER ID   IMAGE                             COMMAND                  CREATED        STATUS        PORTS     NAMES
9691c6111e0f   docker-fpm-frr:latest             "/usr/bin/docker_ini?"   16 hours ago   Up 16 hours             bgp5
...
c7c7159d4e0c   docker-database:latest            "/usr/local/bin/dock?"   31 hours ago   Up 16 hours             database-chassis


admin@ixre-cpm-chassis15:~$ sudo systemctl status database-chassis
? database-chassis.service - database-chassis container
     Loaded: loaded (/lib/systemd/system/database-chassis.service; enabled-runtime; preset: enabled)
     Active: active (running) since Sun 2024-03-03 04:43:12 UTC; 16h ago
    Process: 1640 ExecStartPre=/usr/bin/database.sh start chassisdb (code=exited, status=0/SUCCESS)
   Main PID: 1938 (database.sh)
      Tasks: 10 (limit: 38307)
     Memory: 49.7M
     CGroup: /system.slice/database-chassis.service
             ??1938 /bin/bash /usr/bin/database.sh wait chassisdb
             ??1940 docker wait database-chassis

Notice: journal has been rotated since unit was started, output may be incomplete.
admin@ixre-cpm-chassis15:~$ 


```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

