### PR TITLE
Calulcate subport values and fix key error in hwsku.json

### DIFF
--- a/platform/vs/tests/breakout/sample_output/sample_new_port_config.json
+++ b/platform/vs/tests/breakout/sample_output/sample_new_port_config.json
@@ -4,13 +4,15 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27,28",
 	        "speed": "50000",
-	        "index": "0"
+	        "index": "0",
+	        "subport": "2"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25,26",
 	        "speed": "50000",
-	        "index": "0"
+	        "index": "0",
+	        "subport": "1"
 	    }
     },
     "Ethernet12_1x50G_2x25G": {
@@ -18,19 +20,22 @@
                 "alias": "fortyGigE0/12",
                 "lanes": "37,38",
                 "speed": "50000",
-                "index": "3"
+                "index": "3",
+                "subport": "1"
             },
             "Ethernet14": {
                 "alias": "fortyGigE0/14",
                 "lanes": "39",
                 "speed": "25000",
-                "index": "3"
+                "index": "3",
+                "subport": "2"
             },
 	    "Ethernet15": {
                 "alias": "fortyGigE0/15",
                 "lanes": "40",
                 "speed": "25000",
-                "index": "3"
+                "index": "3",
+                "subport": "3"
             }
     },
     "Ethernet0_2x50G": {
@@ -38,13 +43,15 @@
                 "alias": "fortyGigE0/2",
                 "lanes": "27,28",
                 "speed": "50000",
-                "index": "0"
+                "index": "0",
+                "subport": "2"
             },
             "Ethernet0": {
                 "alias": "fortyGigE0/0",
                 "lanes": "25,26",
                 "speed": "50000",
-                "index": "0"
+                "index": "0",
+                "subport": "1"
             }
     },
     "Ethernet0_1x100G": {
@@ -52,7 +59,8 @@
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25,26,27,28",
 	        "speed": "100000",
-	        "index": "0"
+	        "index": "0",
+	        "subport": "1"
 	    }
     },
     "Ethernet0_4x25G":	{
@@ -60,25 +68,29 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27",
 	        "speed": "25000",
-	        "index": "0"
+	        "index": "0",
+	        "subport": "3"
 	    },
 	    "Ethernet3": {
 	        "alias": "fortyGigE0/3",
 	        "lanes": "28",
 	        "speed": "25000",
-	        "index": "0"
+	        "index": "0",
+	        "subport": "4"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25",
 	        "speed": "25000",
-	        "index": "0"
+	        "index": "0",
+	        "subport": "1"
 	    },
 	    "Ethernet1": {
 	        "alias": "fortyGigE0/1",
 	        "lanes": "26",
 	        "speed": "25000",
-	        "index": "0"
+	        "index": "0",
+	        "subport": "2"
 	    }
     },
     "Ethernet0_2x25G_1x50G": {
@@ -86,19 +98,22 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27,28",
 	        "speed": "50000",
-	        "index": "0"
+	        "index": "0",
+	        "subport": "3"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25",
 	        "speed": "25000",
-	        "index": "0"
+	        "index": "0",
+	        "subport": "1"
 	    },
 	    "Ethernet1": {
 	        "alias": "fortyGigE0/1",
 	        "lanes": "26",
 	        "speed": "25000",
-	        "index": "0"
+	        "index": "0",
+	        "subport": "2"
 	    }
     },
     "Ethernet0_1x50G_2x25G": {
@@ -106,19 +121,22 @@
 	        "alias": "fortyGigE0/2",
 	        "lanes": "27",
 	        "speed": "25000",
-	        "index": "0"
+	        "index": "0",
+	        "subport": "2"
 	    },
 	    "Ethernet3": {
 	        "alias": "fortyGigE0/3",
 	        "lanes": "28",
 	        "speed": "25000",
-	        "index": "0"
+	        "index": "0",
+	        "subport": "3"
 	    },
 	    "Ethernet0": {
 	        "alias": "fortyGigE0/0",
 	        "lanes": "25,26",
 	        "speed": "50000",
-	        "index": "0"
+	        "index": "0",
+	        "subport": "1"
 		}
     },
     "Ethernet4_4x25G": {
@@ -126,25 +144,29 @@
 		"alias": "fortyGigE0/6",
 		"lanes": "31",
 		"speed": "25000",
-		"index": "1"
+		"index": "1",
+		"subport": "3"
 	},
 	"Ethernet7": {
 		"alias": "fortyGigE0/7",
 		"lanes": "32",
 		"speed": "25000",
-		"index": "1"
+		"index": "1",
+		"subport": "4"
 	},
 	"Ethernet4": {
 		"alias": "fortyGigE0/4",
 		"lanes": "29",
 		"speed": "25000",
-		"index": "1"
+		"index": "1",
+		"subport": "1"
 	},
 	"Ethernet5": {
 		"alias": "fortyGigE0/5",
 		"lanes": "30",
 		"speed": "25000",
-		"index": "1"
+		"index": "1",
+		"subport": "2"
 	}
     },
     "Ethernet4_2x50G": {
@@ -152,13 +174,15 @@
 		"alias": "fortyGigE0/6",
 		"lanes": "31,32",
 		"speed": "50000",
-		"index": "1"
+		"index": "1",
+		"subport": "2"
 	},
 	"Ethernet4": {
 		"alias": "fortyGigE0/4",
 		"lanes": "29,30",
 		"speed": "50000",
-		"index": "1"
+		"index": "1",
+		"subport": "1"
 	}
     },
     "Ethernet8_2x50G": {
@@ -166,13 +190,15 @@
 	        "alias": "fortyGigE0/8",
 	        "lanes": "33,34",
 	        "speed": "50000",
-	        "index": "2"
+	        "index": "2",
+	        "subport": "1"
 	    },
 	    "Ethernet10": {
 	        "alias": "fortyGigE0/10",
 	        "lanes": "35,36",
 	        "speed": "50000",
-	        "index": "2"
+	        "index": "2",
+	        "subport": "2"
 	    }
     },
     "Ethernet8_1x50G_2x25G": {
@@ -180,13 +206,15 @@
 	        "alias": "fortyGigE0/10",
 	        "lanes": "35",
 	        "speed": "25000",
-	        "index": "2"
+	        "index": "2",
+	        "subport": "1"
 	    },
 	    "Ethernet11": {
 	        "alias": "fortyGigE0/11",
 	        "lanes": "36",
 	        "speed": "25000",
-	        "index": "2"
+	        "index": "2",
+	        "subport": "2"
 	    }
     },
     "Ethernet8_2x25G_1x50G": {
@@ -194,19 +222,22 @@
 	        "alias": "fortyGigE0/8",
 	        "lanes": "33",
 	        "speed": "25000",
-	        "index": "2"
+	        "index": "2",
+	        "subport": "1"
 	    },
 	    "Ethernet9": {
 	        "alias": "fortyGigE0/9",
 	        "lanes": "34",
 	        "speed": "25000",
-	        "index": "2"
+	        "index": "2",
+	        "subport": "2"
 	    },
 	    "Ethernet10": {
 	        "alias": "fortyGigE0/10",
 	        "lanes": "35,36",
 	        "speed": "50000",
-	        "index": "2"
+	        "index": "2",
+	        "subport": "3"
 	    }
     },
     "Ethernet8_1x100G": {
@@ -214,7 +245,8 @@
 	        "alias": "fortyGigE0/8",
 	        "lanes": "33,34,35,36",
 	        "speed": "100000",
-	        "index": "2"
+	        "index": "2",
+	        "subport": "0"
 	    }
     }
 }

