### PR TITLE
[sonic-slave]: Add remake to debug makefiles

### DIFF
--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -91,6 +91,7 @@ RUN apt-get update && apt-get install -y \
         {{ GZ_COMPRESS_PROGRAM }} \
         git \
         build-essential \
+        remake \
         libtool \
         lintian \
         sudo \

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -97,6 +97,7 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
         {{ GZ_COMPRESS_PROGRAM }} \
         git \
         build-essential \
+        remake \
         libtool \
         lintian \
         sudo \

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -93,6 +93,7 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
         {{ GZ_COMPRESS_PROGRAM }} \
         git \
         build-essential \
+        remake \
         libtool \
         lintian \
         sudo \


### PR DESCRIPTION
Remake supports GDB style debugging for Makefiles making it easier to traverse complicated Makefiles and stepping through build steps, printing variables etc. It supports most of the well-known GDB commands for breakpoints, printing, stepping etc.

https://bashdb.sourceforge.net/remake/

#### Why I did it

`remake` enables developers to debug Makefiles.

##### Work item tracking
Not applicable

#### How I did it
Add remake to the apt install list.

#### How to verify it

Running remake from inside the slave container. For instance, running remake with the `-X` option starts the debugger.

`remake -X -f slave.mk PLATFORM=vs ... EXTRA_DOCKER_TARGETS=docker-ptf.gz buster` 

will run the Makefile and dump into a prompt for further debugging. 

#### Which release branch to backport (provide reason below if selected)

Not applicable.

#### Tested branch (Please provide the tested image version)

Not applicable.

#### Description for the changelog

Add remake to sonic-slave buster, bullseye and bookworm images for easier Makefile debugging

#### Link to config_db schema for YANG module changes
Not applicable

#### A picture of a cute animal (not mandatory but encouraged)

![remake](https://github.com/sonic-net/sonic-buildimage/assets/110003254/3f715698-f613-4ae4-9aaf-762c1fc8f66c)
