### PR TITLE
Introduce a new role for DPU-NPU Interconnect

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O28/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O28/hwsku.json
@@ -113,20 +113,24 @@
             "subport": "1"
         },
         "Ethernet224": {
-	     "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "role": "Dpc"
         },
         "Ethernet232": {
-	     "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "role": "Dpc"
         },
         "Ethernet240": {
-	     "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "role": "Dpc"
         },
         "Ethernet248": {
-	     "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "role": "Dpc"
         }
     }
 }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O28/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O28/hwsku.json
@@ -115,21 +115,25 @@
         "Ethernet224": {
             "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
             "subport": "1",
+            "autoneg": "on",
             "role": "Dpc"
         },
         "Ethernet232": {
             "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
             "subport": "1",
+            "autoneg": "on",
             "role": "Dpc"
         },
         "Ethernet240": {
             "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
             "subport": "1",
+            "autoneg": "on",
             "role": "Dpc"
         },
         "Ethernet248": {
             "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
             "subport": "1",
+            "autoneg": "on",
             "role": "Dpc"
         }
     }

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -37,7 +37,7 @@ PORT_STR = "Ethernet"
 BRKOUT_MODE = "default_brkout_mode"
 CUR_BRKOUT_MODE = "brkout_mode"
 INTF_KEY = "interfaces"
-OPTIONAL_HWSKU_ATTRIBUTES = ["fec", "autoneg", "subport"]
+OPTIONAL_HWSKU_ATTRIBUTES = ["fec", "autoneg", "subport", "role"]
 
 BRKOUT_PATTERN = r'(\d{1,6})x(\d{1,6}G?)(\[(\d{1,6}G?,?)*\])?(\((\d{1,6})\))?'
 BRKOUT_PATTERN_GROUPS = 6

