### PR TITLE
Adds YANG models for configurable intervals in CONFIG_DB for stormond

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -186,8 +186,8 @@
     },
     "STORMOND_CONFIG": {
         "INTERVALS": {
-            "daemon_polling_interval" : "60",
-            "fsstats_sync_interval"   : "360"
+            "daemon_polling_interval" : "3600",
+            "fsstats_sync_interval"   : "86400"
         }
     }
 }

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -184,8 +184,10 @@
             "vrf": "default"
         }
     },
-    "STORAGEMOND_CONFIG" : {
-        "daemon_polling_interval" : "60",
-        "fsstats_sync_interval"   : "60"
+    "STORMOND_CONFIG": {
+        "INTERVALS": {
+            "daemon_polling_interval" : "60",
+            "fsstats_sync_interval"   : "360"
+        }
     }
 }

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -183,11 +183,5 @@
             "admin_state": "enabled",
             "vrf": "default"
         }
-    },
-    "STORMOND_CONFIG": {
-        "INTERVALS": {
-            "daemon_polling_interval" : "",
-            "fsstats_sync_interval"   : ""
-        }
     }
 }

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -183,8 +183,9 @@
             "admin_state": "enabled",
             "vrf": "default"
         }
-    }
-    "STORAGEMOND_DEFAULTS" : {
-        "polling_interval" : "60"
+    },
+    "STORAGEMOND_CONFIG" : {
+        "daemon_polling_interval" : "60",
+        "fsstats_sync_interval"   : "60"
     }
 }

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -186,8 +186,8 @@
     },
     "STORMOND_CONFIG": {
         "INTERVALS": {
-            "daemon_polling_interval" : "3600",
-            "fsstats_sync_interval"   : "86400"
+            "daemon_polling_interval" : "",
+            "fsstats_sync_interval"   : ""
         }
     }
 }

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -184,4 +184,7 @@
             "vrf": "default"
         }
     }
+    "STORAGEMOND_DEFAULTS" : {
+        "polling_interval" : "60"
+    }
 }

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2072,6 +2072,27 @@ key - name
 | collector_port | Destination L4 port of the Sflow collector                                              |             | 6343      |             |
 | collector_vrf  | Specify the Collector VRF. In this revision, it is either default VRF or Management VRF.|             |           |             |
 
+### Storage Monitoring Daemon Interval Configuration
+
+These options are used to configure the daemon polling and sync-to-disk interval
+of the Storage Monitoring Daemon (stormond)
+
+**Config Sample**
+```
+{
+    "STORMOND_CONFIG": {
+        "INTERVALS": {
+            "daemon_polling_interval" : "60",
+            "fsstats_sync_interval"   : "360"
+        }
+    }
+}
+```
+
+*   `daemon_polling_interval` - Determines how often stormond queries the disk for relevant information and posts to STATE_DB
+*   `fsstats_sync_interval`   - Determines how often key information from the STATE_DB is synced to a file on disk
+
+
 ### Syslog Global Configuration
 
 These configuration options are used to configure rsyslog utility and the way

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2683,5 +2683,11 @@
             "global": {
             }
         }
