### PR TITLE
Default COPP DHCP Rate Removal for DHCP DoS Mitigation Feature

### DIFF
--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -97,7 +97,7 @@
 		    "trap_group": "queue4_group3"
 	    },
 	    "dhcp_relay": {
-		    "trap_ids": "dhcp,dhcpv6",
+		    "trap_ids": "dhcpv6",
 		    "trap_group": "queue4_group3"
 	    },
 	    "udld": {


### PR DESCRIPTION
#### Why I did it
To depreciate default COPP DHCPv4 rate limit in support of new [DHCP DoS Mitigation feature](https://github.com/sonic-net/SONiC/pull/1651).

#### How I did it
Edited COPP j2 file to remove existing DHCPv4 trap.

#### How to verify it
Now there is only one rate limit by default in SONiC (via TC) which is kept at 300 packets/sec to ensure backward compatibility after default COPP DHCP rate depreciation.

