### PR TITLE
[build][reproducible]Fix version file access for dbg container build

### DIFF
--- a/scripts/versions_manager.py
+++ b/scripts/versions_manager.py
@@ -419,6 +419,8 @@ class VersionModule:
             return os.path.join(source_path, 'files/build/versions', module_name)
         if module_name.startswith('build-sonic-slave-'):
             return os.path.join(source_path, 'files/build/versions/build', module_name)
+        if module_name.endswith('-dbg'):
+            return os.path.join(source_path, 'files/build/versions/dockers', module_name.removesuffix('-dbg'))
         return os.path.join(source_path, 'files/build/versions/dockers', module_name)
 
     def __repr__(self):


### PR DESCRIPTION
#### Why I did it

Reproducible build fails when building dbg containers `make INSTALL_DEBUG_TOOLS=y target/docker-orchagent-dbg.gz`

##### Work item tracking

#### How I did it

#### How to verify it

```
export SONIC_VERSION_CONTROL_COMPONENTS=all
make configure PLATFORM=broadcom
make INSTALL_DEBUG_TOOLS=y target/docker-orchagent-dbg.gz
```

#### Which release branch to backport (provide reason below if selected)


- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
