### PR TITLE
[Mellanox] Block setting the watchdog in the case that watchdog period is longer than the max period supported by the platform

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -21,6 +21,8 @@ import time
 
 from . import utils
 
+DEFAULT_WD_PERIOD = 65535
+
 DEVICE_DATA = {
     'x86_64-mlnx_msn2700-r0': {
         'thermal': {
@@ -54,6 +56,9 @@ DEVICE_DATA = {
                 "cpu_pack": False,
                 "comex_amb": False
             }
+        },
+        'watchdog': {
+            "max_period": 32
         }
     },
     'x86_64-mlnx_msn2410-r0': {
@@ -69,6 +74,9 @@ DEVICE_DATA = {
                 "cpu_pack": False,
                 "comex_amb": False
             }
+        },
+        'watchdog': {
+            "max_period": 32
         }
     },
     'x86_64-mlnx_msn4700_simx-r0': {
@@ -284,3 +292,16 @@ class DeviceDataManager:
             for sysfs_node in sysfs_nodes:
                 conditions.append(lambda: os.path.exists(f'/sys/module/sx_core/asic0/module{sfp_index}/{sysfs_node}'))
         return utils.wait_until_conditions(conditions, 300, 1)
+
+    @classmethod
+    @utils.read_only_cache()
+    def get_watchdog_max_period(cls):
+        platform_data = DEVICE_DATA.get(cls.get_platform_name(), None)
+        if not platform_data:
+            return DEFAULT_WD_PERIOD
+
+        watchdog_data = platform_data.get('watchdog', None)
+        if not watchdog_data:
+            return DEFAULT_WD_PERIOD
+
+        return watchdog_data.get('max_period', None)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/watchdog.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/watchdog.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2023 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,7 @@ import time
 
 from sonic_platform_base.watchdog_base import WatchdogBase
 from . import utils
+from .device_data import DeviceDataManager
 
 """ ioctl constants """
 IO_WRITE = 0x40000000
@@ -150,7 +151,7 @@ class WatchdogImplBase(WatchdogBase):
         """
 
         ret = WD_COMMON_ERROR
-        if seconds < 0:
+        if seconds < 0 or seconds > DeviceDataManager.get_watchdog_max_period():
             return ret
 
         try:

--- a/platform/mellanox/mlnx-platform-api/tests/test_watchdog.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_watchdog.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -97,9 +97,11 @@ class TestWatchdog:
     @mock.patch('sonic_platform.watchdog.WatchdogImplBase.open_handle', mock.MagicMock())
     @mock.patch('sonic_platform.watchdog.fcntl.ioctl', mock.MagicMock())
     @mock.patch('sonic_platform.watchdog.WatchdogImplBase.is_armed')
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_watchdog_max_period', mock.MagicMock(return_value=32))
     def test_arm_disarm_watchdog2(self, mock_is_armed):
         watchdog = WatchdogType2('watchdog2')
         assert watchdog.arm(-1) == -1
+        assert watchdog.arm(33) == -1
         mock_is_armed.return_value = False
         watchdog.arm(10)
         mock_is_armed.return_value = True


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Currently the platform API will arm the watchdog w/o checking the required watchdog period. If the watchdog period is longer than the max period supported by the platform, it will cause issue on some specific platform. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Verify whether the required watchdog period is longer than the max period supported, if yes then return failure.

#### How to verify it

test with watchdog util to set the watchdog period to different values including larger than the max supported period, all case passed.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

