### PR TITLE
[TACACS] Remove debug messages from TACACS audisp.

### DIFF
--- a/src/tacacs/audisp/patches/0004-Remove-some-debug-log.patch
+++ b/src/tacacs/audisp/patches/0004-Remove-some-debug-log.patch
@@ -1,0 +1,37 @@
+From 59953e070125eca9eabf23c3f83ab69b5be2eeda Mon Sep 17 00:00:00 2001
+From: ubuntu <ubuntu@contoso.com>
+Date: Fri, 23 Sep 2022 02:48:16 +0000
+Subject: [PATCH 4/4] Remove some debug log
+
+---
+ regex_helper.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/regex_helper.c b/regex_helper.c
+index 97c0afc..19a56c3 100644
+--- a/regex_helper.c
++++ b/regex_helper.c
+@@ -30,17 +30,17 @@ int remove_password_by_regex(char* command, regex_t regex)
+ {
+     regmatch_t pmatch[REGEX_MATCH_GROUP_COUNT];
+     if (regexec(&regex, command, REGEX_MATCH_GROUP_COUNT, pmatch, 0) == REG_NOMATCH) {
+-        trace("User command not match.\n");
++        // trace("User command not match.\n");
+         return PASSWORD_NOT_FOUND;
+     }
+ 
+     if (pmatch[1].rm_so < 0) {
+-        trace("Password not found.\n");
++        // trace("Password not found.\n");
+         return PASSWORD_NOT_FOUND;
+     }
+ 
+     /* Found password between pmatch[1].rm_so to pmatch[1].rm_eo, replace it. */
+-    trace("Found password between: %d -- %d\n", pmatch[1].rm_so, pmatch[1].rm_eo);
++    // trace("Found password between: %d -- %d\n", pmatch[1].rm_so, pmatch[1].rm_eo);
+ 
+     /* Replace password with mask. */
+     size_t command_length = strlen(command);
+-- 
+2.30.2
+

--- a/src/tacacs/audisp/patches/series
+++ b/src/tacacs/audisp/patches/series
@@ -1,3 +1,4 @@
 0001-Porting-to-sonic.patch
 0002-Remove-user-secret-from-accounting-log.patch
 0003-Add-local-accounting.patch
+0004-Remove-some-debug-log.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Remove the numerous debug messages logged when TACACS+ users try to execute commands that do not match any of the formats specified in the /etc/sudoers file. The syslog messages "Audisp-tacplus: User command not match." are being logged.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Comment out the trace functions.

#### How to verify it

Repeat the operations and verify that the debug messages are not logged in syslog.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

