### PR TITLE
[e1031] replace host check command in celestica e1031

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/common.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/common.py
@@ -24,7 +24,6 @@ class Common:
 
     SET_METHOD_IPMI = 'ipmitool'
     NULL_VAL = 'N/A'
-    HOST_CHK_CMD = ["docker"]
     REF_KEY = '$ref:'
 
     def __init__(self, conf=None):
@@ -184,12 +183,13 @@ class Common:
             return False
         return True
 
-    def is_host(self):
-        try:
-            subprocess.call(self.HOST_CHK_CMD, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        except FileNotFoundError:
-            return False
-        return True
+    def is_host():
+        """
+        Test whether current process is running on the host or an docker
+        return True for host and False for docker
+        """
+        docker_env_file = '/.dockerenv'
+        return os.path.exists(docker_env_file) is False
 
     def load_json_file(self, path):
         """


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The original host check command docker will hang indefinitely when it is run too early in the boot process, halting determine-reboot-cause and lldp/pmon/snmp service from starting. Replace docker with checking /.dockerenv existence.

##### Work item tracking
- Microsoft ADO **(number only)**: 27085874

#### How I did it
Replace docker with checking /.dockerenv existence.

#### How to verify it
Manually modify image and reboot to see if everything work

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)
202305.18

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Replace host check command for celestica e1031

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

