### PR TITLE
[systemd-generator] add support for platform config file 

### DIFF
--- a/src/systemd-sonic-generator/systemd-sonic-generator.cpp
+++ b/src/systemd-sonic-generator/systemd-sonic-generator.cpp
@@ -27,6 +27,7 @@ const char* CONFIG_FILE = "/etc/sonic/generated_services.conf";
 const char* MACHINE_CONF_FILE = "/host/machine.conf";
 const char* ASIC_CONF_FORMAT = "/usr/share/sonic/device/%s/asic.conf";
 const char* PLATFORM_FILE_FORMAT = "/usr/share/sonic/device/%s/platform.json";
+const char* PLATFORM_CONF_FORMAT = "/usr/share/sonic/device/%s/services.conf";
 const char* DPU_PREFIX = "dpu";
 
 
@@ -64,6 +65,13 @@ const char* g_platform_file_format = NULL;
 const char* get_platform_file_format() {
     return (g_platform_file_format) ? g_platform_file_format : PLATFORM_FILE_FORMAT;
 }
+
+const char* g_platform_conf_format = NULL;
+const char* get_platform_conf_format() {
+    return (g_platform_conf_format) ? g_platform_conf_format : PLATFORM_CONF_FORMAT;
+}
+
+const char* get_platform();
 
 static int num_asics;
 static char** multi_instance_services;
@@ -440,16 +448,15 @@ int get_install_targets(std::string unit_file, char* targets[]) {
 }
 
 
-int get_unit_files(char* unit_files[]) {
+int get_unit_files(const char* config_file, char* unit_files[], int unit_files_size) {
     /***
-    Reads a list of unit files to be installed from /etc/sonic/generated_services.conf
+    Reads a list of unit files to be installed from config_file
     ***/
     FILE *fp;
     char *line = NULL;
     size_t len = 0;
     ssize_t read;
     char *pos;
-    const char* config_file = get_config_file();
 
     fp = fopen(config_file, "r");
 
@@ -459,12 +466,14 @@ int get_unit_files(char* unit_files[]) {
     }
 
     int num_unit_files = 0;
-    num_multi_inst = 0;
 
-    multi_instance_services = (char**) calloc(MAX_NUM_UNITS, sizeof(char *));
+    if (!multi_instance_services) {
+        num_multi_inst = 0;
+        multi_instance_services = (char**) calloc(MAX_NUM_UNITS, sizeof(char *));
+    }
 
     while ((read = getline(&line, &len, fp)) != -1) {
-        if (num_unit_files >= MAX_NUM_UNITS) {
+        if (num_unit_files >= unit_files_size) {
             fprintf(stderr, "Maximum number of units exceeded, ignoring extras\n");
             break;
         }
@@ -499,6 +508,23 @@ int get_unit_files(char* unit_files[]) {
     fclose(fp);
 
     return num_unit_files;
+}
+
+int get_platform_unit_files(char* unit_files[], int unit_files_size)
+{
+    const char* platform = get_platform();
+    if (!platform) {
+        return 0;
+    }
+
+    char config_file[PATH_MAX];
+    snprintf(config_file, PATH_MAX, get_platform_conf_format(), platform);
+
+    if (access(config_file, R_OK) != 0) {
+        return 0;
+    }
+
+    return get_unit_files(config_file, unit_files, unit_files_size);
 }
 
 
@@ -1080,7 +1106,9 @@ int ssg_main(int argc, char **argv) {
     num_dpus = get_num_of_dpu();
 
     install_dir = std::string(argv[1]) + "/";
-    num_unit_files = get_unit_files(unit_files);
+    const char* config_file = get_config_file();
+    num_unit_files = get_unit_files(config_file, unit_files, MAX_NUM_UNITS);
+    num_unit_files += get_platform_unit_files(&unit_files[num_unit_files], MAX_NUM_UNITS - num_unit_files);
 
     // Install and render midplane network service for smart switch
     if (smart_switch) {
@@ -1125,6 +1153,8 @@ int ssg_main(int argc, char **argv) {
         free(multi_instance_services[i]);
     }
     free(multi_instance_services);
+    multi_instance_services = NULL;
+    num_multi_inst = 0;
 
     if (is_valid_pointer(platform_info)) {
         json_object_put(platform_info);

--- a/src/systemd-sonic-generator/systemd-sonic-generator.cpp
+++ b/src/systemd-sonic-generator/systemd-sonic-generator.cpp
@@ -957,7 +957,7 @@ static int render_network_service_for_smart_switch() {
     size_t file_size = ftell(fp);
     fseek(fp, 0, SEEK_SET);
     size_t len = file_size + buffer_instruction.length() + 1;
-    char *unit_content = (char*) malloc(len);
+    char *unit_content = (char*) calloc(len, sizeof(unit_content));
     if (unit_content == NULL) {
         fprintf(stderr, "Failed to allocate memory for %s\n", unit_path.c_str());
         fclose(fp);

--- a/src/systemd-sonic-generator/systemd-sonic-generator.h
+++ b/src/systemd-sonic-generator/systemd-sonic-generator.h
@@ -18,6 +18,7 @@ extern const char* CONFIG_FILE;
 extern const char* MACHINE_CONF_FILE;
 extern const char* ASIC_CONF_FORMAT;
 extern const char* PLATFORM_FILE_FORMAT;
+extern const char* PLATFORM_CONF_FORMAT;
 extern const char* g_lib_systemd;
 extern const char* g_etc_systemd;
 extern const char* g_unit_file_prefix; 
@@ -25,17 +26,20 @@ extern const char* g_config_file;
 extern const char* g_machine_config_file;
 extern const char* g_asic_conf_format;
 extern const char* g_platform_file_format;
+extern const char* g_platform_conf_format;
 
 /* C-functions under test */
 extern const char* get_unit_file_prefix();
 extern const char* get_config_file();
 extern const char* get_machine_config_file();
 extern const char* get_asic_conf_format();
+extern const char* get_platform_conf_format();
 extern std::string insert_instance_number(const std::string& unit_file, int instance, const std::string& instance_prefix);
 extern int ssg_main(int argc, char** argv);
 extern int get_num_of_asic();
 extern int get_install_targets(std::string unit_file, char* targets[]);
-extern int get_unit_files(char* unit_files[]);
+extern int get_unit_files(const char* config_file, char* unit_files[], int unit_files_size);
+extern int get_platform_unit_files(char* unit_files[], int unit_files_size);
 // #ifdef __cplusplus
 // }
 // #endif


### PR DESCRIPTION
In addition to /etc/sonic/generated_services.conf, the generator now processes the platform config in /usr/share/sonic/device/%platform/services.conf

#### Why I did it
This is to support platform-specific systemd-sonic-generator config file. It allows loading additional services based on platform (/etc/machine.conf) information on boot.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added /usr/share/sonic/device/**%platform**/services.conf processing (if such file exists).
The **%platform** is already available in systemd-sonic-generator (read from /etc/machine.conf)
The unit test is updated to cover new functionality.

#### How to verify it
Run the systemd-sonic-generator unit tests

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

