### PR TITLE
[Mellanox] Fix 4600c sensors.conf inverted psu number designation 

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2010-r0/sensors.conf
+++ b/device/mellanox/x86_64-mlnx_msn2010-r0/sensors.conf
@@ -15,7 +15,7 @@ bus "i2c-7" "i2c-1-mux (chan_id 6)"
     chip "lm75-i2c-*-4b"
         label temp1 "Ambient Fan Side Temp (air intake)"
 
-# Power supplies
+# Power controllers
 bus "i2c-5" "i2c-1-mux (chan_id 4)"
     chip "tps53679-i2c-*-70"
         label in1 "PMIC-1 PSU 12V Rail (in1)"

--- a/device/mellanox/x86_64-mlnx_msn4600-r0/sensors.conf
+++ b/device/mellanox/x86_64-mlnx_msn4600-r0/sensors.conf
@@ -162,20 +162,6 @@ bus "i2c-15" "i2c-1-mux (chan_id 6)"
 # Power supplies
 bus "i2c-4" "i2c-1-mux (chan_id 3)"
     chip "dps460-i2c-*-58"
-        label in1 "PSU-1(L) 220V Rail (in)"
-        ignore in2
-        label in3 "PSU-1(L) 12V Rail (out)"
-        label fan1 "PSU-1(L) Fan 1"
-        ignore fan2
-        ignore fan3
-        label temp1 "PSU-1(L) Temp 1"
-        label temp2 "PSU-1(L) Temp 2"
-        label temp3 "PSU-1(L) Temp 3"
-        label power1 "PSU-1(L) 220V Rail Pwr (in)"
-        label power2 "PSU-1(L) 12V Rail Pwr (out)"
-        label curr1 "PSU-1(L) 220V Rail Curr (in)"
-        label curr2 "PSU-1(L) 12V Rail Curr (out)"
-    chip "dps460-i2c-*-59"
         label in1 "PSU-2(R) 220V Rail (in)"
         ignore in2
         label in3 "PSU-2(R) 12V Rail (out)"
@@ -189,6 +175,20 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         label power2 "PSU-2(R) 12V Rail Pwr (out)"
         label curr1 "PSU-2(R) 220V Rail Curr (in)"
         label curr2 "PSU-2(R) 12V Rail Curr (out)"
+    chip "dps460-i2c-*-59"
+        label in1 "PSU-1(L) 220V Rail (in)"
+        ignore in2
+        label in3 "PSU-1(L) 12V Rail (out)"
+        label fan1 "PSU-1(L) Fan 1"
+        ignore fan2
+        ignore fan3
+        label temp1 "PSU-1(L) Temp 1"
+        label temp2 "PSU-1(L) Temp 2"
+        label temp3 "PSU-1(L) Temp 3"
+        label power1 "PSU-1(L) 220V Rail Pwr (in)"
+        label power2 "PSU-1(L) 12V Rail Pwr (out)"
+        label curr1 "PSU-1(L) 220V Rail Curr (in)"
+        label curr2 "PSU-1(L) 12V Rail Curr (out)"
 
 # Chassis fans
 chip "mlxreg_fan-isa-*"

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/sensors.conf
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/sensors.conf
@@ -220,23 +220,6 @@ bus "i2c-15" "i2c-1-mux (chan_id 6)"
 # Power supplies
 bus "i2c-4" "i2c-1-mux (chan_id 3)"
     chip "dps460-i2c-*-58"
-        label in1 "PSU-1(L) 220V Rail (in)"
-        ignore in2
-        label in3 "PSU-1(L) 12V Rail (out)"
-        label fan1 "PSU-1(L) Fan 1"
-        ignore fan2
-        ignore fan3
-        label temp1 "PSU-1(L) Temp 1"
-        label temp2 "PSU-1(L) Temp 2"
-        label temp3 "PSU-1(L) Temp 3"
-        label power1 "PSU-1(L) 220V Rail Pwr (in)"
-        label power2 "PSU-1(L) 12V Rail Pwr (out)"
-        label curr1 "PSU-1(L) 220V Rail Curr (in)"
-        label curr2 "PSU-1(L) 12V Rail Curr (out)"
-        set in3_lcrit in3_crit * 0.662
-        set in3_min in3_crit * 0.745
-        set in3_max in3_crit * 0.952
-    chip "dps460-i2c-*-59"
         label in1 "PSU-2(R) 220V Rail (in)"
         ignore in2
         label in3 "PSU-2(R) 12V Rail (out)"
@@ -250,6 +233,23 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         label power2 "PSU-2(R) 12V Rail Pwr (out)"
         label curr1 "PSU-2(R) 220V Rail Curr (in)"
         label curr2 "PSU-2(R) 12V Rail Curr (out)"
