### PR TITLE
[Mellanox] Verify the value of the control type sysfs before changing it to FW control

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -1493,7 +1493,8 @@ class SFP(NvidiaSFPCommon):
     @classmethod
     def action_on_fw_control(cls, sfp):
         logger.log_info(f'SFP {sfp.sdk_index} is set to firmware control')
-        sfp.set_control_type(SFP_FW_CONTROL)
+        if sfp.get_control_type() != SFP_FW_CONTROL:
+            sfp.set_control_type(SFP_FW_CONTROL)
         
     @classmethod
     def action_on_cancel_wait(cls, sfp):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -1492,8 +1492,8 @@ class SFP(NvidiaSFPCommon):
         
     @classmethod
     def action_on_fw_control(cls, sfp):
-        logger.log_info(f'SFP {sfp.sdk_index} is set to firmware control')
         if sfp.get_control_type() != SFP_FW_CONTROL:
+            logger.log_info(f'SFP {sfp.sdk_index} is set to firmware control')
             sfp.set_control_type(SFP_FW_CONTROL)
         
     @classmethod


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
On Mellanox platforms, changing the control type sysfs value is not supported for ports that are set to firmware control. Therefore, attempting to change this value to firmware control will result in an error log, which we want to avoid.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
I added a check to ensure that the control sysfs value is set to firmware control only if it is not already in firmware control.

#### How to verify it
Ensure that after a warm reboot on the Mellanox platform (an attempt to change the sysfs value from fw_control to fw_control is only applicable in this scenario), the following error does not appear:
sxd_kernel: [error] sx_core_set_module_control: Failed control change: module is dependent (FW control).

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

