### PR TITLE
[Fixbug 18418] [Yang] MACSEC_PROFILE table does not match yang definition

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/macsec.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/macsec.json
@@ -30,6 +30,18 @@
                         "replay_window": 64,
                         "send_sci": "true",
                         "rekey_period": 3600
+                    },
+                    {
+                        "name": "test_nofallback",
+                        "priority": 64,
+                        "cipher_suite": "GCM-AES-XPN-256",
+                        "primary_cak": "5207554155500e5d5157786d6c2a3d2031425a5e577e7e727f6b6c03312432262706080a00005b554f4e007975707670725b0a54540c0252445e5d7a29252b046a",
+                        "primary_ckn": "6162636465666768696A6B6C6D6E6F706162636465666768696A6B6C6D6E6F70",
+                        "policy": "security",
+                        "enable_replay_protect": "true",
+                        "replay_window": 64,
+                        "send_sci": "true",
+                        "rekey_period": 3600
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-macsec.yang
+++ b/src/sonic-yang-models/yang-models/sonic-macsec.yang
@@ -70,9 +70,9 @@ module sonic-macsec {
                     }
                 }
 
-                must "string-length(fallback_cak) = string-length(primary_cak)";
+                must "string-length(fallback_cak) = 0 or string-length(fallback_cak) = string-length(primary_cak)";
 
-                must "primary_ckn != fallback_ckn";
+                must "string-length(fallback_ckn) = 0 or primary_ckn != fallback_ckn";
 
                 leaf policy {
                     type string {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the issue [18418](https://github.com/sonic-net/sonic-buildimage/issues/18418), The YANG model to MACsec fallback cak/ckn is wrong. We should allow the fallback option is empty.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add a condition to check whether the fallback is providered

#### How to verify it
Check Azp

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