+    },
+    "STORMOND_CONFIG": {
+        "INTERVALS": {
+            "daemon_polling_interval" : "3600",
+            "fsstats_sync_interval"   : "86400"
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/stormond.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/stormond.json
@@ -1,0 +1,21 @@
+{
+    "STORMOND_CONFIG_TABLE": {
+        "desc": "Config DB interval parameters for Storage Monitoring Daemon"
+    },
+    "STORMOND_INVALID_POLLING_INTERVAL": {
+        "desc": "Configure an invalid daemon polling interval",
+        "eStrKey" : "InvalidValue"
+    },
+    "STORMOND_INVALID_SYNC_INTERVAL": {
+        "desc": "Configure an invalid fsstats file sync interval",
+        "eStrKey" : "InvalidValue"
+    },
+    "STORMOND_POLLING_INTVL_BAD_LEN_MAX": {
+        "desc": "Configure an invalid daemon polling interval: out of range value",
+        "eStrKey" : "Pattern"
+    },
+    "STORMOND_SYNC_INTVL_BAD_LEN_MAX": {
+        "desc": "Configure an invalid fsstats file sync interval: out of range value",
+        "eStrKey" : "Pattern"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/stormond.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/stormond.json
@@ -17,5 +17,13 @@
     "STORMOND_SYNC_INTVL_BAD_LEN_MAX": {
         "desc": "Configure an invalid fsstats file sync interval: out of range value",
         "eStrKey" : "InvalidValue"
+    },
+    "STORMOND_SYNC_INTVL_EMPTY_VALUE": {
+        "desc": "Configure an empty file sync interval",
+        "eStrKey" : "InvalidValue"
+    },
+    "STORMOND_POLLING_INTVL_EMPTY_VALUE": {
+        "desc": "Configure an empty file sync interval",
+        "eStrKey" : "InvalidValue"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/stormond.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/stormond.json
@@ -12,10 +12,10 @@
     },
     "STORMOND_POLLING_INTVL_BAD_LEN_MAX": {
         "desc": "Configure an invalid daemon polling interval: out of range value",
-        "eStrKey" : "Pattern"
+        "eStrKey" : "InvalidValue"
     },
     "STORMOND_SYNC_INTVL_BAD_LEN_MAX": {
         "desc": "Configure an invalid fsstats file sync interval: out of range value",
-        "eStrKey" : "Pattern"
+        "eStrKey" : "InvalidValue"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/stormond.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/stormond.json
@@ -53,5 +53,27 @@
                 }
             }
         }
+    },
+    "STORMOND_SYNC_INTVL_EMPTY_VALUE": {
+        "sonic-stormond-config:sonic-stormond-config": {
+            "sonic-stormond-config:STORMOND_CONFIG": {
+                "INTERVALS":{
+                    "daemon_polling_interval" : "3600",
+                    "fsstats_sync_interval"   : ""
+
+                }
+            }
+        }
+    },
+    "STORMOND_POLLING_INTVL_EMPTY_VALUE": {
+        "sonic-stormond-config:sonic-stormond-config": {
+            "sonic-stormond-config:STORMOND_CONFIG": {
+                "INTERVALS":{
+                    "daemon_polling_interval" : "",
+                    "fsstats_sync_interval"   : "86400"
+
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/stormond.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/stormond.json
@@ -14,7 +14,7 @@
         "sonic-stormond-config:sonic-stormond-config": {
             "sonic-stormond-config:STORMOND_CONFIG": {
                 "INTERVALS":{
-                    "daemon_polling_interval" : "",
+                    "daemon_polling_interval" : "-1",
                     "fsstats_sync_interval"   : "86400"
 
                 }
@@ -26,7 +26,7 @@
             "sonic-stormond-config:STORMOND_CONFIG": {
                 "INTERVALS":{
                     "daemon_polling_interval" : "3600",
-                    "fsstats_sync_interval"   : ""
+                    "fsstats_sync_interval"   : "five_thousand_two_hundred_seconds"
 
                 }
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/stormond.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/stormond.json
@@ -1,0 +1,57 @@
+{
+    "STORMOND_CONFIG_TABLE": {
+        "sonic-stormond-config:sonic-stormond-config": {
+            "sonic-stormond-config:STORMOND_CONFIG": {
+                "INTERVALS":{
+                    "daemon_polling_interval" : "3600",
+                    "fsstats_sync_interval"   : "86400"
+
+                }
+            }
+        }
+    },
+    "STORMOND_INVALID_POLLING_INTERVAL": {
+        "sonic-stormond-config:sonic-stormond-config": {
+            "sonic-stormond-config:STORMOND_CONFIG": {
+                "INTERVALS":{
+                    "daemon_polling_interval" : "",
+                    "fsstats_sync_interval"   : "86400"
+
+                }
+            }
+        }
+    },
+    "STORMOND_INVALID_SYNC_INTERVAL": {
+        "sonic-stormond-config:sonic-stormond-config": {
+            "sonic-stormond-config:STORMOND_CONFIG": {
+                "INTERVALS":{
+                    "daemon_polling_interval" : "3600",
+                    "fsstats_sync_interval"   : ""
+
+                }
+            }
+        }
+    },
+    "STORMOND_POLLING_INTVL_BAD_LEN_MAX": {
+        "sonic-stormond-config:sonic-stormond-config": {
+            "sonic-stormond-config:STORMOND_CONFIG": {
+                "INTERVALS":{
+                    "daemon_polling_interval" : "360036003600360036003600360036003",
+                    "fsstats_sync_interval"   : "86400"
+
+                }
+            }
+        }
+    },
+    "STORMOND_SYNC_INTVL_BAD_LEN_MAX": {
+        "sonic-stormond-config:sonic-stormond-config": {
+            "sonic-stormond-config:STORMOND_CONFIG": {
+                "INTERVALS":{
+                    "daemon_polling_interval" : "3600",
+                    "fsstats_sync_interval"   : "864008640086400864008640086400864"
+
+                }
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-stormond-config.yang
+++ b/src/sonic-yang-models/yang-models/sonic-stormond-config.yang
@@ -24,6 +24,7 @@ module sonic-stormond-config{
                     type uint32 {
                         range "1..4294967295";
                     }
+                    default "3600";
                 }
 
                 leaf fsstats_sync_interval {
@@ -31,6 +32,7 @@ module sonic-stormond-config{
                     type uint32 {
                         range "1..4294967295";
                     }
+                    default "86400";
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-stormond-config.yang
+++ b/src/sonic-yang-models/yang-models/sonic-stormond-config.yang
@@ -22,14 +22,14 @@ module sonic-stormond-config{
                 leaf daemon_polling_interval {
                     description "Polling inerval for Storage Monitoring Daemon in STORMOND_CONFIG table";
                     type string {
-                        length 1..32;
+                        length 1..86400;
                     }
                 }
 
                 leaf fsstats_sync_interval {
                     description "FSSTATS JSON file syncing interval for the Storage Monitoring Daemon in STORMOND_CONFIG table";
                     type string {
-                        length 1..32;
+                        length 1..604800;
                     }
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-stormond-config.yang
+++ b/src/sonic-yang-models/yang-models/sonic-stormond-config.yang
@@ -21,15 +21,15 @@ module sonic-stormond-config{
 
                 leaf daemon_polling_interval {
                     description "Polling inerval for Storage Monitoring Daemon in STORMOND_CONFIG table";
-                    type string {
-                        length 1..86400;
+                    type uint32 {
+                        range "1..4294967295";
                     }
                 }
 
                 leaf fsstats_sync_interval {
                     description "FSSTATS JSON file syncing interval for the Storage Monitoring Daemon in STORMOND_CONFIG table";
-                    type string {
-                        length 1..604800;
+                    type uint32 {
+                        range "1..4294967295";
                     }
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-stormond-config.yang
+++ b/src/sonic-yang-models/yang-models/sonic-stormond-config.yang
@@ -1,0 +1,38 @@
+module sonic-stormond-config{
+
+    yang-version 1.1;
+
+    namespace "http://github.com/sonic-net/sonic-stormond-config";
+    prefix stormond-config;
+
+    import sonic-types {
+        prefix stypes;
+    }
+
+    description "STORMOND_CONFIG Table yang Module for SONiC";
+
+    container sonic-stormond-config {
+
+        container STORMOND_CONFIG {
+
+            description "stormond_config table in config_db.json";
+
+            container INTERVALS {
+
+                leaf daemon_polling_interval {
+                    description "Polling inerval for Storage Monitoring Daemon in STORMOND_CONFIG table";
+                    type string {
+                        length 1..32;
+                    }
+                }
+
+                leaf fsstats_sync_interval {
+                    description "FSSTATS JSON file syncing interval for the Storage Monitoring Daemon in STORMOND_CONFIG table";
+                    type string {
+                        length 1..32;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is part of a larger feature: [SONiC Storage Monitoring Daemon](https://github.com/sonic-net/SONiC/pull/1481) -- this commit adds the option to configure the daemon's polling interval and fsstats file sync interval (in seconds) of the daemon via config_db by introducing YANG models.

##### Work item tracking
- Microsoft ADO **(number only)**: 17468992

#### How I did it
Gives userside the option to dynamically a new table 'STORMOND' with key INTERVALS and fields 'daemon_polling_interval' with default value of '3600' seconds and 'fsstats_sync_interval' with default value of '86400' seconds as defined in the YANG model.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Flash image onto a DUT and add the aforementioned table to the CONFIG_DB. Verify that `stormond` has picked up your config intervals.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

