### PR TITLE
Fix Orchagent crash during boot because of eth0 not config address

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -82,7 +82,7 @@ if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
     if [[ $midplane_ip != "" ]]; then
         # Enable ZMQ with eth0-midplane address
         ORCHAGENT_ARGS+=" -q tcp://${midplane_mgmt_ip}:8100"
-    elif [[ $mgmt_ip != "" ]]; then
+    elif [[ $mgmt_ip != "" ]] && [[ $mgmt_ip != "null" ]]; then
         # If eth0-midplane interface does not exist, enable ZMQ with eth0 address
         ORCHAGENT_ARGS+=" -q tcp://${mgmt_ip}:8100"
     else


### PR DESCRIPTION
Fix Orchagent crash during boot because of eth0 not config address.

#### Why I did it
Fix https://github.com/sonic-net/sonic-buildimage/issues/19044
On SmartSwitch DPU the eth0 might not config any address

##### Work item tracking
- Microsoft ADO: 28188952

#### How I did it
Fix Orchagent crash during boot because of eth0 not config address.

#### How to verify it
Pass all UT.
Manually verified the orchagent not crash when eth not config address:
root       20026  8.3  1.2 748344 49512 pts/0    Sl   06:25   0:03 /usr/bin/orchagent -d /var/log/swss -b 1024 -s -m 22:48:23:27:33:d8 -q tcp://127.0.0.1:8100

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

will updated with this PR image later.
- [x] Will update later

#### Description for the changelog
Fix Orchagent crash during boot because of eth0 not config address.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

