### PR TITLE
Run logger CLI with parent script PID

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/thermal_overload_control.sh
+++ b/device/celestica/x86_64-cel_e1031-r0/thermal_overload_control.sh
@@ -42,12 +42,12 @@ usage() {
 }
 
 cpu_overload() {
-	logger "Enable CPU thermal overload control"
+	logger --id="$$" "Enable CPU thermal overload control"
 	set_reg=`echo ${TOVERREG} ${CPUOVER} > ${SETREG_FILE}`
 }
 
 asic_overload() {
-	logger "Enable ASIC thermal overload control"
+	logger --id="$$" "Enable ASIC thermal overload control"
 	set_reg=`echo ${TOVERREG} ${ASICOVER} > ${SETREG_FILE}`
 }
 

--- a/device/celestica/x86_64-cel_seastone-r0/thermal_overload_control.sh
+++ b/device/celestica/x86_64-cel_seastone-r0/thermal_overload_control.sh
@@ -42,12 +42,12 @@ usage() {
 }
 
 cpu_overload() {
-	logger "Enable CPU thermal overload control"
+	logger --id="$$" "Enable CPU thermal overload control"
 	set_reg=`echo ${TOVERREG} ${CPUOVER} > ${SETREG_FILE}`
 }
 
 asic_overload() {
-	logger "Enable ASIC thermal overload control"
+	logger --id="$$" "Enable ASIC thermal overload control"
 	set_reg=`echo ${TOVERREG} ${ASICOVER} > ${SETREG_FILE}`
 }
 

--- a/dockers/docker-dhcp-server/lease_update.sh
+++ b/dockers/docker-dhcp-server/lease_update.sh
@@ -5,7 +5,7 @@
 
 pid=`ps aux | grep 'dhcpservd' | grep -nv 'grep' | awk '{print $2}'`
 if [ -z "$pid" ]; then
-    logger -p daemon.error Cannot find running dhcpservd.py.
+    logger --id="$$" -p daemon.error Cannot find running dhcpservd.py.
 else
     # Send SIGUSR1 signal to dhcpservd.py
     kill -s 10 ${pid}

--- a/dockers/docker-fpm-frr/base_image_files/TS
+++ b/dockers/docker-fpm-frr/base_image_files/TS
@@ -46,10 +46,10 @@ if [[ ($NUM_ASIC -gt 1) ]]; then
                 current_tsa_state="$(sonic-cfggen -d -v BGP_DEVICE_GLOBAL.STATE.tsa_enabled -n $NAMESPACE_PREFIX$asic)"
                 if [[ $current_tsa_state  == $desired_tsa_state ]]; then
                     echo "$err_msg"
-                    logger -t $1 -p user.info "$err_msg"
+                    logger --id="$$" -t $1 -p user.info "$err_msg"
                 else 
                     sonic-cfggen -a "$TSA_STATE_UPDATE" -w -n $NAMESPACE_PREFIX$asic
-                    logger -t $1 -p user.info "$log_msg"
+                    logger --id="$$" -t $1 -p user.info "$log_msg"
                     echo "$log_msg"
                 fi
             else
@@ -64,10 +64,10 @@ else
             current_tsa_state="$(sonic-cfggen -d -v BGP_DEVICE_GLOBAL.STATE.tsa_enabled)"
             if [[ $current_tsa_state  == $desired_tsa_state ]]; then
                 echo "$err_msg"
-                logger -t $1 -p user.info "$err_msg"
+                logger --id="$$" -t $1 -p user.info "$err_msg"
             else              
                 sonic-cfggen -a "$TSA_STATE_UPDATE" -w
-                logger -t $1 -p user.info "$log_msg"
+                logger --id="$$" -t $1 -p user.info "$log_msg"
                 echo "$log_msg"
             fi
         else

--- a/dockers/docker-fpm-frr/base_image_files/TSA
+++ b/dockers/docker-fpm-frr/base_image_files/TSA
@@ -12,12 +12,12 @@ if [ -f /etc/sonic/chassisdb.conf ]; then
   current_tsa_state="$(sonic-cfggen -d -v BGP_DEVICE_GLOBAL.STATE.tsa_enabled)"
   if [[ $current_tsa_state  == true ]]; then
     echo "Chassis is already in Maintenance"
-    logger -t TSA -p user.info "Chassis is already in Maintenance"
+    logger --id="$$" -t TSA -p user.info "Chassis is already in Maintenance"
   else
     sonic-db-cli $CHASSIS_TSA_STATE_UPDATE
     sonic-cfggen -a "$CONFIG_DB_TSA_STATE_UPDATE" -w
     echo "Chassis Mode: Normal -> Maintenance"
