### PR TITLE
Fix for sonic-config-engine build failure - test_buffers_dell6100_render_template 

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -927,6 +927,9 @@ $(addprefix $(PYTHON_WHEELS_PATH)/, $(SONIC_PYTHON_WHEELS)) : $(PYTHON_WHEELS_PA
 	# Load the target deb from DPKG cache
 	$(call LOAD_CACHE,$*,$@)
 
+	# unset PLATFORM Flag for python wheel generation
+	PLATFORM=
+	export PLATFORM
 	# Skip building the target if it is already loaded from cache
 	if [ -z '$($*_CACHE_LOADED)' ] ; then
 


### PR DESCRIPTION
#### Why I did it
To fix sonic-config-engine build error at src/sonic-config-engine/tests/test_j2files.py unit test case while using "make PLATFORM=$PLATFORM target/sonic-$PLATFORM.bin" commands. This will fix the issue #18358 
Usage of PLATFORM=$PLATFORM is expected to work, and will be needed where the azure pipeline builds are executing make commands with PLATFORM parameter. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
By unsetting the PLATFORM make flag in python-wheel generator targets in slave.mk 

#### How to verify it
run the minimal build command make PLATFORM=marvell target/python-wheels/buster/sonic_config_engine-1.0-py2-none-any.whl --> To just build config-engine wheel package for buster as an example. 
Verify the errors in below test cases of src/sonic-config-engine/tests/test_j2files.py is NOT seen.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
master

