### PR TITLE
Add boundary check before memset, memcpy, strncpy

### DIFF
--- a/src/iccpd/src/iccp_cli.c
+++ b/src/iccpd/src/iccp_cli.c
@@ -117,7 +117,17 @@ int set_peer_link(int mid, const char* ifname)
                        csm->mlag_id, ifname);
     }
 
+    if (MAX_L_PORT_NAME > strlen(csm->peer_itf_name))
+    {
+        ICCPD_LOG_ERR(__FUNCTION__, "MAX=%d is greater than peer_itf_name length=%d", MAX_L_PORT_NAME, strlen(csm->peer_itf_name));
+        return MCLAG_ERROR;
+    }
     memset(csm->peer_itf_name, 0, MAX_L_PORT_NAME);
+    if (len > strlen(csm->peer_itf_name))
+    {
+        ICCPD_LOG_ERR(__FUNCTION__, "len=%d is greater than peer_itf_name length=%d", len, strlen(csm->peer_itf_name));
+        return MCLAG_ERROR;
+    }
     memcpy(csm->peer_itf_name, ifname, len);
 
     /* update peer-link link handler*/
@@ -208,8 +218,18 @@ int set_local_address(int mid, const char* addr)
 
     len = strlen(addr);
     memset(csm->sender_ip, 0, INET_ADDRSTRLEN);
+    if (len > strlen(csm->sender_ip))
+    {
+        ICCPD_LOG_ERR(__FUNCTION__, "len=%d is greater than sender_ip length=%d", len, strlen(csm->sender_ip));
+        return MCLAG_ERROR;
+    }
     memcpy(csm->sender_ip, addr, len);
     memset(csm->iccp_info.sender_name, 0, INET_ADDRSTRLEN);
+    if (len > strlen(csm->iccp_info.sender_name))
+    {
+        ICCPD_LOG_ERR(__FUNCTION__, "len=%d is greater than sender_name length=%d", len, strlen(csm->iccp_info.sender_name));
+        return MCLAG_ERROR;
+    }
     memcpy(csm->iccp_info.sender_name, addr, len);
 
     return 0;
@@ -268,6 +288,11 @@ int set_peer_address(int mid, const char* addr)
     }
 
     memset(csm->peer_ip, 0, INET_ADDRSTRLEN);
+    if (len > strlen(csm->peer_ip))
+    {
+        ICCPD_LOG_ERR(__FUNCTION__, "len=%d is greater than peer_ip length=%d", len, strlen(csm->peer_ip));
+        return MCLAG_ERROR;
+    }
     memcpy(csm->peer_ip, addr, len);
 
     return 0;

--- a/src/iccpd/src/iccp_cli.c
+++ b/src/iccpd/src/iccp_cli.c
@@ -117,7 +117,7 @@ int set_peer_link(int mid, const char* ifname)
                        csm->mlag_id, ifname);
     }
 
-    explicit_bzero(csm->peer_itf_name, MAX_L_PORT_NAME);
+    memset(csm->peer_itf_name, 0, IFNAMSIZ);
     if (len > MAX_L_PORT_NAME)
     {
         ICCPD_LOG_ERR(__FUNCTION__, "Peer-link %s, Strlen %d greater than MAX:%d ", ifname, len, MAX_L_PORT_NAME);
@@ -212,14 +212,14 @@ int set_local_address(int mid, const char* addr)
     }
 
     len = strlen(addr);
-    explicit_bzero(csm->sender_ip, INET_ADDRSTRLEN);
+    memset(csm->sender_ip, 0, INET_ADDRSTRLEN);
     if (len > INET_ADDRSTRLEN)
     {
         ICCPD_LOG_ERR(__FUNCTION__, "len=%d greater than INET_ADDRSTRLEN=%d ", len, INET_ADDRSTRLEN);
         return MCLAG_ERROR;
     }
     memcpy(csm->sender_ip, addr, len);
-    explicit_bzero(csm->iccp_info.sender_name, INET_ADDRSTRLEN);
+    memset(csm->iccp_info.sender_name, 0, INET_ADDRSTRLEN);
     if (len > INET_ADDRSTRLEN)
     {
         ICCPD_LOG_ERR(__FUNCTION__, "len=%d greater than INET_ADDRSTRLEN=%d ", len, INET_ADDRSTRLEN);
@@ -282,7 +282,7 @@ int set_peer_address(int mid, const char* addr)
         ICCPD_LOG_INFO(__FUNCTION__, "Set peer-address : %s", addr);
     }
 
-    explicit_bzero(csm->peer_ip, INET_ADDRSTRLEN);
+    memset(csm->peer_ip, 0, INET_ADDRSTRLEN);
     if (len > INET_ADDRSTRLEN)
     {
         ICCPD_LOG_ERR(__FUNCTION__, "len=%d greater than INET_ADDRSTRLEN=%d ", len, INET_ADDRSTRLEN);

--- a/src/iccpd/src/iccp_cli.c
+++ b/src/iccpd/src/iccp_cli.c
@@ -117,15 +117,10 @@ int set_peer_link(int mid, const char* ifname)
                        csm->mlag_id, ifname);
     }
 
