### PR TITLE
[iccpd] Add nft-based ebtables utilities.

### DIFF
--- a/dockers/docker-iccpd/Dockerfile.j2
+++ b/dockers/docker-iccpd/Dockerfile.j2
@@ -7,7 +7,8 @@ ARG docker_container_name
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y ebtables
+    apt-get install -y ebtables \
+                       iptables
 
 COPY \
 {% for deb in docker_iccpd_debs.split(' ') -%}

--- a/dockers/docker-iccpd/Dockerfile.j2
+++ b/dockers/docker-iccpd/Dockerfile.j2
@@ -7,8 +7,7 @@ ARG docker_container_name
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y ebtables \
-                       iptables
+    apt-get install -y iptables
 
 COPY \
 {% for deb in docker_iccpd_debs.split(' ') -%}

--- a/rules/docker-iccpd.mk
+++ b/rules/docker-iccpd.mk
@@ -21,7 +21,7 @@ SONIC_INSTALL_DOCKER_DBG_IMAGES += $(DOCKER_ICCPD_DBG)
 endif
 
 $(DOCKER_ICCPD)_CONTAINER_NAME = iccpd
-$(DOCKER_ICCPD)_RUN_OPT += -t
+$(DOCKER_ICCPD)_RUN_OPT += -t --cap-add=NET_ADMIN
 $(DOCKER_ICCPD)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_ICCPD)_RUN_OPT += -v /etc/timezone:/etc/timezone:ro 
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix a problem (fixes #19323) where ebtables command cannot be executed by iccpd. This cause the trapped BUM packets (ipv6 neighbor discovery) looping back to the MCLAG port channel.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Replacing the legacy ebtables with the nft-based ebtables command suite by adding iptables package into the iccpd docker container.
 
#### How to verify it
Verified the ebtables command can be executed from the iccpd docker. When the MCLAG reaches operational state the isolation rules can be added.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
master
202305
202211

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

