### PR TITLE
[subnet decap] Fix VLAN prefix decap term 

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -52,10 +52,8 @@
         {%- set ipv6_vlan_addresses = ipv6_vlan_addresses.append(prefix) %}
     {%- endif %}
 {% endfor %}
-{% if not subnet_decap.enable %}
-    {%- set ipv4_addresses = ipv4_addresses + ipv4_vlan_addresses %}
-    {%- set ipv6_addresses = ipv6_addresses + ipv6_vlan_addresses %}
-{% endif %}
+{%- set ipv4_addresses = ipv4_addresses + ipv4_vlan_addresses %}
+{%- set ipv6_addresses = ipv6_addresses + ipv6_vlan_addresses %}
 [
 {% if ipv4_loopback_addresses %}
 {% if subnet_decap.enable %}

--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -3,6 +3,8 @@
 {% else %}
 {% set ipv4_addresses = [] %}
 {% set ipv6_addresses = [] %}
+{% set ipv4_vlan_addresses = [] %}
+{% set ipv6_vlan_addresses = [] %}
 {% set ipv4_loopback_addresses = [] %}
 {% set ipv6_loopback_addresses = [] %}
 {% if DEVICE_METADATA['localhost']['sub_role'] == 'FrontEnd' or  DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd'%}
@@ -44,12 +46,16 @@
 {% endfor %}
 {% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
     {%- if prefix | ipv4 %}
-        {%- set ipv4_addresses = ipv4_addresses.append(prefix) %}
+        {%- set ipv4_vlan_addresses = ipv4_vlan_addresses.append(prefix) %}
     {%- endif %}
     {%- if prefix | ipv6 %}
-        {%- set ipv6_addresses = ipv6_addresses.append(prefix) %}
+        {%- set ipv6_vlan_addresses = ipv6_vlan_addresses.append(prefix) %}
     {%- endif %}
 {% endfor %}
+{% if not subnet_decap.enable %}
+    {%- set ipv4_addresses = ipv4_addresses + ipv4_vlan_addresses %}
+    {%- set ipv6_addresses = ipv6_addresses + ipv6_vlan_addresses %}
+{% endif %}
 [
 {% if ipv4_loopback_addresses %}
 {% if subnet_decap.enable %}
@@ -66,6 +72,15 @@
         },
         "OP": "SET"
     },
+{% for prefix in ipv4_vlan_addresses|sort %}
+    {
+        "TUNNEL_DECAP_TERM_TABLE:IPINIP_SUBNET:{{ prefix | network }}/{{ prefix | prefixlen }}" : {
+            "term_type":"MP2MP",
+            "subnet_type": "vlan"
+        },
+        "OP": "SET"
+    },
+{% endfor %}
 {% endif %}
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
@@ -110,6 +125,15 @@
         },
         "OP": "SET"
     },
+{% for prefix in ipv6_vlan_addresses|sort %}
+    {
+        "TUNNEL_DECAP_TERM_TABLE:IPINIP_SUBNET_V6:{{ prefix | network }}/{{ prefix | prefixlen }}" : {
+            "term_type":"MP2MP",
+            "subnet_type": "vlan"
+        },
+        "OP": "SET"
+    },
+{% endfor %}
 {% endif %}
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {

--- a/src/sonic-config-engine/tests/sample_output/py2/ipinip_subnet_decap_enable.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/ipinip_subnet_decap_enable.json
@@ -74,6 +74,18 @@
         "OP": "SET"
     },
     {
+        "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:192.168.0.1" : {
+            "term_type":"P2MP"
+        },
+        "OP": "SET"
+    },
+    {
+        "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:192.168.200.1" : {
+            "term_type":"P2MP"
+        },
+        "OP": "SET"
+    },
+    {
         "TUNNEL_DECAP_TABLE:IPINIP_SUBNET_V6" : {
             "tunnel_type":"IPINIP",
             "dscp_mode":"uniform",

--- a/src/sonic-config-engine/tests/sample_output/py2/ipinip_subnet_decap_enable.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/ipinip_subnet_decap_enable.json
@@ -9,6 +9,20 @@
         "OP": "SET"
     },
     {
+        "TUNNEL_DECAP_TERM_TABLE:IPINIP_SUBNET:192.168.0.0/27" : {
+            "term_type":"MP2MP",
+            "subnet_type": "vlan"
+        },
+        "OP": "SET"
+    },
+    {
+        "TUNNEL_DECAP_TERM_TABLE:IPINIP_SUBNET:192.168.200.0/27" : {
+            "term_type":"MP2MP",
+            "subnet_type": "vlan"
+        },
+        "OP": "SET"
+    },
+    {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
             "dscp_mode":"uniform",
@@ -55,18 +69,6 @@
     },
     {
         "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.21.64.2" : {
-            "term_type":"P2MP"
-        },
-        "OP": "SET"
-    },
-    {
-        "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:192.168.0.1" : {
-            "term_type":"P2MP"
-        },
-        "OP": "SET"
-    },
-    {
-        "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:192.168.200.1" : {
             "term_type":"P2MP"
         },
         "OP": "SET"

--- a/src/sonic-config-engine/tests/sample_output/py3/ipinip_subnet_decap_enable.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/ipinip_subnet_decap_enable.json
@@ -74,6 +74,18 @@
         "OP": "SET"
     },
     {
+        "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:192.168.0.1" : {
+            "term_type":"P2MP"
+        },
+        "OP": "SET"
+    },
+    {
+        "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:192.168.200.1" : {
+            "term_type":"P2MP"
+        },
+        "OP": "SET"
+    },
+    {
         "TUNNEL_DECAP_TABLE:IPINIP_SUBNET_V6" : {
             "tunnel_type":"IPINIP",
             "dscp_mode":"uniform",

--- a/src/sonic-config-engine/tests/sample_output/py3/ipinip_subnet_decap_enable.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/ipinip_subnet_decap_enable.json
@@ -9,6 +9,20 @@
         "OP": "SET"
     },
     {
+        "TUNNEL_DECAP_TERM_TABLE:IPINIP_SUBNET:192.168.0.0/27" : {
+            "term_type":"MP2MP",
+            "subnet_type": "vlan"
+        },
+        "OP": "SET"
+    },
+    {
+        "TUNNEL_DECAP_TERM_TABLE:IPINIP_SUBNET:192.168.200.0/27" : {
+            "term_type":"MP2MP",
+            "subnet_type": "vlan"
+        },
+        "OP": "SET"
+    },
+    {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
             "dscp_mode":"uniform",
@@ -55,18 +69,6 @@
     },
     {
         "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.21.64.2" : {
-            "term_type":"P2MP"
-        },
-        "OP": "SET"
-    },
-    {
-        "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:192.168.0.1" : {
-            "term_type":"P2MP"
-        },
-        "OP": "SET"
-    },
-    {
-        "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:192.168.200.1" : {
             "term_type":"P2MP"
         },
         "OP": "SET"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
If subnet decap is enabled on T0, the subnet decap term should be created for VLAN prefixes.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

##### Work item tracking
- Microsoft ADO **(number only)**: 28316828

#### How I did it
For VLAN prefixes, if subnet decap is enabled, created MP2MP decap terms with subnet type `vlan` and under the subnet decap tunnels.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

