### PR TITLE
[E1031] Bugfix for Python syntax error in sonic_platform/common.py

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/common.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/common.py
@@ -183,7 +183,7 @@ class Common:
             return False
         return True
 
-    def is_host():
+    def is_host(self):
         """
         Test whether current process is running on the host or an docker
         return True for host and False for docker


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Bugfix for Python syntax error in sonic_platform/common.py.
A method of class need to have `self` as parameter.

Fixing below issue:
```
e1031:~$ show int st
Traceback (most recent call last):
  File "/usr/local/bin/intfutil", line 836, in <module>
    main()
  File "/usr/local/bin/intfutil", line 819, in main
    interface_stat.display_intf_status()
  File "/usr/local/bin/intfutil", line 448, in display_intf_status
    self.get_intf_status()
  File "/usr/local/lib/python3.9/dist-packages/utilities_common/multi_asic.py", line 157, in wrapped_run_on_all_asics
    func(self,  *args, **kwargs)
  File "/usr/local/bin/intfutil", line 529, in get_intf_status
    self.portchannel_speed_dict = po_speed_dict(self.po_int_dict, self.db)
  File "/usr/local/bin/intfutil", line 334, in po_speed_dict
    optics_type = port_optics_get(appl_db, value[0], PORT_OPTICS_TYPE)
  File "/usr/local/bin/intfutil", line 224, in port_optics_get
    if is_rj45_port(intf_name):
  File "/usr/local/lib/python3.9/dist-packages/utilities_common/platform_sfputil_helper.py", line 120, in is_rj45_port
    platform_chassis = sonic_platform.platform.Platform().get_chassis()
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform/platform.py", line 21, in __init__
    self._chassis = Chassis()
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform/chassis.py", line 37, in __init__
    self._is_host = self._api_common.is_host()
TypeError: is_host() takes 0 positional arguments but 1 was given
```


##### Work item tracking
- Microsoft ADO **(number only)**: 27208152

#### How I did it

Add `self` parameter to function `Common::is_host()`.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Verified on E1031 DUT with this patch.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202305

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

