### PR TITLE
[202311][dhcp_server] Add support for customize string option include comma

### DIFF
--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
@@ -94,7 +94,7 @@ class DhcpServCfgGenerator(object):
             always_send = config["always_send"] if "always_send" in config else "true"
             customized_options[option_name] = {
                 "id": config["id"],
-                "value": config["value"],
+                "value": config["value"].replace(",", "\\\\,") if option_type == "string" else config["value"],
                 "type": option_type,
                 "always_send": always_send
             }

--- a/src/sonic-dhcp-utilities/tests/test_data/test_kea_config.conf
+++ b/src/sonic-dhcp-utilities/tests/test_data/test_kea_config.conf
@@ -1,0 +1,3 @@
+{
+    "key": "dummy_value\\,dummy_value"
+}

--- a/src/sonic-dhcp-utilities/tests/test_dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcp_cfggen.py
@@ -209,61 +209,53 @@ expected_render_obj = {
         }
     }
 }
-tested_options_data = [
-    {
-        "data": {
-            "option223": {
-                "id": "223",
-                "type": "string",
-                "value": "dummy_value"
-            }
+tested_options_data = {
+    "data": {
+        "option223": {
+            "id": "223",
+            "type": "string",
+            "value": "dummy_value"
         },
-        "res": True
+        "option60": {
+            "id": "60",
+            "type": "string",
+            "value": "dummy_value"
+        },
+        "option222": {
+            "id": "222",
+            "type": "text",
+            "value": "dummy_value"
+        },
+        "option219": {
+            "id": "219",
+            "type": "uint8",
+            "value": "259"
+        },
+        "option218": {
+            "id": "218",
+            "type": "string",
+            "value": "long_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_value" +
+                        "long_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_value" +
+                        "long_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_value" +
+                        "long_valuelong_valuelong_valuelong_valuelong_value"
+        },
+        "option217": {
+            "id": "217",
+            "type": "string",
+            "value": "dummy_value,dummy_value"
+        },
+        "option216": {
+            "id": "216",
+            "type": "uint8",
+            "value": "8"
+        }
     },
-    {
-        "data": {
-            "option60": {
-                "id": "60",
-                "type": "string",
-                "value": "dummy_value"
-            }
-        },
-        "res": False
-    },
-    {
-        "data": {
-            "option222": {
-                "id": "222",
-                "type": "text",
-                "value": "dummy_value"
-            }
-        },
-        "res": False
-    },
-    {
-        "data": {
-            "option219": {
-                "id": "219",
-                "type": "uint8",
-                "value": "259"
-            }
-        },
-        "res": False
-    },
-    {
-        "data": {
-            "option223": {
-                "id": "223",
-                "type": "string",
-                "value": "long_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_value" +
-                         "long_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_value" +
-                         "long_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_valuelong_value" +
-                         "long_valuelong_valuelong_valuelong_valuelong_value"
-            }
-        },
-        "res": False
+    "res": {
+        "option223": "dummy_value",
+        "option217": "dummy_value\\\\,dummy_value",
+        "option216": "8"
     }
-]
+}
 
 
 def test_parse_port_alias(mock_swsscommon_dbconnector_init, mock_get_render_template):
@@ -397,21 +389,19 @@ def test_render_config(mock_swsscommon_dbconnector_init, mock_parse_port_map_ali
     assert json.loads(config) == expected_config if with_port_config else expected_config
 
 
-@pytest.mark.parametrize("tested_options_data", tested_options_data)
 def test_parse_customized_options(mock_swsscommon_dbconnector_init, mock_get_render_template,
-                                  mock_parse_port_map_alias, tested_options_data):
+                                  mock_parse_port_map_alias):
     dhcp_db_connector = DhcpDbConnector()
     dhcp_cfg_generator = DhcpServCfgGenerator(dhcp_db_connector)
     customized_options_ipv4 = tested_options_data["data"]
     customized_options = dhcp_cfg_generator._parse_customized_options(customized_options_ipv4)
-    if tested_options_data["res"]:
-        assert customized_options == {
-            "option223": {
-                "id": "223",
-                "value": "dummy_value",
-                "type": "string",
-                "always_send": "true"
-            }
+    expected_res = {}
+    for key, value in tested_options_data["res"].items():
+        expected_res[key] = {
+            "id": customized_options_ipv4[key]["id"],
+            "value": value,
+            "type": customized_options_ipv4[key]["type"],
+            "always_send": "true"
         }
     else:
-        assert customized_options == {}
+        assert customized_options == expected_res


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Manually cherry-pick and resolve conflicts of this PR: https://github.com/sonic-net/sonic-buildimage/pull/18796
Comma-sperated string option value would be cut down by kea-dhcp-server

##### Work item tracking
- Microsoft ADO **(number only)**: 27820324

#### How I did it
Refer to doc of kea-dhcp-server, escape comma.

> When a data field is a string and that string contains the comma (,; U+002C) character, the comma must be escaped with two backslashes (\\,; U+005C). This double escape is required because both the routine splitting of CSV data into fields and JSON use the same escape character; a single escape (\,) would make the JSON invalid. For example, the string "foo,bar" must be represented as:

#### How to verify it
1. UT passed
2. Build image and enable dhcp_server, capture packets to verify

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