--- a/platform/vs/tests/breakout/test_breakout_cli.py
+++ b/platform/vs/tests/breakout/test_breakout_cli.py
@@ -74,22 +74,22 @@ class TestBreakoutCli(object):
         print("**** Breakout Cli test Starts ****")
         output_dict = self.breakout(dvs, 'Ethernet0', '2x50G')
         expected_dict = expected["Ethernet0_2x50G"]
-        assert output_dict == expected_dict
+        assert output_dict == expected_dict, "output: {} != expected: {}".format(output_dict, expected_dict)
         print("**** 1X100G --> 2x50G passed ****")
 
         output_dict = self.breakout(dvs, 'Ethernet4', '4x25G[10G]')
         expected_dict = expected["Ethernet4_4x25G"]
-        assert output_dict == expected_dict
+        assert output_dict == expected_dict, "output: {} != expected: {}".format(output_dict, expected_dict)
         print("**** 1X100G --> 4x25G[10G] passed ****")
 
         output_dict = self.breakout(dvs, 'Ethernet8', '2x25G(2)+1x50G(2)')
         expected_dict = expected["Ethernet8_2x25G_1x50G"]
-        assert output_dict == expected_dict
+        assert output_dict == expected_dict, "output: {} != expected: {}".format(output_dict, expected_dict)
         print("**** 1X100G --> 2x25G(2)+1x50G(2) passed ****")
 
         output_dict = self.breakout(dvs, 'Ethernet12', '1x50G(2)+2x25G(2)')
         expected_dict = expected["Ethernet12_1x50G_2x25G"]
