### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202305.1.0.3
+ref=202311.main.0.1


### PR DESCRIPTION
#### Why I did it

Release notes for Cisco 8111-32EH-O, 8102-64H-O and 8101-32FH

    First code drop for 202311

#### How I did it
Update platform version to 202311.main.0.1

#### How to verify it

#### Which release branch to backport (provide reason below if selected)


#### Link to config_db schema for YANG module changes


#### A picture of a cute animal (not mandatory but encouraged)

