### PR TITLE
[Mellanox] Enhance is_module_host_management_mode to also check syncd's sai.profile

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -267,12 +267,16 @@ class DeviceDataManager:
     @classmethod
     @utils.read_only_cache()
     def is_module_host_management_mode(cls):
+        sai_profile_file_syncd = os.path.join('/tmp/', 'sai.profile')
+        if os.path.exists(sai_profile_file_syncd):
+            data = utils.read_key_value_file(sai_profile_file_syncd, delimeter='=')
+            return data.get('SAI_INDEPENDENT_MODULE_MODE') == '1'
         from sonic_py_common import device_info
         _, hwsku_dir = device_info.get_paths_to_platform_and_hwsku_dirs()
         sai_profile_file = os.path.join(hwsku_dir, 'sai.profile')
         data = utils.read_key_value_file(sai_profile_file, delimeter='=')
         return data.get('SAI_INDEPENDENT_MODULE_MODE') == '1'
-    
+
     @classmethod
     def wait_platform_ready(cls):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -267,13 +267,11 @@ class DeviceDataManager:
     @classmethod
     @utils.read_only_cache()
     def is_module_host_management_mode(cls):
-        sai_profile_file_syncd = os.path.join('/tmp/', 'sai.profile')
-        if os.path.exists(sai_profile_file_syncd):
-            data = utils.read_key_value_file(sai_profile_file_syncd, delimeter='=')
-            return data.get('SAI_INDEPENDENT_MODULE_MODE') == '1'
-        from sonic_py_common import device_info
-        _, hwsku_dir = device_info.get_paths_to_platform_and_hwsku_dirs()
-        sai_profile_file = os.path.join(hwsku_dir, 'sai.profile')
+        sai_profile_file = '/tmp/sai.profile'
+        if not os.path.exists(sai_profile_file):
+            from sonic_py_common import device_info
+            _, hwsku_dir = device_info.get_paths_to_platform_and_hwsku_dirs()
+            sai_profile_file = os.path.join(hwsku_dir, 'sai.profile')
         data = utils.read_key_value_file(sai_profile_file, delimeter='=')
         return data.get('SAI_INDEPENDENT_MODULE_MODE') == '1'
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Two steps (among others) are required to enable the host CMIS management feature: enabling it in the switch's sai.profile and performing a config reload. During the timeframe between these two steps, the control sysfs might be accessed, but they will not be present on the system until the latter step, the config reload, is completed. The code should try to access the control sysfs only after the config reload step. A good indication that this has been done is to check if the relevant entry is included in syncd's sai.profile. In contrast to the switch's sai.profile, syncd's sai.profile is only updated with the Host CMIS management support flag after the reload is complete.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
I updated the is_module_host_management_mode() implementation to first look for the Host CMIS management support flag in syncd's sai.profile, and only if it does not exist for some reason, look for it in the switch's sai.profile.

#### How to verify it
Add the Host CMIS management support flag to the switch's sai.profile and verify that the following log does not appear:
ERR pmon#xcvrd: Exception occured at DomInfoUpdateTask thread due to Exception('control sysfs for SFP 20 does not exist')

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