-    logger -t TSA -p user.info "Chassis Mode: Normal -> Maintenance"
+    logger --id="$$" -t TSA -p user.info "Chassis Mode: Normal -> Maintenance"
   fi
   echo "Please execute \"rexec all -c 'sudo config save -y'\" to preserve System mode in Maintenance after reboot\
   or config reload on all linecards"
@@ -28,7 +28,7 @@ if
 [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype | tr [:upper:] [:lower:])" == *"dualtor"* ]] &&
 [[ $(show mux status | grep active | wc -l) > 0 ]];
 then
-  logger -t TSA -p user.info "Toggle all mux mode to standby"
+  logger --id="$$" -t TSA -p user.info "Toggle all mux mode to standby"
   sudo config mux mode standby all
 fi
 

--- a/dockers/docker-fpm-frr/base_image_files/TSB
+++ b/dockers/docker-fpm-frr/base_image_files/TSB
@@ -12,12 +12,12 @@ if [ -f /etc/sonic/chassisdb.conf ]; then
   current_tsa_state="$(sonic-cfggen -d -v BGP_DEVICE_GLOBAL.STATE.tsa_enabled)"
   if [[ $current_tsa_state  == false ]]; then
     echo "Chassis is already in Normal mode"
-    logger -t TSB -p user.info "Chassis is already in Normal mode"
+    logger --id="$$" -t TSB -p user.info "Chassis is already in Normal mode"
   else
     sonic-db-cli $CHASSIS_TSA_STATE_UPDATE
     sonic-cfggen -a "$CONFIG_DB_TSA_STATE_UPDATE" -w
     echo "Chassis Mode: Maintenance -> Normal"
-    logger -t TSB -p user.info "Chassis Mode: Maintenance -> Normal"
+    logger --id="$$" -t TSB -p user.info "Chassis Mode: Maintenance -> Normal"
   fi
   echo "Please execute \"rexec all -c 'sudo config save -y'\" to preserve System mode in Normal state after reboot\
   or config reload on all linecards"
@@ -27,7 +27,7 @@ fi
 # toggle the mux to auto if dualtor
 if [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype | tr [:upper:] [:lower:])" == *"dualtor"* ]];
 then
-  logger -t TSB -p user.info "Toggle all mux mode to auto"
+  logger --id="$$" -t TSB -p user.info "Toggle all mux mode to auto"
   sudo config mux mode auto all
 fi
 

--- a/dockers/docker-fpm-frr/base_image_files/idf_isolation
+++ b/dockers/docker-fpm-frr/base_image_files/idf_isolation
@@ -60,7 +60,7 @@ if [[ ($NUM_ASIC -gt 1) ]]; then
                     echo "BGP$asic: IDF is already in $1 state"
                 else
                     sonic-cfggen -a "$IDF_ISOLATION_STATE" -w -n $NAMESPACE_PREFIX$asic
-                    logger -t $1 -p user.info "IDF isolation state: $1"
+                    logger --id="$$" -t $1 -p user.info "IDF isolation state: $1"
                     echo "BGP$asic: IDF isolation state: $1"
                 fi
             fi
@@ -76,7 +76,7 @@ else
             echo "IDF is already in $1 state"
         else
             sonic-cfggen -a "$IDF_ISOLATION_STATE" -w
-            logger -t $1 -p user.info "IDF isolation state: $1"
+            logger --id="$$" -t $1 -p user.info "IDF isolation state: $1"
             echo "IDF isolation state: $1"
         fi
     fi

--- a/dockers/docker-fpm-frr/zsocket.sh
+++ b/dockers/docker-fpm-frr/zsocket.sh
@@ -27,10 +27,10 @@ done
 start=$(date +%s.%N)
 timeout 5s bash -c -- "until </dev/tcp/${addr}/${port}; do sleep 0.1;done"
 if [ "$?" != "0" ]; then
-    logger -p error "Error: zebra is not ready to accept connections"
+    logger --id="$$" -p error "Error: zebra is not ready to accept connections"
 else
     timespan=$(awk "BEGIN {print $(date +%s.%N)-$start; exit}")
-    logger -p info "It took ${timespan} seconds to wait for zebra to be ready to accept connections"
+    logger --id="$$" -p info "It took ${timespan} seconds to wait for zebra to be ready to accept connections"
 fi
 
 exit 0

--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -10,7 +10,7 @@ export sub_platform=$(echo $SWSS_VARS | jq -r '.asic_subtype')
 MAC_ADDRESS=$(echo $SWSS_VARS | jq -r '.mac')
 if [ "$MAC_ADDRESS" == "None" ] || [ -z "$MAC_ADDRESS" ]; then
     MAC_ADDRESS=$(ip link show eth0 | grep ether | awk '{print $2}')
