### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202311.main.0.3
+ref=202311.1.0.1


### PR DESCRIPTION
Why I did it
Release notes for Cisco 8102-64H-O, 8101-32FH, and 8111-32EH-O
• [8111] Fix for Mac Aging issue - packet drops while running few traffic tests
• Optimization for TM PFC reaction for all port speeds
• Ether type change for Packet Capture CLI for SDK 1.66.1
• Updated sensors.conf for upstream test_sensors.py mgmt case
• SONiC-Mgmt Test Cases:
      - Several test case failures incurred due to test environment have been addressed.
      - Will upload test results to Kusto once run analysis is complete

How I did it
Update platform version to 202311.1.0.1


