### PR TITLE
[Build][Cache]Calculate sha on real file path of symlinks.

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -164,8 +164,9 @@ define GET_MOD_SHA
 	$(if $(MDEBUG), $(info $(1)_MOD_DEP_FILES: $($(1)_MOD_DEP_FILES)))
 	$(eval $(1)_MOD_HASH    := $(if $(filter GIT_COMMIT_SHA,$($(1)_CACHE_MODE)),\
                             $(shell cd $($(1)_MOD_SRC_PATH) && git log -1 --format="%H"| awk '{print substr($$1,0,23);}' ),\
-                            $(shell git hash-object $($(1)_MOD_DEP_FILES)| \
-                                   sha1sum | awk '{print substr($$1,0,23);}')))
+                            $(if $(filter "", "$($(1)_MOD_DEP_FILES)"), \
+                            $(shell git hash-object $($(1)_MOD_DEP_FILES) | sha1sum | awk '{print substr($$1,0,23);}'), \
+                            $(shell realpath --relative-to=. $($(1)_MOD_DEP_FILES) | xargs git hash-object | sha1sum | awk '{print substr($$1,0,23);}'))))
 endef
 
 
@@ -190,8 +191,11 @@ define GET_MOD_DEP_SHA
 	# Include package dependencies hash values into package hash calculation
 	$(eval $(1)_DEP_PKGS_SHA := $(foreach dfile,$($(1)_MOD_DEP_PKGS),$($(dfile)_DEP_MOD_SHA) $($(dfile)_MOD_HASH)))
 
-	$(eval $(1)_DEP_MOD_SHA := $(shell bash -c "git hash-object  $($(1)_DEP_MOD_SHA_FILES) && echo $($(1)_DEP_PKGS_SHA)" \
-                            | sha1sum | awk '{print substr($$1,0,23);}'))
+	$(eval $(1)_DEP_MOD_SHA := $(if $(filter "","$($(1)_DEP_MOD_SHA_FILES)"), \
+                            $(shell bash -c "git hash-object  $($(1)_DEP_MOD_SHA_FILES) && echo $($(1)_DEP_PKGS_SHA)" \
+	                        | sha1sum | awk '{print substr($$1,0,23);}'), \
+                            $(shell bash -c "realpath --relative-to=. $($(1)_DEP_MOD_SHA_FILES) | xargs git hash-object && echo $($(1)_DEP_PKGS_SHA)" \
+	                        | sha1sum | awk '{print substr($$1,0,23);}')))
 endef
 
 
@@ -548,7 +552,7 @@ $(addsuffix .$(3),$(addprefix $(2)/, $(1))) : $(2)/%.$(3) : \
 	$(2)/%.flags   $$$$($$$$*_SMDEP_FILES)
 	@$$(eval $$*_SMDEP_FILES_MODIFIED := $$? )
 	@$$(file >$$@,$$(patsubst $$($$*_MOD_SRC_PATH)/%,%,$$($$*_SMDEP_FILES)))
-	@( cd $$($$*_MOD_SRC_PATH) ; cat $$($$*_BASE_PATH)/$$@  |xargs git hash-object ) >$$@.smsha
+	@( cd $$($$*_MOD_SRC_PATH) ; cat $$($$*_BASE_PATH)/$$@ | xargs realpath --relative-to=. | xargs git hash-object ) >$$@.smsha
 	@$$(if $$(MDEBUG), $$(info SMDEP:$$@, MOD:$$?))
 endef
 $(eval $(call SMSHA_DEP_RULES, $(SONIC_MAKE_DEBS) $(SONIC_DPKG_DEBS) $(SONIC_ONLINE_DEBS) $(SONIC_COPY_DEBS), $(DEBS_PATH),smdep))
@@ -600,7 +604,7 @@ $(addsuffix .$(3),$(addprefix $(2)/, $(1))) : $(2)/%.$(3) : \
 	$(2)/%.flags $$$$($$$$*_DEP_FILES) $$$$(if $$$$($$$$*_SMDEP_FILES), $(2)/%.smdep)
 	@$$(eval $$*_DEP_FILES_MODIFIED := $$? )
 	@$$(file >$$@.tmp,$$($$*_DEP_FILES))
-	@cat $$@.tmp |xargs git hash-object >$$@.sha.tmp
+	@cat $$@.tmp | xargs realpath --relative-to=. | xargs git hash-object >$$@.sha.tmp
 	@if ! cmp -s $$@.sha.tmp $$@.sha; then cp $$@.tmp $$@; cp $$@.sha.tmp $$@.sha; fi
 	@rm -f $$@.tmp $$@.sha.tmp
 	@$$(if $$(MDEBUG), $$(info DEP: $$@, MOD:$$?))


### PR DESCRIPTION
#### Why I did it
This save efforts from rebuilding artifacts using symlink files every time when `SONIC_DPKG_CACHE_METHOD=rwcache` is enabled
For example, for target/python-wheels/bullseye/sonic_config_engine-1.0-py3-none-any.whl build(used by docker-config-engine-bullseye.gz), hashes of below files are calculated based on symlink files instead of real files without this change.

M	src/sonic-config-engine/tests/ndppd.conf.j2
M	src/sonic-config-engine/tests/ntp.conf.j2
M	src/sonic-config-engine/tests/sample_output/py2/qos-arista7260.json 
M	src/sonic-config-engine/tests/sample_output/py3/qos-arista7260.json

##### Work item tracking
#### How I did it

#### How to verify it

1. Build and save cache.
```
git clone git@github.com:sonic-net/sonic-buildimage.git && cd sonic-buildimage
make init
export SONIC_DPKG_CACHE_METHOD=rwcache SONIC_DPKG_CACHE_SOURCE="/tmp/cache"
make configure PLATFORM=broadcom
make target/python-wheels/bullseye/sonic_config_engine-1.0-py3-none-any.whl
```

2. Build the same container in another cloned location with same code, the cache should be reused directly.

```
git clone git@github.com:sonic-net/sonic-buildimage.git new-buildimage && cd new-buildimage
make init
export SONIC_DPKG_CACHE_METHOD=rwcache SONIC_DPKG_CACHE_SOURCE="/tmp/cache"
make configure PLATFORM=broadcom
make target/python-wheels/bullseye/sonic_config_engine-1.0-py3-none-any.whl
```
Expected results: `git hash src/sonic-config-engine/tests/ndppd.conf.j2` returns different results in 2 repos but the wheel file is expected to reuse cache(`[ cached   ]`) instead of building(`[ finished   ]`)
```
[ building ] [ 2024-03-26T18:54:21+0000 ] [ target/python-wheels/bullseye/sonic_config_engine-1.0-py3-none-any.whl ] 
[ cached   ] [ 2024-03-26T18:54:21+0000 ] [ target/python-wheels/bullseye/sonic_config_engine-1.0-py3-none-any.whl ]
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305


