### PR TITLE
[Nokia][chassis] modify Nokia-IXR7250E-36x400G platform specified reboot to allow SUP to log expected/unexpected midplane/module connectivity msg

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_reboot
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_reboot
@@ -1,12 +1,27 @@
 #!/bin/bash
 
+DEVICE_MGR_REBOOT_FILE=/tmp/device_mgr_reboot
+REBOOT_CAUSE_FILE=/host/reboot-cause/reboot-cause.txt
+DEVICE_REBOOT_CAUSE_FILE=/etc/opt/srlinux/reboot-cause.txt
+kHeartbeatLostRebootCause="Heartbeat with the Supervisor card lost"
+DEVICE_DETAILS_FILE="/etc/opt/srlinux/devices/hw_details.json"
+
+ungraceful_reboot_handle()
+{
+    str=$(grep "$kHeartbeatLostRebootCause" $DEVICE_REBOOT_CAUSE_FILE 2> /dev/null)
+    status=$?
+    if [ $status -eq 0 ]; then
+        slot_num=$(jq -r '.slot_num' $DEVICE_DETAILS_FILE 2>/dev/null)
+        slot_num=$((slot_num - 1))
+        sonic-db-cli CHASSIS_STATE_DB del "CHASSIS_MODULE_REBOOT_INFO_TABLE|LINE-CARD${slot_num}"
+    fi
+}
 update_reboot_cause()
 {
-    DEVICE_MGR_REBOOT_FILE=/tmp/device_mgr_reboot
-    REBOOT_CAUSE_FILE=/host/reboot-cause/reboot-cause.txt
-    DEVICE_REBOOT_CAUSE_FILE=/etc/opt/srlinux/reboot-cause.txt
     if [ -e  $DEVICE_MGR_REBOOT_FILE ]; then
         if [ -e $DEVICE_REBOOT_CAUSE_FILE ]; then
+            # reomve the REBOOT_INFO_TABLE entry for unpexected reboot
+            ungraceful_reboot_handle
             cp -f $DEVICE_REBOOT_CAUSE_FILE $REBOOT_CAUSE_FILE
         fi
         rm -f $DEVICE_MGR_REBOOT_FILE
@@ -18,7 +33,7 @@ update_reboot_cause()
 }
 
 echo "Disable all SFPs"
-python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); platform_chassis.tx_disable_all_sfps()'
+python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); platform_chassis.tx_disable_all_sfps()' &
 sleep 3
 
 # update the reboot_cuase file when reboot is trigger by device-mgr


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For Linecard expected and unexpected reboot, Supervisor needs to log a expected and unexpected lost connectivity message.  After the new mechanism has been introduced by PRs.   For Nokia-IXR7250E-36x600G linecard,  it requires to handle missing heartbeat reboot is unexpected reboot for SUP.   Issue https://github.com/sonic-net/sonic-buildimage/issues/18540

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
On Nokia-IXR7250E-36x400G platform, missing heartbeat reboot also call the "sudo reboot" which creates a CHASSIS_MODULE_REBOOT_INFO_TABLE entry expected reboot on SUP.  Since heartbeat reboot is unexpected reboot, it requires to modify the platform_reboot check if it is missing heart reboot, then remove the CHASSIS_MODULE_REBOOT_INFO_TABLE entry on the SUP. So that, SUP can log the unexpected log.

#### How to verify it
1) Simulated the missing heartbeat reboot on the linecard, then, verify the log message on SUP as below
```
Apr 25 19:50:19.286081 ixre-cpm-chassis7 WARNING pmon#chassisd: Module LINE-CARD0 went off-line!
Apr 25 19:50:22.549416 ixre-cpm-chassis7 WARNING pmon#chassisd: Unexpected: Module LINE-CARD0 lost midplane connectivity.
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

