### PR TITLE
[E1031] Update sonic_platform.sfp.Sfp class to fix xcvrd crash issue

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/sfp.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/sfp.py
@@ -9,7 +9,7 @@
 try:
     import time
     from ctypes import c_char
-    from sonic_platform_base.sfp_base import SfpBase
+    from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
     from sonic_platform_base.sonic_sfp.sff8472 import sff8472InterfaceId
     from sonic_platform_base.sonic_sfp.sff8472 import sff8472Dom
     from sonic_platform_base.sonic_sfp.sff8436 import sff8436InterfaceId
@@ -157,7 +157,7 @@ PORT_START = 1
 PORT_END = 55
 
 
-class Sfp(SfpBase):
+class Sfp(SfpOptoeBase):
     """Platform-specific Sfp class"""
 
     # Port I2C number
@@ -172,7 +172,7 @@ class Sfp(SfpBase):
     PRS_PATH = "/sys/devices/platform/e1031.smc/SFP/sfp_modabs"
 
     def __init__(self, sfp_index, sfp_name):
-        SfpBase.__init__(self)
+        SfpOptoeBase.__init__(self)
 
         # Init common function
         self._api_common = Common()

--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/sfp.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/sfp.py
@@ -235,7 +235,7 @@ class Sfp(SfpOptoeBase):
         for i in range(0, num_bytes):
             eeprom_raw.append("0x00")
 
-        sysfs_sfp_i2c_client_eeprom_path = self.port_to_eeprom_mapping[self.port_num]
+        sysfs_sfp_i2c_client_eeprom_path = self.get_eeprom_path()
         try:
             sysfsfile_eeprom = open(
                 sysfs_sfp_i2c_client_eeprom_path, mode="rb", buffering=0)
@@ -354,6 +354,9 @@ class Sfp(SfpOptoeBase):
             self.dom_volt_supported = False
             self.dom_rx_power_supported = False
             self.dom_tx_power_supported = False
+
+    def get_eeprom_path(self):
+        return self.port_to_eeprom_mapping[self.port_num]
 
     def get_transceiver_info(self):
         """
@@ -1176,7 +1179,7 @@ class Sfp(SfpOptoeBase):
         if self.dom_tx_disable_supported:
             # SFP status/control register at address A2h, byte 110
             offset = 256
-            sysfs_sfp_i2c_client_eeprom_path = self.port_to_eeprom_mapping[self.port_num]
+            sysfs_sfp_i2c_client_eeprom_path = self.get_eeprom_path()
             status_control_raw = self._read_eeprom_specific_bytes(
                 (offset + SFP_STATUS_CONTROL_OFFSET), SFP_STATUS_CONTROL_WIDTH)
             if status_control_raw is not None:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

In PR sonic-net/sonic-platform-daemons#435, xcvrd process calls the `get_transceiver_info_firmware_versions` method of `sonic_platform.sfp.Sfp` class. On Celestica-E1031 platform, `Sfp` class inherits `sonic_platform_base.sfp_base.SfpBase` class which doesn't have this method defined. Hence the xcvrd process crash with below error syslog:

```
Mar 28 07:45:12.800226 e1031-3 ERR pmon#xcvrd: Exception occured at DomInfoUpdateTask thread due to AttributeError("'Sfp' object has no attribute 'get_transceiver_info_firmware_versions'")
Mar 28 07:45:12.804729 e1031-3 ERR pmon#xcvrd: Traceback (most recent call last):
Mar 28 07:45:12.805462 e1031-3 ERR pmon#xcvrd:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1949, in run
Mar 28 07:45:12.805916 e1031-3 ERR pmon#xcvrd:     self.task_worker()
Mar 28 07:45:12.806183 e1031-3 ERR pmon#xcvrd:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1915, in task_worker
Mar 28 07:45:12.806440 e1031-3 ERR pmon#xcvrd:     post_port_sfp_firmware_info_to_db(logical_port_name, self.port_mapping, self.xcvr_table_helper.get_firmware_info_tbl(asic_index), self.task_stopping_event, firmware_info_cache=firmware_info_cache)
Mar 28 07:45:12.806690 e1031-3 ERR pmon#xcvrd:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 482, in post_port_sfp_firmware_info_to_db
Mar 28 07:45:12.806936 e1031-3 ERR pmon#xcvrd:     transceiver_firmware_info_dict = _wrapper_get_transceiver_firmware_info(physical_port)
Mar 28 07:45:12.807227 e1031-3 ERR pmon#xcvrd:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 203, in _wrapper_get_transceiver_firmware_info
Mar 28 07:45:12.807492 e1031-3 ERR pmon#xcvrd:     return platform_chassis.get_sfp(physical_port).get_transceiver_info_firmware_versions()
Mar 28 07:45:12.807740 e1031-3 ERR pmon#xcvrd: AttributeError: 'Sfp' object has no attribute 'get_transceiver_info_firmware_versions'
Mar 28 07:45:12.808127 e1031-3 ERR pmon#xcvrd: Xcvrd: exception found at child thread DomInfoUpdateTask due to AttributeError("'Sfp' object has no attribute 'get_transceiver_info_firmware_versions'")
Mar 28 07:45:12.808404 e1031-3 ERR pmon#xcvrd: Exiting main loop as child thread raised exception!
Mar 28 07:45:12.825879 e1031-3 INFO pmon#supervisord 2024-03-28 07:45:12,823 INFO exited: xcvrd (terminated by SIGKILL; not expected)
Mar 28 07:45:13.833146 e1031-3 INFO pmon#supervisord 2024-03-28 07:45:13,830 INFO spawned: 'xcvrd' with pid 35027
Mar 28 07:45:14.185804 e1031-3 INFO swss#supervisord: arp_update ping6: 
Mar 28 07:45:14.188251 e1031-3 INFO swss#supervisord: arp_update Warning: source address might be selected on device other than: Vlan1000
Mar 28 07:45:14.190729 e1031-3 INFO swss#supervisord: arp_update 
Mar 28 07:45:15.248013 e1031-3 NOTICE pmon#xcvrd[35027]: Starting up...
Mar 28 07:45:15.248668 e1031-3 NOTICE pmon#xcvrd[35027]: XCVRD INIT: Start daemon init...
```

##### Work item tracking
- Microsoft ADO **(number only)**: 27356373

#### How I did it

In this PR, I fixed the issue by:
1. Update `Sfp` class of Celestica-E1031. Let it inherit `sonic_platform_base.sonic_xcvr.sfp_optoe_base.SfpOptoeBase` which has a default implementation of `get_transceiver_info_firmware_versions` method.
2. Implement `get_eeprom_path` method.

#### How to verify it

I built a private image based on 202305 branch, and run nightly test to verify the issue is fixed and no regression introduced.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202305

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