+        set in3_lcrit in3_crit * 0.662
+        set in3_min in3_crit * 0.745
+        set in3_max in3_crit * 0.952
+    chip "dps460-i2c-*-59"
+        label in1 "PSU-1(L) 220V Rail (in)"
+        ignore in2
+        label in3 "PSU-1(L) 12V Rail (out)"
+        label fan1 "PSU-1(L) Fan 1"
+        ignore fan2
+        ignore fan3
+        label temp1 "PSU-1(L) Temp 1"
+        label temp2 "PSU-1(L) Temp 2"
+        label temp3 "PSU-1(L) Temp 3"
+        label power1 "PSU-1(L) 220V Rail Pwr (in)"
+        label power2 "PSU-1(L) 12V Rail Pwr (out)"
+        label curr1 "PSU-1(L) 220V Rail Curr (in)"
+        label curr2 "PSU-1(L) 12V Rail Curr (out)"
         set in3_lcrit in3_crit * 0.662
         set in3_min in3_crit * 0.745
         set in3_max in3_crit * 0.952

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/sensors_respin.conf
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/sensors_respin.conf
@@ -255,23 +255,6 @@ bus "i2c-15" "i2c-1-mux (chan_id 6)"
 # Power supplies
 bus "i2c-4" "i2c-1-mux (chan_id 3)"
     chip "dps460-i2c-*-58"
-        label in1 "PSU-1(L) 220V Rail (in)"
-        ignore in2
-        label in3 "PSU-1(L) 12V Rail (out)"
-        label fan1 "PSU-1(L) Fan 1"
-        ignore fan2
-        ignore fan3
-        label temp1 "PSU-1(L) Temp 1"
-        label temp2 "PSU-1(L) Temp 2"
-        label temp3 "PSU-1(L) Temp 3"
-        label power1 "PSU-1(L) 220V Rail Pwr (in)"
-        label power2 "PSU-1(L) 12V Rail Pwr (out)"
-        label curr1 "PSU-1(L) 220V Rail Curr (in)"
-        label curr2 "PSU-1(L) 12V Rail Curr (out)"
-        set in3_lcrit in3_crit * 0.662
-        set in3_min in3_crit * 0.745
-        set in3_max in3_crit * 0.952
-    chip "dps460-i2c-*-59"
         label in1 "PSU-2(R) 220V Rail (in)"
         ignore in2
         label in3 "PSU-2(R) 12V Rail (out)"
@@ -288,6 +271,23 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         set in3_lcrit in3_crit * 0.662
         set in3_min in3_crit * 0.745
         set in3_max in3_crit * 0.952
+    chip "dps460-i2c-*-59"
+        label in1 "PSU-1(L) 220V Rail (in)"
+        ignore in2
+        label in3 "PSU-1(L) 12V Rail (out)"
+        label fan1 "PSU-1(L) Fan 1"
+        ignore fan2
+        ignore fan3
+        label temp1 "PSU-1(L) Temp 1"
+        label temp2 "PSU-1(L) Temp 2"
+        label temp3 "PSU-1(L) Temp 3"
+        label power1 "PSU-1(L) 220V Rail Pwr (in)"
+        label power2 "PSU-1(L) 12V Rail Pwr (out)"
+        label curr1 "PSU-1(L) 220V Rail Curr (in)"
+        label curr2 "PSU-1(L) 12V Rail Curr (out)"
+        set in3_lcrit in3_crit * 0.662
+        set in3_min in3_crit * 0.745
+        set in3_max in3_crit * 0.952        
 
 # Chassis fans
 chip "mlxreg_fan-isa-*"

--- a/device/mellanox/x86_64-nvidia_sn2201-r0/sensors.conf
+++ b/device/mellanox/x86_64-nvidia_sn2201-r0/sensors.conf
@@ -130,7 +130,7 @@ bus "i2c-8" "i2c-1-mux (chan_id 6)"
         label in8 "MONITOR CPU Board V1P8"
         label in9 "MONITOR CPU Board V1P24"
 
-# PSU PMBus sensors
+# Power supplies
 bus "i2c-3" "i2c-1-mux (chan_id 1)"
     chip "pmbus-i2c-3-58"
         label in1 "PSU-1 220V Rail(in)"

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/sensors.conf
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/sensors.conf
@@ -288,6 +288,7 @@ chip "dps460-i2c-*-5a"
     label power2 "PSU-2(R) 12V Rail Pwr (out)"
     label curr1 "PSU-2(R) 220V Rail Curr (in)"
     label curr2 "PSU-2(R) 12V Rail Curr (out)"
+    set power2_cap 0
 
 # Power converters
 chip "pmbus-i2c-*-10"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR is used to standardize several sensors.conf psu section
I. Fix 4600/4600c inverted psu number designation
II. Fix 5600 second psu miss set_power_cap label
III. Standardized comments

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
check `sensors` command output

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] <!-- image version 1 -->202311
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

