### PR TITLE
[YANG] Align to authentication check with load_minigraph to cover more scenarios

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/aaa.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/aaa.json
@@ -15,8 +15,8 @@
         "eStrKey": "Pattern",
         "eStr": ["false|true|False|True"]
     },
-    "AAA_AUTHORIZATION_TEST": {
-        "desc": "Configure an authorization type in AAA table."
+    "AAA_AUTHENTICATION_TEST": {
+        "desc": "Configure an authentication type in AAA table."
     },
     "AAA_AUTHENTICATION_TEST_TACACS_WITHOUT_TACPLUS": {
         "desc": "Configure tacacs in authentication type in AAA table without TACPLUS table.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/aaa.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/aaa.json
@@ -19,7 +19,7 @@
         "desc": "Configure an authorization type in AAA table."
     },
     "AAA_AUTHENTICATION_TEST_TACACS_WITHOUT_TACPLUS": {
-        "desc": "Configure tacacs in authorization type in AAA table without TACPLUS table.",
+        "desc": "Configure tacacs in authentication type in AAA table without TACPLUS table.",
         "eStr": ["Authentication with 'tacacs+' is not allowed when passkey not exists."]
     },
     "AAA_ACCOUNTING_TEST": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/aaa.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/aaa.json
@@ -18,9 +18,9 @@
     "AAA_AUTHORIZATION_TEST": {
         "desc": "Configure an authorization type in AAA table."
     },
-    "AAA_AUTHORIZATION_TEST_TACACS_WITHOUT_TACPLUS": {
+    "AAA_AUTHENTICATION_TEST_TACACS_WITHOUT_TACPLUS": {
         "desc": "Configure tacacs in authorization type in AAA table without TACPLUS table.",
-        "eStr": ["Authorization with 'tacacs+' is not allowed when passkey not exists."]
+        "eStr": ["Authentication with 'tacacs+' is not allowed when passkey not exists."]
     },
     "AAA_ACCOUNTING_TEST": {
         "desc": "Configure an accounting type in AAA table."

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/aaa.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/aaa.json
@@ -4,7 +4,7 @@
             "sonic-system-aaa:AAA": {
                 "AAA_LIST": [{
                         "type": "authentication",
-                        "login": "tacacs+,local",
+                        "login": "local",
                         "failthrough": "True",
                         "fallback": "True",
                         "trace": "True",
@@ -45,11 +45,11 @@
         }
     },
 
-    "AAA_AUTHORIZATION_TEST": {
+    "AAA_AUTHENTICATION_TEST": {
         "sonic-system-aaa:sonic-system-aaa": {
             "sonic-system-aaa:AAA": {
                 "AAA_LIST": [{
-                        "type": "authorization",
+                        "type": "authentication",
                         "login": "tacacs+"
                 }]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/aaa.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/aaa.json
@@ -64,11 +64,11 @@
         }
     },
 
-    "AAA_AUTHORIZATION_TEST_TACACS_WITHOUT_TACPLUS": {
+    "AAA_AUTHENTICATION_TEST_TACACS_WITHOUT_TACPLUS": {
         "sonic-system-aaa:sonic-system-aaa": {
             "sonic-system-aaa:AAA": {
                 "AAA_LIST": [{
-                        "type": "authorization",
+                        "type": "authentication",
                         "login": "tacacs+"
                 }]
             }

--- a/src/sonic-yang-models/yang-models/sonic-system-aaa.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-aaa.yang
@@ -43,8 +43,8 @@ module sonic-system-aaa {
                     default "local";
                 }
 
-                must 'not(./type = "authorization" and contains(./login, "tacacs+") and not(/tacacs:sonic-system-tacacs/tacacs:TACPLUS/tacacs:global/tacacs:passkey))' {
-                    error-message "Authorization with 'tacacs+' is not allowed when passkey not exists.";
+                must 'not(./type = "authentication" and contains(./login, "tacacs+") and not(/tacacs:sonic-system-tacacs/tacacs:TACPLUS/tacacs:global/tacacs:passkey))' {
+                    error-message "Authentication with 'tacacs+' is not allowed when passkey not exists.";
                 }
 
                 leaf failthrough {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This will cover more cases for those only have authentication enabled with tacacs but not authorization enabled. Also, make it algin with the check in load_minigraph
##### Work item tracking
- Microsoft ADO **(number only)**: 26732148

#### How I did it
Change to authentication
#### How to verify it
unit test
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

