### PR TITLE
Fix Module Detection Flow in modules_mgmt thread, to check power_on before power_good

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -103,10 +103,10 @@ class ModulesMgmtTask(threading.Thread):
     # SFPs state machine
     def get_sm_func(self, sm, port):
         SFP_SM_ENUM = {STATE_HW_NOT_PRESENT: self.check_if_hw_present
-            , STATE_HW_PRESENT: self.check_if_module_available
-            , STATE_MODULE_AVAILABLE: self.check_if_power_on
+            , STATE_HW_PRESENT: self.check_if_power_on
             , STATE_NOT_POWERED: self.power_on_module
-            , STATE_POWERED: self.check_module_type
+            , STATE_POWERED: self.check_if_module_available
+            , STATE_MODULE_AVAILABLE: self.check_module_type
             , STATE_FW_CONTROL: self.save_module_control_mode
             , STATE_SW_CONTROL: self.save_module_control_mode
             , STATE_ERROR_HANDLER: STATE_ERROR_HANDLER


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Old flow checked power_good before powering-on the module. 
If the module is not powered, power_good will always remain 0 and flow will stop at the beginning.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Updated the state machine of MDF to have the right order.
#### How to verify it
I added logs and made sure the right order is being executed. 
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)
- [x] master
- [x] 202311
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->
