### PR TITLE
Use apt preferences to prefer packages from the mirror over the main repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,7 @@ sources.list.*
 
 # Generated mirror configs
 apt-retries-count
+
+# Prefer mirror snapshot packages
+prefer-snapshots.*
+!prefer-snapshots*.j2

--- a/dockers/docker-base-bookworm/Dockerfile.j2
+++ b/dockers/docker-base-bookworm/Dockerfile.j2
@@ -28,6 +28,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Configure data sources for apt/dpkg
 COPY ["dpkg_01_drop", "/etc/dpkg/dpkg.cfg.d/01_drop"]
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]
+COPY ["prefer-snapshots.{{ CONFIGURED_ARCH }}", "/etc/apt/preferences.d/prefer-snapshots"]
 COPY ["no_install_recommend_suggest", "/etc/apt/apt.conf.d"]
 COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
 

--- a/dockers/docker-base-bullseye/Dockerfile.j2
+++ b/dockers/docker-base-bullseye/Dockerfile.j2
@@ -28,6 +28,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Configure data sources for apt/dpkg
 COPY ["dpkg_01_drop", "/etc/dpkg/dpkg.cfg.d/01_drop"]
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]
+COPY ["prefer-snapshots.{{ CONFIGURED_ARCH }}", "/etc/apt/preferences.d/prefer-snapshots"]
 COPY ["no_install_recommend_suggest", "/etc/apt/apt.conf.d"]
 COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
 COPY ["apt-multiple-retries", "/etc/apt/apt.conf.d"]

--- a/files/apt/prefer-snapshots.j2
+++ b/files/apt/prefer-snapshots.j2
@@ -1,0 +1,6 @@
+{% for mirror_domain in MIRROR_DOMAINS.split(',') %}
+# Give a higher preference to packages coming from the snapshot repo
+Package: *
+Pin: origin "{{ mirror_domain }}"
+Pin-Priority: 600
+{% endfor %}

--- a/scripts/build_mirror_config.sh
+++ b/scripts/build_mirror_config.sh
@@ -63,6 +63,14 @@ if [ "$MIRROR_SNAPSHOT" == y ]; then
     sed -i -e "/^#*deb.*packages.trafficmanager.net/! s/^#*deb/#&/" -e "\$a#SET_REPR_MIRRORS" $CONFIG_PATH/sources.list.$ARCHITECTURE
 fi
 
+if [ "$MIRROR_SNAPSHOT" == y ]; then
+    MIRROR_DOMAINS=packages.trafficmanager.net
+else
+    MIRROR_DOMAINS=
+fi
+TEMPLATE=files/apt/prefer-snapshots.j2
+MIRROR_DOMAINS=$MIRROR_DOMAINS j2 $TEMPLATE > $CONFIG_PATH/prefer-snapshots.$ARCHITECTURE
+
 # Handle apt retry count config
 APT_RETRIES_COUNT_FILENAME=apt-retries-count
 TEMPLATE=files/apt/$APT_RETRIES_COUNT_FILENAME.j2

--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -51,6 +51,8 @@ ARG CROSS_CC=${gcc_arch}-gcc
 ARG CROSS_CXX=${gcc_arch}-g++
 {%- endif %}
 
+COPY ["prefer-snapshots.{{ CONFIGURED_ARCH }}", "/etc/apt/preferences.d/prefer-snapshots"]
+
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -52,6 +52,8 @@ ARG CROSS_CC=${gcc_arch}-gcc
 ARG CROSS_CXX=${gcc_arch}-g++
 {%- endif %}
 
+COPY ["prefer-snapshots.{{ CONFIGURED_ARCH }}", "/etc/apt/preferences.d/prefer-snapshots"]
+
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Currently, if snapshots are enabled, then packages from the mirror and packages from the main repos have the same priority. This becomes problematic if the main repos have a package that's of a newer version than the snapshots, and something wants to install that newer version, even though it could be installed with that older version. For example, if a -dev package is being installed, and there's a newer version of the -dev and the main package in the main repos (compared to the snapshots), then apt will try to install the newer -dev package, which will have a dependency on the newer main package, but the older main package will still be installed. It could instead try to install the older -dev package from the snapshots, which would be installable.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

To fix this, use apt preferences to give the pacakges in the snapshot repo a higher priority than the ones in the main repo. This should be enough to convince apt to use packages from the snapshot repo whenever possible, but it still allows packages from the main repo to be installed, in case some change comes in that requires that for whatever reason.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

