### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202305.1.0.9
+ref=202305.1.0.10


### PR DESCRIPTION
Why I did it

Release notes for Cisco 8111-32EH-O
* Fix for PFC not generated on priority 2 when P2 and P3 are used as lossless (MIGSMSFT-444)
* Provide explicit mapping for unmapped DSCP packets (MIGSMSFT-358)


How I did it

Update platform version to 202305.1.0.10
