### PR TITLE
[202311] Fix for DNS service being canceled 

### DIFF
--- a/files/image_config/resolv-config/resolv-config.service
+++ b/files/image_config/resolv-config/resolv-config.service
@@ -2,7 +2,6 @@
 Description=Update DNS configuration
 Requires=updategraph.service
 After=updategraph.service
-BindsTo=sonic.target
 After=sonic.target
 StartLimitIntervalSec=0
 

--- a/files/image_config/resolv-config/resolv-config.service
+++ b/files/image_config/resolv-config/resolv-config.service
@@ -11,5 +11,3 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/resolv-config.sh start
 
-[Install]
-WantedBy=sonic.target


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Cherry Pick of #18670 
#### Why I did it
To fix `resolv-config.service` being cancelled:
`resolv-config.service` is started from `hostcfgd` each time there is an [update to the dns configuration or during the start of hostcfgd.
](https://github.com/sonic-net/sonic-host-services/blob/6fce4781da508709f11be595e3c7048ffd3138cb/scripts/hostcfgd#L1406) When we perform `config reload` because `hostcfgd` is restarted `resolv-config.service` is also restarted, but due to dependency of [`resolv-config.service` on `sonic.target`](https://github.com/sonic-net/sonic-buildimage/blob/ed839c65055c3cbb446ddabdc9c15b0684988139/files/image_config/resolv-config/resolv-config.service#L5)  `systemd` also tries to restart `resolv-config.service` causing cancellation of one of the instances of `resolv-config.service`. This fix removes the dependency of `resolv-config.service` on `sonic.target` and prevents double initialization of `resolv-config.service` since `hostcfgd` calls `resolv-config.service` during it's initialization so the initial configuration will not be missed after removing the dependency

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
By removing the `BindsTo` and `WantedBy` dependency to `sonic.target` the service is not restarted upon `config reload` by `systemd` anymore, which would solve the issue of the service being cancelled.

#### How to verify it
No occurrence of `Job for resolv-config.service canceled.` in `syslog` after this change is considered

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

