### PR TITLE
[202305] [YANG]: Add Yang model support for adding dom_polling to PORT table (#18277)

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1634,7 +1634,8 @@ optional attributes.
             "speed": "40000",
             "link_training": "off",
             "laser_freq": "191300",
-            "tx_power": "-27.3"
+            "tx_power": "-27.3",
+            "dom_polling": "enabled"
         },
         "Ethernet1": {
             "index": "1",
@@ -1646,7 +1647,8 @@ optional attributes.
             "speed": "40000",
             "link_training": "on",
             "laser_freq": "191300",
-            "tx_power": "-27.3"
+            "tx_power": "-27.3",
+            "dom_polling": "enabled"
         },
         "Ethernet63": {
             "index": "63",
@@ -1656,7 +1658,8 @@ optional attributes.
             "alias": "fortyGigE1/4/16",
             "speed": "40000",
             "laser_freq": "191300",
-            "tx_power": "-27.3"
+            "tx_power": "-27.3",
+            "dom_polling": "disabled"
         }
     }
 }
@@ -1672,7 +1675,8 @@ optional attributes.
             "mtu": "9100",
             "alias": "etp1a",
             "speed": "100000",
-            "subport": 1
+            "subport": 1,
+            "dom_polling": "enabled"
         },
         "Ethernet4": {
             "admin_status": "up",
@@ -1682,7 +1686,8 @@ optional attributes.
             "mtu": "9100",
             "alias": "etp1b",
             "speed": "100000",
-            "subport": 2
+            "subport": 2,
+            "dom_polling": "enabled"
         },
     }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -574,7 +574,8 @@
                 "autoneg": "on",
                 "adv_speeds": "all",
                 "adv_interface_types": "all",
-                "subport" : "0"
+                "subport" : "0",
+                "dom_polling":"enabled"
             },
             "Ethernet3": {
                 "alias": "Eth1/4",
@@ -592,7 +593,8 @@
                 "speed": "11100",
                 "tpid": "0x9100",
                 "admin_status": "up",
-                "subport": "2"
+                "subport": "2",
+                "dom_polling":"enabled"
             },
             "Ethernet5": {
                 "alias": "Eth2/2",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
@@ -128,5 +128,13 @@
          "desc": "Out of range subport number",
          "eStrKey": "Range",
          "eStr": "0..8"
-     }
+     },
+     "PORT_VALID_DOM_POLLING": {
+        "desc": "PORT_VALID_DOM_POLLING no failure."
+    },
+    "PORT_INVALID_DOM_POLLING": {
+        "desc": "PORT_INVALID_DOM_POLLING invalid condition failure.",
+        "eStrKey" : "InvalidValue",
+        "eStr": ["dom_polling"]
+    }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -638,5 +638,47 @@
                 ]
             }
         }
-    }
+    },
+
+    "PORT_INVALID_DOM_POLLING": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet0",
+                        "alias": "etp1a",
+                        "lanes": "60, 61",
+                        "speed": 100000,
+                        "subport": 1,
+                        "dom_polling": "on"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_VALID_DOM_POLLING": {
+       "sonic-port:sonic-port": {
+           "sonic-port:PORT": {
+               "PORT_LIST": [
+                   {
+                       "name": "Ethernet0",
+                       "alias": "etp1a",
+                       "lanes": "60, 61",
+                       "speed": 100000,
+                       "subport": 1,
+                       "dom_polling": "enabled"
+                   },
+                   {
+                      "name": "Ethernet2",
+                       "alias": "etp1b",
+                       "lanes": "62, 63",
+                       "speed": 100000,
+                       "subport": 2,
+                       "dom_polling": "disabled"
+                   }
+               ]
+           }
+       }
+   }
 }

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -155,6 +155,10 @@ module sonic-port{
 					}
 				}
 
+				leaf dom_polling {
+					type stypes:admin_mode;
+				}
+
 				leaf pfc_asym {
 					type string {
 						pattern "on|off";


### PR DESCRIPTION
202305 Cherry-pick for https://github.com/sonic-net/sonic-buildimage/pull/18277

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Added YANG related changes for adding `dom_polling` field in PORT table of CONFIG_DB. This field can be set with `config interface transceiver dom PORT_NAME (enable|disable)` CLI.

The `dom_polling` field was added through https://github.com/sonic-net/sonic-utilities/pull/3187. Please refer to this PR for the details on the reason for adding `dom_polling` field.

##### Work item tracking
- Microsoft ADO **(number only)**:
27069573

#### How I did it
Added `dom_polling` field to CONFIG_DB PORT table.

#### How to verify it
Added unit tests for both valid and invalid options for controlling `dom_polling`.
Valid values for for `dom_polling` are `enabled` and `disabled`
Any other value is treated as an invalid value

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

