### PR TITLE
Add nvme-cli tool

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -406,7 +406,8 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     sysstat                 \
     xxd                     \
     wireless-regdb          \
-    zstd
+    zstd                    \
+    nvme-cli
 
 # Have systemd create the auditd log directory
 sudo mkdir -p ${FILESYSTEM_ROOT}/etc/systemd/system/auditd.service.d

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -26,6 +26,7 @@ RUN apt-get update &&   \
         libpci3         \
         iputils-ping    \
         pciutils        \
+        nvme-cli        \
         ethtool &&	\
 # smartmontools version should match the installed smartmontools in sonic_debian_extension build template
     apt-get install -y -t bookworm-backports \


### PR DESCRIPTION
Add nvme-cli tool 

#### Why I did it

Add nvme-cli utility tool for platforms using NVMe

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it



#### How to verify it
```
root@str-D10-U32:~# nvme version
nvme version 2.3 (git 2.3)
libnvme version 1.3 (git 1.3)
root@str-D10-U32:~# 

root@str-D10-U32:~# nvme smart-log /dev/nvme0
Smart Log for NVME device:nvme0 namespace-id:ffffffff
critical_warning                        : 0
temperature                             : 43°C (316 Kelvin)
available_spare                         : 100%
available_spare_threshold               : 10%
percentage_used                         : 0%
endurance group critical warning summary: 0
Data Units Read                         : 4,421,218 (2.26 TB)
Data Units Written                      : 2,590,713 (1.33 TB)
host_read_commands                      : 26,514,410
host_write_commands                     : 30,359,625
controller_busy_time                    : 555
power_cycles                            : 222
power_on_hours                          : 2,528
unsafe_shutdowns                        : 219
media_errors                            : 0
num_err_log_entries                     : 0
Warning Temperature Time                : 18
Critical Composite Temperature Time     : 0
Temperature Sensor 2           : 43°C (316 Kelvin)
Temperature Sensor 3           : 30°C (303 Kelvin)
Temperature Sensor 6           : 43°C (316 Kelvin)
Thermal Management T1 Trans Count       : 4
Thermal Management T2 Trans Count       : 0
Thermal Management T1 Total Time        : 1337
Thermal Management T2 Total Time        : 0
root@str-D10-U32:~#
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

