### PR TITLE
Adding Buffer pool enum type both for sonic chassis

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/buffer_pool.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/buffer_pool.json
@@ -5,6 +5,9 @@
     "BUFFER_POOL_CORRECT_TYPE_EGRESS_VALUE": {
         "desc": "BUFFER_POOL_CORRECT_TYPE_EGRESS_VALUE no failure."
     },
+    "BUFFER_POOL_CORRECT_TYPE_BOTH_VALUE": {
+        "desc": "BUFFER_POOL_CORRECT_TYPE_BOTH_VALUE no failure."
+    },
     "BUFFER_POOL_WRONG_TYPE_VALUE": {
         "desc": "BUFFER_POOL_WRONG_TYPE_VALUE pattern failure.",
         "eStr": "wrong"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/buffer_pool.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/buffer_pool.json
@@ -27,6 +27,20 @@
             }
         }
     },
+    "BUFFER_POOL_CORRECT_TYPE_BOTH_VALUE": {
+        "sonic-buffer-pool:sonic-buffer-pool": {
+            "sonic-buffer-pool:BUFFER_POOL": {
+                "BUFFER_POOL_LIST": [
+                {
+                    "name": "Ethernet4",
+                    "mode": "static",
+                    "size": "12766208",
+                    "type": "both"
+                }
+                ]
+            }
+        }
+    },
     "BUFFER_POOL_WRONG_TYPE_VALUE": {
         "sonic-buffer-pool:sonic-buffer-pool": {
             "sonic-buffer-pool:BUFFER_POOL": {

--- a/src/sonic-yang-models/yang-models/sonic-buffer-pool.yang
+++ b/src/sonic-yang-models/yang-models/sonic-buffer-pool.yang
@@ -33,6 +33,7 @@ module sonic-buffer-pool {
                     type enumeration {
                         enum ingress;
                         enum egress;
+                        enum both;
                     }
                     description "Buffer Pool Type";
                 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Added buffer pool type as both for yang model verification

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

