### PR TITLE
[voq][chassis][dhcp_relay] swss.sh try to start the dhcp_relay service although it is masked

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -242,6 +242,17 @@ function clean_up_chassis_db_tables()
 
 }
 
+is_feature_enabled()
+{
+    s=$1
+    service=${s%@*}
+    state=$(sonic-db-cli CONFIG_DB hget "FEATURE|${service}" "state")
+    if [[ $state == "enabled" ]]; then
+        echo "true"
+    else
+        echo "false"
+    fi
+}
 start_peer_and_dependent_services() {
     check_warm_boot
 
@@ -254,7 +265,10 @@ start_peer_and_dependent_services() {
             fi
         done
         for dep in ${DEPENDENT}; do
-            /bin/systemctl start ${dep}
+            state=$(is_feature_enabled $dep)
+            if [[ $state == "true" ]]; then
+                /bin/systemctl start ${dep}
+            fi
         done
         for dep in ${MULTI_INST_DEPENDENT}; do
             if [[ ! -z $DEV ]]; then

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -265,8 +265,12 @@ start_peer_and_dependent_services() {
             fi
         done
         for dep in ${DEPENDENT}; do
-            state=$(is_feature_enabled $dep)
-            if [[ $state == "true" ]]; then
+            if [[ $dep == "dhcp_relay" ]]; then
+                state=$(is_feature_enabled $dep)
+                if [[ $state == "true" ]]; then
+                    /bin/systemctl start ${dep}
+                fi
+            else
                 /bin/systemctl start ${dep}
             fi
         done


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
on Master branch, dhcp_relay is not supported in VOQ chassis. It is disabled in the FEATURE table. But based on the dependency, swss.sh always call "systemctl start" it although it's service file has been masked/disabled. The following error is logged in syslog which causes the logAnalyze failed on some of the OC tests.  Fix issue https://github.com/sonic-net/sonic-buildimage/issues/18822
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added code to swss.sh to check if service is disabled or not.  If it is disabled, do not start the service although it is in the DPENDENT_LIST.  This avoids the ERROR log shown up in the syslog file

#### How to verify it
1)  Reboot the system or execut the config reload.  The following error messages should not be seen in the syslog file
```
Apr 27 23:15:14.472425 ixre-egl-board7 ERR systemctl[7299]: Failed to start dhcp_relay.service: Unit dhcp_relay.service is masked.
Apr 27 23:15:14.476897 ixre-egl-board7 ERR systemctl[7298]: Failed to start dhcp_relay.service: Unit dhcp_relay.service is masked.
```


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)
This issue only exist in Master branch which is using the newer version of kernel.

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)
tested on Master branch.
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

