### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202305.1.0.9
+ref=202305.1.0.11


### PR DESCRIPTION
#### Why I did it
Release notes for Cisco 8102-64H-O, 8101-32FH-O, and 8111-32EH-O
• Fix for tx_drop counter increasing while the port is oper down (SR 696930881)
• Fix for [8111] MAC learning issue
• Addressed the following test case failures:
1 qos/test_tunnel_qos_remap
2 dualtor.test_tor_ecn.py:test_dscp_to_queue_during_decap_on_active
3 platform_tests.api.test_fan_drawer_fans.TestFanDrawerFans
4 platform_tests.api.test_chassis_fans.TestChassisFans
5 platform_tests.api.test_chassis.TestChassisApi failure
6 platform_tests.api.test_thermal.TestThermalApi failure

Caveats:
• There is a recent change in sonic_buildimage which is causing the test_acl failures:
• The PR link is https://github.com/sonic-net/sonic-swss/pull/3078
• This PR 3078 has since been reverted in sonic-net:master via PR #3092 and should be merged to 202305 for addressing the test_acl failures:
• The revert PR link is https://github.com/sonic-net/sonic-swss/pull/3092
• Proceeding with this code drop with this known upstream issue impacting quality. Image can be built for validation once the upstream issue is addressed in 202305.

#### How I did it
Update platform version to 202305.1.0.11
