### PR TITLE
address the issue of the PDDF driver failing to allocate sysfs in kernel 6.1

### DIFF
--- a/platform/pddf/i2c/modules/fan/driver/pddf_fan_driver.c
+++ b/platform/pddf/i2c/modules/fan/driver/pddf_fan_driver.c
@@ -516,7 +516,7 @@ static int pddf_fan_probe(struct i2c_client *client,
         goto exit_free;
     }
 
-    data->hwmon_dev = hwmon_device_register_with_info(&client->dev, client->name, NULL, NULL, NULL);
+    data->hwmon_dev = hwmon_device_register_with_groups(&client->dev, client->name, NULL, NULL);
     if (IS_ERR(data->hwmon_dev)) {
         status = PTR_ERR(data->hwmon_dev);
         goto exit_remove;

--- a/platform/pddf/i2c/modules/psu/driver/pddf_psu_driver.c
+++ b/platform/pddf/i2c/modules/psu/driver/pddf_psu_driver.c
@@ -243,7 +243,7 @@ static int psu_probe(struct i2c_client *client,
         goto exit_free;
     }
 
-	data->hwmon_dev = hwmon_device_register_with_info(&client->dev, client->name, NULL, NULL, NULL);
+	data->hwmon_dev = hwmon_device_register_with_groups(&client->dev, client->name, NULL, NULL);
 	if (IS_ERR(data->hwmon_dev)) {
 		status = PTR_ERR(data->hwmon_dev);
 		goto exit_remove;

--- a/platform/pddf/i2c/modules/xcvr/driver/pddf_xcvr_driver.c
+++ b/platform/pddf/i2c/modules/xcvr/driver/pddf_xcvr_driver.c
@@ -159,7 +159,7 @@ static int xcvr_probe(struct i2c_client *client,
         goto exit_free;
     }
 
-    data->xdev = hwmon_device_register_with_info(&client->dev, client->name, NULL, NULL, NULL);
+    data->xdev = hwmon_device_register_with_groups(&client->dev, client->name, NULL, NULL);
     if (IS_ERR(data->xdev)) {
         status = PTR_ERR(data->xdev);
         goto exit_remove;


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Address the [issue](https://github.com/sonic-net/sonic-buildimage/issues/18287) of the PDDF driver failing to allocate sysfs in kernel 6.1
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
replaced hwmon_device_register_with_info() with hwmon_device_register_with_groups()
#### How to verify it
pddf_fanutil
pddf_psuutil
show interface commands
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

