### PR TITLE
[eventd]: Close rsyslog plugin when rsyslog SIGTERM and EOF is sent

### DIFF
--- a/files/build_templates/rsyslog_plugin.conf.j2
+++ b/files/build_templates/rsyslog_plugin.conf.j2
@@ -14,6 +14,7 @@ if re_match($programname, "{{ proc.name }}") then {
     action(type="omprog"
         binary="/usr/bin/rsyslog_plugin -r /etc/rsyslog.d/{{ proc.parse_json }} -m {{ yang_module }}"
         output="/var/log/rsyslog_plugin.log"
+        signalOnClose="on"
         template="prog_msg")
 }
 {% endfor %}

--- a/src/sonic-eventd/rsyslog_plugin/rsyslog_plugin.cpp
+++ b/src/sonic-eventd/rsyslog_plugin/rsyslog_plugin.cpp
@@ -9,6 +9,8 @@
 
 using json = nlohmann::json;
 
+bool RsyslogPlugin::g_running;
+
 bool RsyslogPlugin::onMessage(string msg, lua_State* luaState) {
     string tag;
     event_params_t paramDict;
@@ -30,18 +32,18 @@ void parseParams(vector<string> params, vector<EventParam>& eventParams) {
         if(params[i].empty()) {
             SWSS_LOG_ERROR("Empty param provided in regex file\n");
             continue;
-       	}
+        }
         EventParam ep = EventParam();
         auto delimPos = params[i].find(':');
         if(delimPos == string::npos) { // no lua code
             ep.paramName = params[i];
         } else {
             ep.paramName = params[i].substr(0, delimPos);
-	    ep.luaCode = params[i].substr(delimPos + 1);
+            ep.luaCode = params[i].substr(delimPos + 1);
             if(ep.luaCode.empty()) {
                 SWSS_LOG_ERROR("Lua code missing after :\n");
             }
-	}
+        }
         eventParams.push_back(ep);
     }
 }
@@ -71,11 +73,11 @@ bool RsyslogPlugin::createRegexList() {
         vector<EventParam> eventParams;
         try {
             string eventRegex = jsonList[i]["regex"];
-	    regexString = timestampRegex + eventRegex;
+            regexString = timestampRegex + eventRegex;
             string tag = jsonList[i]["tag"];
             vector<string> params = jsonList[i]["params"];
-	    vector<string> timestampParams = { "month", "day", "time" };
-	    params.insert(params.begin(), timestampParams.begin(), timestampParams.end());
+            vector<string> timestampParams = { "month", "day", "time" };
+            params.insert(params.begin(), timestampParams.begin(), timestampParams.end());
             regex expr(regexString);
             expression = expr;
             parseParams(params, eventParams);
@@ -83,13 +85,13 @@ bool RsyslogPlugin::createRegexList() {
             rs.tag = tag;
             rs.regexExpression = expression;
             regexList.push_back(rs);
-	} catch (domain_error& deException) {
+        } catch (domain_error& deException) {
             SWSS_LOG_ERROR("Missing required key, throws exception: %s\n", deException.what());
             return false;
         } catch (regex_error& reException) {
             SWSS_LOG_ERROR("Invalid regex, throws exception: %s\n", reException.what());
-	    return false;
-	}
+            return false;
+        }
     }
 
     if(regexList.empty()) {
@@ -104,11 +106,11 @@ bool RsyslogPlugin::createRegexList() {
 }
 
 void RsyslogPlugin::run() {
+    signal(SIGTERM, RsyslogPlugin::signalHandler);
     lua_State* luaState = luaL_newstate();
     luaL_openlibs(luaState);
-    while(true) {
-        string line;
-        getline(cin, line);
+    string line;
+    while(RsyslogPlugin::g_running && getline(cin, line)) {
         if(line.empty()) {
             continue;
         }
@@ -132,4 +134,5 @@ RsyslogPlugin::RsyslogPlugin(string moduleName, string regexPath) {
     m_parser = unique_ptr<SyslogParser>(new SyslogParser());
     m_moduleName = moduleName;
     m_regexPath = regexPath;
+    RsyslogPlugin::g_running = true;
 }

--- a/src/sonic-eventd/rsyslog_plugin/rsyslog_plugin.h
+++ b/src/sonic-eventd/rsyslog_plugin/rsyslog_plugin.h
@@ -9,6 +9,7 @@ extern "C"
 }
 #include <string>
 #include <memory>
+#include <csignal>
 #include "syslog_parser.h"
 #include "events.h"
 #include "logger.h"
@@ -24,10 +25,17 @@ using namespace swss;
 
 class RsyslogPlugin {
 public:
+    static bool g_running;
     int onInit();
     bool onMessage(string msg, lua_State* luaState);
     void run();
     RsyslogPlugin(string moduleName, string regexPath);
+    static void signalHandler(int signum) {
+        if (signum == SIGTERM) {
+            SWSS_LOG_INFO("Rsyslog plugin received SIGTERM, shutting down");
+	    RsyslogPlugin::g_running = false;
+        }
+    }
 private:
     unique_ptr<SyslogParser> m_parser;
     event_handle_t m_eventHandle;


### PR DESCRIPTION
Backport (#18835)

Fix #18771

Microsoft ADO (number only):27882794

How I did it

Add signalOnClose for omprog as well as close rsyslog plugin when receives an EOF.

How to verify it

Verify rsyslog_plugin is running inside bgp or swss container

Run docker exec -it bgp supervisorctl restart rsyslogd

Before change:

This will not kill current rsyslog_plugin process but instead rsyslogd will now break off its end of writing to cin and send EOF to rsyslog_plugin, however will not send a signal SIGTERM or SIGKILL to rsyslog_plugin. Therefore, rsyslog plugin will run in an infinite loop forever, constantly calling getline raising CPU to 100% inside docker.

After change of adding signalOnClose="on" to conf file inside omprog, rsyslogd will now send SIGTERM to rsyslog_plugin process running inside container, and rsyslog_plugin will die.

? ( ): rsyslog_plugin/578637 ... [continued]: read()) = -1 (unknown) (INTERNAL ERROR: strerror_r(512, [buf], 128)=22)

UT (will add sonic-mgmt testcase for storming events with logs)

RCA:

1. When rsyslogd is terminated, no signal is sent to child process of rsyslog_plugin meaning that rsyslog_plugin will be constantly trying to read from cin with no writer on the other end of the pipe. This leads to rsyslog_plugin process will constantly be reading via getline infinitely.

2. Because rsyslog is terminated and the spawned rsyslog_plugin is still alive, when rsyslog starts backup again, and log is triggered, a new rsyslog_plugin will be spawned for that rsyslog process, which can lead to many "ghost" rsyslog_plugin processes that will be at high CPU usage.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

