### PR TITLE
Remove PMON and XCVRD delay on system boot for modules controlled by SW

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
@@ -1,7 +1,7 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "delay_xcvrd": true,
+    "delay_xcvrd": false,
     "skip_xcvrd_cmis_mgr": true
 }
 

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -36,7 +36,7 @@
 {%- set features = [("bgp", "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}", false, "enabled"),
                    ("database", "always_enabled", false, "always_enabled"),
                    ("lldp", "enabled", true, "enabled"),
-                   ("pmon", "enabled", true, "enabled"),
+                   ("pmon", "enabled", false, "enabled"),
                    ("snmp", "enabled", true, "enabled"),
                    ("swss", "enabled", false, "enabled"),
                    ("syncd", "enabled", false, "enabled")] %}

--- a/files/scripts/gbsyncd.sh
+++ b/files/scripts/gbsyncd.sh
@@ -15,10 +15,6 @@ function startplatform() {
     done
 }
 
-function waitplatform() {
-    :
-}
-
 function stopplatform1() {
     if ! docker top gbsyncd$DEV | grep -q /usr/bin/syncd; then
         debug "syncd process in container gbsyncd$DEV is not running"

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -96,18 +96,9 @@ function waitplatform() {
 
     BOOT_TYPE=`getBootType`
     if [[ x"$sonic_asic_platform" == x"mellanox" ]]; then
-        if [[ x"$BOOT_TYPE" = @(x"fast"|x"warm"|x"fastfast") ]]; then
-            PMON_TIMER_STATUS=$(systemctl is-active pmon.timer)
-            if [[ x"$PMON_TIMER_STATUS" = x"inactive" ]]; then
-                systemctl start pmon.timer
-            else
-                debug "PMON service is delayed by a timer for better fast/warm boot performance"
-            fi
-        else
-            debug "Starting pmon service..."
-            /bin/systemctl start pmon
-            debug "Started pmon service"
-        fi
+        debug "Starting pmon service..."
+        /bin/systemctl start pmon
+        debug "Started pmon service"
     fi
 }
 

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -92,16 +92,6 @@ function startplatform() {
     fi
 }
 
-function waitplatform() {
-
-    BOOT_TYPE=`getBootType`
-    if [[ x"$sonic_asic_platform" == x"mellanox" ]]; then
-        debug "Starting pmon service..."
-        /bin/systemctl start pmon
-        debug "Started pmon service"
-    fi
-}
-
 function stopplatform1() {
 
     if [[ x$sonic_asic_platform == x"mellanox" ]] && [[ x$TYPE == x"cold" ]]; then

--- a/files/scripts/syncd_common.sh
+++ b/files/scripts/syncd_common.sh
@@ -5,7 +5,6 @@
 # scripts using this must provide implementations of the following functions:
 #
 # startplatform
-# waitplatform
 # stopplatform1 and stopplatform2
 #
 # For examples of these, see gbsyncd.sh and syncd.sh.
@@ -140,8 +139,6 @@ wait() {
             debug "Started ${SERVICE}$DEV service..."
         fi
     fi
-
-    waitplatform
 
     /usr/bin/${SERVICE}.sh wait $DEV
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To support the `fastboot` feature alongside `module controlled by sw ` feature.
Because if the  feature is enabled we need the `XCVRD` to start as soon as possible to identify if the port is `SW` or `FW` controlled and bring the port to the UP state.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Remove the delays for the `PMON` docker and `XCVRD` daemon on the SONiC image start.

#### How to verify it
Run the [sonic-mgmt/tests/platform_tests/test_advanced_reboot.py - test_fast_reboot](https://github.com/sonic-net/sonic-mgmt/blob/89c4a1a0a560772c2ac02c5bd8c8c23d6883fd93/tests/platform_tests/test_advanced_reboot.py#L62)


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

