### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202305.1.0.11
+ref=202305.1.0.12


### PR DESCRIPTION

Why I did it

Release notes for Cisco 8111-32EH-O, 8102-64H-O and 8101-32FH

- [8111] Fix for Mac Aging issue - packet drops while running few traffic tests
- [8111] Fix for show platform idprom Issue
- [8101] Support for migration of platform config during upgrade for 400G
- Fix for queue watermark for lossless queues
- Optimization for TM PFC reaction for all port speeds
- Add voq numbers in “show platform npu voq stats” CLI
- Support for Single CLI to display all captured dropped packets
- Build updates for bullseye SDK debian support
- Addressed the following test case failures:
      1. [8102] syncd: Unrecognized la_event LA_EVENT_ETHERNET_PTP_OVER_ETH
      2. test_watchdog_reboot: AssertionError

- Caveats:
      1. For [8111][t0] failures in test_copp.py due to residual ptf processes in ptf container.  Test cases passed when re-run after a cleanup.
      2. For [8111][t0] failures in test_acl.py.  Passed when test cases run individually.  Investigating the failures
      3. Expediting the code drop for [8111].  Run analysis pending for other platforms.

How I did it

Update platform version to 202305.1.0.12


