### PR TITLE
Modification for kdump for remote server dump

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -206,6 +206,10 @@ sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/mke2fs
 sudo cp files/initramfs-tools/setfacl $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/setfacl
 sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/setfacl
 
+# Hook into initramfs: configure the network-interfaces on boot, and also enabling the DHCP for all interfaces
+sudo cp files/initramfs-tools/network-interface-preboot-init $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/network-interface-preboot-init
+sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/network-interface-preboot-init
+
 # Hook into initramfs: rename the management interfaces on arista switches
 sudo cp files/initramfs-tools/arista-net $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-net
 sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-net

--- a/files/initramfs-tools/network-interface-preboot-init
+++ b/files/initramfs-tools/network-interface-preboot-init
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Iterate over all detected network interfaces and configure them to use DHCP   
+interfaces=$(ip -o link show | awk -F': ' '{print $2}' | grep -E '^e')
+
+# Bring up each Ethernet interface
+for interface in $interfaces; do
+    ip link set dev $interface up
+    dhclient $interface
+done
+
+echo("Maigc for kdump: All interfaces have been intialized and DHCP is enabled. Can be verified by command,  \"ip addr\"")
+ip addr


### PR DESCRIPTION
#### Why I did it
For pre-boot initialization of network interfaces.
For my case, I had to test and implement the remote kdump file transfer using SSH and the crash kernel did not load configs from /etc/network/interfaces config file.

#### How I did it
1) New file created for a custom script, "network-interface-preboot-init"
2) Modified the "build_debian.sh" file for adding this to the initramfs-tools/scripts/ directory.

#### How to verify it
After this change the remote SSH kdump file transfer would be possible because network not reachable issue arose as the default "vmliuz" image did not change state of the interfaces to "UP" on crash kernel load. Neither did it load configs from /etc/network/interfaces config file.
