### PR TITLE
arista: Fix monState in fabric monitor config

### DIFF
--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/fabric_monitor_config.json
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/fabric_monitor_config.json
@@ -5,6 +5,6 @@
       "monPollThreshRecovery": 8,
       "monPollThreshIsolation": 1,
       "monCapacityThreshWarn": 10,
-      "monState": enable
+      "monState": "enable"
    }
 }

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/fabric_monitor_config.json
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/fabric_monitor_config.json
@@ -5,6 +5,6 @@
       "monPollThreshRecovery": 8,
       "monPollThreshIsolation": 1,
       "monCapacityThreshWarn": 10,
-      "monState": enable
+      "monState": "enable"
    }
 }

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/fabric_monitor_config.json
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/fabric_monitor_config.json
@@ -5,6 +5,6 @@
       "monPollThreshRecovery": 8,
       "monPollThreshIsolation": 1,
       "monCapacityThreshWarn": 10,
-      "monState": enable
+      "monState": "enable"
    }
 }

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/fabric_monitor_config.json
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/fabric_monitor_config.json
@@ -5,6 +5,6 @@
       "monPollThreshRecovery": 8,
       "monPollThreshIsolation": 1,
       "monCapacityThreshWarn": 86,
-      "monState": enable
+      "monState": "enable"
    }
 }

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/fabric_monitor_config.json
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/fabric_monitor_config.json
@@ -5,6 +5,6 @@
       "monPollThreshRecovery": 8,
       "monPollThreshIsolation": 1,
       "monCapacityThreshWarn": 86,
-      "monState": enable
+      "monState": "enable"
    }
 }

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/fabric_monitor_config.json
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/fabric_monitor_config.json
@@ -5,6 +5,6 @@
       "monPollThreshRecovery": 8,
       "monPollThreshIsolation": 1,
       "monCapacityThreshWarn": 86,
-      "monState": enable
+      "monState": "enable"
    }
 }

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/fabric_monitor_config.json
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/fabric_monitor_config.json
@@ -5,6 +5,6 @@
       "monPollThreshRecovery": 8,
       "monPollThreshIsolation": 1,
       "monCapacityThreshWarn": 86,
-      "monState": enable
+      "monState": "enable"
    }
 }

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/fabric_monitor_config.json
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/fabric_monitor_config.json
@@ -5,6 +5,6 @@
       "monPollThreshRecovery": 8,
       "monPollThreshIsolation": 1,
       "monCapacityThreshWarn": 100,
-      "monState": enable
+      "monState": "enable"
    }
 }

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/fabric_monitor_config.json
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/fabric_monitor_config.json
@@ -5,6 +5,6 @@
       "monPollThreshRecovery": 8,
       "monPollThreshIsolation": 1,
       "monCapacityThreshWarn": 86,
-      "monState": enable
+      "monState": "enable"
    }
 }

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/fabric_monitor_config.json
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/fabric_monitor_config.json
@@ -5,6 +5,6 @@
       "monPollThreshRecovery": 8,
       "monPollThreshIsolation": 1,
       "monCapacityThreshWarn": 100,
-      "monState": enable
+      "monState": "enable"
    }
 }


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

PR #19128 introduced a regression where the minigraph would fail to load, due to missing quotes in the new monState field in the fabric monitor config.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Quoting the "enable" string fixes the issue.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Verified that `load_minigraph -y -n` does not fail with a traceback due to a parse error.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

