### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202311.1.0.1
+ref=202311.1.0.2


### PR DESCRIPTION

Release notes for Cisco 8102-64H-O, 8101-32FH, and 8111-32EH-O
- Fix for priority-group drop issue for lossless traffic
- Fix for tx_drop counter increasing while port is oper down
- Fix for BGP remains UP even when egress/ingress disable is TRUE on LAG member ports
- SAI support for drop reasons L3_EGRESS_LINK_DOWN and DIP_LINK_LOCAL
- Upgraded SAI version to 1.13.0 for addressing log analyzer error causing multiple test failures
- SONiC-Mgmt Test Cases:
       Will upload test results to Kusto once run analysis is complete

How I did it
Update platform version to 202311.1.0.2