### PR TITLE
kdump fix, initializing network interface on boot over 2023-05 release

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -223,6 +223,12 @@ sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/ssd-upg
 sudo cp files/initramfs-tools/fsck-rootfs $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/fsck-rootfs
 sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/fsck-rootfs
 
+
+# Hook into initramfs: Initialize network interfaces on boot, useful for kdump kernel image
+sudo cp files/initramfs-tools/network-interface-preboot-init $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/network-interface-preboot-init
+sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/network-interface-preboot-init
+
+
 ## Hook into initramfs: after partition mount and loop file mount
 ## 1. Prepare layered file system
 ## 2. Bind-mount docker working directory (docker overlay storage cannot work over overlay rootfs)

--- a/files/scripts/network-interface-preboot-init
+++ b/files/scripts/network-interface-preboot-init
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Iterate over all detected network interfaces and configure them to use DHCP   
+interfaces=$(ip -o link show | awk -F': ' '{print $2}' | grep -E '^e')
+
+# Bring up each Ethernet interface
+for interface in $interfaces; do
+    ip link set dev $interface up
+    dhclient $interface
+done
+
+echo("All interfaces have been intialized and DHCP is enabled. Can be verified by command,  \"ip addr\"")
+ip addr
+
+


### PR DESCRIPTION

#### Why I did it
For pre-boot initialization of network interfaces.
For my case, I had to test and implement the remote kdump file transfer using SSH and the crash kernel did not load configs from /etc/network/interfaces config file.

#### How I did it
New file created for a custom script, "network-interface-preboot-init"
Modified the "build_debian.sh" file for adding this to the initramfs-tools/scripts/ directory.

#### How to verify it
After this change the remote SSH kdump file transfer would be possible because network not reachable issue arose as the default "vmlinuz" image did not change state of the interfaces to "UP" on crash kernel load. Neither did it load configs from /etc/network/interfaces config file.