--- a/src/sonic-config-engine/tests/sample_hwsku.json
+++ b/src/sonic-config-engine/tests/sample_hwsku.json
@@ -268,7 +268,8 @@
             "default_brkout_mode": "2x25G(2)+1x50000(2)"
         },
         "Ethernet142": {
-            "default_brkout_mode": "2x25G(2)+1x50000(2)"
+            "default_brkout_mode": "2x25G(2)+1x50000(2)",
+            "role": "Dpc"
         },
         "Ethernet144": {
             "default_brkout_mode": "1x100000[50G,40000,25G,10000]"

--- a/src/sonic-config-engine/tests/sample_output/platform_output.json
+++ b/src/sonic-config-engine/tests/sample_output/platform_output.json
@@ -908,7 +908,8 @@
     "mtu": "9100",
     "alias": "Eth36/3",
     "pfc_asym": "off",
-    "speed": "50000"
+    "speed": "50000",
+    "role": "Dpc"
   },
   "Ethernet144": {
     "index": "37",

--- a/src/sonic-device-data/tests/hwsku_json_checker
+++ b/src/sonic-device-data/tests/hwsku_json_checker
@@ -7,7 +7,7 @@ import sys
 
 # Global variable
 PORT_ATTRIBUTES = ["default_brkout_mode"]
-OPTIONAL_PORT_ATTRIBUTES = ["fec", "autoneg", "port_type", "subport"]
+OPTIONAL_PORT_ATTRIBUTES = ["fec", "autoneg", "port_type", "subport", "role"]
 PORT_REG = "Ethernet(\d+)"
 HWSKU_JSON = '*hwsku.json'
 INTF_KEY = "interfaces"

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -494,7 +494,7 @@ def get_asic_presence_list():
     return asics_list
 
 
-def is_front_panel_port(port: str, role=None):
+def is_front_panel_port(port, role=None):
     """
     @summary: This function will check if the interface is a front-panel port
     @return:  Boolean

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -7,6 +7,7 @@ from swsscommon import swsscommon
 
 from .device_info import get_asic_conf_file_path
 from .device_info import is_supervisor, is_chassis
+from .interface import inband_prefix, backplane_prefix, recirc_prefix, front_panel_prefix
 
 ASIC_NAME_PREFIX = 'asic'
 NAMESPACE_PATH_GLOB = '/run/netns/*'
@@ -17,7 +18,8 @@ FABRIC_ASIC_SUB_ROLE = 'Fabric'
 EXTERNAL_PORT = 'Ext'
 INTERNAL_PORT = 'Int'
 INBAND_PORT = 'Inb'
-RECIRC_PORT ='Rec'
+RECIRC_PORT = 'Rec'
+DPU_CONNECT_PORT = 'Dpc'
 PORT_CHANNEL_MEMBER_CFG_DB_TABLE = 'PORTCHANNEL_MEMBER'
 PORT_CFG_DB_TABLE = 'PORT'
 BGP_NEIGH_CFG_DB_TABLE = 'BGP_NEIGHBOR'
@@ -323,15 +325,18 @@ def get_port_role(port_name, namespace=None):
     role = ports_config[PORT_ROLE]
     return role
 
+def is_role_internal(role=None):
+    """
+    Check if the role belongs to one of the internal variants
+    """
+    if role and role in [INTERNAL_PORT, INBAND_PORT, RECIRC_PORT, DPU_CONNECT_PORT]:
+        return True
+    return False
+
 
 def is_port_internal(port_name, namespace=None):
-
     role = get_port_role(port_name, namespace)
-
-    if role in [INTERNAL_PORT, INBAND_PORT, RECIRC_PORT]:
-        return True
-
-    return False
+    return is_role_internal(role)
 
 
 def get_external_ports(port_names, namespace=None):
@@ -487,3 +492,21 @@ def get_asic_presence_list():
         # This is not multi-asic, all asics should be present.
         asics_list = list(range(0, get_num_asics()))
     return asics_list
+
+
+def is_front_panel_port(port: str, role=None):
+    """
+    @summary: This function will check if the interface is a front-panel port
+    @return:  Boolean
+    """
+    if not port.startswith(front_panel_prefix()):
+        return False
+
+    if port.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
+        return False
+
+    # subinterfaces
+    if '.' in port:
+        return False
+
+    return not is_role_internal(role)

--- a/src/sonic-py-common/tests/interface_test.py
+++ b/src/sonic-py-common/tests/interface_test.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from sonic_py_common import interface
+from sonic_py_common.multi_asic import is_front_panel_port
 
 class TestInterface(object):
     def test_get_interface_table_name(self):
@@ -39,3 +40,14 @@ class TestInterface(object):
         assert result == "VLAN_SUB_INTERFACE"
         result = interface.get_port_table_name("Po0.1001")
         assert result == "VLAN_SUB_INTERFACE"
+
+    def test_verify_front_panel_api(self):
+        assert is_front_panel_port("Ethernet0")
+        assert not is_front_panel_port("Ethernet-BP")
+        assert not is_front_panel_port("Ethernet-IB")
+        assert not is_front_panel_port("Ethernet-Rec")
+        assert not is_front_panel_port("Ethernet254", "Dpc")
+        assert not is_front_panel_port("Ethernet254", "Int")
+        assert is_front_panel_port("Ethernet254", "Ext")
+        assert not is_front_panel_port("Ethernet254.30")
+        assert not is_front_panel_port("PortConfigDone")

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -601,6 +601,7 @@
                 "speed": "11100",
                 "tpid": "0x8100",
                 "admin_status": "up",
+                "role": "Dpc",
                 "autoneg": "on",
                 "adv_speeds": "all",
                 "adv_interface_types": "all",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -728,5 +728,21 @@
                 ]
             }
         }
+    },
+
+    "PORT_DPC_ROLE_TEST": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet0",
+                        "alias": "etp1a",
+                        "lanes": "60, 61",
+                        "speed": 100000,
+                        "role": "Dpc"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -145,9 +145,9 @@ module sonic-port{
 
 				leaf role {
 					type string {
-						pattern "Ext|Int|Inb|Rec";
+						pattern "Ext|Int|Inb|Rec|Dpc";
 					}
-					description "Internal port or External port for multi-asic platform";
+					description "Internal port or External port for multi-asic or SmartSwitch platform";
 					default "Ext";
 				}
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

- Platform api related to xcvr and sfp should not be called for internal ports of SmartSwitch
- To avoid doing this from platform agnostic code of SONiC, a new role called 'Dpc' is added, which would mean DPU-NPU Data Port
- Any new sku which is used as a smartswitch should add this argument to hwsku.json for the ports that fit this category

 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added Dpc to the relevant SKU

#### How to verify it

```
root@mtvr-leopard-01:/home/admin# show interfaces status
  Interface                            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                                             Type    Asym PFC
-----------  -------------------------------  -------  -----  -----  -------  ------  ------  -------  -----------------------------------------------  ----------
  Ethernet0                  0,1,2,3,4,5,6,7     400G   9100    N/A     etp1  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
  Ethernet8            8,9,10,11,12,13,14,15     400G   9100    N/A     etp2  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet16          16,17,18,19,20,21,22,23     400G   9100    N/A     etp3  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet24          24,25,26,27,28,29,30,31     400G   9100    N/A     etp4  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet32          32,33,34,35,36,37,38,39     400G   9100    N/A     etp5  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet40          40,41,42,43,44,45,46,47     400G   9100    N/A     etp6  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet48          48,49,50,51,52,53,54,55     400G   9100    N/A     etp7  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet56          56,57,58,59,60,61,62,63     400G   9100    N/A     etp8  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet64          64,65,66,67,68,69,70,71     400G   9100    N/A     etp9  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
..........................
Ethernet208  208,209,210,211,212,213,214,215     400G   9100    N/A    etp27  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
Ethernet216  216,217,218,219,220,221,222,223     400G   9100    N/A    etp28  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
Ethernet224  224,225,226,227,228,229,230,231     400G   9100    N/A    etp29  routed     N/A       up                                DPU-NPU Data Port         N/A
Ethernet232  232,233,234,235,236,237,238,239     400G   9100    N/A    etp30  routed     N/A       up                                DPU-NPU Data Port         N/A
Ethernet240  240,241,242,243,244,245,246,247     400G   9100    N/A    etp31  routed     N/A       up                                DPU-NPU Data Port         N/A
Ethernet248  248,249,250,251,252,253,254,255     400G   9100    N/A    etp32  routed     N/A       up                                DPU-NPU Data Port         N/A
```


```
root@mtvr-leopard-01:/home/admin# sfputil show presence
Port         Presence
-----------  ----------
Ethernet0    Present
Ethernet8    Present
Ethernet16   Present
Ethernet24   Present
Ethernet32   Present
Ethernet40   Present
Ethernet48   Present
Ethernet56   Present
Ethernet64   Present
Ethernet72   Present
Ethernet80   Present
Ethernet88   Present
Ethernet96   Present
Ethernet104  Present
Ethernet112  Present
Ethernet120  Present
Ethernet128  Present
Ethernet136  Present
Ethernet144  Present
Ethernet152  Present
Ethernet160  Present
Ethernet168  Present
Ethernet176  Present
Ethernet184  Present
Ethernet192  Present
Ethernet200  Present
Ethernet208  Present
Ethernet216  Present
```

Nothing related to Dpc ports is populated in the XCVRD tables
```
root@mtvr-leopard-01:/home/admin# redis-cli -n 6 keys "TRANSCEIVER_INFO*"
 1) "TRANSCEIVER_INFO|Ethernet112"
 2) "TRANSCEIVER_INFO|Ethernet88"
 3) "TRANSCEIVER_INFO|Ethernet160"
 4) "TRANSCEIVER_INFO|Ethernet192"
 5) "TRANSCEIVER_INFO|Ethernet0"
 6) "TRANSCEIVER_INFO|Ethernet72"
 7) "TRANSCEIVER_INFO|Ethernet16"
 8) "TRANSCEIVER_INFO|Ethernet64"
 9) "TRANSCEIVER_INFO|Ethernet40"
10) "TRANSCEIVER_INFO|Ethernet208"
11) "TRANSCEIVER_INFO|Ethernet104"
12) "TRANSCEIVER_INFO|Ethernet152"
13) "TRANSCEIVER_INFO|Ethernet48"
14) "TRANSCEIVER_INFO|Ethernet184"
15) "TRANSCEIVER_INFO|Ethernet176"
16) "TRANSCEIVER_INFO|Ethernet56"
17) "TRANSCEIVER_INFO|Ethernet200"
18) "TRANSCEIVER_INFO|Ethernet128"
19) "TRANSCEIVER_INFO|Ethernet120"
20) "TRANSCEIVER_INFO|Ethernet96"
21) "TRANSCEIVER_INFO|Ethernet216"
22) "TRANSCEIVER_INFO|Ethernet8"
23) "TRANSCEIVER_INFO|Ethernet144"
24) "TRANSCEIVER_INFO|Ethernet32"
25) "TRANSCEIVER_INFO|Ethernet168"
26) "TRANSCEIVER_INFO|Ethernet24"
27) "TRANSCEIVER_INFO|Ethernet136"
28) "TRANSCEIVER_INFO|Ethernet80"
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

