### PR TITLE
[Arista] Update system-health configurations

### DIFF
--- a/device/arista/x86_64-arista_720dt_48s/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_720dt_48s/system_health_monitoring_config.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/system_health_monitoring_config.json
+../x86_64-arista_common/system_health_monitoring_config_fixed_psu.json

--- a/device/arista/x86_64-arista_7800_sup/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7800_sup/pmon_daemon_control.json
@@ -1,4 +1,5 @@
 {
+   "skip_fancontrol": true,
    "skip_ledd": true,
    "skip_xcvrd": true
 }

--- a/device/arista/x86_64-arista_common/pmon_daemon_control_linecard.json
+++ b/device/arista/x86_64-arista_common/pmon_daemon_control_linecard.json
@@ -1,5 +1,4 @@
 {
-    "skip_fancontrol": true,
-    "skip_pcied": true
+    "skip_fancontrol": true
 }
 

--- a/device/arista/x86_64-arista_common/system_health_monitoring_config_fixed_psu.json
+++ b/device/arista/x86_64-arista_common/system_health_monitoring_config_fixed_psu.json
@@ -1,7 +1,11 @@
 {
     "services_to_ignore": [],
     "devices_to_ignore": [
-        "asic"
+        "asic",
+        "psu.temperature",
+        "psu.voltage",
+        "PSU2 Fan",
+        "PSU1 Fan"
     ],
     "user_defined_checkers": [],
     "polling_interval": 60,


### PR DESCRIPTION
#### Why I did it

Some system-health features were initially disabled on Arista platform due to being unsupported.
However these have been implemented a while ago but configurations have remained.
This change addresses that issue.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Update the configurations under `device/arista/x86_64-arista-common` to update all Arista products to use the new configurations. 

#### How to verify it

Run `show system-health` to make sure no error is reported.
Make sure `fancontrol` is not running on the system.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311

#### Description for the changelog

Update system-health configurations for Arista devices

