### PR TITLE
[Yang][Bugfix] Vxlan tunnel yang model to support dest_ip and name length.

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2487,7 +2487,8 @@ VXLAN_EVPN_NVO holds the VXLAN_TUNNEL object to be used for BGP-EVPN discovered 
 {
 "VXLAN_TUNNEL": {
         "vtep1": {
-            "src_ip": "10.10.10.10"
+            "src_ip": "10.10.10.10",
+            "dst_ip": "12.12.12.12"
         }
   }
 "VXLAN_TUNNEL_MAP" : {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vxlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vxlan.json
@@ -17,13 +17,6 @@
         "desc": "VNI Out of Range in VXLAN_TUNNEL_MAP TABLE",
         "eStrKey": "Range"
     },
-    "VXLAN_TUNNEL_NAME_VALID_TEST": {
-        "desc": "Tunnel Name string length 30 is valid"
-    },
-    "VXLAN_TUNNEL_NAME_INVALID_TEST": {
-        "desc": "Tunnel Name string length 31 is invalid",
-        "eStrKey": "Range"
-    },
     "VXLAN_TUNNEL_NAME_VALID_DST_IPV4_TEST": {
         "desc": "Valid IPv4 Destination Address"
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vxlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vxlan.json
@@ -16,5 +16,18 @@
     "VXLAN_MAP_OOR_VNI": {
         "desc": "VNI Out of Range in VXLAN_TUNNEL_MAP TABLE",
         "eStrKey": "Range"
+    },
+    "VXLAN_TUNNEL_NAME_VALID_TEST": {
+        "desc": "Tunnel Name string length 30 is valid"
+    },
+    "VXLAN_TUNNEL_NAME_INVALID_TEST": {
+        "desc": "Tunnel Name string length 31 is invalid",
+        "eStrKey": "Range"
+    },
+    "VXLAN_TUNNEL_NAME_VALID_DST_IPV4_TEST": {
+        "desc": "Valid IPv4 Destination Address"
+    },
+    "VXLAN_TUNNEL_NAME_VALID_DST_IPV6_TEST": {
+        "desc": "Valid IPv6 Destination Address"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vxlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vxlan.json
@@ -17,6 +17,13 @@
         "desc": "VNI Out of Range in VXLAN_TUNNEL_MAP TABLE",
         "eStrKey": "Range"
     },
+    "VXLAN_TUNNEL_NAME_VALID_TEST": {
+        "desc": "Tunnel Name string length 30 is valid"
+    },
+    "VXLAN_TUNNEL_NAME_INVALID_TEST": {
+        "desc": "Tunnel Name string length 0 is invalid",
+        "eStrKey": "Must"
+    },
     "VXLAN_TUNNEL_NAME_VALID_DST_IPV4_TEST": {
         "desc": "Valid IPv4 Destination Address"
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vxlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vxlan.json
@@ -165,6 +165,68 @@
             }
         }
     },
