### PR TITLE
[Mellanox]: Improve FW upgrade: add locking mechanism

### DIFF
--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -17,6 +17,8 @@ declare -r SCRIPT_NAME="$(basename "$0")"
 declare -r SCRIPT_PATH="$(readlink -f "$0")"
 declare -r SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
 
+declare -r LOCKFILE="/tmp/mlxfwmanager-lock"
+
 declare -r YES_PARAM="yes"
 declare -r NO_PARAM="no"
 
@@ -157,6 +159,20 @@ function ExitSuccess() {
     fi
 
     exit "${EXIT_SUCCESS}"
+}
+
+function LockStateChange() {
+    LogInfo "Locking ${LOCKFILE} from ${SCRIPT_NAME}"
+
+    exec {LOCKFD}>${LOCKFILE}
+    /usr/bin/flock -x ${LOCKFD}
+
+    LogInfo "Locked ${LOCKFILE} (${LOCKFD}) from ${SCRIPT_NAME}"
+}
+
+function UnlockStateChange() {
+    LogInfo "Unlocking ${LOCKFILE} (${LOCKFD}) from ${SCRIPT_NAME}"
+    /usr/bin/flock -u ${LOCKFD}
 }
 
 function WaitForDevice() {
@@ -356,9 +372,19 @@ function ExitIfQEMU() {
     fi
 }
 
+function Cleanup() {
+    if [[ -n "${LOCKFD}" ]]; then
+        UnlockStateChange
+    fi
+}
+
+trap Cleanup EXIT
+
 ParseArguments "$@"
 
 ExitIfQEMU
+
+LockStateChange
 
 WaitForDevice
 


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
The enhancement allows avoiding errors in the logs when cold reboot is executed during service restart

#### Why I did it
* To improve Mellanox FW upgrade

#### Work item tracking
* N/A

#### How I did it
* Added locking mechanism for Mellanox FW upgrade

#### How to verify it
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
1. Run cold reboot after DUT first install

#### Which release branch to backport (provide reason below if selected)
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master <!-- image version 1 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
* N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```