### PR TITLE
[E1031] Ensure determine-reboot-cause start after platform fully initialized

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/thermal.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/thermal.py
@@ -109,12 +109,16 @@ class Thermal(ThermalBase):
 
         self.name = self.get_name()
         self.postion = self._thermal_info["postion"]
-        self.minimum_thermal = self.get_temperature()
-        self.maximum_thermal = self.get_temperature()
+        self.minimum_thermal = None
+        self.maximum_thermal = None
 
     def _get_hwmon_path(self):
         hwmon_path = os.path.join(
             I2C_ADAPTER_PATH, self._thermal_info["i2c_path"])
+        if self._thermal_info["i2c_path"] == "i2c-11/11-001a/hwmon":
+            hwmon_dir = "hwmon2"
+        else:
+            hwmon_dir = "hwmon1"
         hwmon_dir = os.listdir(hwmon_path)[0]
         return os.path.join(hwmon_path, hwmon_dir)
 
@@ -239,7 +243,7 @@ class Thermal(ThermalBase):
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
         tmp = self.get_temperature()
-        if tmp < self.minimum_thermal:
+        if self.minimum_thermal is None or tmp < self.minimum_thermal:
             self.minimum_thermal = tmp
         return self.minimum_thermal
 
@@ -251,7 +255,7 @@ class Thermal(ThermalBase):
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
         tmp = self.get_temperature()
-        if tmp > self.maximum_thermal:
+        if self.maximum_thermal is None or tmp > self.maximum_thermal:
             self.maximum_thermal = tmp
         return self.maximum_thermal
 

--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/thermal.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/thermal.py
@@ -109,16 +109,12 @@ class Thermal(ThermalBase):
 
         self.name = self.get_name()
         self.postion = self._thermal_info["postion"]
-        self.minimum_thermal = None
-        self.maximum_thermal = None
+        self.minimum_thermal = self.get_temperature()
+        self.maximum_thermal = self.get_temperature()
 
     def _get_hwmon_path(self):
         hwmon_path = os.path.join(
             I2C_ADAPTER_PATH, self._thermal_info["i2c_path"])
-        if self._thermal_info["i2c_path"] == "i2c-11/11-001a/hwmon":
-            hwmon_dir = "hwmon2"
-        else:
-            hwmon_dir = "hwmon1"
         hwmon_dir = os.listdir(hwmon_path)[0]
         return os.path.join(hwmon_path, hwmon_dir)
 
@@ -243,7 +239,7 @@ class Thermal(ThermalBase):
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
         tmp = self.get_temperature()
-        if self.minimum_thermal is None or tmp < self.minimum_thermal:
+        if tmp < self.minimum_thermal:
             self.minimum_thermal = tmp
         return self.minimum_thermal
 
@@ -255,7 +251,7 @@ class Thermal(ThermalBase):
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
         tmp = self.get_temperature()
-        if self.maximum_thermal is None or tmp > self.maximum_thermal:
+        if tmp > self.maximum_thermal:
             self.maximum_thermal = tmp
         return self.maximum_thermal
 

--- a/platform/broadcom/sonic-platform-modules-cel/haliburton/systemd/platform-modules-haliburton.service
+++ b/platform/broadcom/sonic-platform-modules-cel/haliburton/systemd/platform-modules-haliburton.service
@@ -2,7 +2,7 @@
 [Unit]
 Description=Celestica haliburton platform modules
 After=local-fs.target
-Before=pmon.service
+Before=process-reboot-cause.service determine-reboot-cause.service pmon.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Echo #18507 and fix comments.

#### Why I did it

When determine-reboot-cause is run early, there is very chance it will fail on call to Chassis(), which calls Thermal(), because it checks hwmon that was not yet initialized.

##### Work item tracking
- Microsoft ADO **(number only)**: 27456392

#### How I did it

Update platform-modules-haliburton.service file. Let determine-reboot-cause.service start after platform fully initialized.

#### How to verify it

Built dev image based on 202305 branch.
1. Manually reboot multiple times to confirm determine-reboot-cause.service always start currectly.
2. Run nightly test and confirmed no regression introduced.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202305 <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

