### PR TITLE
Close rsyslog plugin when rsyslog SIGTERM and EOF is sent to stream

### DIFF
--- a/files/build_templates/rsyslog_plugin.conf.j2
+++ b/files/build_templates/rsyslog_plugin.conf.j2
@@ -12,6 +12,7 @@ if re_match($programname, "{{ proc.name }}") then {
     action(type="omprog"
         binary="/usr/bin/rsyslog_plugin -r /etc/rsyslog.d/{{ proc.parse_json }} -m {{ yang_module }}"
         output="/var/log/rsyslog_plugin.log"
+        signalOnClose="SIGTERM"
         template="prog_msg")
 }
 {% endfor %}

--- a/src/sonic-eventd/rsyslog_plugin/rsyslog_plugin.cpp
+++ b/src/sonic-eventd/rsyslog_plugin/rsyslog_plugin.cpp
@@ -106,9 +106,8 @@ bool RsyslogPlugin::createRegexList() {
 void RsyslogPlugin::run() {
     lua_State* luaState = luaL_newstate();
     luaL_openlibs(luaState);
-    while(true) {
-        string line;
-        getline(cin, line);
+    string line;
+    while(getline(cin, line)) {
         if(line.empty()) {
             continue;
         }

--- a/src/sonic-eventd/rsyslog_plugin_tests/rsyslog_plugin_ut.cpp
+++ b/src/sonic-eventd/rsyslog_plugin_tests/rsyslog_plugin_ut.cpp
@@ -253,6 +253,16 @@ TEST(rsyslog_plugin, onMessage_noParams) {
     infile.close();
 }
 
+TEST(rsyslog_plugin, run) {
+    unique_ptr<RsyslogPlugin> plugin(new RsyslogPlugin("test_mod_name", "./rsyslog_plugin_tests/test_regex_5.rc.json"));
+    EXPECT_EQ(0, plugin->onInit());
+    istringstream ss("");
+    streambuf* cinbuf = cin.rdbuf();
+    cin.rdbuf(ss.rdbuf());
+    plugin->run();
+    cin.rdbuf(cinbuf);
+}
+
 TEST(timestampFormatter, changeTimestampFormat) {
     unique_ptr<TimestampFormatter> formatter(new TimestampFormatter());
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:27882794

#### How I did it

Add signalOnClose for omprog as well as close rsyslog plugin when receives an EOF.

#### How to verify it

UT (will add sonic-mgmt testcase for storming events with logs)

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

