### PR TITLE
[dhcp_sever] Add missing param in config cli

### DIFF
--- a/dockers/docker-dhcp-server/cli/config/plugins/dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli/config/plugins/dhcp_server.py
@@ -47,7 +47,7 @@ def validate_str_type(type_, value):
 
 @click.group(cls=clicommon.AbbreviationGroup, name="dhcp_server")
 @clicommon.pass_db
-def dhcp_server():
+def dhcp_server(db):
     """config DHCP Server information"""
     ctx = click.get_current_context()
     dbconn = db.db

--- a/rules/config
+++ b/rules/config
@@ -150,7 +150,7 @@ INCLUDE_NAT = y
 INCLUDE_DHCP_RELAY = y
 
 # INCLUDE_DHCP_SERVER - build and install dhcp-server package
-INCLUDE_DHCP_SERVER ?= n
+INCLUDE_DHCP_SERVER ?= y
 
 # INCLUDE_P4RT - build docker-p4rt for P4RT support
 INCLUDE_P4RT = n

--- a/rules/config
+++ b/rules/config
@@ -150,7 +150,7 @@ INCLUDE_NAT = y
 INCLUDE_DHCP_RELAY = y
 
 # INCLUDE_DHCP_SERVER - build and install dhcp-server package
-INCLUDE_DHCP_SERVER ?= y
+INCLUDE_DHCP_SERVER ?= n
 
 # INCLUDE_P4RT - build docker-p4rt for P4RT support
 INCLUDE_P4RT = n


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
db param missed in dhcp_server config cli

##### Work item tracking
- Microsoft ADO **(number only)**: 27300333

#### How I did it
Add param

#### How to verify it
Build image, run cli

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

