### PR TITLE
[build][FedRAMP]Update docker-base-bullseye to build from python:3.9.17-slim-bullseye

### DIFF
--- a/dockers/docker-base-bullseye/Dockerfile.j2
+++ b/dockers/docker-base-bullseye/Dockerfile.j2
@@ -5,7 +5,7 @@ FROM {{ prefix }}multiarch/debian-debootstrap:armhf-bullseye
 {% elif CONFIGURED_ARCH == "arm64" and (MULTIARCH_QEMU_ENVIRON == "y" or CROSS_BUILD_ENVIRON == "y") %}
 FROM {{ prefix }}multiarch/debian-debootstrap:arm64-bullseye
 {% else %}
-FROM {{ prefix }}{{DOCKER_BASE_ARCH}}/debian:bullseye
+FROM {{ prefix }}{{DOCKER_BASE_ARCH}}/python:3.9.17-slim-bullseye
 {% endif %}
 
 # Clean documentation in FROM image

--- a/files/build/versions/dockers/docker-base-bullseye/versions-deb-bullseye
+++ b/files/build/versions/dockers/docker-base-bullseye/versions-deb-bullseye
@@ -1,3 +1,4 @@
+build-essential==12.9
 ca-certificates==20210119
 curl==7.74.0-1.3+deb11u11
 iproute2==5.10.0-4
@@ -8,6 +9,8 @@ libbpf0==1:0.3-2
 libbrotli1==1.0.9-2+b2
 libbsd0==0.11.3-1+deb11u1
 libc6==2.31-13+deb11u10
+libc6==2.31-13+deb11u8
+libc6-dev==2.31-13+deb11u8
 libcap2==1:2.44-1
 libcap2-bin==1:2.44-1
 libcurl4==7.74.0-1.3+deb11u11
@@ -51,6 +54,7 @@ libsqlite3-0==3.34.1-3
 libssh2-1==1.9.0-2
 libssl-dev==1.1.1n-0+deb11u5+fips
 libssl1.1==1.1.1n-0+deb11u5+fips
+libtinfo6==6.2+20201114-2+deb11u2
 libwrap0==7.6.q-31
 libxtables12==1.8.7-1
 libzmq5==4.3.4-1+deb11u1


### PR DESCRIPTION
#### Why I did it


python3=3.9.2-3 version in bullseye release has CVEs filed:

* CVE-2023-24535 ([https://security-tracker.debian.org/tracker/CVE-2023-24535](https://www.google.com/url?q=https://security-tracker.debian.org/tracker/CVE-2023-24535&sa=D&source=buganizer&usg=AOvVaw3YeWfZ4nErOeqkED7_p5Gv))
    * CVE-2023-27043 ([https://security-tracker.debian.org/tracker/CVE-2023-27043](https://www.google.com/url?q=https://security-tracker.debian.org/tracker/CVE-2023-27043&sa=D&source=buganizer&usg=AOvVaw3NcwHiqti257K2kggCYOtn))
    * CVE-2023-40217 ([https://security-tracker.debian.org/tracker/CVE-2023-40217](https://www.google.com/url?q=https://security-tracker.debian.org/tracker/CVE-2023-40217&sa=D&source=buganizer&usg=AOvVaw1WvS6kzhrCXwkCF1CQthih))
    *  CVE-2015-20107 (https://security-tracker.debian.org/tracker/CVE-2015-20107) 
    * CVE-2020-10735 (https://security-tracker.debian.org/tracker/CVE-2020-10735) 
    * CVE-2020-27619 (https://security-tracker.debian.org/tracker/CVE-2020-27619) 
    * CVE-2021-28861 (https://security-tracker.debian.org/tracker/CVE-2021-28861) 
    * CVE-2021-29921 (https://security-tracker.debian.org/tracker/CVE-2021-29921) 
    * CVE-2021-3426 (https://security-tracker.debian.org/tracker/CVE-2021-3426) 
    * CVE-2021-3733 (https://security-tracker.debian.org/tracker/CVE-2021-3733) 
    * CVE-2021-3737 (https://security-tracker.debian.org/tracker/CVE-2021-3737) 
    * CVE-2021-4189 (https://security-tracker.debian.org/tracker/CVE-2021-4189) 
    * CVE-2022-0391 (https://security-tracker.debian.org/tracker/CVE-2022-0391) 
    * CVE-2022-37454 (https://security-tracker.debian.org/tracker/CVE-2022-37454) 
    * CVE-2022-42919 (https://security-tracker.debian.org/tracker/CVE-2022-42919) 
    * CVE-2022-45061 (https://security-tracker.debian.org/tracker/CVE-2022-45061) 
    * CVE-2023-24329 (https://security-tracker.debian.org/tracker/CVE-2023-24329)

Using slim version of base image python:3.9.17-slim-bullseye also helps to reduce overall docker container size.

##### Work item tracking

#### How I did it

#### How to verify it

Start a docker container and run bash commands.
```
$ python3 --version
Python 3.9.17
```
#### Which release branch to backport (provide reason below if selected)


- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
