### PR TITLE
Revert "Calulcate subport values and fix key error in hwsku.json"

### DIFF
--- a/platform/vs/tests/breakout/sample_output/sample_new_port_config.json
+++ b/platform/vs/tests/breakout/sample_output/sample_new_port_config.json
@@ -4,15 +4,13 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27,28",
 	        "speed": "50000",
-	        "index": "0",
-	        "subport": "2"
+	        "index": "0"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25,26",
 	        "speed": "50000",
-	        "index": "0",
-	        "subport": "1"
+	        "index": "0"
 	    }
     },
     "Ethernet12_1x50G_2x25G": {
@@ -20,22 +18,19 @@
                 "alias": "fortyGigE0/12",
                 "lanes": "37,38",
                 "speed": "50000",
-                "index": "3",
-                "subport": "1"
+                "index": "3"
             },
             "Ethernet14": {
                 "alias": "fortyGigE0/14",
                 "lanes": "39",
                 "speed": "25000",
-                "index": "3",
-                "subport": "2"
+                "index": "3"
             },
 	    "Ethernet15": {
                 "alias": "fortyGigE0/15",
                 "lanes": "40",
                 "speed": "25000",
-                "index": "3",
-                "subport": "3"
+                "index": "3"
             }
     },
     "Ethernet0_2x50G": {
@@ -43,15 +38,13 @@
                 "alias": "fortyGigE0/2",
                 "lanes": "27,28",
                 "speed": "50000",
-                "index": "0",
-                "subport": "2"
+                "index": "0"
             },
             "Ethernet0": {
                 "alias": "fortyGigE0/0",
                 "lanes": "25,26",
                 "speed": "50000",
-                "index": "0",
-                "subport": "1"
+                "index": "0"
             }
     },
     "Ethernet0_1x100G": {
@@ -59,8 +52,7 @@
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25,26,27,28",
 	        "speed": "100000",
-	        "index": "0",
-	        "subport": "1"
+	        "index": "0"
 	    }
     },
     "Ethernet0_4x25G":	{
@@ -68,29 +60,25 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27",
 	        "speed": "25000",
-	        "index": "0",
-	        "subport": "3"
+	        "index": "0"
 	    },
 	    "Ethernet3": {
 	        "alias": "fortyGigE0/3",
 	        "lanes": "28",
 	        "speed": "25000",
-	        "index": "0",
-	        "subport": "4"
+	        "index": "0"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25",
 	        "speed": "25000",
-	        "index": "0",
-	        "subport": "1"
+	        "index": "0"
 	    },
 	    "Ethernet1": {
 	        "alias": "fortyGigE0/1",
 	        "lanes": "26",
 	        "speed": "25000",
-	        "index": "0",
-	        "subport": "2"
+	        "index": "0"
 	    }
     },
     "Ethernet0_2x25G_1x50G": {
@@ -98,22 +86,19 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27,28",
 	        "speed": "50000",
-	        "index": "0",
-	        "subport": "3"
+	        "index": "0"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25",
 	        "speed": "25000",
-	        "index": "0",
-	        "subport": "1"
+	        "index": "0"
 	    },
 	    "Ethernet1": {
 	        "alias": "fortyGigE0/1",
 	        "lanes": "26",
 	        "speed": "25000",
-	        "index": "0",
-	        "subport": "2"
+	        "index": "0"
 	    }
     },
     "Ethernet0_1x50G_2x25G": {
@@ -121,22 +106,19 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27",
 	        "speed": "25000",
-	        "index": "0",
-	        "subport": "2"
+	        "index": "0"
 	    },
 	    "Ethernet3": {
 	        "alias": "fortyGigE0/3",
 	        "lanes": "28",
 	        "speed": "25000",
-	        "index": "0",
-	        "subport": "3"
+	        "index": "0"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25,26",
 	        "speed": "50000",
-	        "index": "0",
-	        "subport": "1"
+	        "index": "0"
 		}
     },
     "Ethernet4_4x25G": {
@@ -144,29 +126,25 @@
 		"alias": "fortyGigE0/6",
 		"lanes": "31",
 		"speed": "25000",
-		"index": "1",
-		"subport": "3"
+		"index": "1"
 	},
 	"Ethernet7": {
 		"alias": "fortyGigE0/7",
 		"lanes": "32",
 		"speed": "25000",
-		"index": "1",
-		"subport": "4"
+		"index": "1"
 	},
 	"Ethernet4": {
 		"alias": "fortyGigE0/4",
 		"lanes": "29",
 		"speed": "25000",
-		"index": "1",
-		"subport": "1"
+		"index": "1"
 	},
 	"Ethernet5": {
 		"alias": "fortyGigE0/5",
 		"lanes": "30",
 		"speed": "25000",
-		"index": "1",
-		"subport": "2"
+		"index": "1"
 	}
     },
     "Ethernet4_2x50G": {
@@ -174,15 +152,13 @@
 		"alias": "fortyGigE0/6",
 		"lanes": "31,32",
 		"speed": "50000",
-		"index": "1",
-		"subport": "2"
+		"index": "1"
 	},
 	"Ethernet4": {
 		"alias": "fortyGigE0/4",
 		"lanes": "29,30",
 		"speed": "50000",
-		"index": "1",
-		"subport": "1"
+		"index": "1"
 	}
     },
     "Ethernet8_2x50G": {
@@ -190,15 +166,13 @@
 	        "alias": "fortyGigE0/8",
 	        "lanes": "33,34",
 	        "speed": "50000",
-	        "index": "2",
-	        "subport": "1"
+	        "index": "2"
 	    },
 	    "Ethernet10": {
 	        "alias": "fortyGigE0/10",
 	        "lanes": "35,36",
 	        "speed": "50000",
-	        "index": "2",
-	        "subport": "2"
+	        "index": "2"
 	    }
     },
     "Ethernet8_1x50G_2x25G": {
@@ -206,15 +180,13 @@
 	        "alias": "fortyGigE0/10",
 	        "lanes": "35",
 	        "speed": "25000",
-	        "index": "2",
-	        "subport": "1"
+	        "index": "2"
 	    },
 	    "Ethernet11": {
 	        "alias": "fortyGigE0/11",
 	        "lanes": "36",
 	        "speed": "25000",
-	        "index": "2",
-	        "subport": "2"
+	        "index": "2"
 	    }
     },
     "Ethernet8_2x25G_1x50G": {
@@ -222,22 +194,19 @@
 	        "alias": "fortyGigE0/8",
 	        "lanes": "33",
 	        "speed": "25000",
-	        "index": "2",
-	        "subport": "1"
+	        "index": "2"
 	    },
 	    "Ethernet9": {
 	        "alias": "fortyGigE0/9",
 	        "lanes": "34",
 	        "speed": "25000",
-	        "index": "2",
-	        "subport": "2"
+	        "index": "2"
 	    },
 	    "Ethernet10": {
 	        "alias": "fortyGigE0/10",
 	        "lanes": "35,36",
 	        "speed": "50000",
-	        "index": "2",
-	        "subport": "3"
+	        "index": "2"
 	    }
     },
     "Ethernet8_1x100G": {
@@ -245,8 +214,7 @@
 	        "alias": "fortyGigE0/8",
 	        "lanes": "33,34,35,36",
 	        "speed": "100000",
-	        "index": "2",
-	        "subport": "0"
+	        "index": "2"
 	    }
     }
 }