+    "VXLAN_TUNNEL_NAME_VALID_TEST": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan100"
+                    }
+                ]
+            }
+        },
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "30CharachterLongName1234567890",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            },
+            "sonic-vxlan:VXLAN_TUNNEL_MAP": {
+                "VXLAN_TUNNEL_MAP_LIST": [
+                    {
+                        "name": "30CharachterLongName1234567890",
+                        "mapname": "map_100_Vlan100",
+                        "vlan": "Vlan100",
+                        "vni": "16777214"
+                    }
+                ]
+            }
+        }
+    },
+    "VXLAN_TUNNEL_NAME_INVALID_TEST": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan100"
+                    }
+                ]
+            }
+         },
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+             },
+            "sonic-vxlan:VXLAN_TUNNEL_MAP": {
+                "VXLAN_TUNNEL_MAP_LIST": [
+                    {
+                        "name": "",
+                        "mapname": "map_100_Vlan100",
+                        "vlan": "Vlan100",
+                        "vni": "16777214"
+                    }
+                ]
+            }
+        }
+    },
     "VXLAN_TUNNEL_NAME_VALID_DST_IPV4_TEST": {
         "sonic-vlan:sonic-vlan": {
             "sonic-vlan:VLAN": {
@@ -211,7 +273,7 @@
             "sonic-vxlan:VXLAN_TUNNEL": {
                 "VXLAN_TUNNEL_LIST": [
                     {
-                        "name": "30CharachterLongName1234567890",
+                        "name": "tunnel1",
                         "src_ip": "1.2.3.4",
                         "dst_ip": "2001::1:2:3:4"
                     }
@@ -220,7 +282,7 @@
             "sonic-vxlan:VXLAN_TUNNEL_MAP": {
                 "VXLAN_TUNNEL_MAP_LIST": [
                     {
-                        "name": "30CharachterLongName1234567890",
+                        "name": "tunnel1",
                         "mapname": "map_100_Vlan100",
                         "vlan": "Vlan100",
                         "vni": "16777214"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vxlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vxlan.json
@@ -8,7 +8,7 @@
                     }
                 ]
             }
-         },
+        },
         "sonic-vxlan:sonic-vxlan": {
             "sonic-vxlan:VXLAN_TUNNEL": {
                 "VXLAN_TUNNEL_LIST": [
@@ -17,7 +17,7 @@
                         "src_ip": "1.2.3.4"
                     }
                 ]
-             },
+            },
             "sonic-vxlan:VXLAN_EVPN_NVO": {
                 "VXLAN_EVPN_NVO_LIST": [
                     {
@@ -25,7 +25,7 @@
                         "source_vtep": "vtep1"
                     }
                 ]
-             },
+            },
             "sonic-vxlan:VXLAN_TUNNEL_MAP": {
                 "VXLAN_TUNNEL_MAP_LIST": [
                     {
@@ -35,8 +35,8 @@
                         "vni": "100"
                     }
                 ]
-             }
-         }
+            }
+        }
     },
     "VXLAN_VALID_V6_TUNNEL_TEST": {
         "sonic-vlan:sonic-vlan": {
@@ -47,7 +47,7 @@
                     }
                 ]
             }
-         },
+        },
         "sonic-vxlan:sonic-vxlan": {
             "sonic-vxlan:VXLAN_TUNNEL": {
                 "VXLAN_TUNNEL_LIST": [
@@ -56,7 +56,7 @@
                         "src_ip": "2001::1:2:3:4"
                     }
                 ]
-             },
+            },
             "sonic-vxlan:VXLAN_EVPN_NVO": {
                 "VXLAN_EVPN_NVO_LIST": [
                     {
@@ -64,7 +64,7 @@
                         "source_vtep": "vtep1"
                     }
                 ]
-             },
+            },
             "sonic-vxlan:VXLAN_TUNNEL_MAP": {
                 "VXLAN_TUNNEL_MAP_LIST": [
                     {
@@ -74,8 +74,8 @@
                         "vni": "100"
                     }
                 ]
-             }
-         }
+            }
+        }
     },
     "VXLAN_EVPN_NVO_WITHOUT_VTEP": {
         "sonic-vxlan:sonic-vxlan": {
@@ -86,8 +86,8 @@
                         "source_vtep": "vtep1"
                     }
                 ]
-             }
-         }
+            }
+        }
     },
     "VXLAN_MAP_WITHOUT_VTEP": {
         "sonic-vlan:sonic-vlan": {
@@ -98,7 +98,7 @@
                     }
                 ]
             }
-         },
+        },
         "sonic-vxlan:sonic-vxlan": {
             "sonic-vxlan:VXLAN_TUNNEL_MAP": {
                 "VXLAN_TUNNEL_MAP_LIST": [
@@ -109,8 +109,8 @@
                         "vni": "100"
                     }
                 ]
-             }
-         }
+            }
+        }
     },
     "VXLAN_MAP_WITHOUT_VLAN": {
         "sonic-vxlan:sonic-vxlan": {
@@ -121,7 +121,7 @@
                         "src_ip": "1.2.3.4"
                     }
                 ]
