### PR TITLE
Support SAI native ASIC DRAM thermal sensor polling

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform.json
@@ -68,11 +68,11 @@
 		"controllable": false
 	    },
 	    {
-	        "name": "ASIC0_dram-0x0",
+	        "name": "ASIC0_9--DRAM0",
 		"controllable": false
 	    },
 	    {
-	        "name": "ASIC0_dram-0x1",
+	        "name": "ASIC0_10--DRAM1",
 		"controllable": false
 	    },
 	    {
@@ -112,11 +112,11 @@
 		"controllable": false
 	    },
 	    {
-	        "name": "ASIC1_dram-0x0",
+	        "name": "ASIC1_9--DRAM0",
 		"controllable": false
 	    },
 	    {
-	        "name": "ASIC1_dram-0x1",
+	        "name": "ASIC1_10--DRAM1",
 		"controllable": false
 	    },
             {

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_ndk.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_ndk.json
@@ -28,10 +28,6 @@
         "key": "sonic_bdb_mode",
         "intval": 0
     },
-    { 
-      "key": "update_asic_pvt",
-      "intval": 10
-    },
     {
       "key": "amd_pcon",
       "intval": 4


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To support SAI native ASIC DRAM thermal sensor polling (as added by BCM in SAI 10.1.15)

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update to latest Nokia PMON submodule and provide appropriate settings in our platform specific .json files to properly identify the DRAM thermal sensor values and to stop our NDK from polling these DRAM thermal sensors.
 
#### How to verify it
Be certain to enable SAI native ASIC thermal sensor polling (see below for procedure) and then ensure that all thermal sensor values are listed using the 'show platform temperature' command after the system has booted and quiesced.

![image](https://github.com/sonic-net/sonic-buildimage/assets/76123698/9e2c83df-2c2a-43fc-913f-7a2def986973)
 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
- [x] master

#### Description for the changelog
[Nokia][sonic-platform] Support SAI native ASIC DRAM thermal sensor polling (as added by BCM in SAI 10.1.15)

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

