### PR TITLE
Fix QoS configuations for Quicksilver

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-256x200G/th5-a7060x6-64de.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-256x200G/th5-a7060x6-64de.config.bcm
@@ -1926,3 +1926,48 @@ device:
         DEVICE_CONFIG:
             AUTOLOAD_BOARD_SETTINGS: 0
 ...
+---
+device:
+    0:
+        TM_ING_THD_HEADROOM_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_HEADROOM_POOL_ID: [[0,3]]
+            :
+                LIMIT_CELLS: 0
+
+        TM_ING_THD_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_ING_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_OFFSET_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+
+        TM_EGR_THD_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_EGR_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_LIMIT_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+                YELLOW_SHARED_LIMIT_CELLS: 0
+                YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
+                RED_SHARED_LIMIT_CELLS: 0
+                RED_SHARED_RESUME_LIMIT_CELLS: 0
+
+        TM_THD_MC_EGR_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_EGR_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_LIMIT_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+                YELLOW_SHARED_LIMIT_CELLS: 0
+                YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
+                RED_SHARED_LIMIT_CELLS: 0
+                RED_SHARED_RESUME_LIMIT_CELLS: 0
+...

--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-256x200G/th5-a7060x6-64de.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-256x200G/th5-a7060x6-64de.config.bcm
@@ -1926,6 +1926,14 @@ device:
         DEVICE_CONFIG:
             AUTOLOAD_BOARD_SETTINGS: 0
 ...
+## Baseline
+---
+device:
+    0:
+        TM_THD_CONFIG:
+            SKIP_BUFFER_RESERVATION: 1
+            THRESHOLD_MODE: LOSSY_AND_LOSSLESS
+...
 ---
 device:
     0:
@@ -1970,4 +1978,43 @@ device:
                 YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
                 RED_SHARED_LIMIT_CELLS: 0
                 RED_SHARED_RESUME_LIMIT_CELLS: 0
+
+        TM_ING_PORT_PRI_GRP:
+            ?
+                PORT_ID: [[1, 8],
+                          [11, 18],
+                          [22, 29],
+                          [33, 40],
+                          [44, 51],
+                          [55, 62],
+                          [66, 73],
+                          [77, 84],
+                          [88, 95],
+                          [99, 106],
+                          [110, 117],
+                          [121, 128],
+                          [132, 139],
+                          [143, 150],
+                          [154, 161],
+                          [165, 172],
+                          [176, 183],
+                          [187, 194],
+                          [198, 205],
+                          [209, 216],
+                          [220, 227],
+                          [231, 238],
+                          [242, 249],
+                          [253, 260],
+                          [264, 271],
+                          [275, 282],
+                          [286, 293],
+                          [297, 304],
+                          [308, 315],
+                          [319, 326],
+                          [330, 337],
+                          [341, 348]]
+                TM_PRI_GRP_ID: 3
+            :
+                PFC: 1
+                LOSSLESS: 1
 ...