-             },
+            },
             "sonic-vxlan:VXLAN_TUNNEL_MAP": {
                 "VXLAN_TUNNEL_MAP_LIST": [
                     {
@@ -131,10 +131,72 @@
                         "vni": "100"
                     }
                 ]
-             }
-         }
+            }
+        }
     },
     "VXLAN_MAP_OOR_VNI": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan100"
+                    }
+                ]
+            }
+        },
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            },
+            "sonic-vxlan:VXLAN_TUNNEL_MAP": {
+                "VXLAN_TUNNEL_MAP_LIST": [
+                    {
+                        "name": "vtep1",
+                        "mapname": "map_100_Vlan100",
+                        "vlan": "Vlan100",
+                        "vni": "16777299"
+                    }
+                ]
+            }
+        }
+    },
+    "VXLAN_TUNNEL_NAME_VALID_TEST": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan100"
+                    }
+                ]
+            }
+        },
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "30CharachterLongName1234567890",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            },
+            "sonic-vxlan:VXLAN_TUNNEL_MAP": {
+                "VXLAN_TUNNEL_MAP_LIST": [
+                    {
+                        "name": "30CharachterLongName1234567890",
+                        "mapname": "map_100_Vlan100",
+                        "vlan": "Vlan100",
+                        "vni": "16777214"
+                    }
+                ]
+            }
+        }
+    },
+    "VXLAN_TUNNEL_NAME_INVALID_TEST": {
         "sonic-vlan:sonic-vlan": {
             "sonic-vlan:VLAN": {
                 "VLAN_LIST": [
@@ -148,7 +210,7 @@
             "sonic-vxlan:VXLAN_TUNNEL": {
                 "VXLAN_TUNNEL_LIST": [
                     {
-                        "name": "vtep1",
+                        "name": "31CharachterLongName12345678901",
                         "src_ip": "1.2.3.4"
                     }
                 ]
@@ -156,13 +218,77 @@
             "sonic-vxlan:VXLAN_TUNNEL_MAP": {
                 "VXLAN_TUNNEL_MAP_LIST": [
                     {
-                        "name": "vtep1",
+                        "name": "31CharachterLongName12345678901",
                         "mapname": "map_100_Vlan100",
                         "vlan": "Vlan100",
-                        "vni": "16777299"
+                        "vni": "16777214"
                     }
                 ]
-             }
-         }
+            }
+        }
+    },
+    "VXLAN_TUNNEL_NAME_VALID_DST_IPV4_TEST": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan100"
+                    }
+                ]
+            }
+        },
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "30CharachterLongName1234567890",
+                        "src_ip": "1.2.3.4",
+                        "dst_ip": "1.2.3.4"
+                    }
+                ]
+            },
+            "sonic-vxlan:VXLAN_TUNNEL_MAP": {
+                "VXLAN_TUNNEL_MAP_LIST": [
+                    {
+                        "name": "30CharachterLongName1234567890",
+                        "mapname": "map_100_Vlan100",
+                        "vlan": "Vlan100",
+                        "vni": "16777214"
+                    }
+                ]
+            }
+        }
+    },
+    "VXLAN_TUNNEL_NAME_VALID_DST_IPV6_TEST": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan100"
+                    }
+                ]
+            }
+        },
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "30CharachterLongName1234567890",
+                        "src_ip": "1.2.3.4",
+                        "dst_ip": "2001::1:2:3:4"
+                    }
+                ]
+            },
+            "sonic-vxlan:VXLAN_TUNNEL_MAP": {
+                "VXLAN_TUNNEL_MAP_LIST": [
+                    {
+                        "name": "30CharachterLongName1234567890",
+                        "mapname": "map_100_Vlan100",
+                        "vlan": "Vlan100",
+                        "vni": "16777214"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vxlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vxlan.json
@@ -165,68 +165,6 @@
             }
         }
     },
