### PR TITLE
[dhcp_server] Fix config cli plugin missing parameter db

### DIFF
--- a/dockers/docker-dhcp-server/cli/config/plugins/dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli/config/plugins/dhcp_server.py
@@ -45,14 +45,17 @@ def validate_str_type(type_, value):
     return False
 
 
-@click.group(cls=clicommon.AbbreviationGroup, name="dhcp_server")
+@click.group(cls=clicommon.AbbreviationGroup, name="dhcp_server", invoke_without_command=True)
 @clicommon.pass_db
-def dhcp_server():
+def dhcp_server(db):
     """config DHCP Server information"""
     ctx = click.get_current_context()
     dbconn = db.db
     if dbconn.get("CONFIG_DB", "FEATURE|dhcp_server", "state") != "enabled":
         ctx.fail("Feature dhcp_server is not enabled")
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+        ctx.exit()
 
 
 @dhcp_server.group(cls=clicommon.AliasedGroup, name="ipv4")

--- a/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
@@ -13,7 +13,7 @@ def ts_to_str(ts):
     return datetime.fromtimestamp(int(ts)).strftime("%Y-%m-%d %H:%M:%S")
 
 
-@click.group(cls=clicommon.AbbreviationGroup, name="dhcp_server")
+@click.group(cls=clicommon.AbbreviationGroup, name="dhcp_server", invoke_without_command=True)
 @clicommon.pass_db
 def dhcp_server(db):
     """Show dhcp_server related info"""
@@ -21,6 +21,9 @@ def dhcp_server(db):
     dbconn = db.db
     if dbconn.get("CONFIG_DB", "FEATURE|dhcp_server", "state") != "enabled":
         ctx.fail("Feature dhcp_server is not enabled")
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+        ctx.exit()
 
 
 @dhcp_server.group(cls=clicommon.AliasedGroup)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. The dhcp_server command didn't receive the db passed by @clicommon.pass_db correctly and there is no unit test case covering this.
2. The feature state checking logic in dhcp_server command won't run when there is no sub-command provided.

##### Work item tracking
- Microsoft ADO **(number only)**: 27384157

#### How I did it
1. Add the missing parameter and write UT to test it,
2. Add parameter invoke_without_command=True to make sure the command would check feature state no matter if sub-command provided.
3. Because I add the invoke_without_command=True, so I need to explicitly print help message and exit when there is no sub-command provided.

#### How to verify it
Write UT to capture the issue before fixing it.
Write UT to check the feature state checking logic.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