--- a/platform/vs/tests/breakout/test_breakout_cli.py
+++ b/platform/vs/tests/breakout/test_breakout_cli.py
@@ -74,22 +74,22 @@ class TestBreakoutCli(object):
         print("**** Breakout Cli test Starts ****")
         output_dict = self.breakout(dvs, 'Ethernet0', '2x50G')
         expected_dict = expected["Ethernet0_2x50G"]
-        assert output_dict == expected_dict, "output: {} != expected: {}".format(output_dict, expected_dict)
+        assert output_dict == expected_dict
         print("**** 1X100G --> 2x50G passed ****")
 
         output_dict = self.breakout(dvs, 'Ethernet4', '4x25G[10G]')
         expected_dict = expected["Ethernet4_4x25G"]
-        assert output_dict == expected_dict, "output: {} != expected: {}".format(output_dict, expected_dict)
+        assert output_dict == expected_dict
         print("**** 1X100G --> 4x25G[10G] passed ****")
 
         output_dict = self.breakout(dvs, 'Ethernet8', '2x25G(2)+1x50G(2)')
         expected_dict = expected["Ethernet8_2x25G_1x50G"]
-        assert output_dict == expected_dict, "output: {} != expected: {}".format(output_dict, expected_dict)
+        assert output_dict == expected_dict
         print("**** 1X100G --> 2x25G(2)+1x50G(2) passed ****")
 
         output_dict = self.breakout(dvs, 'Ethernet12', '1x50G(2)+2x25G(2)')
         expected_dict = expected["Ethernet12_1x50G_2x25G"]
