### PR TITLE
[202012] dhcrelay: Don't look up the ifindex for the fallback interface (#17797)

### DIFF
--- a/src/isc-dhcp/patch/0016-Don-t-look-up-the-ifindex-for-fallback.patch
+++ b/src/isc-dhcp/patch/0016-Don-t-look-up-the-ifindex-for-fallback.patch
@@ -1,0 +1,34 @@
+From 079ff1bb570dae96c4ca513e210c9856e9cc75b0 Mon Sep 17 00:00:00 2001
+From: Saikrishna Arcot <sarcot@microsoft.com>
+Date: Wed, 10 Jan 2024 23:30:17 -0800
+Subject: [PATCH] Don't look up the ifindex for fallback
+
+If sending a packet on the "fallback" interface, then don't try to get the
+ifindex for that interface. There will never be an actual interface named
+"fallback" in SONiC (at least, not one that we will want to use).
+
+This might save 0.009-0.012 seconds per upstream server, and when there
+are as many as 48 upstream servers, it can save about 0.4-0.5 seconds of
+time. This then allows dhcrelay to process more packets.
+
+Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>
+
+diff --git a/common/socket.c b/common/socket.c
+index da9f501..e707a7f 100644
+--- a/common/socket.c
++++ b/common/socket.c
+@@ -767,7 +767,10 @@ ssize_t send_packet (interface, packet, raw, len, from, to, hto)
+ 	memcpy(&dst, to, sizeof(dst));
+ 	m.msg_name = &dst;
+ 	m.msg_namelen = sizeof(dst);
+-	ifindex = if_nametoindex(interface->name);
++	if (strcmp(interface->name, "fallback") != 0)
++		ifindex = if_nametoindex(interface->name);
++	else
++		ifindex = 0;
+ 
+ 	/*
+ 	 * Set the data buffer we're sending. (Using this wacky
+-- 
+2.34.1
+

--- a/src/isc-dhcp/patch/series
+++ b/src/isc-dhcp/patch/series
@@ -12,3 +12,4 @@
 0011-dhcp-relay-Prevent-Buffer-Overrun.patch
 0012-add-option-si-to-support-using-src-intf-ip-in-relay.patch
 0013-Fix-dhcrelay-agent-option-buffer-pointer-logic.patch
+0016-Don-t-look-up-the-ifindex-for-fallback.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Manually backport of this PR: https://github.com/sonic-net/sonic-buildimage/pull/17797
Currently, whenever isc-dhcp-relay forwards a packet upstream, internally, it will try to send it on a "fallback" interface. My understanding is that this isn't meant to be a real interface, but instead is basically saying to use Linux's regular routing stack to route the packet appropriately (rather than having isc-dhcp-relay specify specifically which interface to use).

The problem is that on systems with a weak CPU, a large number of interfaces, and many upstream servers specified, this can introduce a noticeable delay in packets getting sent. The delay comes from trying to get the ifindex of the fallback interface. In one test case, it got to the point that only 2 packets could be processed per second. Because of this, dhcrelay will easily get backlogged and likely get to a point where packets get dropped in the kernel.

Fix this by adding a check saying if we're using the fallback interface, then don't try to get the ifindex of this interface. We're never going to have an interface named this in SONiC.

##### Work item tracking
- Microsoft ADO **(number only)**: 26273071

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

