### PR TITLE
[backend] Update backend acl template and unit tests

### DIFF
--- a/files/build_templates/backend_acl.j2
+++ b/files/build_templates/backend_acl.j2
@@ -1,15 +1,3 @@
-{%- set vlan2ports = {} %}
-{%- for vlan in VLAN %}
-    {% set portlist = [] %}
-    {%- for vlan_name, port in VLAN_MEMBER %}
-        {%- if vlan_name == vlan %}
-            {%- if portlist.append(port) %}{%- endif %}
-        {%- endif %}
-    {%- endfor %}
-    {%- set _ = vlan2ports.update({vlan: portlist| sort | join(',')}) %}
-{%- endfor %}
-
-
 {
         "acl": {
                 "acl-sets": {
@@ -31,13 +19,6 @@
                                                                      "config": {
                                                                              "vlan_id": "{{ vlan_entries['vlanid'] }}"
                                                                      }
-                                                             },
-                                                             "input_interface": {
-                                                                     "interface_ref": {
-                                                                             "config": {
-                                                                                     "interface": "{{ vlan2ports[vlan] }}"
-                                                                             }
-                                                                      }
                                                              }
 
                                                      }{% if not loop.last %},{% endif %} 

--- a/src/sonic-config-engine/tests/data/backend_acl/acl_multi_vlan.json
+++ b/src/sonic-config-engine/tests/data/backend_acl/acl_multi_vlan.json
@@ -19,13 +19,6 @@
                                                                      "config": {
                                                                              "vlan_id": "1000"
                                                                      }
-                                                             },
-                                                             "input_interface": {
-                                                                     "interface_ref": {
-                                                                             "config": {
-                                                                                     "interface": "Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76"
-                                                                             }
-                                                                      }
                                                              }
 
                                                      },                                                     "2": {
@@ -41,13 +34,6 @@
                                                                      "config": {
                                                                              "vlan_id": "2000"
                                                                      }
-                                                             },
-                                                             "input_interface": {
-                                                                     "interface_ref": {
-                                                                             "config": {
-                                                                                     "interface": "Ethernet4,Ethernet8"
-                                                                             }
-                                                                      }
                                                              }
 
                                                      }                                                 }

--- a/src/sonic-config-engine/tests/data/backend_acl/acl_single_vlan.json
+++ b/src/sonic-config-engine/tests/data/backend_acl/acl_single_vlan.json
@@ -19,13 +19,6 @@
                                                                      "config": {
                                                                              "vlan_id": "1000"
                                                                      }
-                                                             },
-                                                             "input_interface": {
-                                                                     "interface_ref": {
-                                                                             "config": {
-                                                                                     "interface": "Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet4,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet8"
-                                                                             }
-                                                                      }
                                                              }
 
                                                      }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Backend acl load is failing since IN_PORTS qualifier is no longer supported. Changing the template to match only on vlan since the only the vlan ports are bound to the DATAACL for backend (https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-config-engine/minigraph.py#L1346)

##### Work item tracking
- Microsoft ADO: 27172619

#### How to verify it
Unit test to validate the template rendering
Tested on 202305 branch. Acl loaded successfully after this change.  
```
admin@str2-7050qx-32s-acs-02:~$ sudo systemctl restart backend-acl.service 
admin@str2-7050qx-32s-acs-02:/usr/share/sonic/templates$ show acl rule
Table    Rule          Priority    Action    Match             Status
-------  ------------  ----------  --------  ----------------  --------
DATAACL  RULE_1        9999        FORWARD   ETHER_TYPE: 2048  Active
                                             VLAN_ID: 1000
DATAACL  RULE_2        9998        FORWARD   ETHER_TYPE: 2048  Active
                                             VLAN_ID: 1100
DATAACL  DEFAULT_RULE  1           DROP      ETHER_TYPE: 2048  Active
```
Cannot test on internal branch since the slim image is too big to load on 7050qx and this change is only applicable to 7050qx.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)
20230531.24 with the patch

