### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202311.main.0.2
+ref=202311.main.0.3


### PR DESCRIPTION


Why I did it

Release notes for Cisco 8111-32EH-O, 8102-64H-O and 8101-32FH
•	Enable Cisco Debug Shell by default
•	Support for Single CLI to display all captured dropped packets
•	Fix for [8111] MAC learning issue
•	Fix for tx_drop counter increasing while the port is oper down
•	Addressed the following test case failures:
1.	ERR pmon#sensord: Error getting sensor data: ltc2
2.	[8102] syncd: SAI_LOG|SAI_API_SWITCH: Unrecognized la_event LA_EVENT_ETHERNET_PTP_OVER_ETH
3.	test_watchdog_reboot: AssertionError
4.	DualTor: qos/test_tunnel_qos_remap
5.	platform_tests.api.test_fan_drawer_fans.TestFanDrawerFans

How I did it

Update platform version to 202311.main.0.3


