### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202305.1.0.10
+ref=202305.1.0.11


### PR DESCRIPTION
Why I did it
Release notes for Cisco 8102-64H-O, 8101-32FH-O, and 8111-32EH-O • Fix for tx_drop counter increasing while the port is oper down (SR 696930881) • Fix for [8111] MAC learning issue
• Addressed the following test case failures:
1 qos/test_tunnel_qos_remap
2 dualtor.test_tor_ecn.py:test_dscp_to_queue_during_decap_on_active 3 platform_tests.api.test_fan_drawer_fans.TestFanDrawerFans 4 platform_tests.api.test_chassis_fans.TestChassisFans 5 platform_tests.api.test_chassis.TestChassisApi failure 6 platform_tests.api.test_thermal.TestThermalApi failure

Caveats:
• There is a recent change in sonic_buildimage which is causing the test_acl failures: • The PR link is sonic-net/sonic-swss#3078
• This PR 3078 has since been reverted in sonic-net:master via PR #3092 and should be merged to 202305 for addressing the test_acl failures: • The revert PR link is sonic-net/sonic-swss#3092
• Proceeding with this code drop with this known upstream issue impacting quality. Image can be built for validation once the upstream issue is addressed in 202305.

How I did it
Update platform version to 202305.1.0.11

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