-    if (MAX_L_PORT_NAME > strlen(csm->peer_itf_name))
+    explicit_bzero(csm->peer_itf_name, MAX_L_PORT_NAME);
+    if (len > MAX_L_PORT_NAME)
     {
-        ICCPD_LOG_ERR(__FUNCTION__, "MAX=%d is greater than peer_itf_name length=%d", MAX_L_PORT_NAME, strlen(csm->peer_itf_name));
-        return MCLAG_ERROR;
-    }
-    memset(csm->peer_itf_name, 0, MAX_L_PORT_NAME);
-    if (len > strlen(csm->peer_itf_name))
-    {
-        ICCPD_LOG_ERR(__FUNCTION__, "len=%d is greater than peer_itf_name length=%d", len, strlen(csm->peer_itf_name));
+        ICCPD_LOG_ERR(__FUNCTION__, "Peer-link %s, Strlen %d greater than MAX:%d ", ifname, len, MAX_L_PORT_NAME);
         return MCLAG_ERROR;
     }
     memcpy(csm->peer_itf_name, ifname, len);
@@ -217,17 +212,17 @@ int set_local_address(int mid, const char* addr)
     }
 
     len = strlen(addr);
-    memset(csm->sender_ip, 0, INET_ADDRSTRLEN);
-    if (len > strlen(csm->sender_ip))
+    explicit_bzero(csm->sender_ip, INET_ADDRSTRLEN);
+    if (len > INET_ADDRSTRLEN)
     {
-        ICCPD_LOG_ERR(__FUNCTION__, "len=%d is greater than sender_ip length=%d", len, strlen(csm->sender_ip));
+        ICCPD_LOG_ERR(__FUNCTION__, "len=%d greater than INET_ADDRSTRLEN=%d ", len, INET_ADDRSTRLEN);
         return MCLAG_ERROR;
     }
     memcpy(csm->sender_ip, addr, len);
-    memset(csm->iccp_info.sender_name, 0, INET_ADDRSTRLEN);
-    if (len > strlen(csm->iccp_info.sender_name))
+    explicit_bzero(csm->iccp_info.sender_name, INET_ADDRSTRLEN);
+    if (len > INET_ADDRSTRLEN)
     {
-        ICCPD_LOG_ERR(__FUNCTION__, "len=%d is greater than sender_name length=%d", len, strlen(csm->iccp_info.sender_name));
+        ICCPD_LOG_ERR(__FUNCTION__, "len=%d greater than INET_ADDRSTRLEN=%d ", len, INET_ADDRSTRLEN);
         return MCLAG_ERROR;
     }
     memcpy(csm->iccp_info.sender_name, addr, len);
@@ -287,10 +282,10 @@ int set_peer_address(int mid, const char* addr)
         ICCPD_LOG_INFO(__FUNCTION__, "Set peer-address : %s", addr);
     }
 
-    memset(csm->peer_ip, 0, INET_ADDRSTRLEN);
-    if (len > strlen(csm->peer_ip))
+    explicit_bzero(csm->peer_ip, INET_ADDRSTRLEN);
+    if (len > INET_ADDRSTRLEN)
     {
-        ICCPD_LOG_ERR(__FUNCTION__, "len=%d is greater than peer_ip length=%d", len, strlen(csm->peer_ip));
+        ICCPD_LOG_ERR(__FUNCTION__, "len=%d greater than INET_ADDRSTRLEN=%d ", len, INET_ADDRSTRLEN);
         return MCLAG_ERROR;
     }
     memcpy(csm->peer_ip, addr, len);

--- a/src/iccpd/src/iccp_cli.c
+++ b/src/iccpd/src/iccp_cli.c
@@ -118,9 +118,9 @@ int set_peer_link(int mid, const char* ifname)
     }
 
     memset(csm->peer_itf_name, 0, IFNAMSIZ);
-    if (len > MAX_L_PORT_NAME)
+    if (len > IFNAMSIZ)
     {
-        ICCPD_LOG_ERR(__FUNCTION__, "Peer-link %s, Strlen %d greater than MAX:%d ", ifname, len, MAX_L_PORT_NAME);
+        ICCPD_LOG_ERR(__FUNCTION__, "len=%d greater than IFNAMESIZ=%d", len, IFNAMSIZ);
         return MCLAG_ERROR;
     }
     memcpy(csm->peer_itf_name, ifname, len);

--- a/src/iccpd/src/iccp_cmd.c
+++ b/src/iccpd/src/iccp_cmd.c
@@ -135,6 +135,10 @@ int iccp_config_from_command(char * line)
                 cp++;
 
             slen = cp - start;
+            if (slen > strlen(token))
+            {
+                return MCLAG_ERROR;
+            }
             strncpy(token, start, slen);
             *(token + slen) = '\0';
             iccp_cli_attach_mclag_domain_to_port_channel(mid, token);


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add boundary check before memset, memcpy, strncpy calls to prevent buffer overflow
##### Work item tracking
- Microsoft ADO **(number only)**: 27008041

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106
- [x] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

