### PR TITLE
Fix the issue that device become slow after enabling TACACS authentication.

### DIFF
--- a/src/tacacs/nss/patch/0013-Lookup-etc-passwd-first-to-accelerate-the-getpwnam-p.patch
+++ b/src/tacacs/nss/patch/0013-Lookup-etc-passwd-first-to-accelerate-the-getpwnam-p.patch
@@ -1,0 +1,49 @@
+From fd237afe04f2418ddd74d6d4ac32b5cfce9a4969 Mon Sep 17 00:00:00 2001
+From: Steven Guo <steven_guo@edge-core.com>
+Date: Tue, 27 Sep 2022 15:27:42 +0800
+Subject: Lookup /etc/passwd first to accelerate the getpwnam
+ process.
+
+In getpwnam function, it tries to get user from tacacs servers if the user is tacacs user.
+The lookup process will take long time if there are some unreachable servers.
+
+To avoid spending lot of time on trying to make connection to an unreachable server, lookup
+user in /etc/passwd first to accelerate the lookup process.
+---
+ nss_tacplus.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/nss_tacplus.c b/nss_tacplus.c
+index 2de00a6..a276557 100644
+--- a/nss_tacplus.c
++++ b/nss_tacplus.c
+@@ -817,6 +817,8 @@ enum nss_status _nss_tacplus_getpwnam_r(const char *name, struct passwd *pw,
+     enum nss_status status = NSS_STATUS_NOTFOUND;
+     int result;
+     struct pwbuf pbuf;
++    bool found = false;
++    int ret = 0;
+ 
+     /*
+      * When filename completion is used with the tab key in bash, getpwnam
+@@ -847,6 +849,17 @@ enum nss_status _nss_tacplus_getpwnam_r(const char *name, struct passwd *pw,
+         pbuf.buflen = buflen;
+         pbuf.errnop = errnop;
+ 
++        /*
++         *  For the logged-in user, use the local file instead of sending TACACS
++         *  request to speed up.
++         */
++        ret = lookup_pw_local(name, &pbuf, &found);
++        if(0 == ret && found) {
++            syslog(LOG_DEBUG, "%s: get TACACS user information (%s) from local", nssname, name);
++            return NSS_STATUS_SUCCESS;
++        }
++
++        /* Send the TACACS request only for authentication process. */
+         if(0 == lookup_tacacs_user(&pbuf)) {
+             status = NSS_STATUS_SUCCESS;
+             if(debug)
+-- 
+2.25.1
+


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### What I did
Fix the issue that device become slow after enabling TACACS authentication.

#### Why I did it

In getpwnam function of libnss-tacacs, it tries to get user from tacacs servers if the user is tacacs user. The lookup process will take long time if there are some unreachable servers. To avoid spending lot of time on trying to make connection to an unreachable server, lookup user in /etc/passwd first to accelerate the lookup process.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

 Configure AAA and login by tacacsplus, check the response time become normal, also run few test cases to ensure the modification doesn't have side effect.
```
tacacs/test_accounting.py::test_accounting_tacacs_only[wedge100bf-32x-2] PASSED                                                                                  [  4%]
tacacs/test_accounting.py::test_accounting_tacacs_only_all_tacacs_server_down[wedge100bf-32x-2] PASSED                                                           [  9%]
tacacs/test_accounting.py::test_accounting_tacacs_only_some_tacacs_server_down[wedge100bf-32x-2] PASSED                                                          [ 13%]
tacacs/test_accounting.py::test_accounting_local_only[wedge100bf-32x-2] PASSED                                                                                   [ 18%]
tacacs/test_accounting.py::test_accounting_tacacs_and_local[wedge100bf-32x-2] PASSED                                                                             [ 22%]
tacacs/test_accounting.py::test_accounting_tacacs_and_local_all_tacacs_server_down[wedge100bf-32x-2] PASSED                                                      [ 27%]
tacacs/test_authorization.py::test_authorization_tacacs_only[wedge100bf-32x-2] PASSED                                                                            [ 31%]
tacacs/test_authorization.py::test_authorization_tacacs_only_some_server_down[wedge100bf-32x-2] PASSED                                                           [ 36%]
tacacs/test_authorization.py::test_authorization_tacacs_only_then_server_down_after_login[wedge100bf-32x-2] PASSED                                               [ 40%]
tacacs/test_authorization.py::test_authorization_tacacs_and_local[wedge100bf-32x-2] PASSED                                                                       [ 45%]
tacacs/test_authorization.py::test_authorization_tacacs_and_local_then_server_down_after_login[wedge100bf-32x-2] PASSED                                          [ 50%]
tacacs/test_authorization.py::test_authorization_local[wedge100bf-32x-2] PASSED                                                                                  [ 54%]
tacacs/test_authorization.py::test_bypass_authorization[wedge100bf-32x-2] PASSED                                                                                 [ 59%]
tacacs/test_authorization.py::test_backward_compatibility_disable_authorization[wedge100bf-32x-2] PASSED                                                         [ 63%]
tacacs/test_jit_user.py::test_jit_user[wedge100bf-32x-2] PASSED                                                                                                  [ 68%]
tacacs/test_ro_disk.py::test_ro_disk[wedge100bf-32x-2] SKIPPED                                                                                                   [ 72%]
tacacs/test_ro_user.py::test_ro_user[wedge100bf-32x-2] PASSED                                                                                                    [ 77%]
tacacs/test_ro_user.py::test_ro_user_ipv6[wedge100bf-32x-2] SKIPPED                                                                                              [ 81%]
tacacs/test_ro_user.py::test_ro_user_allowed_command[wedge100bf-32x-2]
PASSED                                                                                                                                                           [ 86%]
tacacs/test_ro_user.py::test_ro_user_banned_command[wedge100bf-32x-2] PASSED                                                                                     [ 90%]
tacacs/test_rw_user.py::test_rw_user[wedge100bf-32x-2] PASSED                                                                                                    [ 95%]
tacacs/test_rw_user.py::test_rw_user_ipv6[wedge100bf-32x-2] SKIPPED                                                                                              [100%]

ntp/test_ntp.py::test_ntp_long_jump_enabled SKIPPED                                                                                                              [ 33%]
ntp/test_ntp.py::test_ntp_long_jump_disabled SKIPPED                                                                                                             [ 66%]
ntp/test_ntp.py::test_ntp PASSED

syslog/test_syslog.py::test_syslog[7.0.80.166-None] PASSED                                                                                                       [ 20%]
syslog/test_syslog.py::test_syslog[fd82:b34f:cc99::100-None] PASSED                                                                                              [ 40%]
syslog/test_syslog.py::test_syslog[7.0.80.165-7.0.80.166] PASSED                                                                                                 [ 60%]
syslog/test_syslog.py::test_syslog[fd82:b34f:cc99::100-7.0.80.166] PASSED                                                                                        [ 80%]
syslog/test_syslog.py::test_syslog[fd82:b34f:cc99::100-fd82:b34f:cc99::200] PASSED                                                                               [100%]

```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [X] 202111
- [X] 202205
- [X] 202211
- [X] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] <!--202111 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

