### PR TITLE
Bump up rif_id_max to match other 7280cr3 SKUs

### DIFF
--- a/device/arista/x86_64-arista_7280cr3_32d4/Arista-7280CR3-C32D4/jr2-a7280cr3-32d4-32x100G+4x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32d4/Arista-7280CR3-C32D4/jr2-a7280cr3-32d4-32x100G+4x400G.config.bcm
@@ -744,7 +744,7 @@ ucode_port_34=CDGE5:core_0.34
 ucode_port_35=CDGE11:core_1.35
 ucode_port_36=CDGE10:core_1.36
 
-rif_id_max=0x4000
+rif_id_max=0x6000
 
 dma_desc_aggregator_chain_length_max.BCM8869X=1000
 dma_desc_aggregator_buff_size_kb.BCM8869X=100

--- a/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C32P4/jr2-a7280cr3-32p4-32x100G+4x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C32P4/jr2-a7280cr3-32p4-32x100G+4x400G.config.bcm
@@ -734,7 +734,7 @@ ucode_port_34=CDGE5:core_0.34
 ucode_port_35=CDGE11:core_1.35
 ucode_port_36=CDGE10:core_1.36
 
-rif_id_max=0x4000
+rif_id_max=0x6000
 
 dma_desc_aggregator_chain_length_max.BCM8869X=1000
 dma_desc_aggregator_buff_size_kb.BCM8869X=100


### PR DESCRIPTION
In the following commit the rif_id_max was increased from 0x4000 to 0x6000 but it appears a few 7280cr3 SKUs were missed:
https://github.com/sonic-net/sonic-buildimage/pull/7529/commits/c3506ceaa8fdb1f98ee08239afa426ed0d914f46

Fixing those missing SKUs

