### PR TITLE
[sflow]Changing the verbosity of ERR log when interface is unavailable

### DIFF
--- a/src/sflow/hsflowd/patch/0004-When-interface-removed-just-as-we-discover-it-log-wi.patch
+++ b/src/sflow/hsflowd/patch/0004-When-interface-removed-just-as-we-discover-it-log-wi.patch
@@ -1,0 +1,33 @@
+From 3d6a3a02d12bcd742e9bcd701cb77da5f265adee Mon Sep 17 00:00:00 2001
+From: Neil McKee <neil.mckee@inmon.com>
+Date: Fri, 26 Apr 2024 11:05:19 -0700
+Subject: [PATCH] When interface removed just as we discover it, log with
+ LOG_INFO, not LOG_ERR.
+
+
+diff --git a/src/Linux/readInterfaces.c b/src/Linux/readInterfaces.c
+index 438d8ed..06427eb 100644
+--- a/src/Linux/readInterfaces.c
++++ b/src/Linux/readInterfaces.c
+@@ -758,7 +758,8 @@ extern "C" {
+ 
+       // Get the flags for this interface
+       if(ioctl(fd,SIOCGIFFLAGS, &ifr) < 0) {
+-	myLog(LOG_ERR, "device %s Get SIOCGIFFLAGS failed : %s",
++	// Can get here if the interface was just removed under our feet.
++	myLog(LOG_INFO, "device %s Get SIOCGIFFLAGS failed : %s",
+ 	      devName,
+ 	      strerror(errno));
+ 	continue;
+@@ -781,7 +782,7 @@ extern "C" {
+       u_char macBytes[6];
+       int gotMac = NO;
+       if(ioctl(fd,SIOCGIFHWADDR, &ifr) < 0) {
+-	myLog(LOG_ERR, "device %s Get SIOCGIFHWADDR failed : %s",
++	myLog(LOG_INFO, "device %s Get SIOCGIFHWADDR failed : %s",
+ 	      devName,
+ 	      strerror(errno));
+       }
+-- 
+2.30.2
+

--- a/src/sflow/hsflowd/patch/series
+++ b/src/sflow/hsflowd/patch/series
@@ -1,3 +1,4 @@
 0001-host_sflow_psample.patch
 0002-host_sflow_debian.patch
 0003-sflow-enabled-drop-monitor-support-for-SONiC.patch
+0004-When-interface-removed-just-as-we-discover-it-log-wi.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Fixes https://github.com/sonic-net/sonic-buildimage/issues/18804
#### Why I did it
Ported patch from hsflow that reduces verbosity of log from ERR to INFO when interface is unavailable.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added patch to the commit https://github.com/sflow/host-sflow/commit/e4689c674b4390681dd8ef725a8d0473abbf0572

#### How to verify it
Running tests.


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

