### PR TITLE
Add configuration optimization to run SONiC on DPU

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -1,3 +1,6 @@
+{% if DEVICE_METADATA['localhost']['switch_type'] == "dpu" %}
+[]
+{% else %}
 {% set ipv4_addresses = [] %}
 {% set ipv6_addresses = [] %}
 {% set ipv4_loopback_addresses = [] %}
@@ -77,3 +80,5 @@
     }
 {% endif %}
 ]
+{% endif %}
+

--- a/dockers/docker-orchagent/switch.json.j2
+++ b/dockers/docker-orchagent/switch.json.j2
@@ -18,6 +18,7 @@
 [
     {
         "SWITCH_TABLE:switch": {
+{% if not DEVICE_METADATA.localhost.switch_type or DEVICE_METADATA.localhost.switch_type != "dpu" %}
             "ecmp_hash_seed": "{{ hash_seed_value }}",
             "lag_hash_seed": "{{ hash_seed_value }}",
             "fdb_aging_time": "600",
@@ -25,6 +26,7 @@
             "ordered_ecmp": "true"
 {% else %}
             "ordered_ecmp": "false"
+{% endif %}
 {% endif %}
         },
         "OP": "SET"

--- a/dockers/docker-platform-monitor/docker_init.j2
+++ b/dockers/docker-platform-monitor/docker_init.j2
@@ -91,6 +91,10 @@ if [ -e $SENSORS_CONF_PATH_GETTER ]; then
 fi
 {% endif %}
 
+{% if CONFIGURED_PLATFORM == "nvidia-bluefield" %}
+    mount -t debugfs none /sys/kernel/debug
+{% endif %}
+
 if [ -e $SENSORS_CONF_FILE ]; then
     HAVE_SENSORS_CONF=1
     mkdir -p /etc/sensors.d


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

- The Appliance DPU supports a limited subset of the configuration defined in the [SONiC DASH HLD](https://github.com/sonic-net/SONiC/blob/master/doc/dash/dash-sonic-hld.md).

- Configure SWSS and GMNI to communicate on the Appliance DPU.

- Add a sample configuration for the `appliance` topology.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Disable configuration unsupported by the Appliance DPU based on the device type.

#### How to verify it
Run VNET-to-VNET sonic-mgmt test.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

