### PR TITLE
[202311] Fix TACACS local accounting disabled when debug flag disabled.

### DIFF
--- a/src/tacacs/audisp/patches/0002-Remove-user-secret-from-accounting-log.patch
+++ b/src/tacacs/audisp/patches/0002-Remove-user-secret-from-accounting-log.patch
@@ -13,7 +13,7 @@ Subject: [PATCH] Remove user secret from accounting log.
  regex_helper.h           |  17 +++
  sudoers_helper.c         | 250 +++++++++++++++++++++++++++++++++++++++
  sudoers_helper.h         |  18 +++
- trace.c                  |  21 ++++
+ trace.c                  |  31 +++++
  trace.h                  |  10 ++
  unittest/Makefile        |  21 ++++
  unittest/mock.h          |  17 +++
@@ -21,7 +21,7 @@ Subject: [PATCH] Remove user secret from accounting log.
  unittest/mock_helper.h   |  48 ++++++++
  unittest/password_test.c | 199 +++++++++++++++++++++++++++++++
  unittest/sudoers         |   5 +
- 17 files changed, 931 insertions(+), 4 deletions(-)
+ 17 files changed, 941 insertions(+), 4 deletions(-)
  create mode 100644 password.c
  create mode 100644 password.h
  create mode 100644 regex_helper.c
@@ -700,7 +700,7 @@ new file mode 100644
 index 0000000..44bbbc7
 --- /dev/null
 +++ b/trace.c
-@@ -0,0 +1,21 @@
+@@ -0,0 +1,31 @@
 +#include <stdarg.h>
 +#include <stdio.h>
 +#include <string.h>
@@ -709,9 +709,19 @@ index 0000000..44bbbc7
 +
 +#include "trace.h"
 +
++/* Tacacs+ support lib */
++#include <libtac/support.h>
++
++/* Tacacs control flag */
++extern int tacacs_ctrl;
++
 +/* Output trace log. */
 +void trace(const char *format, ...)
 +{
++    if ((tacacs_ctrl & PAM_TAC_DEBUG) == 0) {
++        return;
++    }
++
 +    // convert log to a string because va args resoursive issue:
 +    // http://www.c-faq.com/varargs/handoff.html
 +    char logBuffer[MAX_LINE_SIZE];

--- a/src/tacacs/audisp/patches/0003-Add-local-accounting.patch
+++ b/src/tacacs/audisp/patches/0003-Add-local-accounting.patch
@@ -70,12 +70,12 @@ index 0000000..e23acec
 +#include "trace.h"
 +
 +/* Accounting log format. */
-+#define ACCOUNTING_LOG_FORMAT "Accounting: user: %s, tty: %s, host: %s, command: %s, type: %d, task ID: %d"
++#define ACCOUNTING_LOG_FORMAT "Audisp-tacplus: Accounting: user: %s, tty: %s, host: %s, command: %s, type: %d, task ID: %d"
 +
 +/* Write the accounting information to syslog. */
 +void accounting_to_syslog(char *user, char *tty, char *host, char *cmdmsg, int type, uint16_t task_id)
 +{
-+    trace(ACCOUNTING_LOG_FORMAT, user, tty, host, cmdmsg, type, task_id);
++    syslog(LOG_INFO, ACCOUNTING_LOG_FORMAT, user, tty, host, cmdmsg, type, task_id);
 +}
 \ No newline at end of file
 diff --git a/local_accounting.h b/local_accounting.h


### PR DESCRIPTION
Ignore TACACS accounting trace log when debug disabled.

#### Why I did it
TACACS accounting trace log is only for debug, improve code to not generate trace log when debug disabled.

Manually cherry-pick following 2 PR, because fir PR has a code bug, PR validation will block it:
https://github.com/sonic-net/sonic-buildimage/pull/16482
https://github.com/sonic-net/sonic-buildimage/pull/18357

##### Work item tracking
- Microsoft ADO: 25270078

#### How I did it
Ignore TACACS accounting trace log when debug disabled.

#### How to verify it
Pass all UT.
Manually verified the auditd-tacplus not generate trace log when debug disabled. 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

will updated with this PR image later.
- [x] SONiC.master-16482.360728-2c8b4066f
- [x] SONiC.202205-16653.368721-c45a92ff2
- [x] SONiC.202305-19061.554667-4e17fde97 
- [x] SONiC.202311-19060.554666-5dc06ca6c

#### Description for the changelog
Ignore TACACS accounting trace log when debug disabled.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

