### PR TITLE
[NTP] 🐞 Fix config template to init default parameters

### DIFF
--- a/files/image_config/ntp/ntp.conf.j2
+++ b/files/image_config/ntp/ntp.conf.j2
@@ -18,14 +18,14 @@ leapfile /usr/share/zoneinfo/leap-seconds.list
 {# Adding NTP servers. We need to know if we have some pools, to set proper
 config -#}
 {% set ns = namespace(is_pools=false) %}
-{% for server in NTP_SERVER if NTP_SERVER[server].admin_state != 'disabled' and
-                               NTP_SERVER[server].resolve_as and
-                               NTP_SERVER[server].association_type -%}
+{% for server in NTP_SERVER if NTP_SERVER[server].admin_state != 'disabled' -%}
     {% set config = NTP_SERVER[server] -%}
     {# Server options -#}
     {% set soptions = '' -%}
-    {# Server access control options -#}
-    {% set aoptions = '' -%}
+
+    {# Define defaults if not defined -#}
+    {% set association_type = config.association_type | d('server') -%}
+    {% set resolve_as = config.resolve_as | d(server) -%}
 
     {# Authentication key -#}
     {% if global.authentication == 'enabled' -%}
@@ -47,17 +47,13 @@ config -#}
     {# Check if there are any pool configured. BTW it doesn't matter what was
     configured as "resolve_as" for pools. If they were configured with FQDN they
     must remain like that -#}
-    {% set config_as = config.resolve_as -%}
-    {% if config.association_type == 'pool' -%}
-        {% set ns.is_pools = true -%}
-        {% set config_as = server -%}
-    {% else -%}
-        {% set aoptions = aoptions ~ ' nopeer' -%}
+    {% if association_type == 'pool' -%}
+        {% set resolve_as = server -%}
     {% endif -%}
 
-{{ config.association_type }} {{ config_as }}{{ soptions }}
+{{ association_type }} {{ resolve_as }}{{ soptions }}
 {% if global.server_role == 'disabled' %}
-restrict {{ config_as }} kod limited nomodify notrap noquery{{ aoptions }}
+restrict {{ resolve_as }} kod limited nomodify noquery
 {% endif %}
 
 {% endfor -%}

--- a/src/sonic-config-engine/tests/sample_output/py3/ntp.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/ntp.conf
@@ -13,10 +13,10 @@ driftfile /var/lib/ntpsec/ntp.drift
 leapfile /usr/share/zoneinfo/leap-seconds.list
 
 server 10.20.30.50 key 42 iburst version 3
-restrict 10.20.30.50 kod limited nomodify notrap noquery nopeer
+restrict 10.20.30.50 kod limited nomodify noquery
 
 pool pool.ntp.org iburst version 3
-restrict pool.ntp.org kod limited nomodify notrap noquery
+restrict pool.ntp.org kod limited nomodify noquery
 
 
 keys /etc/ntpsec/ntp.keys


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
fixes #17906

#### Why I did it
To fix NTP config generation from the minigraph and save backward compatability

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Align `ntp.conf.j2` template to generate config out of empty `NTP_SERVER` DB configuration

#### How to verify it
Out of that NTP_SERVER configuration:
```json
{
  "10.210.25.32": {},
  "10.75.202.2": {}
}
```

The next config in `ntp.conf` file should be produced:
```
server 10.210.25.32
restrict 10.210.25.32 kod limited nomodify notrap noquery nopeer

server 10.75.202.2
restrict 10.75.202.2 kod limited nomodify notrap noquery nopeer
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (it is my cat Finn)
![PXL_20230413_140941610 PORTRAIT](https://user-images.githubusercontent.com/35844154/231862413-cb630c8f-895f-4051-85e5-86802f9ccf40.jpg)