-        assert output_dict == expected_dict
+        assert output_dict == expected_dict, "output: {} != expected: {}".format(output_dict, expected_dict)
         print("**** 1X100G --> 1x50G(2)+2x25G(2) passed ****")
 
         # TODOFIX: remove comments once #4442 PR got merged and

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -37,7 +37,7 @@ PORT_STR = "Ethernet"
 BRKOUT_MODE = "default_brkout_mode"
 CUR_BRKOUT_MODE = "brkout_mode"
 INTF_KEY = "interfaces"
-OPTIONAL_HWSKU_ATTRIBUTES = ["fec", "autoneg", "subport"]
+OPTIONAL_HWSKU_ATTRIBUTES = ["fec", "autoneg"]
 
 BRKOUT_PATTERN = r'(\d{1,6})x(\d{1,6}G?)(\[(\d{1,6}G?,?)*\])?(\((\d{1,6})\))?'
 BRKOUT_PATTERN_GROUPS = 6
@@ -353,8 +353,10 @@ class BreakoutCfg(object):
     def get_config(self):
         # Ensure that we have corret number of configured lanes
         lanes_used = 0
+        total_num_ports = 0
         for entry in self._breakout_mode_entry:
             lanes_used += entry.num_assigned_lanes
+            total_num_ports += entry.num_ports
 
         if lanes_used > len(self._lanes):
             raise RuntimeError("Assigned lines count is more that available!")
@@ -376,7 +378,8 @@ class BreakoutCfg(object):
                     'alias': self._breakout_capabilities[alias_id],
                     'lanes': ','.join(lanes),
                     'speed': str(entry.default_speed),
-                    'index': self._indexes[lane_id]
+                    'index': self._indexes[lane_id],
+                    'subport': "0" if total_num_ports == 1 else str(alias_id + 1)
                 }
 
                 lane_id += lanes_per_port
@@ -422,10 +425,12 @@ def parse_platform_json_file(hwsku_json_file, platform_json_file):
         child_ports = get_child_ports(intf, brkout_mode, platform_json_file)
 
         # take optional fields from hwsku.json
+        hwsku_entry = hwsku_dict[INTF_KEY]
         for child_port in child_ports:
-            for key, item in hwsku_dict[INTF_KEY][child_port].items():
-                if key in OPTIONAL_HWSKU_ATTRIBUTES:
-                    child_ports.get(child_port)[key] = item
+            if child_port in hwsku_entry:
+                for key, item in hwsku_entry[child_port].items():
+                    if key in OPTIONAL_HWSKU_ATTRIBUTES:
+                        child_ports.get(child_port)[key] = item
 
         ports.update(child_ports)
 

--- a/src/sonic-config-engine/tests/sample_output/platform_output.json
+++ b/src/sonic-config-engine/tests/sample_output/platform_output.json
@@ -7,6 +7,7 @@
     "alias": "Eth3/1",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet9": {
