### PR TITLE
Migrate the dpkg lock to container path

### DIFF
--- a/rules/functions
+++ b/rules/functions
@@ -157,8 +157,8 @@ expand = $(foreach d,$(1),$(call expand,$($(d)_$(2)),$(2))) $(1)
 define UNINSTALL_DEBS
 if [ -n "$(1)" ]; then \
     while true; do \
-        if mkdir $(DEBS_PATH)/dpkg_lock &> /dev/null; then \
-		    { sudo DEBIAN_FRONTEND=noninteractive dpkg -P $(foreach deb,$(1),$(firstword $(subst _, ,$(basename $(deb))))) $(LOG) && rm -d $(DEBS_PATH)/dpkg_lock && break; } || { rm -d $(DEBS_PATH)/dpkg_lock && exit 1 ; } \
+        if mkdir $(CONTAINER_TMP_PATH)/dpkg_lock &> /dev/null; then \
+		    { sudo DEBIAN_FRONTEND=noninteractive dpkg -P $(foreach deb,$(1),$(firstword $(subst _, ,$(basename $(deb))))) $(LOG) && rm -d $(CONTAINER_TMP_PATH)/dpkg_lock && break; } || { rm -d $(CONTAINER_TMP_PATH)/dpkg_lock && exit 1 ; } \
         fi; \
     done; \
 fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Because dpkg does not allow installing packages in parallel, we added a lock.

The lock is under repo path target/debs/$(BLDENV)/dpkg_lock, when the building progress is terminated by user, and the lock is not cleaned, the next time building progress will stuck at dpkg command.

As the lock should only exists when building, we raise this PR to migrate the lock to container path, so the lock will live on in the container.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Migrate the lock to folder /tmp/dpkg_lock which is in the container.

#### How to verify it
Triger the pipeline for build 
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

