### PR TITLE
[Seastone] fix issue #18767 psu fan speed issue

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/fan.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/fan.py
@@ -188,6 +188,8 @@ class Fan(FanBase):
             sysfs_path = sysfs_path.format(fan_index[self.fan_tray_index])
             pwm = self._api_helper.read_txt_file(sysfs_path)
             target = round(int(pwm) / 255 * 100.0)
+        else:
+            return self.get_speed()
 
         return target
 


### PR DESCRIPTION
#### Why I did it

Fix issue #18767 fan information could not been shown issue.

#### How I did it

Add psu fan get_target_speed api support.

#### How to verify it

Use `show platform fan` in branch 202311.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