-        assert output_dict == expected_dict, "output: {} != expected: {}".format(output_dict, expected_dict)
+        assert output_dict == expected_dict
         print("**** 1X100G --> 1x50G(2)+2x25G(2) passed ****")
 
         # TODOFIX: remove comments once #4442 PR got merged and

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -37,7 +37,7 @@ PORT_STR = "Ethernet"
 BRKOUT_MODE = "default_brkout_mode"
 CUR_BRKOUT_MODE = "brkout_mode"
 INTF_KEY = "interfaces"
-OPTIONAL_HWSKU_ATTRIBUTES = ["fec", "autoneg", "role"]
+OPTIONAL_HWSKU_ATTRIBUTES = ["fec", "autoneg", "subport", "role"]
 
 BRKOUT_PATTERN = r'(\d{1,6})x(\d{1,6}G?)(\[(\d{1,6}G?,?)*\])?(\((\d{1,6})\))?'
 BRKOUT_PATTERN_GROUPS = 6
@@ -353,10 +353,8 @@ class BreakoutCfg(object):
     def get_config(self):
         # Ensure that we have corret number of configured lanes
         lanes_used = 0
-        total_num_ports = 0
         for entry in self._breakout_mode_entry:
             lanes_used += entry.num_assigned_lanes
-            total_num_ports += entry.num_ports
 
         if lanes_used > len(self._lanes):
             raise RuntimeError("Assigned lines count is more that available!")
@@ -378,8 +376,7 @@ class BreakoutCfg(object):
                     'alias': self._breakout_capabilities[alias_id],
                     'lanes': ','.join(lanes),
                     'speed': str(entry.default_speed),
-                    'index': self._indexes[lane_id],
-                    'subport': "0" if total_num_ports == 1 else str(alias_id + 1)
+                    'index': self._indexes[lane_id]
                 }
 
                 lane_id += lanes_per_port
@@ -425,12 +422,10 @@ def parse_platform_json_file(hwsku_json_file, platform_json_file):
         child_ports = get_child_ports(intf, brkout_mode, platform_json_file)
 
         # take optional fields from hwsku.json
-        hwsku_entry = hwsku_dict[INTF_KEY]
         for child_port in child_ports:
-            if child_port in hwsku_entry:
-                for key, item in hwsku_entry[child_port].items():
-                    if key in OPTIONAL_HWSKU_ATTRIBUTES:
-                        child_ports.get(child_port)[key] = item
+            for key, item in hwsku_dict[INTF_KEY][child_port].items():
+                if key in OPTIONAL_HWSKU_ATTRIBUTES:
+                    child_ports.get(child_port)[key] = item
 
         ports.update(child_ports)
 

--- a/src/sonic-config-engine/tests/sample_output/platform_output.json
+++ b/src/sonic-config-engine/tests/sample_output/platform_output.json
@@ -7,7 +7,6 @@
     "alias": "Eth3/1",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet9": {
