### PR TITLE
Set owner and group for redis_chassis to "redis" in database-chassis

### DIFF
--- a/dockers/docker-database/docker-database-init.sh
+++ b/dockers/docker-database/docker-database-init.sh
@@ -59,6 +59,8 @@ db_cfg_file_tmp="/var/run/redis/sonic-db/database_config.json.tmp"
 cp $db_cfg_file $db_cfg_file_tmp
 
 if [[ $DATABASE_TYPE == "chassisdb" ]]; then
+    REDIS_CHASSIS_DIR=/var/run/redis-chassis
+    REDIS_CHASSIS_LIB_DIR=/var/lib/redis_chassis
     # Docker init for database-chassis
     echo "Init docker-database-chassis..."
     update_chassisdb_config -j $db_cfg_file_tmp -k -p $chassis_db_port
@@ -66,6 +68,9 @@ if [[ $DATABASE_TYPE == "chassisdb" ]]; then
     sonic-cfggen -j $db_cfg_file_tmp \
     -t /usr/share/sonic/templates/supervisord.conf.j2,/etc/supervisor/conf.d/supervisord.conf \
     -t /usr/share/sonic/templates/critical_processes.j2,/etc/supervisor/critical_processes
+    echo "Create directories and set ownership recursively..."
+    mkdir -p $REDIS_CHASSIS_DIR/sonic-db $REDIS_CHASSIS_LIB_DIR
+    chown -R redis:redis $REDIS_CHASSIS_DIR $REDIS_CHASSIS_LIB_DIR
     rm $db_cfg_file_tmp
     exec /usr/local/bin/supervisord
     exit 0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
With 202311 (and master) branch, when database-chassis docker container is brought up by SONiC at boot-time, the 'redis' server running within container is spawned as user 'root'. It accordingly opens the following two paths with the root user privileges.
/var/lib/redis_chassis
/var/run/redis_chassis

root@Leaf1:/var/lib# ls -lrt | grep redis
drwxr-x--- 2 redis redis 4096 Jan 16 06:12 redis
drwxr-xr-x 2 root root 4096 Feb 21 02:05 redis_chassis

the supervisor code however tries to spawn server instance with 'redis' as user.

[program:redis_chassis]
command=/bin/bash -c "{ [[ -s /var/lib/redis_chassis/dump.rdb ]] || rm -f /var/lib/redis_chassis/dump.rdb; } && mkdir -p /var/lib/redis_chassis &&
exec /usr/bin/redis-server /etc/redis/redis.conf --bind redis_chassis.server --port 6380 --unixsocket /var/run/redis-chassis/redis_chassis.sock --
pidfile /var/run/redis/redis_chassis.pid --dir /var/lib/redis_chassis"
priority=2
user=redis
autostart=true
autorestart=false
stdout_logfile=syslog
stderr_logfile=syslog

At system bring-up time, when database-chassis is instantiated, the redis_chassis.server bails out citing permission issues.
The fix is hence required to ensure initialization of redis-chassis and its related databases.##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
made code changes to docker-database-init.sh

#### How to verify it

root@Leaf1:/var/run# ls -lrt
total 8
-rw-rw-r-- 1 root utmp 0 Jan 10 00:00 utmp
drwxrwxrwt 2 root root 4096 Jan 10 00:00 lock
srwx------ 1 root root 0 Feb 21 02:05 supervisor.sock
-rw-r--r-- 1 root root 2 Feb 21 02:05 supervisord.pid
drwxrwxrwx 3 redis redis 100 Feb 21 02:05 redis-chassis
drwxrwxrwx 3 redis redis 100 Feb 21 02:05 redis
root@Leaf1:/var/run# ls -lrt /var/lib | grep redis
drwxr-x--- 2 redis redis 4096 Jan 16 06:12 redis
drwxr-xr-x 2 redis redis 4096 Feb 21 02:05 redis_chassis
root@Leaf1:/home/cisco# docker ps | grep database
11f441c45bbd docker-database:latest "/usr/local/bin/dock…" 17 hours ago Up 17 hours database
0d0445eba5e5 docker-database:latest "/usr/local/bin/dock…" 18 hours ago Up 17 hours database-chassis
root@Leaf1:/home/cisco# docker ps
CONTAINER ID IMAGE COMMAND CREATED STATUS PORTS NAMES
11f441c45bbd docker-database:latest "/usr/local/bin/dock…" 17 hours ago Up 17 hours database
0d0445eba5e5 docker-database:latest "/usr/local/bin/dock…" 18 hours ago Up 17 hours database-chassis
6a55972db4ef docker-orchagent:latest "/usr/bin/docker-ini…" 21 hours ago Up 17 hours swss
1b655c70b1a0 docker-snmp:latest "/usr/local/bin/supe…" 5 weeks ago Up 17 hours snmp
d8dd80563ec4 docker-platform-monitor:latest "/usr/bin/docker_ini…" 5 weeks ago Up 17 hours pmon
8c5a30744ddb docker-sonic-mgmt-framework:latest "/usr/local/bin/supe…" 5 weeks ago Up 17 hours mgmt-framework
c54ef5f687f7 docker-lldp:latest "/usr/bin/docker-lld…" 5 weeks ago Up 17 hours lldp
4dcb2b637eab docker-sonic-gnmi:latest "/usr/local/bin/supe…" 5 weeks ago Up 17 hours gnmi
4bf983355fcb 41594494637b "/usr/bin/docker_ini…" 5 weeks ago Up 17 hours dhcp_relay
bc19ff1747d7 docker-router-advertiser:latest "/usr/bin/docker-ini…" 5 weeks ago Up 17 hours radv
9a847da60ae8 docker-syncd-cisco:latest "/usr/local/bin/supe…" 5 weeks ago Up 17 hours syncd
9b69a4e9f379 docker-fpm-frr:latest "/usr/bin/docker_ini…" 5 weeks ago Up 17 hours bgp
58093aca5d1a docker-teamd:latest "/usr/local/bin/supe…" 5 weeks ago Up 17 hours teamd
933250dd3518 docker-eventd:latest "/usr/local/bin/supe…" 5 weeks ago Up 17 hours eventd
root@Leaf1:/home/cisco# show chassis system-neighbors
System Port Interface Neighbor MAC Encap Index

Leaf1|Asic0|Ethernet-IB0 4.4.4.4 f8:e5:7e:7f:6c:00 1104
root@Leaf1:/home/cisco# docker exec -it database-chassis bash
root@Leaf1:/# ps ax
PID TTY STAT TIME COMMAND
1 pts/0 Ss+ 0:14 /usr/bin/python3 /usr/local/bin/supervisord
43 pts/0 Sl 0:03 python3 /usr/bin/supervisor-proc-exit-listener --container-name database
44 pts/0 Sl 1:20 /usr/bin/redis-server redis_chassis.server:6380
65 pts/0 Sl 0:00 /usr/sbin/rsyslogd -n -iNONE
136 pts/1 Ss+ 0:00 bash
144 pts/2 Ss 0:00 bash
152 pts/2 S+ 0:00 more /usr/local/bin/docker-database-init.sh
178 pts/3 Ss 0:00 bash
184 pts/3 R+ 0:00 ps ax



<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202311
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
 Set owner and group of redis_chassis to redis in database-chassis
-->
<!--
GCU
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

