### PR TITLE
Add environs to test PFCWD on DNX

### DIFF
--- a/platform/vs/docker-sonic-vs/orchagent.sh
+++ b/platform/vs/docker-sonic-vs/orchagent.sh
@@ -8,6 +8,20 @@ else
     export platform=vs
 fi
 
+# Force orchagent to run with the given ASIC.
+if [ "$ASIC_TYPE" == "broadcom-dnx" ]; then
+    export platform="broadcom"
+    export sub_platform="broadcom-dnx"
+fi
+
+# Allow test to override PfcDlrInitEnable for VS switch so that
+# we can test PfcWdAclHandler, instead of PfcWdDlrHandler.
+if [ "$PFC_DLR_INIT_ENABLE" == "1" ]; then
+    export pfcDlrInitEnable="1"
+elif [ "$PFC_DLR_INIT_ENABLE" == "0" ]; then
+    export pfcDlrInitEnable="0"
+fi
+
 SWSS_VARS_FILE=/usr/share/sonic/templates/swss_vars.j2
 
 # Retrieve SWSS vars from sonic-cfggen


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This is required to test DNX specific implementation for PFCWD on VS.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Add ASIC_TYPE to force orchagent to run with the given ASIC.
- Add PFC_DLR_INIT_ENABLE to allow test to override PfcDlrInitEnable for VS switch. This is required to test PfcWdAclHandler, instead of PfcWdDlrHandler.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

