### PR TITLE
[Marvell-arm64]: Fix sonic-installer

### DIFF
--- a/platform/marvell/platform_arm64.conf
+++ b/platform/marvell/platform_arm64.conf
@@ -216,8 +216,8 @@ prepare_boot_menu() {
 
     fw_setenv ${FW_ARG} linuxargs "net.ifnames=0 loopfstype=squashfs loop=$image_dir/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG ${ONIE_PLATFORM_EXTRA_CMDLINE_LINUX}" > /dev/null
     fw_setenv ${FW_ARG} linuxargs_old "net.ifnames=0 loopfstype=squashfs loop=$image_dir_old/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG ${ONIE_PLATFORM_EXTRA_CMDLINE_LINUX}" > /dev/null
-    sonic_bootargs_old='setenv bootargs root='$demo_dev' rw rootwait rootfstype=ext4 panic=1 console=ttyS0,${baudrate} ${othbootargs} ${mtdparts} ${linuxargs_old}'
-    fw_setenv ${FW_ARG} sonic_bootargs_old $sonic_bootargs_old > /dev/null || true
+    sonic_bootargs_old='setenv bootargs root='$demo_dev' rw rootwait panic=1 console=ttyS0,${baudrate} ${othbootargs} ${mtdparts} ${linuxargs_old}'
+    fw_setenv ${FW_ARG} sonic_bootargs_old "$sonic_bootargs_old" > /dev/null || true
     sonic_boot_load_old=$(fw_printenv -n sonic_boot_load || true)
     old_str="_old"
     fw_setenv ${FW_ARG} sonic_boot_load_old "$sonic_boot_load_old$old_str" > /dev/null || true
@@ -231,14 +231,14 @@ prepare_boot_menu() {
     fw_setenv ${FW_ARG} sonic_boot_load "$MMC_LOAD" > /dev/null
     SONIC_BOOT_CMD='run sonic_bootargs; run sonic_boot_load; bootm $fit_addr${fit_conf_name}'
     SONIC_BOOT_CMD_OLD='run sonic_bootargs_old; run sonic_boot_load_old; bootm $fit_addr${fit_conf_name}'
-    BOOTARGS='setenv bootargs root='$demo_dev' rw rootwait rootfstype=ext4 panic=1 console=ttyS0,${baudrate} ${othbootargs} ${mtdparts} ${linuxargs}'
-    fw_setenv ${FW_ARG} sonic_bootargs $BOOTARGS > /dev/null
-    fw_setenv ${FW_ARG} sonic_bootcmd $SONIC_BOOT_CMD > /dev/null
-    fw_setenv ${FW_ARG} sonic_image_2 $SONIC_BOOT_CMD_OLD > /dev/null
+    BOOTARGS='setenv bootargs root='$demo_dev' rw rootwait panic=1 console=ttyS0,${baudrate} ${othbootargs} ${mtdparts} ${linuxargs}'
+    fw_setenv ${FW_ARG} sonic_bootargs "$BOOTARGS" > /dev/null
+    fw_setenv ${FW_ARG} sonic_image_2 "$SONIC_BOOT_CMD_OLD" > /dev/null
     fw_setenv ${FW_ARG} sonic_image_1 "$SONIC_BOOT_CMD" > /dev/null
     fw_setenv ${FW_ARG} boot_next  'run sonic_image_1'> /dev/null
     fw_setenv ${FW_ARG} bootcmd 'run print_menu; usb start; test -n "$boot_once" && run boot_once; run boot_next' > /dev/null
 
+    echo "Installed SONiC base image SONiC-OS successfully"
 }
 
 bootloader_menu_config() {

--- a/platform/marvell/platform_arm64.conf
+++ b/platform/marvell/platform_arm64.conf
@@ -219,7 +219,7 @@ prepare_boot_menu() {
     BOOT2='echo " > Boot2: $sonic_version_2 - run sonic_image_2";echo;'
     BOOT3='echo " > Boot3: ONIE - run onie_boot";echo;'
     BORDER='echo "---------------------------------------------------";echo;'
-    fw_setenv ${FW_ARG} print_menu $BORDER $BOOT1 $BOOT2 $BOOT3 $BORDER > /dev/null
+    fw_setenv ${FW_ARG} print_menu "$BORDER $BOOT1 $BOOT2 $BOOT3 $BORDER" > /dev/null
 
     fw_setenv ${FW_ARG} linuxargs "net.ifnames=0 loopfstype=squashfs loop=$image_dir/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG ${ONIE_PLATFORM_EXTRA_CMDLINE_LINUX}" > /dev/null
     sonic_bootargs_old='setenv bootargs root='$demo_dev' rw rootwait panic=1 console=ttyS0,${baudrate} ${othbootargs} ${mtdparts} ${linuxargs_old}'

--- a/platform/marvell/platform_arm64.conf
+++ b/platform/marvell/platform_arm64.conf
@@ -242,7 +242,7 @@ prepare_boot_menu() {
     fw_setenv ${FW_ARG} sonic_image_2 "$SONIC_BOOT_CMD_OLD" > /dev/null
     fw_setenv ${FW_ARG} sonic_image_1 "$SONIC_BOOT_CMD" > /dev/null
     fw_setenv ${FW_ARG} boot_next  'run sonic_image_1'> /dev/null
-    fw_setenv ${FW_ARG} bootcmd 'run print_menu; usb start; test -n "$boot_once" && run boot_once; run boot_next' > /dev/null
+    fw_setenv ${FW_ARG} bootcmd 'run print_menu; usb start; test -n "$boot_once" && setenv do_boot_once "$boot_once" && setenv boot_once "" && saveenv && run do_boot_once; run boot_next' > /dev/null
 
     echo "Installed SONiC base image SONiC-OS successfully"
 }

--- a/platform/marvell/platform_arm64.conf
+++ b/platform/marvell/platform_arm64.conf
@@ -180,19 +180,32 @@ prepare_boot_menu() {
 
     if [ "$install_env" = "onie" ]; then
         FW_ARG="-f"
-        image_dir_old=""
-        image_name_old=""
-        initrd_name_old=""
-        fdt_name_old=""
-        fit_name_old=""
-        sonic_version_2="None"
+        fw_setenv ${FW_ARG} image_dir_old "" > /dev/null
+        fw_setenv ${FW_ARG} image_name_old "" > /dev/null
+        fw_setenv ${FW_ARG} initrd_name_old "" > /dev/null
+        fw_setenv ${FW_ARG} fdt_name_old "" > /dev/null
+        fw_setenv ${FW_ARG} fit_name_old "" > /dev/null
+        fw_setenv ${FW_ARG} sonic_version_2 "None" > /dev/null
+        fw_setenv ${FW_ARG} linuxargs_old "" > /dev/null
     else
-        image_dir_old=$(fw_printenv -n image_dir || true)
-        image_name_old=$(fw_printenv -n image_name || true)
-        initrd_name_old=$(fw_printenv -n initrd_name || true)
-        fdt_name_old=$(fw_printenv -n fdt_name || true)
-        fit_name_old=$(fw_printenv -n fit_name || true)
-        sonic_version_2=$(fw_printenv -n sonic_version_1 || true)
+        CURR_SONIC_IMAGE="$(sonic-installer list | grep "Current: " | cut -f2 -d' ')"
+        FIRST_SONIC_IMAGE="$(fw_printenv sonic_version_1 | cut -f2 -d'=')"
+        if [ "$CURR_SONIC_IMAGE" = "$FIRST_SONIC_IMAGE" ]; then
+            image_dir_old=$(fw_printenv -n image_dir || true)
+            image_name_old=$(fw_printenv -n image_name || true)
+            initrd_name_old=$(fw_printenv -n initrd_name || true)
+            fdt_name_old=$(fw_printenv -n fdt_name || true)
+            fit_name_old=$(fw_printenv -n fit_name || true)
+            sonic_version_2=$(fw_printenv -n sonic_version_1 || true)
+            linuxargs_old=$(fw_printenv -n linuxargs || true)
+            fw_setenv ${FW_ARG} image_dir_old "$image_dir_old" > /dev/null
+            fw_setenv ${FW_ARG} image_name_old "$image_name_old" > /dev/null
+            fw_setenv ${FW_ARG} initrd_name_old "$initrd_name_old" > /dev/null
+            fw_setenv ${FW_ARG} fdt_name_old "$fdt_name_old" > /dev/null
+            fw_setenv ${FW_ARG} fit_name_old "$fit_name_old" > /dev/null
+            fw_setenv ${FW_ARG} sonic_version_2 "$sonic_version_2" > /dev/null
+            fw_setenv ${FW_ARG} linuxargs_old "$linuxargs_old" > /dev/null
+        fi
     fi
 
     # Set boot variables
@@ -202,12 +215,6 @@ prepare_boot_menu() {
     fw_setenv ${FW_ARG} fdt_name $fdt_name > /dev/null
     fw_setenv ${FW_ARG} fit_name $fit_name > /dev/null
     fw_setenv ${FW_ARG} sonic_version_1 $demo_volume_revision_label > /dev/null
-    fw_setenv ${FW_ARG} image_dir_old $image_dir_old > /dev/null
-    fw_setenv ${FW_ARG} image_name_old $image_name_old > /dev/null
-    fw_setenv ${FW_ARG} initrd_name_old $initrd_name_old > /dev/null
-    fw_setenv ${FW_ARG} fdt_name_old $fdt_name_old > /dev/null
-    fw_setenv ${FW_ARG} fit_name_old $fit_name_old > /dev/null
-    fw_setenv ${FW_ARG} sonic_version_2 $sonic_version_2 > /dev/null
     BOOT1='echo " > Boot1: $sonic_version_1 - run sonic_image_1";echo;'
     BOOT2='echo " > Boot2: $sonic_version_2 - run sonic_image_2";echo;'
     BOOT3='echo " > Boot3: ONIE - run onie_boot";echo;'
@@ -215,7 +222,6 @@ prepare_boot_menu() {
     fw_setenv ${FW_ARG} print_menu $BORDER $BOOT1 $BOOT2 $BOOT3 $BORDER > /dev/null
 
     fw_setenv ${FW_ARG} linuxargs "net.ifnames=0 loopfstype=squashfs loop=$image_dir/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG ${ONIE_PLATFORM_EXTRA_CMDLINE_LINUX}" > /dev/null
-    fw_setenv ${FW_ARG} linuxargs_old "net.ifnames=0 loopfstype=squashfs loop=$image_dir_old/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG ${ONIE_PLATFORM_EXTRA_CMDLINE_LINUX}" > /dev/null
     sonic_bootargs_old='setenv bootargs root='$demo_dev' rw rootwait panic=1 console=ttyS0,${baudrate} ${othbootargs} ${mtdparts} ${linuxargs_old}'
     fw_setenv ${FW_ARG} sonic_bootargs_old "$sonic_bootargs_old" > /dev/null || true
     sonic_boot_load_old=$(fw_printenv -n sonic_boot_load || true)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
fixes #18681

#### Why I did it
Fix sonic installer issues for marvell-arm64 platform. Following fixes are part of change,
- Fix illegal character error
- Set second image based on current image
- Fix boot_once uboot environment variable
- Fix print boot menu

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Changed the platform.conf scripts which sets uboot environment variables.
 
#### How to verify it
Tested following cases to verify the issue,
 - sonic-installer install
 - sonic-installer set-next-boot
 - sonic-installer set-default

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

