### PR TITLE
Fix for YANG Mode Attribute 

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -55,7 +55,6 @@ module sonic-port{
 				leaf mode {
 					description "SwitchPort Modes possible values are routed|access|trunk. Default value  for mode is routed"; 
 					type stypes:switchport_mode; 
-					default "routed";
 				}
 
 				leaf description {

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -67,7 +67,6 @@ module sonic-portchannel {
                leaf mode {
                    description "PortChannel SwitchPort Mode possible values are routed|access|trunk. Default value for mode is routed.";
                    type stypes:switchport_mode;
-                   default "routed";
 
                 }
 


### PR DESCRIPTION


#### Why I did it

Removed Default Mode value from sonic-port.yang & sonic-portchannel.yang to avoid disruptive change


#### How I did it
This PR is created in reference with [PR](https://github.com/sonic-net/sonic-buildimage/pull/13580)

