### PR TITLE
[minigraph-parser] Update UT to avoid race condition during build image

### DIFF
--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -528,7 +528,7 @@ class TestCfgGenCaseInsensitive(TestCase):
         }
         # TC1: Minigraph contains acl table type BmcData
         sample_mx_graph = os.path.join(self.test_dir,'simple-sample-graph-mx.xml')
-        result = minigraph.parse_xml(sample_mx_graph)
+        result = minigraph.parse_xml(sample_mx_graph, port_config_file=self.port_config)
         self.assertIn('ACL_TABLE_TYPE', result)
         self.assertIn('BMCDATA', result['ACL_TABLE_TYPE'])
         self.assertIn('BMCDATAV6', result['ACL_TABLE_TYPE'])
@@ -537,7 +537,7 @@ class TestCfgGenCaseInsensitive(TestCase):
         self.assertDictEqual(result['ACL_TABLE']['BMC_ACL_NORTHBOUND'], expected_acl_table_bmc_acl_northbound)
         self.assertDictEqual(result['ACL_TABLE']['BMC_ACL_NORTHBOUND_V6'], expected_acl_table_bmc_acl_northbound_v6)
         # TC2: Minigraph doesn't contain acl table type BmcData
-        result = minigraph.parse_xml(self.sample_graph)
+        result = minigraph.parse_xml(self.sample_graph, port_config_file=self.port_config)
         self.assertNotIn('ACL_TABLE_TYPE', result)
 
     def test_parse_device_desc_xml_mgmt_interface(self):
@@ -564,7 +564,7 @@ class TestCfgGenCaseInsensitive(TestCase):
         mgmt_graphs = ['simple-sample-graph-mx.xml', 'simple-sample-graph-m0.xml']
         for graph in mgmt_graphs:
             graph_path = os.path.join(self.test_dir, graph)
-            result = minigraph.parse_xml(graph_path)
+            result = minigraph.parse_xml(graph_path, port_config_file=self.port_config)
             self.assertIn('FLEX_COUNTER_TABLE', result)
             for counter in expected_mgmt_disabled_counters:
                 self.assertIn(counter, result['FLEX_COUNTER_TABLE'])
@@ -573,5 +573,5 @@ class TestCfgGenCaseInsensitive(TestCase):
                 if counter in result['FLEX_COUNTER_TABLE']:
                     self.assertDictEqual(result['FLEX_COUNTER_TABLE'][counter], {'FLEX_COUNTER_STATUS': 'enable'})
         # TC2: For other minigraph, result should not contain FLEX_COUNTER_TABLE
-        result = minigraph.parse_xml(self.sample_graph)
+        result = minigraph.parse_xml(self.sample_graph, port_config_file=self.port_config)
         self.assertNotIn('FLEX_COUNTER_TABLE', result)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix issue #18180. 
I suspect this issue caused by race condition during building SONiC image. Some UT cases of minigraph-parser missed `port_config_path`. Hence the testcases will rely on method `device_info.get_path_to_port_config_file` in `sonic-py-common` to read port config info. As multiple components in SONiC are built in parallel, that method may not finish built when it's called by UT.

##### Work item tracking
- Microsoft ADO **(number only)**: 27109878

#### How I did it

Transfer value to param `port_config_path` when calling function `parse_xml` in UT. Then the UT will not rely on `sonic-py-common`.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Verified by PR test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [x] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

