### PR TITLE
kdump fix, initializing network interface on crash kernel boot over 2023_11 release

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -448,6 +448,13 @@ sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "echo 'MODULES=most' >> /etc/in
 # Copy vmcore-sysctl.conf to add more vmcore dump flags to kernel
 sudo cp files/image_config/kdump/vmcore-sysctl.conf $FILESYSTEM_ROOT/etc/sysctl.d/
 
+# Required for kdump_remote_ssh_dump: Initialize network interfaces and enable DHCP.
+# Currently used on crash kernel boot only
+sudo cp files/scripts/network-interface-state-init.sh $FILESYSTEM_ROOT/usr/sbin/network-interface-state-init.sh
+sudo chmod +x $FILESYSTEM_ROOT/usr/sbin/network-interface-state-init.sh
+
+
+
 #Adds a locale to a debian system in non-interactive mode
 sudo sed -i '/^#.* en_US.* /s/^#//' $FILESYSTEM_ROOT/etc/locale.gen && \
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT locale-gen "en_US.UTF-8"

--- a/files/scripts/network-interface-state-init.sh
+++ b/files/scripts/network-interface-state-init.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Get list of Ethernet interfaces excluding Docker interfaces
+interfaces=$(ip -o link show | awk -F': ' '$2 ~ /^e/ && $2 !~ /^docker/ {print $2}')
+
+# Loop through each Ethernet interface
+for interface in $interfaces; do
+    # Check if the interface is already up
+    if ! ip link show dev $interface | grep -q 'state UP'; then
+        # Bring up the interface if it's not already up
+        ip link set dev $interface up || { echo "Failed to bring up interface $interface"; continue; }
+    fi
+
+    # Configure the interface to use DHCP
+    dhclient $interface || echo "Failed to configure DHCP for interface $interface"
+done


### PR DESCRIPTION

#### Why I did it
For pre-boot initialization of network interfaces.
For my case, I had to test and implement the remote kdump file transfer using SSH and the crash kernel did not load configs from /etc/network/interfaces config file.

#### How I did it
New file created for a custom script, "network-interface-state-init.sh"
Modified the "build_debian.sh" file for adding this to the /usr/sbin/network-interface-state-init.sh.

#### How to verify it
After this change the remote SSH kdump file transfer would be possible because network not reachable issue arose as the default crash kernel image did not change state of the interfaces to "UP" upon load. Neither did it load configs from /etc/network/interfaces config file.