### PR TITLE
Fix to use IPv6 linklocal address as snmp agent address

### DIFF
--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -17,7 +17,7 @@
 # Listen on managment and loopback0 ips for single asic platform
 #
 {% macro protocol(ip_addr) %}
-{%- if ip_addr|ipv6 -%}
+{%- if ip_addr.split('%')[0]|ipv6 -%}
 {{ 'udp6' }}
 {%- else -%}
 {{ 'udp' }}

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1763,7 +1763,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         results['SNMP_AGENT_ADDRESS_CONFIG'] = {}
         port = '161'
         for intf in list(mgmt_intf.keys()) + list(lo_intfs.keys()):
-            ip_addr = ipaddress.ip_address(intf[1].split('/')[0])
+            ip_addr = ipaddress.ip_address(UNICODE_TYPE(intf[1].split('/')[0]))
             if ip_addr.version == 6 and ip_addr.is_link_local:
                 agent_addr = str(ip_addr) + '%' + intf[0]
             else:

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1762,12 +1762,13 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     if not is_multi_asic() and asic_name is None:
         results['SNMP_AGENT_ADDRESS_CONFIG'] = {}
         port = '161'
-        for mgmt_intf in mgmt_intf.keys():
-            snmp_key = mgmt_intf[1].split('/')[0] + '|' + port + '|'
-            results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
-        # Add Loopback IP as agent address for single asic
-        for loip in lo_intfs.keys():
-            snmp_key = loip[1].split('/')[0] + '|' + port + '|'
+        for intf in list(mgmt_intf.keys()) + list(lo_intfs.keys()):
+            ip_addr = ipaddress.ip_address(intf[1].split('/')[0])
+            if ip_addr.version == 6 and ip_addr.is_link_local:
+                agent_addr = str(ip_addr) + '%' + intf[0]
+            else:
+                agent_addr = str(ip_addr)
+            snmp_key = agent_addr + '|' + port + '|'
             results['SNMP_AGENT_ADDRESS_CONFIG'][snmp_key] = {}
     else:
         results['SNMP_AGENT_ADDRESS_CONFIG'] = {}

--- a/src/sonic-config-engine/tests/sample_graph.xml
+++ b/src/sonic-config-engine/tests/sample_graph.xml
@@ -81,6 +81,14 @@
           </a:Prefix>
           <a:PrefixStr>192.168.200.15/24</a:PrefixStr>
         </a:ManagementIPInterface>
+        <a:ManagementIPInterface>
+          <Name>ManagementIPv6</Name>
+          <AttachTo>Management0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+            <b:IPPrefix>fe80::1/64</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>fe80::1/64</a:PrefixStr>
+        </a:ManagementIPInterface>
       </ManagementIPInterfaces>
       <MplsInterfaces/>
       <MplsTeInterfaces/>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -1150,4 +1150,4 @@ class TestCfgGen(TestCase):
         output = self.run_script(argument)
         self.assertEqual(
             utils.liststr_to_dict(output.strip()),
-            utils.liststr_to_dict("['192.168.200.15|161|', '100.0.0.6|161|', '100.0.0.7|161|']"))
+            utils.liststr_to_dict("['192.168.200.15|161|', '100.0.0.6|161|', '100.0.0.7|161|', 'fe80::1%Management0|161|']"))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. fix https://github.com/sonic-net/sonic-buildimage/issues/16001
2. fix https://github.com/sonic-net/sonic-buildimage/issues/17807

https://github.com/sonic-net/sonic-buildimage/pull/17045 modified minigraph parser to use management and loopback IPs to support SNMP query over IPv6. With this fix, if mgmt or loopback IP contains link local IP, that will not work as link local IP has to be appended with scope id associating the IP address to a specific interface. This PR change is to ensure that snmp works with link local IPv6 address.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
1. Modify minigraph parser to append the Ip address with % scope id if snmp agent address being used is link local IP address.
2. Modify snmpd.conf.j2 to take this change while checking if an IP address is ipv4 or ipv6.

#### How to verify it
Verified by configuring link local ipv6 address.
Last login: Wed Mar 13 01:45:09 2024 from 10.1.84.57
admin@<>:~$ sudo netstat -tulnp | grep 161
...    
udp6       0      0 fe80::f6ee:31ff:fe9:161 :::*                                70355/snmpd         
..
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

