### PR TITLE
Support for container_checker to add database-chassis container for Smartswitch platforms

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/TSA
+++ b/dockers/docker-fpm-frr/base_image_files/TSA
@@ -6,7 +6,16 @@ if [ "$EUID" -ne 0 ] ; then
   exit 1
 fi
 
-if [ -f /etc/sonic/chassisdb.conf ]; then
+PLATFORM="$(sonic-cfggen -d -v DEVICE_METADATA.localhost.platform)"
+PLATFORM_ENV_CONF=/usr/share/sonic/device/$PLATFORM/platform_env.conf
+SMARTSWITCH=false
+if [ -f "$PLATFORM_ENV_CONF" ]; then
+    if grep -Fxq "SMARTSWITCH=1" $PLATFORM_ENV_CONF; then
+        SMARTSWITCH=true
+    fi
+fi
+
+if [ -f /etc/sonic/chassisdb.conf ] && [ "$SMARTSWITCH" = false ] ; then
   rexec all -c "sudo TSA chassis"
   echo "Please execute \"rexec all -c 'sudo config save -y'\" to preserve System mode in Maintenance after reboot\
   or config reload on all linecards"

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -109,7 +109,7 @@ def get_expected_running_containers():
             else:
                 always_running_containers.add(container_name)
 
-    if device_info.is_supervisor():
+    if device_info.is_supervisor() or device_info.is_smartswitch():
         always_running_containers.add("database-chassis")
     return expected_running_containers, always_running_containers
 

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -573,6 +573,22 @@ def is_chassis():
     return is_voq_chassis() or is_packet_chassis()
 
 
+def is_smartswitch():
+    platform_env_conf_file_path = get_platform_env_conf_file_path()
+    if platform_env_conf_file_path is None:
+        return False
+    with open(platform_env_conf_file_path) as platform_env_conf_file:
+        for line in platform_env_conf_file:
+            tokens = line.split('=')
+            if len(tokens) < 2:
+               continue
+            if tokens[0].lower() == 'smartswitch':
+                val = tokens[1].strip()
+                if val == '1':
+                    return True
+        return False
+
+
 def is_supervisor():
     platform_env_conf_file_path = get_platform_env_conf_file_path()
     if platform_env_conf_file_path is None:


### PR DESCRIPTION
Support for container_checker to add database-chassis container for Smartswitch platforms

1. Platforms create 
      device/x86_64-8102_28fh_dpu_o-r0/platform_env.conf

2. Add the below line to the file       
SMARTSWITCH=1

3. This upstream patch will pickup the flag and add the databas-chassis container