### PR TITLE
Update sonic-mux-linkmgr yang model

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2335,6 +2335,9 @@
                 "src_mac": "ToRMac",
                 "interval_pck_loss_count_update": "3"
             },
+            "TIMED_OSCILLATION": {
+                "oscillation_enabled": "false"
+            },
             "MUXLOGGER": {
                 "log_verbosity": "debug"
             },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mux-linkmgr.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mux-linkmgr.json
@@ -5,6 +5,9 @@
     "MUX_LINKMGR_LINK_PROBER_CHANGE_MAC_ADDR": {
         "desc": "Use well-known mac and vlan mac as dst/src in linkmgrd link prober. "
     },
+    "MUX_LINKMGR_TIMED_OSCILLATION_DISABLE_OSCILLATION": {
+        "desc": "Disable timed oscillation."
+    },
     "MUX_LINKMGR_MUXLOGGER_CHANGE_VERBOSITY_LEVEL": {
         "desc": "Consume verbosity level config changes. "
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mux-linkmgr.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mux-linkmgr.json
@@ -23,6 +23,16 @@
             }
         }
     },
+    "MUX_LINKMGR_TIMED_OSCILLATION_DISABLE_OSCILLATION": {
+        "sonic-mux-linkmgr:sonic-mux-linkmgr": {
+            "sonic-mux-linkmgr:MUX_LINKMGR": {
+                "sonic-mux-linkmgr:TIMED_OSCILLATION":
+                    {
+                        "oscillation_enabled": "false"
+                    }
+            }
+        }
+    },
     "MUX_LINKMGR_MUXLOGGER_CHANGE_VERBOSITY_LEVEL": {
         "sonic-mux-linkmgr:sonic-mux-linkmgr": {
             "sonic-mux-linkmgr:MUX_LINKMGR": {

--- a/src/sonic-yang-models/yang-models/sonic-mux-linkmgr.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mux-linkmgr.yang
@@ -84,6 +84,22 @@ module sonic-mux-linkmgr {
                 }
             }
 
+            container TIMED_OSCILLATION {
+
+                leaf oscillation_enabled {
+                    type boolean;
+                    default true;
+                    description "Flag to enable/disable timed oscillation. ";
+                }
+
+                leaf interval_sec {
+                    type uint32;
+                    default 300;
+                    units seconds;
+                    description "Interval between MUX oscillations. ";
+                }
+            }
+
             container MUXLOGGER {
 
                 leaf log_verbosity {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
A new flag was introduced in https://github.com/sonic-net/sonic-linkmgrd/pull/250 to disable mux oscillations but yang model wasn't updated. We are seeing multiple tests failing due to this, some of them are -
1.  `generic_config_updater/test_dynamic_acl.py`
2. `passw_hardening/test_passw_hardening.py`
3. `dualtor_mgmt/test_toggle_mux.py`

##### Work item tracking
- [#153](https://github.com/aristanetworks/sonic-qual.msft/issues/153)
#### How I did it

#### How to verify it
Ran the failing tests with the image.


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

