### PR TITLE
Fix smart switch check command in gnmi and orchagent start script.

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -75,7 +75,7 @@ fi
 # Enable ZMQ for SmartSwitch
 LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "subtype"`
 if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
-    mgmt_ip=$( ip -4 -o addr show eth0 | awk '{print $4}' | cut -d'/' -f1 )
+    mgmt_ip=$( ip -json -4 addr show eth0 | jq -r ".[0].addr_info[0].local" )
     if [[ $midplane_ip != "" ]]
         ORCHAGENT_ARGS+=" -q tcp://${mgmt_ip}:8100"
     else

--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -75,8 +75,13 @@ fi
 # Enable ZMQ for SmartSwitch
 LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "subtype"`
 if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
-    mgmt_ip=$( ip -json -4 addr show eth0 | jq -r ".[0].addr_info[0].local" )
-    if [[ $midplane_ip != "" ]]
+    midplane_mgmt_ip=$( ip -json -4 addr show eth0-midplane | jq -r ".[0].addr_info[0].local" )
+    mgmt_ip=$( ip -json -4 addr show eth0-midplane | jq -r ".[0].addr_info[0].local" )
+    if [[ $midplane_ip != "" ]]; then
+        # Enable ZMQ with eth0-midplane address
+        ORCHAGENT_ARGS+=" -q tcp://${midplane_mgmt_ip}:8100"
+    elif [[ $mgmt_ip != "" ]]; then
+        # If eth0-midplane interface does not exist, enable ZMQ with eth0 address
         ORCHAGENT_ARGS+=" -q tcp://${mgmt_ip}:8100"
     else
         ORCHAGENT_ARGS+=" -q tcp://127.0.0.1:8100"

--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -73,7 +73,7 @@ else
 fi
 
 # Enable ZMQ for SmartSwitch
-LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget localhost "subtype"`
+LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "subtype"`
 if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
     ORCHAGENT_ARGS+=" -q tcp://127.0.0.1:8100"
 fi

--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -75,7 +75,7 @@ fi
 # Enable ZMQ for SmartSwitch
 LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "subtype"`
 if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
-    ORCHAGENT_ARGS+=" -q tcp://127.0.0.1:8100"
+    ORCHAGENT_ARGS+=" -q tcp://0.0.0.0:8100"
 fi
 
 exec /usr/bin/orchagent ${ORCHAGENT_ARGS}

--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -75,7 +75,12 @@ fi
 # Enable ZMQ for SmartSwitch
 LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "subtype"`
 if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
-    ORCHAGENT_ARGS+=" -q tcp://0.0.0.0:8100"
+    mgmt_ip=$( ip -4 -o addr show eth0 | awk '{print $4}' | cut -d'/' -f1 )
+    if [[ $midplane_ip != "" ]]
+        ORCHAGENT_ARGS+=" -q tcp://${mgmt_ip}:8100"
+    else
+        ORCHAGENT_ARGS+=" -q tcp://127.0.0.1:8100"
+    fi
 fi
 
 exec /usr/bin/orchagent ${ORCHAGENT_ARGS}

--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -76,7 +76,7 @@ fi
 LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "subtype"`
 if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
     midplane_mgmt_ip=$( ip -json -4 addr show eth0-midplane | jq -r ".[0].addr_info[0].local" )
-    mgmt_ip=$( ip -json -4 addr show eth0-midplane | jq -r ".[0].addr_info[0].local" )
+    mgmt_ip=$( ip -json -4 addr show eth0 | jq -r ".[0].addr_info[0].local" )
     if [[ $midplane_ip != "" ]]; then
         # Enable ZMQ with eth0-midplane address
         ORCHAGENT_ARGS+=" -q tcp://${midplane_mgmt_ip}:8100"

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -73,7 +73,7 @@ fi
 # Enable ZMQ for SmartSwitch
 LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "subtype"`
 if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
-    TELEMETRY_ARGS+=" -zmq_address=tcp://127.0.0.1:8100"
+    TELEMETRY_ARGS+=" -zmq_port=8100"
 fi
 
 # Server will handle threshold connections consecutively

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -71,7 +71,7 @@ else
 fi
 
 # Enable ZMQ for SmartSwitch
-LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget localhost "subtype"`
+LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "subtype"`
 if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
     TELEMETRY_ARGS+=" -zmq_address=tcp://127.0.0.1:8100"
 fi


### PR DESCRIPTION
Fix smart switch check command in gnmi and orchagent start script.

#### Why I did it
Smart switch check command in gnmi and orchagent start script check wrong Redis table.

#### How I did it
Change smart switch check command check "DEVICE_METADATA|localhost" table.

#### How to verify it
Pass all UT & E2E test