### PR TITLE
[dhcp_server cli] fix dhcp_server config cli didnt delete customized options when empty

### DIFF
--- a/dockers/docker-dhcp-server/cli-plugin-tests/test_config_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/test_config_dhcp_server.py
@@ -755,7 +755,7 @@ class TestConfigDHCPServer(object):
                 ["Vlan100", "option60"], obj=db)
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
         result = mock_db.get("CONFIG_DB", "DHCP_SERVER_IPV4|Vlan100", "customized_options@")
-        assert result == None or result == ""
+        assert result == None
 
     def test_config_dhcp_server_ipv4_option_unbind_nonexisting_intf(self, mock_db):
         runner = CliRunner()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When unbinding customized options, if there is no customized options binding on a dhcp_interface,
the cli will set the key with value empty string which will be parse as [""] by config generator.

##### Work item tracking
- Microsoft ADO **(number only)**: 27708341

#### How I did it
Delete the key when value is empty.

#### How to verify it
Unit test and local build.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
![image](https://github.com/sonic-net/sonic-buildimage/assets/32250288/da88d106-ab42-483d-8a3d-e562181f4f2b)

