### PR TITLE
[FRR]Fix zebra parse attribute problem for encap

### DIFF
--- a/src/sonic-frr/patch/0028-zebra-fix-parse-attr-problems-for-encap.patch
+++ b/src/sonic-frr/patch/0028-zebra-fix-parse-attr-problems-for-encap.patch
@@ -1,0 +1,290 @@
+From bef0dda1527782830b034dce9fbdc35a5b3aa88e Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Wed, 8 May 2024 12:46:08 -0400
+Subject: [PATCH 1/3] zebra: Move netlink_route_nexthop_encap
+
+Move this static function earlier so we can avoid
+a predecleartion.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+---
+ zebra/rt_netlink.c | 82 +++++++++++++++++++++++-----------------------
+ 1 file changed, 41 insertions(+), 41 deletions(-)
+
+diff --git a/zebra/rt_netlink.c b/zebra/rt_netlink.c
+index fc9e8c457c..42b4d7c199 100644
+--- a/zebra/rt_netlink.c
++++ b/zebra/rt_netlink.c
+@@ -1732,6 +1732,47 @@ static inline bool _netlink_set_tag(struct nlmsghdr *n, unsigned int maxlen,
+ 	return true;
+ }
+ 
++/*
++ * The function returns true if the attribute could be added
++ * to the message, otherwise false is returned.
++ */
++static int netlink_route_nexthop_encap(struct nlmsghdr *n, size_t nlen,
++				       struct nexthop *nh)
++{
++	struct rtattr *nest;
++	struct vxlan_nh_encap* encap_data;
++
++	switch (nh->nh_encap_type) {
++	case NET_VXLAN:
++		if (!nl_attr_put16(n, nlen, RTA_ENCAP_TYPE, nh->nh_encap_type))
++			return false;
++
++		nest = nl_attr_nest(n, nlen, RTA_ENCAP);
++		if (!nest)
++			return false;
++
++		encap_data = &nh->nh_encap.encap_data;
++
++		if (!nl_attr_put32(n, nlen, 0 /* VXLAN_VNI */,
++				   encap_data->vni))
++			return false;
++
++		if (ZEBRA_DEBUG_KERNEL)
++			zlog_debug(
++				"%s: VNI:%d RMAC:%pEA", __func__, encap_data->vni,
++				&encap_data->rmac);
++
++		if (!nl_attr_put(n, nlen, 1 /* VXLAN_RMAC */,
++					&encap_data->rmac, sizeof(encap_data->rmac)))
++			return false;
++
++		nl_attr_nest_end(n, nest);
++		break;
++	}
++
++	return true;
++}
++
+ /* This function takes a nexthop as argument and
+  * appends to the given netlink msg. If the nexthop
+  * defines a preferred source, the src parameter
+@@ -1972,47 +2013,6 @@ static bool nexthop_set_src(const struct nexthop *nexthop, int family,
+ 	return false;
+ }
+ 
+-/*
+- * The function returns true if the attribute could be added
+- * to the message, otherwise false is returned.
+- */
+-static int netlink_route_nexthop_encap(struct nlmsghdr *n, size_t nlen,
+-				       struct nexthop *nh)
+-{
+-	struct rtattr *nest;
+-	struct vxlan_nh_encap* encap_data;
+-
+-	switch (nh->nh_encap_type) {
+-	case NET_VXLAN:
+-		if (!nl_attr_put16(n, nlen, RTA_ENCAP_TYPE, nh->nh_encap_type))
+-			return false;
+-
+-		nest = nl_attr_nest(n, nlen, RTA_ENCAP);
+-		if (!nest)
+-			return false;
+-
+-		encap_data = &nh->nh_encap.encap_data;
+-
+-		if (!nl_attr_put32(n, nlen, 0 /* VXLAN_VNI */,
+-				   encap_data->vni))
+-			return false;
+-
+-		if (ZEBRA_DEBUG_KERNEL)
+-			zlog_debug(
+-				"%s: VNI:%d RMAC:%pEA", __func__, encap_data->vni,
+-				&encap_data->rmac);
+-
+-		if (!nl_attr_put(n, nlen, 1 /* VXLAN_RMAC */,
+-					&encap_data->rmac, sizeof(encap_data->rmac)))
+-			return false;
+-
+-		nl_attr_nest_end(n, nest);
+-		break;
+-	}
+-
+-	return true;
+-}
+-
+ /*
+  * Routing table change via netlink interface, using a dataplane context object
+  *
+-- 
+2.17.1
+
+
+From 35e1282543bda57563a68046489e0fdb1a0416d1 Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Wed, 8 May 2024 12:48:12 -0400
+Subject: [PATCH 2/3] zebra: Move fpm check to inside of
+ netlink_route_nexthop_encap
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+---
+ zebra/rt_netlink.c | 26 +++++++++++++-------------
+ 1 file changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/zebra/rt_netlink.c b/zebra/rt_netlink.c
+index 42b4d7c199..e52916fa07 100644
+--- a/zebra/rt_netlink.c
++++ b/zebra/rt_netlink.c
+@@ -1736,12 +1736,15 @@ static inline bool _netlink_set_tag(struct nlmsghdr *n, unsigned int maxlen,
+  * The function returns true if the attribute could be added
+  * to the message, otherwise false is returned.
+  */
+-static int netlink_route_nexthop_encap(struct nlmsghdr *n, size_t nlen,
+-				       struct nexthop *nh)
++static int netlink_route_nexthop_encap(bool fpm, struct nlmsghdr *n,
++				       size_t nlen, struct nexthop *nh)
+ {
+ 	struct rtattr *nest;
+ 	struct vxlan_nh_encap* encap_data;
+ 
++	if (!fpm)
++		return true;
++
+ 	switch (nh->nh_encap_type) {
+ 	case NET_VXLAN:
+ 		if (!nl_attr_put16(n, nlen, RTA_ENCAP_TYPE, nh->nh_encap_type))
+@@ -2276,12 +2279,10 @@ ssize_t netlink_route_multipath_msg_encode(int cmd,
+ 				 * Add encapsulation information when
+ 				 * installing via FPM.
+ 				 */
+-				if (fpm) {
+-					if (!netlink_route_nexthop_encap(&req->n,
+-									 datalen,
+-									 nexthop))
+-						return 0;
+-				}
++				if (!netlink_route_nexthop_encap(fpm, &req->n,
++								 datalen,
++								 nexthop))
++					return 0;
+ 
+ 				nexthop_num++;
+ 				break;
+@@ -2336,11 +2337,10 @@ ssize_t netlink_route_multipath_msg_encode(int cmd,
+ 				 * Add encapsulation information when installing via
+ 				 * FPM.
+ 				 */
+-				if (fpm) {
+-					if (!netlink_route_nexthop_encap(
+-						    &req->n, datalen, nexthop))
+-						return 0;
+-				}
++				if (!netlink_route_nexthop_encap(fpm, &req->n,
++								 datalen,
++								 nexthop))
++					return 0;
+ 
+ 				if (!setsrc && src1) {
+ 					if (p->family == AF_INET)
+-- 
+2.17.1
+
+
+From 9f3314723a0569c1d2b5aec5088af87c1d06d40e Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Wed, 8 May 2024 12:52:12 -0400
+Subject: [PATCH 3/3] zebra: Ensure multipath encodes vxlan right for fpm usage
+
+The fpm code path for the dplane_fpm_nl module was improperly
+encoding the multipath nexthop data for vxlan type routes.
+Move this into the embedded nexthop encoding where it belongs.
+
+This change makes it so that the usage of `-M dplane_fpm_nl`
+is now producing the same netlink messages that `-M fpm`
+produces when using vxlan based nexthops.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+---
+ zebra/rt_netlink.c | 43 ++++++++++++++++++++++++-------------------
+ 1 file changed, 24 insertions(+), 19 deletions(-)
+
+diff --git a/zebra/rt_netlink.c b/zebra/rt_netlink.c
+index e52916fa07..3f51894be3 100644
+--- a/zebra/rt_netlink.c
++++ b/zebra/rt_netlink.c
+@@ -1737,7 +1737,7 @@ static inline bool _netlink_set_tag(struct nlmsghdr *n, unsigned int maxlen,
+  * to the message, otherwise false is returned.
+  */
+ static int netlink_route_nexthop_encap(bool fpm, struct nlmsghdr *n,
+-				       size_t nlen, struct nexthop *nh)
++				       size_t nlen, const struct nexthop *nh)
+ {
+ 	struct rtattr *nest;
+ 	struct vxlan_nh_encap* encap_data;
+@@ -1794,10 +1794,13 @@ static int netlink_route_nexthop_encap(bool fpm, struct nlmsghdr *n,
+  * The function returns true if the nexthop could be added
+  * to the message, otherwise false is returned.
+  */
+-static bool _netlink_route_build_multipath(
+-	const struct prefix *p, const char *routedesc, int bytelen,
+-	const struct nexthop *nexthop, struct nlmsghdr *nlmsg, size_t req_size,
+-	struct rtmsg *rtmsg, const union g_addr **src, route_tag_t tag)
++static bool _netlink_route_build_multipath(const struct prefix *p,
++					   const char *routedesc, int bytelen,
++					   const struct nexthop *nexthop,
++					   struct nlmsghdr *nlmsg,
++					   size_t req_size, struct rtmsg *rtmsg,
++					   const union g_addr **src,
++					   route_tag_t tag, bool fpm)
+ {
+ 	char label_buf[256];
+ 	struct vrf *vrf;
+@@ -1906,6 +1909,13 @@ static bool _netlink_route_build_multipath(
+ 	if (!_netlink_set_tag(nlmsg, req_size, tag))
+ 		return false;
+ 
++	/*
++	 * Add encapsulation information when installing via
++	 * FPM.
++	 */
++	if (!netlink_route_nexthop_encap(fpm, nlmsg, req_size, nexthop))
++		return false;
++
+ 	nl_attr_rtnh_end(nlmsg, rtnh);
+ 	return true;
+ }
+@@ -1940,7 +1950,7 @@ _netlink_mpls_build_multipath(const struct prefix *p, const char *routedesc,
+ 	bytelen = (family == AF_INET ? 4 : 16);
+ 	return _netlink_route_build_multipath(p, routedesc, bytelen,
+ 					      nhlfe->nexthop, nlmsg, req_size,
+-					      rtmsg, src, 0);
++					      rtmsg, src, 0, false);
+ }
+ 
+ static void _netlink_mpls_debug(int cmd, uint32_t label, const char *routedesc)
+@@ -2327,19 +2337,14 @@ ssize_t netlink_route_multipath_msg_encode(int cmd,
+ 						    : "multipath";
+ 				nexthop_num++;
+ 
+-				if (!_netlink_route_build_multipath(
+-					    p, routedesc, bytelen, nexthop,
+-					    &req->n, datalen, &req->r, &src1,
+-					    tag))
+-					return 0;
+-
+-				/*
+-				 * Add encapsulation information when installing via
+-				 * FPM.
+-				 */
+-				if (!netlink_route_nexthop_encap(fpm, &req->n,
+-								 datalen,
+-								 nexthop))
++				if (!_netlink_route_build_multipath(p, routedesc,
++								    bytelen,
++								    nexthop,
++								    &req->n,
++								    datalen,
++								    &req->r,
++								    &src1, tag,
++								    fpm))
+ 					return 0;
+ 
+ 				if (!setsrc && src1) {
+-- 
+2.17.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -25,3 +25,4 @@
 0025-bgp-community-memory-leak-fix.patch
 0026-bgp-fib-suppress-announce-fix.patch
 0027-lib-Do-not-convert-EVPN-prefixes-into-IPv4-IPv6-if-n.patch
+0028-zebra-fix-parse-attr-problems-for-encap.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Adding patch https://github.com/FRRouting/frr/pull/15968.
This fixes zebra encap problem for multipath with evpn

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Ported the fix as patch.

#### How to verify it
Testing EVPN scenarios.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

