### PR TITLE
[hardware_checker] Check fan status immediately after fan presence st…

### DIFF
--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -99,6 +99,11 @@ class HardwareChecker(HealthChecker):
                 self.set_object_not_ok('Fan', name, '{} is missing'.format(name))
                 continue
 
+            status = data_dict.get('status', 'false')
+            if status.lower() != 'true':
+                self.set_object_not_ok('Fan', name, '{} is broken'.format(name))
+                continue
+
             if not self._ignore_check(config.ignore_devices, 'fan', name, 'speed'):
                 speed = data_dict.get('speed', None)
                 speed_target = data_dict.get('speed_target', None)
@@ -148,11 +153,6 @@ class HardwareChecker(HealthChecker):
                         self.set_object_not_ok('Fan', name,
                                                f'{name} direction {direction} is not aligned with {expect_fan_direction[0]} direction {expect_fan_direction[1]}')
                         continue
-
-            status = data_dict.get('status', 'false')
-            if status.lower() != 'true':
-                self.set_object_not_ok('Fan', name, '{} is broken'.format(name))
-                continue
 
             self.set_object_ok('Fan', name)
 


### PR DESCRIPTION
…atus check

Description:
First, check the fan status. Then, verify the fan speed and other parameters. If the fan status is false, there's no need to proceed with the fan speed check.

Motivation and Context:
When the fan status is false, checking the fan speed and fan direction becomes irrelevant.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When the fan status is false, checking the fan speed and fan direction becomes irrelevant.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Check fan status immediately after fan presence status check

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

