### PR TITLE
Fix docker-wait-any script crash issue

### DIFF
--- a/files/image_config/misc/docker-wait-any
+++ b/files/image_config/misc/docker-wait-any
@@ -49,8 +49,15 @@ def wait_for_container(docker_client, container_name):
     log.log_info("Waiting on container '{}'".format(container_name))
 
     while True:
-        docker_client.wait(container_name)
-
+        try:
+            docker_client.wait(container_name)
+        except TypeError as e:
+            if g_thread_exit_event.is_set():
+                # When other thread exist, main thread will exit and docker_client will be destoryed
+                log.log_info("Container {} wait thread get exception: {}".format(container_name, e))
+            else:
+                raise e
+        
         log.log_info("No longer waiting on container '{}'".format(container_name))
 
         # If this is a dependent service and warm restart is enabled for the system/container,

--- a/files/image_config/misc/docker-wait-any
+++ b/files/image_config/misc/docker-wait-any
@@ -55,6 +55,7 @@ def wait_for_container(docker_client, container_name):
             if g_thread_exit_event.is_set():
                 # When other thread exist, main thread will exit and docker_client will be destoryed
                 log.log_info("Container {} wait thread get exception: {}".format(container_name, e))
+                return
             else:
                 raise e
         


### PR DESCRIPTION
Fix docker-wait-any script crash issue.

#### Why I did it
docker-wait-any script will create a waiting thread for multiple containers.
When any container thread exit, g_thread_exit_event will set, and main thread will exit.
However when this happen, some thread may still waiting container with following code:
    docker_client.wait(container_name)
Because docker_client will be destroyed when main thread exist, some time wait method will throw TypeError, and this will cause swss.sh crash then swss container can't start.

##### Work item tracking
- Microsoft ADO: 28052815

#### How I did it
Ignore TypeError and exit current wait thread when g_thread_exit_event set.

#### How to verify it
Pass all UT.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

#### Description for the changelog
Fix docker-wait-any script crash issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