@@ -17,6 +18,7 @@
     "alias": "Eth3/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet36": {
@@ -27,6 +29,7 @@
     "alias": "Eth10/1",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet98": {
@@ -37,6 +40,7 @@
     "alias": "Eth25/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet0": {
@@ -49,6 +53,7 @@
     "alias": "Eth1",
     "pfc_asym": "off",
     "speed": "100000",
+    "subport": "0",
     "tpid": "0x8100"
   },
   "Ethernet6": {
@@ -60,6 +65,7 @@
     "alias": "Eth2/2",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet4": {
@@ -71,6 +77,7 @@
     "alias": "Eth2/1",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet109": {
@@ -81,6 +88,7 @@
     "alias": "Eth28/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet108": {
@@ -91,6 +99,7 @@
     "alias": "Eth28/1",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet18": {
@@ -101,6 +110,7 @@
     "alias": "Eth5/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet100": {
@@ -112,6 +122,7 @@
     "alias": "Eth26",
     "pfc_asym": "off",
     "speed": "100000",
+    "subport": "0",
     "tpid": "0x8100"
   },
   "Ethernet34": {
@@ -122,6 +133,7 @@
     "alias": "Eth9/3",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet104": {
@@ -132,6 +144,7 @@
     "alias": "Eth27/1",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet106": {
@@ -142,6 +155,7 @@
     "alias": "Eth27/2",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet94": {
@@ -152,6 +166,7 @@
     "alias": "Eth24/3",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet126": {
@@ -162,6 +177,7 @@
     "alias": "Eth32/2",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet96": {
@@ -172,6 +188,7 @@
     "alias": "Eth25/1",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet124": {
@@ -182,6 +199,7 @@
     "alias": "Eth32/1",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet90": {
@@ -192,6 +210,7 @@
     "alias": "Eth23/3",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet91": {
@@ -202,6 +221,7 @@
     "alias": "Eth23/4",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "4",
     "tpid": "0x8100"
   },
   "Ethernet92": {
@@ -212,6 +232,7 @@
     "alias": "Eth24/1",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet93": {
@@ -222,6 +243,7 @@
     "alias": "Eth24/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet50": {
@@ -232,6 +254,7 @@
     "alias": "Eth13/3",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet51": {
@@ -242,6 +265,7 @@
     "alias": "Eth13/4",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "4",
     "tpid": "0x8100"
   },
   "Ethernet52": {
@@ -252,6 +276,7 @@
     "alias": "Eth14/1",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet53": {
@@ -262,6 +287,7 @@
     "alias": "Eth14/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet54": {
@@ -272,6 +298,7 @@
     "alias": "Eth14/3",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet99": {
@@ -282,6 +309,7 @@
     "alias": "Eth25/3",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet56": {
@@ -292,6 +320,7 @@
     "alias": "Eth15/1",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet113": {
@@ -302,6 +331,7 @@
     "alias": "Eth29/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet76": {
@@ -312,6 +342,7 @@
     "alias": "Eth20/1",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet74": {
@@ -322,6 +353,7 @@
     "alias": "Eth19/3",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet39": {
@@ -332,6 +364,7 @@
     "alias": "Eth10/3",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet72": {
@@ -342,6 +375,7 @@
     "alias": "Eth19/1",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet73": {
@@ -352,6 +386,7 @@
     "alias": "Eth19/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet70": {
@@ -362,6 +397,7 @@
     "alias": "Eth18/3",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet71": {
@@ -372,6 +408,7 @@
     "alias": "Eth18/4",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "4",
     "tpid": "0x8100"
   },
   "Ethernet32": {
@@ -382,6 +419,7 @@
     "alias": "Eth9/1",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet33": {
@@ -392,6 +430,7 @@
     "alias": "Eth9/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet16": {
@@ -402,6 +441,7 @@
     "alias": "Eth5/1",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet111": {
@@ -412,6 +452,7 @@
     "alias": "Eth28/4",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "4",
     "tpid": "0x8100"
   },
   "Ethernet10": {
@@ -422,6 +463,7 @@
     "alias": "Eth3/3",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet11": {
@@ -432,6 +474,7 @@
     "alias": "Eth3/4",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "4",
     "tpid": "0x8100"
   },
   "Ethernet12": {
@@ -442,6 +485,7 @@
     "alias": "Eth4/1",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet13": {
@@ -452,6 +496,7 @@
     "alias": "Eth4/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet58": {
@@ -462,6 +507,7 @@
     "alias": "Eth15/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet19": {
@@ -472,6 +518,7 @@
     "alias": "Eth5/3",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet59": {
@@ -482,6 +529,7 @@
     "alias": "Eth15/3",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet38": {
@@ -492,6 +540,7 @@
     "alias": "Eth10/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet78": {
@@ -502,6 +551,7 @@
     "alias": "Eth20/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet68": {
@@ -512,6 +562,7 @@
     "alias": "Eth18/1",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet14": {
@@ -522,6 +573,7 @@
     "alias": "Eth4/3",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet89": {
@@ -532,6 +584,7 @@
     "alias": "Eth23/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet88": {
@@ -542,6 +595,7 @@
     "alias": "Eth23/1",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet118": {
@@ -552,6 +606,7 @@
     "alias": "Eth30/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet119": {
@@ -562,6 +617,7 @@
     "alias": "Eth30/3",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet116": {
@@ -572,6 +628,7 @@
     "alias": "Eth30/1",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet114": {
@@ -582,6 +639,7 @@
     "alias": "Eth29/3",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet80": {
@@ -593,6 +651,7 @@
     "alias": "Eth21",
     "pfc_asym": "off",
     "speed": "100000",
+    "subport": "0",
     "tpid": "0x8100"
   },
   "Ethernet112": {
@@ -603,6 +662,7 @@
     "alias": "Eth29/1",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet86": {
@@ -613,6 +673,7 @@
     "alias": "Eth22/2",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet110": {
@@ -623,6 +684,7 @@
     "alias": "Eth28/3",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet84": {
@@ -633,6 +695,7 @@
     "alias": "Eth22/1",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet31": {
@@ -643,6 +706,7 @@
     "alias": "Eth8/4",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "4",
     "tpid": "0x8100"
   },
   "Ethernet49": {
@@ -653,6 +717,7 @@
     "alias": "Eth13/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet48": {
@@ -663,6 +728,7 @@
     "alias": "Eth13/1",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet46": {
@@ -673,6 +739,7 @@
     "alias": "Eth12/2",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet30": {
@@ -683,6 +750,7 @@
     "alias": "Eth8/3",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet29": {
@@ -693,6 +761,7 @@
     "alias": "Eth8/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet40": {
@@ -704,6 +773,7 @@
     "alias": "Eth11",
     "pfc_asym": "off",
     "speed": "100000",
+    "subport": "0",
     "tpid": "0x8100"
   },
   "Ethernet120": {
@@ -715,6 +785,7 @@
     "alias": "Eth31",
     "pfc_asym": "off",
     "speed": "100000",
+    "subport": "0",
     "tpid": "0x8100"
   },
   "Ethernet28": {
@@ -725,6 +796,7 @@
     "alias": "Eth8/1",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet66": {
@@ -735,6 +807,7 @@
     "alias": "Eth17/2",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet60": {
@@ -746,6 +819,7 @@
     "alias": "Eth16",
     "pfc_asym": "off",
     "speed": "100000",
+    "subport": "0",
     "tpid": "0x8100"
   },
   "Ethernet64": {
@@ -756,6 +830,7 @@
     "alias": "Eth17/1",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet44": {
@@ -766,6 +841,7 @@
     "alias": "Eth12/1",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet20": {
@@ -778,6 +854,7 @@
     "alias": "Eth6",
     "pfc_asym": "off",
     "speed": "100000",
+    "subport": "0",
     "tpid": "0x8100"
   },
   "Ethernet79": {
@@ -788,6 +865,7 @@
     "alias": "Eth20/3",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "3",
     "tpid": "0x8100"
   },
   "Ethernet69": {
@@ -798,6 +876,7 @@
     "alias": "Eth18/2",
     "pfc_asym": "off",
     "speed": "25000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet24": {
@@ -808,6 +887,7 @@
     "alias": "Eth7/1",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "1",
     "tpid": "0x8100"
   },
   "Ethernet26": {
@@ -818,6 +898,7 @@
     "alias": "Eth7/2",
     "pfc_asym": "off",
     "speed": "50000",
+    "subport": "2",
     "tpid": "0x8100"
   },
   "Ethernet128": {
@@ -828,7 +909,8 @@
     "mtu": "9100",
     "alias": "Eth33",
     "pfc_asym": "off",
-    "speed": "40000"
+    "speed": "40000",
+    "subport": "0"
   },
   "Ethernet132": {
     "index": "34",
@@ -838,7 +920,8 @@
     "mtu": "9100",
     "alias": "Eth34",
     "pfc_asym": "off",
-    "speed": "25000"
+    "speed": "25000",
+    "subport": "0"
   },
   "Ethernet136": {
     "index": "35",
@@ -848,7 +931,8 @@
     "mtu": "9100",
     "alias": "Eth35/1",
     "pfc_asym": "off",
-    "speed": "10000"
+    "speed": "10000",
+    "subport": "1"
   },
   "Ethernet137": {
     "index": "35",
@@ -858,7 +942,8 @@
     "mtu": "9100",
     "alias": "Eth35/2",
     "pfc_asym": "off",
-    "speed": "10000"
+    "speed": "10000",
+    "subport": "2"
   },
   "Ethernet138": {
     "index": "35",
@@ -868,7 +953,8 @@
     "mtu": "9100",
     "alias": "Eth35/3",
     "pfc_asym": "off",
-    "speed": "10000"
+    "speed": "10000",
+    "subport": "3"
   },
   "Ethernet139": {
     "index": "35",
@@ -878,7 +964,8 @@
     "mtu": "9100",
     "alias": "Eth35/4",
     "pfc_asym": "off",
-    "speed": "10000"
+    "speed": "10000",
+    "subport": "4"
   },
   "Ethernet140": {
     "index": "36",
@@ -888,6 +975,7 @@
     "mtu": "9100",
     "alias": "Eth36/1",
     "pfc_asym": "off",
+    "subport": "1",
     "speed": "25000"
   },
   "Ethernet141": {
@@ -898,7 +986,8 @@
     "mtu": "9100",
     "alias": "Eth36/2",
     "pfc_asym": "off",
-    "speed": "25000"
+    "speed": "25000",
+    "subport": "2"
   },
   "Ethernet142": {
     "index": "36",
@@ -908,6 +997,7 @@
     "mtu": "9100",
     "alias": "Eth36/3",
     "pfc_asym": "off",
+    "subport": "3",
     "speed": "50000"
   },
   "Ethernet144": {
@@ -919,6 +1009,7 @@
     "alias": "Eth37",
     "pfc_asym": "off",
     "speed": "100000",
+    "subport": "0",
     "fec": "rs"
   }
 }

--- a/src/sonic-config-engine/tests/test_cfggen_platformJson.py
+++ b/src/sonic-config-engine/tests/test_cfggen_platformJson.py
@@ -79,19 +79,19 @@ class TestCfgGenPlatformJson(TestCase):
         argument = ['-m', self.platform_sample_graph, '-p', self.platform_json, '-S', self.hwsku_json, '-v', "PORT[\'Ethernet8\']"]
         output = self.run_script(argument)
         self.maxDiff = None
-        expected = "{'index': '3', 'lanes': '8', 'description': 'Eth3/1', 'mtu': '9100', 'alias': 'Eth3/1', 'pfc_asym': 'off', 'speed': '25000', 'tpid': '0x8100'}"
+        expected = "{'index': '3', 'lanes': '8', 'description': 'Eth3/1', 'mtu': '9100', 'alias': 'Eth3/1', 'pfc_asym': 'off', 'speed': '25000', 'subport': '1', 'tpid': '0x8100'}"
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict(expected))
 
         argument = ['-m', self.platform_sample_graph, '-p', self.platform_json, '-S', self.hwsku_json, '-v', "PORT[\'Ethernet112\']"]
         output = self.run_script(argument)
         self.maxDiff = None
-        expected = "{'index': '29', 'lanes': '112', 'description': 'Eth29/1', 'mtu': '9100', 'alias': 'Eth29/1', 'pfc_asym': 'off', 'speed': '25000', 'tpid': '0x8100'}"
+        expected = "{'index': '29', 'lanes': '112', 'description': 'Eth29/1', 'mtu': '9100', 'alias': 'Eth29/1', 'pfc_asym': 'off', 'speed': '25000', 'subport': '1', 'tpid': '0x8100'}"
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict(expected))
 
         argument = ['-m', self.platform_sample_graph, '-p', self.platform_json, '-S', self.hwsku_json, '-v', "PORT[\'Ethernet4\']"]
         output = self.run_script(argument)
         self.maxDiff = None
-        expected = "{'index': '2', 'lanes': '4,5', 'description': 'Eth2/1', 'admin_status': 'up', 'mtu': '9100', 'alias': 'Eth2/1', 'pfc_asym': 'off', 'speed': '50000', 'tpid': '0x8100'}"
+        expected = "{'index': '2', 'lanes': '4,5', 'description': 'Eth2/1', 'admin_status': 'up', 'mtu': '9100', 'alias': 'Eth2/1', 'pfc_asym': 'off', 'speed': '50000', 'subport': '1', 'tpid': '0x8100'}"
         print(output.strip())
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict(expected))
 


### PR DESCRIPTION
This pull request merges https://github.com/sonic-net/sonic-buildimage/pull/18499 to 202311

Automatically populate the correct subport value for an interface and insert into config_db.json

How to verify it
I verified this by checking the output of sonic-cfggen, updating config_db. and checking that both the host and media lane masks were correct for a 400GBASE-DR4 xcvr in both 2x200G-4 mode and 4x100G-2 mode.

All links came up and xcvrd prints the correct lanemasks in logs.

I also made sure that portconfig.py no longer causes an exception; it only checks for the optional HWSKU value if childports are present in hwsku.json file (this is to make sure we don't break Mellanox hwsku's)

I also changed the unit test for config_db generation and ensured the correct values match. The test passes.