### PR TITLE
[Nokia][supervisor] add linecard_reboot_timeout value to platform_env.conf for Nokia-IXR7250E platform

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_env.conf
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_env.conf
@@ -2,3 +2,4 @@ usemsi=1
 dmasize=128M
 default_mtu=9100
 supervisor=1
+linecard_reboot_timeout=180


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR add the platform specified linecard_reboot_timeout value to the platform_evn.conf.  It works PR https://github.com/sonic-net/sonic-platform-daemons/pull/480 and https://github.com/sonic-net/sonic-utilities/pull/3292 to address issue https://github.com/sonic-net/sonic-buildimage/issues/18540

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add line "linecard_reboot_timeout=180" to Nokia-IXR7250E Supervisor platform_env.conf file.  This will allow the chassisd to derive the linecard_reboot_timeout value.  

Related PRs:
https://github.com/sonic-net/sonic-utilities/pull/3292
https://github.com/sonic-net/sonic-platform-daemons/pull/480
https://github.com/sonic-net/sonic-buildimage/pull/18805

#### How to verify it
This PR requires PRhttps://github.com/sonic-net/sonic-utilities/pull/3292 and  to work with
1) Test expected log. Use the CLI command "sudo reboot" to reboot  a linecard, then check the syslog on Supervisor.  The below message is logged
```
Apr 25 19:44:40.818378 ixre-cpm-chassis7 WARNING pmon#chassisd: Expected: Module LINE-CARD0 lost midplane connectivity
``` 
2. Test unepxpected log.  Using "sudo /sbin/reboot" or reboot a linecard with any crash method, then ccheck the syslog on Supervusor. The below message is logged.
```
Apr 25 19:50:22.549416 ixre-cpm-chassis7 WARNING pmon#chassisd: Unexpected: Module LINE-CARD0 lost midplane connectivity
``` 
3. Test the expexcted reboot with timeout case.  Use the CLI command "sudo reboot" on linecard. and keep it down for more than 4 minutes. The below messages are logged. 
```
Apr 25 01:25:53.877143 ixre-cpm-chassis7 WARNING sr_device_mgr: Unable to reach slot 1 (Linecard) via Midplane
Apr 25 01:25:58.402511 ixre-cpm-chassis7 WARNING pmon#chassisd: Module LINE-CARD0 went off-line!
Apr 25 01:26:01.658959 ixre-cpm-chassis7 WARNING pmon#chassisd: Expected: Module LINE-CARD0 lost midplane connectivity.
( 3 minutes after the first log)
Apr 25 01:29:10.259527 ixre-cpm-chassis7 WARNING pmon#chassisd: Unexpected: Module LINE-CARD0 midplane connectivity is not restored in 180 seconds
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