-    logger "Mac address not found in Device Metadata, Falling back to eth0"
+    logger --id="$$" "Mac address not found in Device Metadata, Falling back to eth0"
 fi
 
 # Create a folder for SwSS record files

--- a/dockers/docker-sonic-restapi/restapi.sh
+++ b/dockers/docker-sonic-restapi/restapi.sh
@@ -26,7 +26,7 @@ do
                 fi
         fi
     fi
-    logger "Waiting for certificates..."
+    logger --id="$$" "Waiting for certificates..."
     sleep 60
 done
 
@@ -37,5 +37,5 @@ else
     RESTAPI_ARGS+=" -loglevel=trace"
 fi 
 
-logger "RESTAPI_ARGS: $RESTAPI_ARGS"
+logger --id="$$" "RESTAPI_ARGS: $RESTAPI_ARGS"
 exec /usr/sbin/go-server-server ${RESTAPI_ARGS}

--- a/files/image_config/logrotate/rsyslog.j2
+++ b/files/image_config/logrotate/rsyslog.j2
@@ -88,11 +88,11 @@
                 OLDEST_ARCHIVE_FILE=$(find /var/log -type f -printf '%T+ %p\n' | grep -E '.+\.[0-9]+(\.gz)?$' | sort | head -n 1 | awk '{ print $2; }')
 
                 if [ -z "$OLDEST_ARCHIVE_FILE" ]; then
-                    logger -p syslog.err -t "logrotate" "No archive file to delete -- potential for filling up /var/log partition!"
+                    logger --id="$$" -p syslog.err -t "logrotate" "No archive file to delete -- potential for filling up /var/log partition!"
                     break
                 fi
 
-                logger -p syslog.info -t "logrotate" "Deleting archive file $OLDEST_ARCHIVE_FILE to free up space"
+                logger --id="$$" -p syslog.info -t "logrotate" "Deleting archive file $OLDEST_ARCHIVE_FILE to free up space"
                 rm -rf "$OLDEST_ARCHIVE_FILE"
             fi
         done
