### PR TITLE
[multi-asic] Fixed 13137 ERR python3: :- initializeGlobalConfig: SonicDBConfig Global config is already initialized 

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -72,12 +72,7 @@ def db_connect_configdb(namespace=None):
     """
     Connect to configdb
     """
-    try:
-        if namespace is not None:
-            swsscommon.SonicDBConfig.load_sonic_global_db_config(namespace=namespace)
-        config_db = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
-    except Exception as e:
-        return None
+    config_db = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
     if config_db is None:
         return None
     try:

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -138,11 +138,12 @@ def ip_network(value):
     return r_v.network
 
 def load_namespace_config(asic_name):
-    if not SonicDBConfig.isInit():
-        if is_multi_asic():
-            SonicDBConfig.load_sonic_global_db_config(namespace=asic_name)
-        else:
-            SonicDBConfig.load_sonic_db_config()
+    if is_multi_asic():
+        if not SonicDBConfig.isGlobalInit():
+            SonicDBConfig.initializeGlobalConfig()
+    else:
+        if not SonicDBConfig.isInit():
+            SonicDBConfig.initialize()
 
 class FormatConverter:
     """Convert config DB based schema to legacy minigraph based schema for backward capability.

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -137,7 +137,7 @@ def ip_network(value):
         return "Invalid ip address %s" % value
     return r_v.network
 
-def load_namespace_config(asic_name):
+def load_namespace_config():
     if is_multi_asic():
         if not SonicDBConfig.isGlobalInit():
             SonicDBConfig.initializeGlobalConfig()
@@ -309,7 +309,7 @@ def main():
         deep_update(data, hardware_data)
         if args.port_config is None:
             args.port_config = device_info.get_path_to_port_config_file(hwsku)
-        load_namespace_config(asic_name)
+        load_namespace_config()
         (ports, _, _) = get_port_config(hwsku, platform, args.port_config, asic_id)
         if ports is None:
             print('Failed to get port config', file=sys.stderr)
@@ -335,7 +335,7 @@ def main():
 
     if args.minigraph is not None:
         minigraph = args.minigraph
-        load_namespace_config(asic_name)
+        load_namespace_config()
         if platform:
             if args.port_config is not None:
                 deep_update(data, parse_xml(minigraph, platform, args.port_config, asic_name=asic_name, hwsku_config_file=args.hwsku_config))
@@ -363,7 +363,7 @@ def main():
         if args.namespace is None:
             configdb = ConfigDBPipeConnector(use_unix_socket_path=use_unix_sock, **db_kwargs)
         else:
-            load_namespace_config(args.namespace)
+            load_namespace_config()
             configdb = ConfigDBPipeConnector(use_unix_socket_path=use_unix_sock, namespace=args.namespace, **db_kwargs)
 
         configdb.connect()
@@ -435,7 +435,7 @@ def main():
         if args.namespace is None:
             configdb = ConfigDBPipeConnector(use_unix_socket_path=True, **db_kwargs)
         else:
-            load_namespace_config(args.namespace)
+            load_namespace_config()
             configdb = ConfigDBPipeConnector(use_unix_socket_path=True, namespace=args.namespace, **db_kwargs)
 
         configdb.connect(False)

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -31,7 +31,7 @@ from config_samples import generate_sample_config, get_available_config
 from functools import partial
 from minigraph import minigraph_encoder, parse_xml, parse_device_desc_xml, parse_asic_sub_role, parse_asic_switch_type
 from portconfig import get_port_config, get_breakout_mode
-from sonic_py_common.multi_asic import get_asic_id_from_name, get_asic_device_id
+from sonic_py_common.multi_asic import get_asic_id_from_name, get_asic_device_id, is_multi_asic
 from sonic_py_common import device_info
 from swsscommon.swsscommon import ConfigDBConnector, SonicDBConfig, ConfigDBPipeConnector
 
@@ -136,6 +136,13 @@ def ip_network(value):
     except:
         return "Invalid ip address %s" % value
     return r_v.network
+
+def load_namespace_config(asic_name):
+    if not SonicDBConfig.isInit():
+        if is_multi_asic():
+            SonicDBConfig.load_sonic_global_db_config(namespace=asic_name)
+        else:
+            SonicDBConfig.load_sonic_db_config()
 
 class FormatConverter:
     """Convert config DB based schema to legacy minigraph based schema for backward capability.
@@ -301,6 +308,7 @@ def main():
         deep_update(data, hardware_data)
         if args.port_config is None:
             args.port_config = device_info.get_path_to_port_config_file(hwsku)
+        load_namespace_config(asic_name)
         (ports, _, _) = get_port_config(hwsku, platform, args.port_config, asic_id)
         if ports is None:
             print('Failed to get port config', file=sys.stderr)
@@ -326,6 +334,7 @@ def main():
 
     if args.minigraph is not None:
         minigraph = args.minigraph
+        load_namespace_config(asic_name)
         if platform:
             if args.port_config is not None:
                 deep_update(data, parse_xml(minigraph, platform, args.port_config, asic_name=asic_name, hwsku_config_file=args.hwsku_config))
@@ -353,7 +362,7 @@ def main():
         if args.namespace is None:
             configdb = ConfigDBPipeConnector(use_unix_socket_path=use_unix_sock, **db_kwargs)
         else:
-            SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
+            load_namespace_config(args.namespace)
             configdb = ConfigDBPipeConnector(use_unix_socket_path=use_unix_sock, namespace=args.namespace, **db_kwargs)
 
         configdb.connect()
@@ -425,7 +434,7 @@ def main():
         if args.namespace is None:
             configdb = ConfigDBPipeConnector(use_unix_socket_path=True, **db_kwargs)
         else:
-            SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
+            load_namespace_config(args.namespace)
             configdb = ConfigDBPipeConnector(use_unix_socket_path=True, namespace=args.namespace, **db_kwargs)
 
         configdb.connect(False)


### PR DESCRIPTION
**Issue**: 
https://github.com/sonic-net/sonic-buildimage/issues/13137
If run "show interfaces status" we often see error in syslog "SonicDBConfig Global config is already initialized".

**Analysis**: 
During investigation it is found the swsscommon.load_sonic_global_db_config() has been triggered multiple times. Especially in a multi Asic scenario.

CLI triggers "intfutil -c status" with a separate process. Within the process it will trigger IntfStatus init --> MultiAsic() init-->load_db_config()-->load_sonic_global_db_config(). This time initializeGlobalConfig() will run to the end as m_global_init flag is false.

CLI will also run get_port_config() --> db_connect_configdb() --> load_sonic_global_db_config() (for different namepaces. In our case is asic0 and asic1). This time m_global_init flag is true which causes error log and return.

**Solution**: 
There was a PR in master already fixed this issue(https://github.com/sonic-net/sonic-buildimage/pull/10960). Cherry-picked this back to 202205. Added checks in 2 other places where load_sonic_global_db_config is called without check in the code and was not covered by PR 10960. 

**Testing**
Run on chassis with 202205 loaded. Loaded the python files modified with this PR into the chassis. Run "show interface status" and will not see the error log. Show command has interface status results correctly.
