### PR TITLE
[202311][dhcp_server] Add support for monitoring used but invalid range/option #18945

### DIFF
--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
@@ -377,10 +377,10 @@ class DhcpServCfgGenerator(object):
                                               port_ips)
             if "ranges" in port_config and len(port_config["ranges"]) != 0:
                 for range_name in list(port_config["ranges"]):
+                    used_ranges.add(range_name)
                     if range_name not in ranges:
                         syslog.syslog(syslog.LOG_WARNING, f"Range {range_name} is not in range table, skip")
                         continue
-                    used_ranges.add(range_name)
                     range = ranges[range_name]
                     # Loop the IP of the dhcp interface and find the network that target range is in this network.
                     self._match_range_network(dhcp_interface, dhcp_interface_name, port, range, port_ips)

--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
@@ -150,6 +150,7 @@ class DhcpServCfgGenerator(object):
                 curr_options = {}
                 if "customized_options" in dhcp_config:
                     for option in dhcp_config["customized_options"]:
+                        used_options.add(option)
                         if option not in customized_option_keys:
                             syslog.syslog(syslog.LOG_WARNING, "Customized option {} configured for {} is not defined"
                                           .format(option, dhcp_interface_name))
@@ -185,7 +186,6 @@ class DhcpServCfgGenerator(object):
                         "lease_time": dhcp_config["lease_time"] if "lease_time" in dhcp_config else DEFAULT_LEASE_TIME,
                         "customized_options": curr_options
                     }
-                    used_options = used_options | set(subnet_obj["customized_options"])
                     subnets.append(subnet_obj)
         render_obj = {
             "subnets": subnets,

--- a/src/sonic-dhcp-utilities/tests/test_dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcp_cfggen.py
@@ -312,7 +312,7 @@ def test_parse_port(test_config_db, mock_swsscommon_dbconnector_init, mock_get_r
     parsed_port, used_ranges = dhcp_cfg_generator._parse_port(ipv4_port, tested_vlan_interfaces, vlan_members,
                                                               tested_ranges)
     assert parsed_port == (expected_parsed_port if test_config_db == "mock_config_db.json" else {})
-    assert used_ranges == ({"range1", "range0", "range3"}
+    assert used_ranges == ({"range1", "range0", "range3", "range2", "range6"}
                            if test_config_db == "mock_config_db.json" else set())
 
 
@@ -361,7 +361,7 @@ def test_construct_obj_for_template(mock_swsscommon_dbconnector_init, mock_parse
                                                        port_ips, tested_hostname, customized_options)
     assert render_obj == expected_render_obj
     assert enabled_dhcp_interfaces == {"Vlan1000", "Vlan4000", "Vlan3000", "Vlan6000"}
-    assert used_options == set(["option223"])
+    assert used_options == set(["option223", "option60"])
     assert subscribe_table == set(PORT_MODE_CHECKER)
 
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Manually cherry-pick and resolve conflicts of https://github.com/sonic-net/sonic-buildimage/pull/18945 (In 202311 we didn't have smart_switch support)
Currently, dhcpservd wouldn't monitor option / range change which is referred in DHCP_SERVER_IPV4 table but is invalid or not been defined. It would miss config when they are defined or become valid.

##### Work item tracking
- Microsoft ADO **(number only)**: 28067655

#### How I did it
Treat invalid or not defined option / range as interested items.

#### How to verify it
UT passed

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