@@ -109,10 +109,10 @@
             if [ $NUM_ASIC -gt 1 ]; then
                 log_file=$1
                 log_file_name=${log_file#/var/log/swss/}
-                logger -p syslog.info -t "logrotate" "Sending SIGHUP to OA log_file_name: $log_file_name"
+                logger --id="$$" -p syslog.info -t "logrotate" "Sending SIGHUP to OA log_file_name: $log_file_name"
                 pgrep -xa orchagent | grep $log_file_name | awk '{ print $1; }' | xargs /bin/kill -HUP 2>/dev/null || true
             else
-                logger -p syslog.info -t "logrotate" "Sending SIGHUP to OA log_file_name: $1"
+                logger --id="$$" -p syslog.info -t "logrotate" "Sending SIGHUP to OA log_file_name: $1"
                 pgrep -x orchagent | xargs /bin/kill -HUP 2>/dev/null || true
             fi
         else

--- a/files/image_config/pcie-check/pcie-check.sh
+++ b/files/image_config/pcie-check/pcie-check.sh
@@ -9,7 +9,7 @@ PCIE_STATUS_TABLE="PCIE_DEVICES|status"
 
 function debug()
 {
-    /usr/bin/logger "$0 : $1"
+    /usr/bin/logger --id="$$" "$0 : $1"
     if [[ x"${VERBOSE}" == x"yes" ]]; then
         echo "$(date) $0: $1"
     fi

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -210,7 +210,7 @@ program_console_speed()
 
 #### Begin Main Body ####
 
-logger "SONiC version ${SONIC_VERSION} starting up..."
+logger --id="$$" "SONiC version ${SONIC_VERSION} starting up..."
 
 # If the machine.conf is absent, it indicates that the unit booted
 # into SONiC from another NOS. Extract the machine.conf from ONIE.
@@ -400,7 +400,7 @@ fi
 
 # Copy the fsck log into syslog
 if [ -f /var/log/fsck.log.gz ]; then
-    gunzip -d -c /var/log/fsck.log.gz | logger -t "FSCK"
+    gunzip -d -c /var/log/fsck.log.gz | logger --id="$$" -t "FSCK"
     rm -f /var/log/fsck.log.gz
 fi
 

--- a/files/image_config/reset-factory/reset-factory
+++ b/files/image_config/reset-factory/reset-factory
@@ -56,12 +56,12 @@ error_cleanup()
 
     if [ $SERVICES_STOPPED -eq 0 ]; then
         ERRMSG="reset-factory: halted with error before stopping critical services; exiting"
-        logger $ERRMSG
+        logger --id="$$" $ERRMSG
         echo $ERRMSG
         exit 1
     else
         ERRMSG="reset-factory: halted with error after stopping critical services; rebooting"
-        logger $ERRMSG
+        logger --id="$$" $ERRMSG
         echo $ERRMSG
         run_reboot
     fi

--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -26,7 +26,7 @@ ASSISTANT_SCRIPT="/usr/local/bin/neighbor_advertiser"
 
 function debug()
 {
-    /usr/bin/logger "WARMBOOT_FINALIZER : $1"
+    /usr/bin/logger --id="$$" "WARMBOOT_FINALIZER : $1"
     if [[ x"${VERBOSE}" == x"yes" ]]; then
         echo `date` "- $1"
     fi

--- a/files/image_config/watchdog-control/watchdog-control.sh
+++ b/files/image_config/watchdog-control/watchdog-control.sh
@@ -5,7 +5,7 @@ WATCHDOG_UTIL="/usr/local/bin/watchdogutil"
 
 function debug()
 {
-    /usr/bin/logger "$0 : $1"
+    /usr/bin/logger --id="$$" "$0 : $1"
     if [[ x"${VERBOSE}" == x"yes" ]]; then
         echo "$(date) $0: $1"
     fi

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -11,7 +11,7 @@ ARP_UPDATE_VARS_FILE="/usr/share/sonic/templates/arp_update_vars.j2"
 
 # Overload `logger` command to include arp_update tag
 logger () {
-    command logger -t "arp_update" "$@"
+    command logger --id="$$" -t "arp_update" "$@"
 }
 
 while /bin/true; do

--- a/files/scripts/bgp.sh
+++ b/files/scripts/bgp.sh
@@ -2,7 +2,7 @@
 
 function debug()
 {
-    /usr/bin/logger $1
+    /usr/bin/logger --id="$$" $1
     /bin/echo `date` "- $1" >> ${DEBUGLOG}
 }
 

--- a/files/scripts/lldp.sh
+++ b/files/scripts/lldp.sh
@@ -4,7 +4,7 @@
 
 function debug()
 {
-    /usr/bin/logger $1
+    /usr/bin/logger --id="$$" $1
     /bin/echo `date` "- $1" >> ${DEBUGLOG}
 }
 

--- a/files/scripts/service_mgmt.sh
+++ b/files/scripts/service_mgmt.sh
@@ -2,7 +2,7 @@
 
 function debug()
 {
-    /usr/bin/logger $1
+    /usr/bin/logger --id="$$" $1
 }
 
 function check_warm_boot()

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -14,7 +14,7 @@ ETC_SONIC_PATH="/etc/sonic/"
 
 function debug()
 {
-    /usr/bin/logger $1
+    /usr/bin/logger --id="$$" $1
     /bin/echo `date` "- $1" >> ${DEBUGLOG}
 }
 

--- a/files/scripts/syncd_common.sh
+++ b/files/scripts/syncd_common.sh
@@ -15,7 +15,7 @@
 
 function debug()
 {
-    /usr/bin/logger $1
+    /usr/bin/logger --id="$$" $1
     /bin/echo `date` "- $1" >> ${DEBUGLOG}
 }
 

--- a/files/scripts/teamd.sh
+++ b/files/scripts/teamd.sh
@@ -4,7 +4,7 @@
 
 function debug()
 {
-    /usr/bin/logger $1
+    /usr/bin/logger --id="$$" $1
     /bin/echo `date` "- $1" >> ${DEBUG_LOG}
 }
 

--- a/platform/broadcom/sonic-platform-modules-cel/haliburton/script/cpu_wdt
+++ b/platform/broadcom/sonic-platform-modules-cel/haliburton/script/cpu_wdt
@@ -7,7 +7,7 @@ KEEPALIVE=60
 
 function log_info()
 {
-    logger -p info -t ${SYSLOG_IDENTIFIER}  "$@"
+    logger --id="$$" -p info -t ${SYSLOG_IDENTIFIER}  "$@"
 }
 
 function usage()

--- a/platform/broadcom/sonic-platform-modules-dell/common/dell_lpc_mon.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/common/dell_lpc_mon.sh
@@ -15,7 +15,7 @@ smf_scratch_reg=0x202
 function log_crit() {
    local msg=$1
 
-  `logger -p user.crit -t DELL_LPC_BUS_MON $msg`
+  `logger --id="$$" -p user.crit -t DELL_LPC_BUS_MON $msg`
 }
 
 function validate_lpc() {

--- a/platform/broadcom/sonic-platform-modules-dell/common/onie_mode_set
+++ b/platform/broadcom/sonic-platform-modules-dell/common/onie_mode_set
@@ -51,7 +51,7 @@ function debug()
     if [[ x"${VERBOSE}" == x"yes" ]]; then
         echo `date` $@
     fi
-    logger "$@"
+    logger --id="$$" "$@"
 }
 
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/reset-qsfp
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/reset-qsfp
@@ -5,7 +5,7 @@
 
 QSFP_RESET=/sys/bus/platform/devices/dell-s6000-cpld.0/qsfp_reset
 
-logger -t platform-modules "Reset QSFP modules"
+logger --id="$$" -t platform-modules "Reset QSFP modules"
 
 # Retry three times
 for i in `seq 1 3`
@@ -21,5 +21,5 @@ do
   sleep 3
 done
 
-logger -p user.error -t platform-modules "Failed to reset QSFP modules!"
+logger --id="$$" -p user.error -t platform-modules "Failed to reset QSFP modules!"
 exit 1

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/set-fan-speed
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/set-fan-speed
@@ -29,7 +29,7 @@ FAN5=/sys/class/i2c-adapter/i2c-11/11-002a/hwmon/hwmon*/fan1_target
 FAN6=/sys/class/i2c-adapter/i2c-11/11-002a/hwmon/hwmon*/fan2_target
 
 speed=$1
-logger -t platform-modules "Trying to set fan speed to $speed"
+logger --id="$$" -t platform-modules "Trying to set fan speed to $speed"
 
 # Retry three times
 for i in `seq 1 3`
@@ -46,7 +46,7 @@ do
     echo $speed > $FAN5
     echo $speed > $FAN6
 
-    logger -t platform-modules "Fan speed is set to $speed"
+    logger --id="$$" -t platform-modules "Fan speed is set to $speed"
 
     exit 0
   fi
@@ -54,5 +54,5 @@ do
   sleep 3
 done
 
-logger -p user.error -t platform-modules "Failed to set fan speed!"
+logger --id="$$" -p user.error -t platform-modules "Failed to set fan speed!"
 exit 1

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_reboot_pre_check
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_reboot_pre_check
@@ -4,8 +4,8 @@ SSD_FW_UPGRADE="/host/ssd_fw_upgrade"
 _error_msg(){
     echo "The SSD on this unit is $1. Do not power-cycle/reboot this unit."
     echo "soft-/fast-/warm-reboot is allowed."
-    logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is $1. Do not power-cycle/reboot this unit."
-    logger -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
+    logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is $1. Do not power-cycle/reboot this unit."
+    logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
 }
 
 # Check SSD Status

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_bitbang_reset.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_bitbang_reset.sh
@@ -39,8 +39,8 @@ do
     
     mctrl=$((10#$mctrl))
     if [ $msts_ip = 0 ]; then
-	logger -p NOTICE "I2C_bitbang-Bit banging done on I2C bus"
-	logger -p NOTICE "After I2C_bitbang- MCTRL:$(printf "0x%x" $mctrl)","MSTS:$(printf "0x%x" $msts)","DBSTS:$(printf "0x%x" $dbsts)"
+	logger --id="$$" -p NOTICE "I2C_bitbang-Bit banging done on I2C bus"
+	logger --id="$$" -p NOTICE "After I2C_bitbang- MCTRL:$(printf "0x%x" $mctrl)","MSTS:$(printf "0x%x" $msts)","DBSTS:$(printf "0x%x" $dbsts)"
 	break
     fi
     count=$(( $count + 1 ))
@@ -54,6 +54,6 @@ pcisysfs.py --set --val 0x00000003 --offset 0x388 --res /sys/devices/pci0000\:00
 mctrl=$((`pcisysfs.py --get --offset 0x108 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 | sed 's/^.*:/0x/'`))
 msts=$((`pcisysfs.py --get --offset 0x10c --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 | sed 's/^.*:/0x/'`))
 dbsts=$((`pcisysfs.py --get --offset 0x38c --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 | sed 's/^.*:/0x/'`))
-logger -p NOTICE "Before I2C_bitbang- MCTRL:$(printf "0x%x" $mctrl)","MSTS:$(printf "0x%x" $msts)","DBSTS:$(printf "0x%x" $dbsts)"
+logger --id="$$" -p NOTICE "Before I2C_bitbang- MCTRL:$(printf "0x%x" $mctrl)","MSTS:$(printf "0x%x" $msts)","DBSTS:$(printf "0x%x" $dbsts)"
 sleep 2
 bit_bang_recovery

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_ssd_mon.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_ssd_mon.sh
@@ -10,8 +10,8 @@ if [ -e $SSD_FW_UPGRADE/GPIO7_high ]; then
     GPIO_STATUS=$(echo "$iSMART_CMD" | grep GPIO | awk '{print $NF}')
 
     if [ $GPIO_STATUS != "0x01" ];then
-        logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty. Do not power-cycle/reboot this unit!"
-        logger -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
+        logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty. Do not power-cycle/reboot this unit!"
+        logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
         rm -rf $SSD_FW_UPGRADE/GPIO7_*
         touch $SSD_FW_UPGRADE/GPIO7_low
         systemctl stop s6100-ssd-monitor.timer

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_ssd_upgrade_status.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_ssd_upgrade_status.sh
@@ -23,32 +23,32 @@ SMART_CMD=`smartctl -a /dev/sda`
 SSD_FW_VERSION=$(echo "$iSMART_CMD" | grep "FW Version" | awk '{print $NF}')
 SSD_FW_VERSION=${SSD_FW_VERSION,,}
 SSD_MODEL=$(echo "$iSMART_CMD" | grep "Model" | awk '{print $NF}')
-logger -p user.crit -t DELL_S6100_SSD_MON "SSD Model = $SSD_MODEL ; FWVERSION = $SSD_FW_VERSION"
+logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "SSD Model = $SSD_MODEL ; FWVERSION = $SSD_FW_VERSION"
 
 if [ -e $SSD_FW_UPGRADE/GPIO7_pending_upgrade ]; then
     if [ $SSD_MODEL == "3IE" ] && [ $SSD_FW_VERSION == "s141002c" ]; then
         # If SSD Firmware is not upgraded
-        logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is running older firmware. Do not power-cycle/reboot this unit."
-        logger -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
+        logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is running older firmware. Do not power-cycle/reboot this unit."
+        logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
         exit 0
     fi
     if [ $SSD_FW_VERSION == "s16425c1" ] || [ $SSD_FW_VERSION == "s16425cq" ]; then
         # If SSD Firmware is not upgraded
-        logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is running older firmware. Do not power-cycle/reboot this unit."
-        logger -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
+        logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is running older firmware. Do not power-cycle/reboot this unit."
+        logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
         exit 0
     fi
 fi
 
 echo "$0 `date` SSD FW upgrade logs post reboot." >> $SSD_UPGRADE_LOG
-logger -p user.crit -t DELL_S6100_SSD_MON "SSD FW upgrade logs post reboot."
+logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "SSD FW upgrade logs post reboot."
 
 SSD_UPGRADE_STATUS1=`io_rd_wr.py --set --val 06 --offset 210; io_rd_wr.py --set --val 09 --offset 211; io_rd_wr.py --get --offset 212`
 SSD_UPGRADE_STATUS1=$(echo "$SSD_UPGRADE_STATUS1" | awk '{print $NF}')
 
 SSD_UPGRADE_STATUS2=`io_rd_wr.py --set --val 06 --offset 210; io_rd_wr.py --set --val 0A --offset 211; io_rd_wr.py --get --offset 212`
 SSD_UPGRADE_STATUS2=$(echo "$SSD_UPGRADE_STATUS2" | awk '{print $NF}')
-logger -p user.crit -t DELL_S6100_SSD_MON "SSD Status REG1 = $SSD_UPGRADE_STATUS1 ; REG2 = $SSD_UPGRADE_STATUS2"
+logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "SSD Status REG1 = $SSD_UPGRADE_STATUS1 ; REG2 = $SSD_UPGRADE_STATUS2"
 
 if [ $SSD_UPGRADE_STATUS1 == "2" ]; then
     rm -rf $SSD_FW_UPGRADE/GPIO7_*
@@ -67,8 +67,8 @@ elif [ $SSD_FW_VERSION == "s210506g" ] || [ $SSD_FW_VERSION == "s16425cg" ]; the
     GPIO_STATUS=$(echo "$iSMART_CMD" | grep GPIO | awk '{print $NF}')
 
     if [ $GPIO_STATUS != "0x01" ];then
-        logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty. Do not power-cycle/reboot this unit!"
-        logger -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
+        logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty. Do not power-cycle/reboot this unit!"
+        logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
         rm -rf $SSD_FW_UPGRADE/GPIO7_*
         touch $SSD_FW_UPGRADE/GPIO7_low
         echo "$0 `date` The SSD on this unit is faulty. Do not power-cycle/reboot this unit!" >> $SSD_UPGRADE_LOG
@@ -78,20 +78,20 @@ elif [ $SSD_FW_VERSION == "s210506g" ] || [ $SSD_FW_VERSION == "s16425cg" ]; the
         rm -rf $SSD_FW_UPGRADE/GPIO7_*
         touch $SSD_FW_UPGRADE/GPIO7_high
         systemctl start --no-block s6100-ssd-monitor.timer
-        logger -p user.crit -t DELL_S6100_SSD_MON "SSD FW upgraded already."
+        logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "SSD FW upgraded already."
         if [ $SSD_UPGRADE_STATUS1 == "0" ]; then
             if [ $SSD_MODEL  == "3IE" ];then
                 echo "$0 `date` SSD FW upgraded from S141002C to S210506G in first mp_64." >> $SSD_UPGRADE_LOG
-                logger -p user.crit -t DELL_S6100_SSD_MON "SSD FW upgraded from S141002C to S210506G"
+                logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "SSD FW upgraded from S141002C to S210506G"
             else
                 echo "$0 `date` SSD FW upgraded from S16425c1 to S16425cG in first mp_64." >> $SSD_UPGRADE_LOG
-                logger -p user.crit -t DELL_S6100_SSD_MON "SSD FW upgraded from S16425c1 to S16425cG"
+                logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "SSD FW upgraded from S16425c1 to S16425cG"
             fi
         elif [ $SSD_MODEL == "3IE3" ] && [ $SSD_UPGRADE_STATUS2 == "1" ]; then
             rm -rf $SSD_FW_UPGRADE/GPIO7_*
             touch $SSD_FW_UPGRADE/GPIO7_low
-            logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty. Do not power-cycle/reboot this unit!"
-            logger -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
+            logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty. Do not power-cycle/reboot this unit!"
+            logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
 
             echo "$0 `date` SSD entered loader mode in first mp_64 and upgraded to latest version after second mp_64." >> $SSD_UPGRADE_LOG
         fi
@@ -103,13 +103,13 @@ else
         touch $SSD_FW_UPGRADE/GPIO7_pending_upgrade
 
         echo "$0 `date` SSD upgrade didn’t happen." >> $SSD_UPGRADE_LOG
-        logger -p user.crit -t DELL_S6100_SSD_MON "No SSD upgrade attempted."
+        logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "No SSD upgrade attempted."
 
     elif [ $SSD_UPGRADE_STATUS1 == "1" ]; then
         rm -rf $SSD_FW_UPGRADE/GPIO7_*
         touch $SSD_FW_UPGRADE/GPIO7_low
-        logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty. Do not power-cycle/reboot this unit!"
-        logger -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
+        logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty. Do not power-cycle/reboot this unit!"
+        logger --id="$$" -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
 
         echo "$0 `date` SSD entered loader mode in first mp_64 upgrade." >> $SSD_UPGRADE_LOG
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/track_reboot_reason.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/track_reboot_reason.sh
@@ -81,13 +81,13 @@ _get_smf_reset_register(){
             echo "Third reset - $third_reset" >> $RESET_REASON_FILE
             echo "Fourth reset - $fourth_reset" >> $RESET_REASON_FILE
         fi
-        logger -p user.info -t DELL_S6100_REBOOT_CAUSE "RST value in NVRAM: $first_reset, $second_reset, $third_reset, $fourth_reset"
+        logger --id="$$" -p user.info -t DELL_S6100_REBOOT_CAUSE "RST value in NVRAM: $first_reset, $second_reset, $third_reset, $fourth_reset"
 
         if [[ $BIOS_VERSION_MINOR -gt 8 ]]; then
             # Retrieve TCO reset status
             tco_nvram=$((16#$(nvram_rd_wr.py --get --offset $TCO_RESET_NVRAM_OFFSET | cut -d " " -f 2)))
             TCO_WD_RESET=$(($tco_nvram & 1))
-            logger -p user.info -t DELL_S6100_REBOOT_CAUSE "TCO status value in NVRAM: $TCO_WD_RESET"
+            logger --id="$$" -p user.info -t DELL_S6100_REBOOT_CAUSE "TCO status value in NVRAM: $TCO_WD_RESET"
 
             # Clear TCO reset status in NVRAM
             tco_nvram=$(printf "%x" $(($tco_nvram & 0xfe)))
@@ -185,7 +185,7 @@ update_mailbox_register(){
         rst=$(cat $SMF_RESET_REASON)
         mbr=$(cat $MAILBOX_POWERON_REASON)
         reason=$(echo $mbr | cut -d 'x' -f2)
-        logger -p user.info -t DELL_S6100_REBOOT_CAUSE "POR: $por, RST: $rst, MBR: $mbr"
+        logger --id="$$" -p user.info -t DELL_S6100_REBOOT_CAUSE "POR: $por, RST: $rst, MBR: $mbr"
 
         SMF_MSS_VERSION=$(cat $SMF_MSS_VERSION_FILE)
         SMF_MSS_VERSION_MAJOR=$(echo $SMF_MSS_VERSION | cut -d '.' -f1)

--- a/platform/broadcom/sonic-platform-modules-mitac/ly1200-32x/opt/fan-ctrl/fan-ctrl
+++ b/platform/broadcom/sonic-platform-modules-mitac/ly1200-32x/opt/fan-ctrl/fan-ctrl
@@ -215,7 +215,7 @@ function log_msg() {
   local msg=$2
 
   if [ $GBL_LOG_FILE == $DEF_LOG_FILE ]; then
-    `logger -t $DAEMON_NAME -p $msg_lvl $msg`
+    `logger --id="$$" -t $DAEMON_NAME -p $msg_lvl $msg`
   else
     echo -e "`date +"%b %_d %T"` `hostname` $DAEMON_NAME[$DAEMON_PID]: ${msg}" >> ${GBL_LOG_FILE}
   fi

--- a/platform/broadcom/sonic-platform-modules-mitac/ly1200-32x/opt/script/funcs.sh
+++ b/platform/broadcom/sonic-platform-modules-mitac/ly1200-32x/opt/script/funcs.sh
@@ -19,5 +19,5 @@ DEF_SEVERITY="INFO"
 function log_msg() {
   local msg=$1
 
-  `logger -t $DAEMON_NAME -p $DEF_SEVERITY $msg`
+  `logger --id="$$" -t $DAEMON_NAME -p $DEF_SEVERITY $msg`
 }

--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -105,11 +105,11 @@ function ParseArguments() {
 function LogError() {
     if [[ "${VERBOSE_LEVEL}" -ge "${VERBOSE_ERROR}" ]]; then
         echo "ERROR: $*"
-        logger -p "ERROR" -t "${SCRIPT_NAME}" "$*"
+        logger --id="$$" -p "ERROR" -t "${SCRIPT_NAME}" "$*"
     fi
 
     if [[ "${SYSLOG_LOGGER}" = "${YES_PARAM}" ]]; then
-        logger -p "ERROR" -t "${SCRIPT_NAME}" "$*"
+        logger --id="$$" -p "ERROR" -t "${SCRIPT_NAME}" "$*"
     fi
 }
 
@@ -119,7 +119,7 @@ function LogWarning() {
     fi
 
     if [[ "${SYSLOG_LOGGER}" = "${YES_PARAM}" ]]; then
-        logger -p "WARNING" -t "${SCRIPT_NAME}" "$*"
+        logger --id="$$" -p "WARNING" -t "${SCRIPT_NAME}" "$*"
     fi
 }
 
@@ -129,7 +129,7 @@ function LogNotice() {
     fi
 
     if [[ "${SYSLOG_LOGGER}" = "${YES_PARAM}" ]]; then
-        logger -p "NOTICE" -t "${SCRIPT_NAME}" "$*"
+        logger --id="$$" -p "NOTICE" -t "${SCRIPT_NAME}" "$*"
     fi
 }
 
@@ -139,7 +139,7 @@ function LogInfo() {
     fi
 
     if [[ "${SYSLOG_LOGGER}" = "${YES_PARAM}" ]]; then
-        logger -p "INFO" -t "${SCRIPT_NAME}" "$*"
+        logger --id="$$" -p "INFO" -t "${SCRIPT_NAME}" "$*"
     fi
 }
 

--- a/platform/p4/docker-sonic-p4/orchagent.sh
+++ b/platform/p4/docker-sonic-p4/orchagent.sh
@@ -8,7 +8,7 @@ SWSS_VARS=$(sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t $SWSS_VARS_FILE) 
 MAC_ADDRESS=$(echo $SWSS_VARS | jq -r '.mac')
 if [ "$MAC_ADDRESS" == "None" ] || [ -z "$MAC_ADDRESS" ]; then
     MAC_ADDRESS=$(ip link show eth0 | grep ether | awk '{print $2}')
-    logger "Mac address not found in Device Metadata, Falling back to eth0"
+    logger --id="$$" "Mac address not found in Device Metadata, Falling back to eth0"
 fi
 
 # Create a folder for SsWW record files

--- a/platform/vs/docker-sonic-vs/orchagent.sh
+++ b/platform/vs/docker-sonic-vs/orchagent.sh
@@ -16,7 +16,7 @@ SWSS_VARS=$(sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t $SWSS_VARS_FILE) 
 MAC_ADDRESS=$(echo $SWSS_VARS | jq -r '.mac')
 if [ "$MAC_ADDRESS" == "None" ] || [ -z "$MAC_ADDRESS" ]; then
     MAC_ADDRESS=$(ip link show eth0 | grep ether | awk '{print $2}')
-    logger "Mac address not found in Device Metadata, Falling back to eth0"
+    logger --id="$$" "Mac address not found in Device Metadata, Falling back to eth0"
 fi
 
 # Create a folder for SwSS record files


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When a script calls the `logger` utility, each individual call gets its own PID assigned. Rsyslogd creates an internal rate-limit  object per PID that sends a log message. If the `logger` utility is called repeatedly, it will cause rsyslogd memory usage to increase permanently since a rate-limit object is being created for each call.


##### Work item tracking
- Microsoft ADO **28263484**:

#### How I did it
Anytime the `logger` command is used, also use the `--id` argument to specify the parent script PID that rsyslogd should use for rate limiting.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

