### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202311.main.0.1
+ref=202311.main.0.2


### PR DESCRIPTION

Why I did it

Release notes for Cisco 8111-32EH-O, 8102-64H-O and 8101-32FH
• Fix for PFC not generated on priority 2 when P2 and P3 are used as lossless
• Provide explicit mapping for unmapped DSCP packets
• Fix to address Netscan packet drop issue
• Fix for show platform npu router route-table CLI
• Double commit of fix for ECC errors for 202305 (SR 695600099)
Caveat:
• The sonic-buildimage used for validation was based on older sha from 01/10/24.

How I did it

Update platform version to 202311.main.0.2