@@ -18,7 +17,6 @@
     "alias": "Eth3/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet36": {
@@ -29,7 +27,6 @@
     "alias": "Eth10/1",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet98": {
@@ -40,7 +37,6 @@
     "alias": "Eth25/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet0": {
@@ -53,7 +49,6 @@
     "alias": "Eth1",
     "pfc_asym": "off",
     "speed": "100000",
-    "subport": "0",
     "tpid": "0x8100"
   },
   "Ethernet6": {
@@ -65,7 +60,6 @@
     "alias": "Eth2/2",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet4": {
@@ -77,7 +71,6 @@
     "alias": "Eth2/1",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet109": {
@@ -88,7 +81,6 @@
     "alias": "Eth28/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet108": {
@@ -99,7 +91,6 @@
     "alias": "Eth28/1",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet18": {
@@ -110,7 +101,6 @@
     "alias": "Eth5/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet100": {
@@ -122,7 +112,6 @@
     "alias": "Eth26",
     "pfc_asym": "off",
     "speed": "100000",
-    "subport": "0",
     "tpid": "0x8100"
   },
   "Ethernet34": {
@@ -133,7 +122,6 @@
     "alias": "Eth9/3",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet104": {
@@ -144,7 +132,6 @@
     "alias": "Eth27/1",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet106": {
@@ -155,7 +142,6 @@
     "alias": "Eth27/2",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet94": {
@@ -166,7 +152,6 @@
     "alias": "Eth24/3",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet126": {
@@ -177,7 +162,6 @@
     "alias": "Eth32/2",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet96": {
@@ -188,7 +172,6 @@
     "alias": "Eth25/1",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet124": {
@@ -199,7 +182,6 @@
     "alias": "Eth32/1",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet90": {
@@ -210,7 +192,6 @@
     "alias": "Eth23/3",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet91": {
@@ -221,7 +202,6 @@
     "alias": "Eth23/4",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "4",
     "tpid": "0x8100"
   },
   "Ethernet92": {
@@ -232,7 +212,6 @@
     "alias": "Eth24/1",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet93": {
@@ -243,7 +222,6 @@
     "alias": "Eth24/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet50": {
@@ -254,7 +232,6 @@
     "alias": "Eth13/3",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet51": {
@@ -265,7 +242,6 @@
     "alias": "Eth13/4",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "4",
     "tpid": "0x8100"
   },
   "Ethernet52": {
@@ -276,7 +252,6 @@
     "alias": "Eth14/1",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet53": {
@@ -287,7 +262,6 @@
     "alias": "Eth14/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet54": {
@@ -298,7 +272,6 @@
     "alias": "Eth14/3",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet99": {
@@ -309,7 +282,6 @@
     "alias": "Eth25/3",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet56": {
@@ -320,7 +292,6 @@
     "alias": "Eth15/1",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet113": {
@@ -331,7 +302,6 @@
     "alias": "Eth29/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet76": {
@@ -342,7 +312,6 @@
     "alias": "Eth20/1",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet74": {
@@ -353,7 +322,6 @@
     "alias": "Eth19/3",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet39": {
@@ -364,7 +332,6 @@
     "alias": "Eth10/3",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet72": {
@@ -375,7 +342,6 @@
     "alias": "Eth19/1",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet73": {
@@ -386,7 +352,6 @@
     "alias": "Eth19/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet70": {
@@ -397,7 +362,6 @@
     "alias": "Eth18/3",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet71": {
@@ -408,7 +372,6 @@
     "alias": "Eth18/4",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "4",
     "tpid": "0x8100"
   },
   "Ethernet32": {
@@ -419,7 +382,6 @@
     "alias": "Eth9/1",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet33": {
@@ -430,7 +392,6 @@
     "alias": "Eth9/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet16": {
@@ -441,7 +402,6 @@
     "alias": "Eth5/1",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet111": {
@@ -452,7 +412,6 @@
     "alias": "Eth28/4",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "4",
     "tpid": "0x8100"
   },
   "Ethernet10": {
@@ -463,7 +422,6 @@
     "alias": "Eth3/3",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet11": {
@@ -474,7 +432,6 @@
     "alias": "Eth3/4",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "4",
     "tpid": "0x8100"
   },
   "Ethernet12": {
@@ -485,7 +442,6 @@
     "alias": "Eth4/1",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet13": {
@@ -496,7 +452,6 @@
     "alias": "Eth4/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet58": {
@@ -507,7 +462,6 @@
     "alias": "Eth15/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet19": {
@@ -518,7 +472,6 @@
     "alias": "Eth5/3",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet59": {
@@ -529,7 +482,6 @@
     "alias": "Eth15/3",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet38": {
@@ -540,7 +492,6 @@
     "alias": "Eth10/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet78": {
@@ -551,7 +502,6 @@
     "alias": "Eth20/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet68": {
@@ -562,7 +512,6 @@
     "alias": "Eth18/1",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet14": {
@@ -573,7 +522,6 @@
     "alias": "Eth4/3",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet89": {
@@ -584,7 +532,6 @@
     "alias": "Eth23/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet88": {
@@ -595,7 +542,6 @@
     "alias": "Eth23/1",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet118": {
@@ -606,7 +552,6 @@
     "alias": "Eth30/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet119": {
@@ -617,7 +562,6 @@
     "alias": "Eth30/3",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet116": {
@@ -628,7 +572,6 @@
     "alias": "Eth30/1",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet114": {
@@ -639,7 +582,6 @@
     "alias": "Eth29/3",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet80": {
@@ -651,7 +593,6 @@
     "alias": "Eth21",
     "pfc_asym": "off",
     "speed": "100000",
-    "subport": "0",
     "tpid": "0x8100"
   },
   "Ethernet112": {
@@ -662,7 +603,6 @@
     "alias": "Eth29/1",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet86": {
@@ -673,7 +613,6 @@
     "alias": "Eth22/2",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet110": {
@@ -684,7 +623,6 @@
     "alias": "Eth28/3",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet84": {
@@ -695,7 +633,6 @@
     "alias": "Eth22/1",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet31": {
@@ -706,7 +643,6 @@
     "alias": "Eth8/4",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "4",
     "tpid": "0x8100"
   },
   "Ethernet49": {
@@ -717,7 +653,6 @@
     "alias": "Eth13/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet48": {
@@ -728,7 +663,6 @@
     "alias": "Eth13/1",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet46": {
@@ -739,7 +673,6 @@
     "alias": "Eth12/2",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet30": {
@@ -750,7 +683,6 @@
     "alias": "Eth8/3",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet29": {
@@ -761,7 +693,6 @@
     "alias": "Eth8/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet40": {
@@ -773,7 +704,6 @@
     "alias": "Eth11",
     "pfc_asym": "off",
     "speed": "100000",
-    "subport": "0",
     "tpid": "0x8100"
   },
   "Ethernet120": {
@@ -785,7 +715,6 @@
     "alias": "Eth31",
     "pfc_asym": "off",
     "speed": "100000",
-    "subport": "0",
     "tpid": "0x8100"
   },
   "Ethernet28": {
@@ -796,7 +725,6 @@
     "alias": "Eth8/1",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet66": {
@@ -807,7 +735,6 @@
     "alias": "Eth17/2",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet60": {
@@ -819,7 +746,6 @@
     "alias": "Eth16",
     "pfc_asym": "off",
     "speed": "100000",
-    "subport": "0",
     "tpid": "0x8100"
   },
   "Ethernet64": {
@@ -830,7 +756,6 @@
     "alias": "Eth17/1",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet44": {
@@ -841,7 +766,6 @@
     "alias": "Eth12/1",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet20": {
@@ -854,7 +778,6 @@
     "alias": "Eth6",
     "pfc_asym": "off",
     "speed": "100000",
-    "subport": "0",
     "tpid": "0x8100"
   },
   "Ethernet79": {
@@ -865,7 +788,6 @@
     "alias": "Eth20/3",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet69": {
@@ -876,7 +798,6 @@
     "alias": "Eth18/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet24": {
@@ -887,7 +808,6 @@
     "alias": "Eth7/1",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet26": {
@@ -898,7 +818,6 @@
     "alias": "Eth7/2",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet128": {
@@ -909,8 +828,7 @@
     "mtu": "9100",
     "alias": "Eth33",
     "pfc_asym": "off",
-    "speed": "40000",
-    "subport": "0"
+    "speed": "40000"
   },
   "Ethernet132": {
     "index": "34",
@@ -920,8 +838,7 @@
     "mtu": "9100",
     "alias": "Eth34",
     "pfc_asym": "off",
-    "speed": "25000",
-    "subport": "0"
+    "speed": "25000"
   },
   "Ethernet136": {
     "index": "35",
@@ -931,8 +848,7 @@
     "mtu": "9100",
     "alias": "Eth35/1",
     "pfc_asym": "off",
-    "speed": "10000",
-    "subport": "1"
+    "speed": "10000"
   },
   "Ethernet137": {
     "index": "35",
@@ -942,8 +858,7 @@
     "mtu": "9100",
     "alias": "Eth35/2",
     "pfc_asym": "off",
-    "speed": "10000",
-    "subport": "2"
+    "speed": "10000"
   },
   "Ethernet138": {
     "index": "35",
@@ -953,8 +868,7 @@
     "mtu": "9100",
     "alias": "Eth35/3",
     "pfc_asym": "off",
-    "speed": "10000",
-    "subport": "3"
+    "speed": "10000"
   },
   "Ethernet139": {
     "index": "35",
@@ -964,8 +878,7 @@
     "mtu": "9100",
     "alias": "Eth35/4",
     "pfc_asym": "off",
-    "speed": "10000",
-    "subport": "4"
+    "speed": "10000"
   },
   "Ethernet140": {
     "index": "36",
@@ -975,7 +888,6 @@
     "mtu": "9100",
     "alias": "Eth36/1",
     "pfc_asym": "off",
-    "subport": "1",
     "speed": "25000"
   },
   "Ethernet141": {
@@ -986,8 +898,7 @@
     "mtu": "9100",
     "alias": "Eth36/2",
     "pfc_asym": "off",
-    "speed": "25000",
-    "subport": "2"
+    "speed": "25000"
   },
   "Ethernet142": {
     "index": "36",
@@ -998,7 +909,6 @@
     "alias": "Eth36/3",
     "pfc_asym": "off",
     "speed": "50000",
-    "subport": "3",
     "role": "Dpc"
   },
   "Ethernet144": {
@@ -1010,7 +920,6 @@
     "alias": "Eth37",
     "pfc_asym": "off",
     "speed": "100000",
-    "subport": "0",
     "fec": "rs"
   }
 }

--- a/src/sonic-config-engine/tests/test_cfggen_platformJson.py
+++ b/src/sonic-config-engine/tests/test_cfggen_platformJson.py
@@ -79,19 +79,19 @@ class TestCfgGenPlatformJson(TestCase):
         argument = ['-m', self.platform_sample_graph, '-p', self.platform_json, '-S', self.hwsku_json, '-v', "PORT[\'Ethernet8\']"]
         output = self.run_script(argument)
         self.maxDiff = None
-        expected = "{'index': '3', 'lanes': '8', 'description': 'Eth3/1', 'mtu': '9100', 'alias': 'Eth3/1', 'pfc_asym': 'off', 'speed': '25000', 'subport': '1', 'tpid': '0x8100'}"
+        expected = "{'index': '3', 'lanes': '8', 'description': 'Eth3/1', 'mtu': '9100', 'alias': 'Eth3/1', 'pfc_asym': 'off', 'speed': '25000', 'tpid': '0x8100'}"
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict(expected))
 
         argument = ['-m', self.platform_sample_graph, '-p', self.platform_json, '-S', self.hwsku_json, '-v', "PORT[\'Ethernet112\']"]
         output = self.run_script(argument)
         self.maxDiff = None
-        expected = "{'index': '29', 'lanes': '112', 'description': 'Eth29/1', 'mtu': '9100', 'alias': 'Eth29/1', 'pfc_asym': 'off', 'speed': '25000', 'subport': '1', 'tpid': '0x8100'}"
+        expected = "{'index': '29', 'lanes': '112', 'description': 'Eth29/1', 'mtu': '9100', 'alias': 'Eth29/1', 'pfc_asym': 'off', 'speed': '25000', 'tpid': '0x8100'}"
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict(expected))
 
         argument = ['-m', self.platform_sample_graph, '-p', self.platform_json, '-S', self.hwsku_json, '-v', "PORT[\'Ethernet4\']"]
         output = self.run_script(argument)
         self.maxDiff = None
-        expected = "{'index': '2', 'lanes': '4,5', 'description': 'Eth2/1', 'admin_status': 'up', 'mtu': '9100', 'alias': 'Eth2/1', 'pfc_asym': 'off', 'speed': '50000', 'subport': '1', 'tpid': '0x8100'}"
+        expected = "{'index': '2', 'lanes': '4,5', 'description': 'Eth2/1', 'admin_status': 'up', 'mtu': '9100', 'alias': 'Eth2/1', 'pfc_asym': 'off', 'speed': '50000', 'tpid': '0x8100'}"
         print(output.strip())
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict(expected))
 


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#18499

Causing all orchagent PR tests to fail. **Please fix orchagent parsing code before this can be merged:**

`May 21 19:42:17.072936 227b974fe750 WARNING #orchagent: message repeated 18564 times: [ :- parsePortConfig: Unknown field(subport): skipping ...]`