-    "VXLAN_TUNNEL_NAME_VALID_TEST": {
-        "sonic-vlan:sonic-vlan": {
-            "sonic-vlan:VLAN": {
-                "VLAN_LIST": [
-                    {
-                        "name": "Vlan100"
-                    }
-                ]
-            }
-        },
-        "sonic-vxlan:sonic-vxlan": {
-            "sonic-vxlan:VXLAN_TUNNEL": {
-                "VXLAN_TUNNEL_LIST": [
-                    {
-                        "name": "30CharachterLongName1234567890",
-                        "src_ip": "1.2.3.4"
-                    }
-                ]
-            },
-            "sonic-vxlan:VXLAN_TUNNEL_MAP": {
-                "VXLAN_TUNNEL_MAP_LIST": [
-                    {
-                        "name": "30CharachterLongName1234567890",
-                        "mapname": "map_100_Vlan100",
-                        "vlan": "Vlan100",
-                        "vni": "16777214"
-                    }
-                ]
-            }
-        }
-    },
-    "VXLAN_TUNNEL_NAME_INVALID_TEST": {
-        "sonic-vlan:sonic-vlan": {
-            "sonic-vlan:VLAN": {
-                "VLAN_LIST": [
-                    {
-                        "name": "Vlan100"
-                    }
-                ]
-            }
-         },
-        "sonic-vxlan:sonic-vxlan": {
-            "sonic-vxlan:VXLAN_TUNNEL": {
-                "VXLAN_TUNNEL_LIST": [
-                    {
-                        "name": "31CharachterLongName12345678901",
-                        "src_ip": "1.2.3.4"
-                    }
-                ]
-             },
-            "sonic-vxlan:VXLAN_TUNNEL_MAP": {
-                "VXLAN_TUNNEL_MAP_LIST": [
-                    {
-                        "name": "31CharachterLongName12345678901",
-                        "mapname": "map_100_Vlan100",
-                        "vlan": "Vlan100",
-                        "vni": "16777214"
-                    }
-                ]
-            }
-        }
-    },
     "VXLAN_TUNNEL_NAME_VALID_DST_IPV4_TEST": {
         "sonic-vlan:sonic-vlan": {
             "sonic-vlan:VLAN": {

--- a/src/sonic-yang-models/yang-models/sonic-vxlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vxlan.yang
@@ -51,6 +51,7 @@ module sonic-vxlan {
                 leaf name {
                     type string;
                 }
+                must "string-length(name) != 0";
 
                 leaf src_ip {
                     type inet:ip-address;

--- a/src/sonic-yang-models/yang-models/sonic-vxlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vxlan.yang
@@ -49,14 +49,7 @@ module sonic-vxlan {
                 max-elements 1;
 
                 leaf name {
-                /* vni devices are created of the form 'name'-vlanid
-                   The kernel has a max limit of 15 chars for netdevices.
-                   keeping aside 5 chars for hyphen and vlanid the
-                   name should have a max of 10 chars */
-
-                    type string {
-                        length 1..30;
-                    }
+                    type string;
                 }
 
                 leaf src_ip {

--- a/src/sonic-yang-models/yang-models/sonic-vxlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vxlan.yang
@@ -55,11 +55,15 @@ module sonic-vxlan {
                    name should have a max of 10 chars */
 
                     type string {
-                        length 1..10;
+                        length 1..30;
                     }
                 }
 
                 leaf src_ip {
+                    type inet:ip-address;
+                }
+
+                leaf dst_ip {
                     type inet:ip-address;
                 }
             }


### PR DESCRIPTION
Fixed  the Vxlan tunnel yang model to add support for
1) Tunnel name length restriction has been removed
2) dst_ip field.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The yand modle was misisng an element and supported tunnel anme was very small.
##### Work item tracking
- Microsoft ADO **(number only)**:
27996821
#### How I did it

#### How to verify it
run yang model tests
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [X] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