--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-64x400G/buffer_ports.j2
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-64x400G/buffer_ports.j2
@@ -1,0 +1,6 @@
+{%- macro generate_port_lists(PORT_ALL) %}
+    {# Generate list of ports #}
+    {%- for port_idx in range(0, 512, 8) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
+    {%- endfor %}
+{%- endmacro %}

--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE/buffer_ports.j2
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE/buffer_ports.j2
@@ -1,0 +1,6 @@
+{%- macro generate_port_lists(PORT_ALL) %}
+    {# Generate list of ports #}
+    {%- for port_idx in range(0, 512, 8) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
+    {%- endfor %}
+{%- endmacro %}

--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE/th5-a7060x6-64de.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE/th5-a7060x6-64de.config.bcm
@@ -1158,6 +1158,14 @@ device:
         DEVICE_CONFIG:
             AUTOLOAD_BOARD_SETTINGS: 0
 ...
+## Baseline
+---
+device:
+    0:
+        TM_THD_CONFIG:
+            SKIP_BUFFER_RESERVATION: 1
+            THRESHOLD_MODE: LOSSY_AND_LOSSLESS
+...
 ---
 device:
     0:
@@ -1202,4 +1210,43 @@ device:
                 YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
                 RED_SHARED_LIMIT_CELLS: 0
                 RED_SHARED_RESUME_LIMIT_CELLS: 0
+
+        TM_ING_PORT_PRI_GRP:
+            ?
+                PORT_ID: [[1, 2],
+                          [11, 12],
+                          [22, 23],
+                          [33, 34],
+                          [44, 45],
+                          [55, 56],
+                          [66, 67],
+                          [77, 78],
+                          [88, 89],
+                          [99, 100],
+                          [110, 111],
+                          [121, 122],
+                          [132, 133],
+                          [143, 144],
+                          [154, 155],
+                          [165, 166],
+                          [176, 177],
+                          [187, 188],
+                          [198, 199],
+                          [209, 210],
+                          [220, 221],
+                          [231, 232],
+                          [242, 243],
+                          [253, 254],
+                          [264, 265],
+                          [275, 276],
+                          [286, 287],
+                          [297, 298],
+                          [308, 309],
+                          [319, 320],
+                          [330, 331],
+                          [341, 342]]
+                TM_PRI_GRP_ID: 3
+            :
+                PFC: 1
+                LOSSLESS: 1
 ...

--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE/th5-a7060x6-64de.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE/th5-a7060x6-64de.config.bcm
@@ -1158,3 +1158,48 @@ device:
         DEVICE_CONFIG:
             AUTOLOAD_BOARD_SETTINGS: 0
 ...
+---
+device:
+    0:
+        TM_ING_THD_HEADROOM_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_HEADROOM_POOL_ID: [[0,3]]
+            :
+                LIMIT_CELLS: 0
+
+        TM_ING_THD_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_ING_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_OFFSET_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+
+        TM_EGR_THD_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_EGR_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_LIMIT_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+                YELLOW_SHARED_LIMIT_CELLS: 0
+                YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
+                RED_SHARED_LIMIT_CELLS: 0
+                RED_SHARED_RESUME_LIMIT_CELLS: 0
+
+        TM_THD_MC_EGR_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_EGR_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_LIMIT_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+                YELLOW_SHARED_LIMIT_CELLS: 0
+                YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
+                RED_SHARED_LIMIT_CELLS: 0
+                RED_SHARED_RESUME_LIMIT_CELLS: 0
+...

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-128x400G/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-128x400G/th5-a7060x6-64pe.config.bcm
@@ -1414,3 +1414,48 @@ device:
         DEVICE_CONFIG:
             AUTOLOAD_BOARD_SETTINGS: 0
 ...
+---
+device:
+    0:
+        TM_ING_THD_HEADROOM_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_HEADROOM_POOL_ID: [[0,3]]
+            :
+                LIMIT_CELLS: 0
+
+        TM_ING_THD_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_ING_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_OFFSET_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+
+        TM_EGR_THD_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_EGR_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_LIMIT_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+                YELLOW_SHARED_LIMIT_CELLS: 0
+                YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
+                RED_SHARED_LIMIT_CELLS: 0
+                RED_SHARED_RESUME_LIMIT_CELLS: 0
+
+        TM_THD_MC_EGR_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_EGR_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_LIMIT_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+                YELLOW_SHARED_LIMIT_CELLS: 0
+                YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
+                RED_SHARED_LIMIT_CELLS: 0
+                RED_SHARED_RESUME_LIMIT_CELLS: 0
+...

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-128x400G/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-128x400G/th5-a7060x6-64pe.config.bcm
@@ -1414,6 +1414,14 @@ device:
         DEVICE_CONFIG:
             AUTOLOAD_BOARD_SETTINGS: 0
 ...
+## Baseline
+---
+device:
+    0:
+        TM_THD_CONFIG:
+            SKIP_BUFFER_RESERVATION: 1
+            THRESHOLD_MODE: LOSSY_AND_LOSSLESS
+...
 ---
 device:
     0:
@@ -1458,4 +1466,43 @@ device:
                 YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
                 RED_SHARED_LIMIT_CELLS: 0
                 RED_SHARED_RESUME_LIMIT_CELLS: 0
+
+        TM_ING_PORT_PRI_GRP:
+            ?
+                PORT_ID: [[1, 4],
+                          [11, 14],
+                          [22, 25],
+                          [33, 36],
+                          [44, 47],
+                          [55, 58],
+                          [66, 69],
+                          [77, 80],
+                          [88, 91],
+                          [99, 102],
+                          [110, 113],
+                          [121, 124],
+                          [132, 135],
+                          [143, 146],
+                          [154, 157],
+                          [165, 168],
+                          [176, 179],
+                          [187, 190],
+                          [198, 201],
+                          [209, 212],
+                          [220, 223],
+                          [231, 234],
+                          [242, 245],
+                          [253, 256],
+                          [264, 267],
+                          [275, 278],
+                          [286, 289],
+                          [297, 300],
+                          [308, 311],
+                          [319, 322],
+                          [330, 333],
+                          [341, 344]]
+                TM_PRI_GRP_ID: 3
+            :
+                PFC: 1
+                LOSSLESS: 1
 ...

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-256x200G/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-256x200G/th5-a7060x6-64pe.config.bcm
@@ -1926,3 +1926,48 @@ device:
         DEVICE_CONFIG:
             AUTOLOAD_BOARD_SETTINGS: 0
 ...
+---
+device:
+    0:
+        TM_ING_THD_HEADROOM_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_HEADROOM_POOL_ID: [[0,3]]
+            :
+                LIMIT_CELLS: 0
+
+        TM_ING_THD_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_ING_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_OFFSET_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+
+        TM_EGR_THD_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_EGR_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_LIMIT_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+                YELLOW_SHARED_LIMIT_CELLS: 0
+                YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
+                RED_SHARED_LIMIT_CELLS: 0
+                RED_SHARED_RESUME_LIMIT_CELLS: 0
+
+        TM_THD_MC_EGR_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_EGR_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_LIMIT_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+                YELLOW_SHARED_LIMIT_CELLS: 0
+                YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
+                RED_SHARED_LIMIT_CELLS: 0
+                RED_SHARED_RESUME_LIMIT_CELLS: 0
+...

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-256x200G/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-256x200G/th5-a7060x6-64pe.config.bcm
@@ -1926,6 +1926,14 @@ device:
         DEVICE_CONFIG:
             AUTOLOAD_BOARD_SETTINGS: 0
 ...
+## Baseline
+---
+device:
+    0:
+        TM_THD_CONFIG:
+            SKIP_BUFFER_RESERVATION: 1
+            THRESHOLD_MODE: LOSSY_AND_LOSSLESS
+...
 ---
 device:
     0:
@@ -1970,4 +1978,43 @@ device:
                 YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
                 RED_SHARED_LIMIT_CELLS: 0
                 RED_SHARED_RESUME_LIMIT_CELLS: 0
+
+        TM_ING_PORT_PRI_GRP:
+            ?
+                PORT_ID: [[1, 8],
+                          [11, 18],
+                          [22, 29],
+                          [33, 40],
+                          [44, 51],
+                          [55, 62],
+                          [66, 73],
+                          [77, 84],
+                          [88, 95],
+                          [99, 106],
+                          [110, 117],
+                          [121, 128],
+                          [132, 139],
+                          [143, 150],
+                          [154, 161],
+                          [165, 172],
+                          [176, 183],
+                          [187, 194],
+                          [198, 205],
+                          [209, 216],
+                          [220, 227],
+                          [231, 238],
+                          [242, 249],
+                          [253, 260],
+                          [264, 271],
+                          [275, 282],
+                          [286, 293],
+                          [297, 304],
+                          [308, 315],
+                          [319, 326],
+                          [330, 337],
+                          [341, 348]]
+                TM_PRI_GRP_ID: 3
+            :
+                PFC: 1
+                LOSSLESS: 1
 ...

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-64x400G/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-64x400G/th5-a7060x6-64pe.config.bcm
@@ -1158,6 +1158,14 @@ device:
         DEVICE_CONFIG:
             AUTOLOAD_BOARD_SETTINGS: 0
 ...
+## Baseline
+---
+device:
+    0:
+        TM_THD_CONFIG:
+            SKIP_BUFFER_RESERVATION: 1
+            THRESHOLD_MODE: LOSSY_AND_LOSSLESS
+...
 ---
 device:
     0:
@@ -1202,4 +1210,43 @@ device:
                 YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
                 RED_SHARED_LIMIT_CELLS: 0
                 RED_SHARED_RESUME_LIMIT_CELLS: 0
+
+        TM_ING_PORT_PRI_GRP:
+            ?
+                PORT_ID: [[1, 2],
+                          [11, 12],
+                          [22, 23],
+                          [33, 34],
+                          [44, 45],
+                          [55, 56],
+                          [66, 67],
+                          [77, 78],
+                          [88, 89],
+                          [99, 100],
+                          [110, 111],
+                          [121, 122],
+                          [132, 133],
+                          [143, 144],
+                          [154, 155],
+                          [165, 166],
+                          [176, 177],
+                          [187, 188],
+                          [198, 199],
+                          [209, 210],
+                          [220, 221],
+                          [231, 232],
+                          [242, 243],
+                          [253, 254],
+                          [264, 265],
+                          [275, 276],
+                          [286, 287],
+                          [297, 298],
+                          [308, 309],
+                          [319, 320],
+                          [330, 331],
+                          [341, 342]]
+                TM_PRI_GRP_ID: 3
+            :
+                PFC: 1
+                LOSSLESS: 1
 ...

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-64x400G/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-64x400G/th5-a7060x6-64pe.config.bcm
@@ -1158,3 +1158,48 @@ device:
         DEVICE_CONFIG:
             AUTOLOAD_BOARD_SETTINGS: 0
 ...
+---
+device:
+    0:
+        TM_ING_THD_HEADROOM_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_HEADROOM_POOL_ID: [[0,3]]
+            :
+                LIMIT_CELLS: 0
+
+        TM_ING_THD_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_ING_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_OFFSET_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+
+        TM_EGR_THD_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_EGR_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_LIMIT_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+                YELLOW_SHARED_LIMIT_CELLS: 0
+                YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
+                RED_SHARED_LIMIT_CELLS: 0
+                RED_SHARED_RESUME_LIMIT_CELLS: 0
+
+        TM_THD_MC_EGR_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_EGR_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_LIMIT_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+                YELLOW_SHARED_LIMIT_CELLS: 0
+                YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
+                RED_SHARED_LIMIT_CELLS: 0
+                RED_SHARED_RESUME_LIMIT_CELLS: 0
+...

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE/th5-a7060x6-64pe.config.bcm
@@ -1158,6 +1158,14 @@ device:
         DEVICE_CONFIG:
             AUTOLOAD_BOARD_SETTINGS: 0
 ...
+## Baseline
+---
+device:
+    0:
+        TM_THD_CONFIG:
+            SKIP_BUFFER_RESERVATION: 1
+            THRESHOLD_MODE: LOSSY_AND_LOSSLESS
+...
 ---
 device:
     0:
@@ -1202,4 +1210,43 @@ device:
                 YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
                 RED_SHARED_LIMIT_CELLS: 0
                 RED_SHARED_RESUME_LIMIT_CELLS: 0
+
+        TM_ING_PORT_PRI_GRP:
+            ?
+                PORT_ID: [[1, 2],
+                          [11, 12],
+                          [22, 23],
+                          [33, 34],
+                          [44, 45],
+                          [55, 56],
+                          [66, 67],
+                          [77, 78],
+                          [88, 89],
+                          [99, 100],
+                          [110, 111],
+                          [121, 122],
+                          [132, 133],
+                          [143, 144],
+                          [154, 155],
+                          [165, 166],
+                          [176, 177],
+                          [187, 188],
+                          [198, 199],
+                          [209, 210],
+                          [220, 221],
+                          [231, 232],
+                          [242, 243],
+                          [253, 254],
+                          [264, 265],
+                          [275, 276],
+                          [286, 287],
+                          [297, 298],
+                          [308, 309],
+                          [319, 320],
+                          [330, 331],
+                          [341, 342]]
+                TM_PRI_GRP_ID: 3
+            :
+                PFC: 1
+                LOSSLESS: 1
 ...

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE/th5-a7060x6-64pe.config.bcm
@@ -1158,3 +1158,48 @@ device:
         DEVICE_CONFIG:
             AUTOLOAD_BOARD_SETTINGS: 0
 ...
+---
+device:
+    0:
+        TM_ING_THD_HEADROOM_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_HEADROOM_POOL_ID: [[0,3]]
+            :
+                LIMIT_CELLS: 0
+
+        TM_ING_THD_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_ING_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_OFFSET_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+
+        TM_EGR_THD_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_EGR_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_LIMIT_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+                YELLOW_SHARED_LIMIT_CELLS: 0
+                YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
+                RED_SHARED_LIMIT_CELLS: 0
+                RED_SHARED_RESUME_LIMIT_CELLS: 0
+
+        TM_THD_MC_EGR_SERVICE_POOL:
+            ?
+                BUFFER_POOL: [[0,1]]
+                TM_EGR_SERVICE_POOL_ID: [[0,3]]
+            :
+                SHARED_LIMIT_CELLS: 0
+                SHARED_RESUME_LIMIT_CELLS: 0
+                COLOR_SPECIFIC_LIMITS: 0
+                YELLOW_SHARED_LIMIT_CELLS: 0
+                YELLOW_SHARED_RESUME_LIMIT_CELLS: 0
+                RED_SHARED_LIMIT_CELLS: 0
+                RED_SHARED_RESUME_LIMIT_CELLS: 0
+...

--- a/device/common/profiles/th5/gen/BALANCED/buffers_defaults_t0.j2
+++ b/device/common/profiles/th5/gen/BALANCED/buffers_defaults_t0.j2
@@ -5,32 +5,37 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
+            "size": "60000000",
             "type": "ingress",
             "mode": "dynamic",
-            "size": "60000000",
             "xoff": "22600000"
         },
-        "egress_lossless_pool": {
+        "egress_lossy_pool": {
+            "size": "41300000",
             "type": "egress",
-            "mode": "static",
-            "size": "82600000"
+            "mode": "dynamic"
+        },
+        "egress_lossless_pool": {
+            "size": "41300000",
+            "type": "egress",
+            "mode": "static"
         }
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool": "ingress_lossless_pool",
-            "size": "0",
-            "dynamic_th": "3"
-        },
-        "egress_lossless_profile": {
-            "pool": "egress_lossless_pool",
-            "size": "0",
-            "static_th": "82600000"
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
-            "pool": "egress_lossless_pool",
-            "size": "0",
-            "dynamic_th": "3"
+            "pool":"egress_lossy_pool",
+            "size":"4096",
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"egress_lossless_pool",
+            "size":"4096",
+            "static_th":"41300000"
         }
     },
 {%- endmacro %}

--- a/device/common/profiles/th5/gen/BALANCED/buffers_defaults_t1.j2
+++ b/device/common/profiles/th5/gen/BALANCED/buffers_defaults_t1.j2
@@ -5,32 +5,37 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
+            "size": "60000000",
             "type": "ingress",
             "mode": "dynamic",
-            "size": "60000000",
             "xoff": "22600000"
         },
-        "egress_lossless_pool": {
+        "egress_lossy_pool": {
+            "size": "41300000",
             "type": "egress",
-            "mode": "static",
-            "size": "82600000"
+            "mode": "dynamic"
+        },
+        "egress_lossless_pool": {
+            "size": "41300000",
+            "type": "egress",
+            "mode": "static"
         }
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool": "ingress_lossless_pool",
-            "size": "0",
-            "dynamic_th": "3"
-        },
-        "egress_lossless_profile": {
-            "pool": "egress_lossless_pool",
-            "size": "0",
-            "static_th": "82600000"
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
-            "pool": "egress_lossless_pool",
-            "size": "0",
-            "dynamic_th": "3"
+            "pool":"egress_lossy_pool",
+            "size":"4096",
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"egress_lossless_pool",
+            "size":"4096",
+            "static_th":"41300000"
         }
     },
 {%- endmacro %}


### PR DESCRIPTION
Adds egress_lossy_pool and fixes SAI error caused by TH5 default config

#### Why I did it

This change is needed to fix a SAI crash on boot. These values zero out the reserved buffer space that by default would cause the pools defined in config_db.json to fail to create due to insufficient remaining room.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

The buffer pool values were chosen by simply dividing the total available MMU memory into 3 pools.

#### How to verify it

Without this change device fails to boot correctly.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311
- [x] 202405

#### Description for the changelog

Fix QoS configuations for Quicksilver
