### PR TITLE
[supervisor][sfm]Fix the issue of swss.sh shows backtrace when shutdown a SFM

### DIFF
--- a/files/scripts/asic_status.py
+++ b/files/scripts/asic_status.py
@@ -69,8 +69,9 @@ def main():
                 logger.log_info('Detected asic{} is online'.format(global_asic_id))
                 sys.exit(0)
         elif asic_op == 'DEL':
-            logger.log_info('Detected asic{} is offline'.format(global_asic_id))
-            sys.exit(1)
+            if (global_asic_id == args_asic_id):
+                logger.log_info('Detected asic{} is offline'.format(global_asic_id))
+                sys.exit(1)
         else:
             continue
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
On a Supervisor card of a VOQ chassis, when remove or shutdown a Fabric card, swss.sh shows Stacktrace for all related empty SFM slots in the syslog file.  This PR fixes https://github.com/sonic-net/sonic-buildimage/issues/18384

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
In the asic_status.py, all empty SFM slots related swss.sh is in the waiting state to wait for the presence event of SFM -- SET operation.  The subscriber event handler also includes the "DEL" operation when a SFM is shutdown/removal.  When a SFM is shutdown, all empty slot's swss.sh also get the "DEL" event although it is not for them.  In the "DEL" operation, the current implementation doesn't check if this "DEL" operation for them, and then they exit the wait state and proceed to docker-wait-any with wrong operation in the wrong slot.  docker-wait0any raise the backtarce.           

#### How to verify it
1.   In a chassis which has some empty SMF slot, remove or shutdown a SFM.  There should not be related stacktrace shown in syslog 
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

