### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202305.1.0.8
+ref=202305.1.0.9


### PR DESCRIPTION

#### Why I did it
Release notes for Cisco 8102-64H-O, 8101-32FH-O, and 8111-32EH-O
• Fix to address Netscan packet drop issue
• Fix for show platform npu router route-table CLI
• Addressed testcase errors for test_drop_counter syslog 
• Addressed testcase failures for test_thermal.TestThermalApi for 8111
• Double commit of fix for ECC errors for 202305

#### How I did it
Update platform version to 202305.1.0.9
