### PR TITLE
Support yang model for buffer pool percentage

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -573,6 +573,7 @@ When the system is running in traditional buffer model, the size of all of the b
 ```
 
 When the system is running in dynamic buffer model, the size of some of the buffer pools can be omitted and will be dynamically calculated.
+In this case, A percentage can be configured on a pool, representing how many the available buffer can be allloced to the pool.
 
 ```
 {
@@ -584,11 +585,12 @@ When the system is running in dynamic buffer model, the size of some of the buff
     },
     "egress_lossy_pool": {
         "type": "egress",
-        "mode": "dynamic",
+        "mode": "dynamic"
     },
     "ingress_lossless_pool": {
         "type": "ingress",
         "mode": "dynamic",
+        "percentage": "80"
     }
   }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -36,6 +36,11 @@
                 "size": "12766208",
                 "type": "egress",
                 "mode": "dynamic"
+            },
+            "ingress_percentage_pool": {
+                "type": "ingress",
+                "mode": "dynamic",
+                "percentage": "90"
             }
         },
         "BUFFER_PROFILE": {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -356,6 +356,7 @@
         },
         "DEVICE_METADATA": {
             "localhost": {
+                "buffer_model": "dynamic",
                 "type": "ToRRouter",
                 "asic_id": "06:00.0",
                 "mac": "00:11:22:33:dd:5a",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/buffer_pool.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/buffer_pool.json
@@ -39,5 +39,24 @@
     "BUFFER_POOL_WRONG_SIZE_VALUE": {
         "desc": "BUFFER_POOL_WRONG_SIZE_VALUE pattern failure.",
         "eStr": "wrong"
+    },
+    "BUFFER_POOL_CORRECT_PERCENTAGE_VALUE": {
+        "desc": "BUFFER_POOL_CORRECT_PERCENTAGE_VALUE no failure."
+    },
+    "BUFFER_POOL_WRONG_PERCENTAGE_VALUE_100": {
+        "desc": "BUFFER_POOL_WRONG_PERCENTAGE_VALUE_100 pattern failure.",
+        "eStr": "does not satisfy the constraint"
+    },
+    "BUFFER_POOL_WRONG_PERCENTAGE_NEGATIVE_VALUE": {
+        "desc": "BUFFER_POOL_WRONG_PERCENTAGE_NEGATIVE_VALUE pattern failure.",
+        "eStr": "Invalid value"
+    },
+    "BUFFER_POOL_WRONG_PERCENTAGE_NOT_A_NUMBER_VALUE": {
+        "desc": "BUFFER_POOL_WRONG_PERCENTAGE_NOT_A_NUMBER_VALUE pattern failure.",
+        "eStr": "Invalid value"
+    },
+    "BUFFER_POOL_WRONG_PERCENTAGE_VALUE_WITH_SIZE": {
+        "desc": "BUFFER_POOL_WRONG_PERCENTAGE_VALUE_WITH_SIZE pattern failure.",
+        "eStr": "Percentage should not be configured along with size"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/buffer_pool.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/buffer_pool.json
@@ -43,10 +43,6 @@
     "BUFFER_POOL_CORRECT_PERCENTAGE_VALUE": {
         "desc": "BUFFER_POOL_CORRECT_PERCENTAGE_VALUE no failure."
     },
-    "BUFFER_POOL_WRONG_PERCENTAGE_VALUE_100": {
-        "desc": "BUFFER_POOL_WRONG_PERCENTAGE_VALUE_100 pattern failure.",
-        "eStr": "does not satisfy the constraint"
-    },
     "BUFFER_POOL_WRONG_PERCENTAGE_NEGATIVE_VALUE": {
         "desc": "BUFFER_POOL_WRONG_PERCENTAGE_NEGATIVE_VALUE pattern failure.",
         "eStr": "Invalid value"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/buffer_pool.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/buffer_pool.json
@@ -43,6 +43,9 @@
     "BUFFER_POOL_CORRECT_PERCENTAGE_VALUE": {
         "desc": "BUFFER_POOL_CORRECT_PERCENTAGE_VALUE no failure."
     },
+    "BUFFER_POOL_CORRECT_LARGE_PERCENTAGE_VALUE": {
+        "desc": "BUFFER_POOL_CORRECT_PERCENTAGE_VALUE no failure."
+    },
     "BUFFER_POOL_WRONG_PERCENTAGE_NEGATIVE_VALUE": {
         "desc": "BUFFER_POOL_WRONG_PERCENTAGE_NEGATIVE_VALUE pattern failure.",
         "eStr": "Invalid value"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/buffer_pool.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/buffer_pool.json
@@ -169,6 +169,13 @@
         }
     },
     "BUFFER_POOL_CORRECT_PERCENTAGE_VALUE": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "localhost":{
+                        "buffer_model": "dynamic"
+                }
+            }
+        },
         "sonic-buffer-pool:sonic-buffer-pool": {
             "sonic-buffer-pool:BUFFER_POOL": {
                 "BUFFER_POOL_LIST": [
@@ -176,20 +183,6 @@
                     "name": "ingress_lossless_pool",
                     "mode": "dynamic",
                     "percentage": "99",
-                    "type": "ingress"
-                }
-                ]
-            }
-        }
-    },
-    "BUFFER_POOL_WRONG_PERCENTAGE_VALUE_100": {
-        "sonic-buffer-pool:sonic-buffer-pool": {
-            "sonic-buffer-pool:BUFFER_POOL": {
-                "BUFFER_POOL_LIST": [
-                {
-                    "name": "ingress_lossless_pool",
-                    "mode": "static",
-                    "percentage": "100",
                     "type": "ingress"
                 }
                 ]

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/buffer_pool.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/buffer_pool.json
@@ -167,5 +167,76 @@
                 ]
             }
         }
+    },
+    "BUFFER_POOL_CORRECT_PERCENTAGE_VALUE": {
+        "sonic-buffer-pool:sonic-buffer-pool": {
+            "sonic-buffer-pool:BUFFER_POOL": {
+                "BUFFER_POOL_LIST": [
+                {
+                    "name": "ingress_lossless_pool",
+                    "mode": "dynamic",
+                    "percentage": "99",
+                    "type": "ingress"
+                }
+                ]
+            }
+        }
+    },
+    "BUFFER_POOL_WRONG_PERCENTAGE_VALUE_100": {
+        "sonic-buffer-pool:sonic-buffer-pool": {
+            "sonic-buffer-pool:BUFFER_POOL": {
+                "BUFFER_POOL_LIST": [
+                {
+                    "name": "ingress_lossless_pool",
+                    "mode": "static",
+                    "percentage": "100",
+                    "type": "ingress"
+                }
+                ]
+            }
+        }
+    },
+    "BUFFER_POOL_WRONG_PERCENTAGE_NEGATIVE_VALUE": {
+        "sonic-buffer-pool:sonic-buffer-pool": {
+            "sonic-buffer-pool:BUFFER_POOL": {
+                "BUFFER_POOL_LIST": [
+                {
+                    "name": "ingress_lossless_pool",
+                    "mode": "static",
+                    "percentage": "-10",
+                    "type": "ingress"
+                }
+                ]
+            }
+        }
+    },
+    "BUFFER_POOL_WRONG_PERCENTAGE_NOT_A_NUMBER_VALUE": {
+        "sonic-buffer-pool:sonic-buffer-pool": {
+            "sonic-buffer-pool:BUFFER_POOL": {
+                "BUFFER_POOL_LIST": [
+                {
+                    "name": "ingress_lossless_pool",
+                    "mode": "static",
+                    "percentage": "NaN",
+                    "type": "ingress"
+                }
+                ]
+            }
+        }
+    },
+    "BUFFER_POOL_WRONG_PERCENTAGE_VALUE_WITH_SIZE": {
+        "sonic-buffer-pool:sonic-buffer-pool": {
+            "sonic-buffer-pool:BUFFER_POOL": {
+                "BUFFER_POOL_LIST": [
+                {
+                    "name": "ingress_lossless_pool",
+                    "mode": "static",
+                    "percentage": "90",
+                    "size": "12766208",
+                    "type": "ingress"
+                }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/buffer_pool.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/buffer_pool.json
@@ -189,6 +189,27 @@
             }
         }
     },
+    "BUFFER_POOL_CORRECT_LARGE_PERCENTAGE_VALUE": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "localhost":{
+                        "buffer_model": "dynamic"
+                }
+            }
+        },
+        "sonic-buffer-pool:sonic-buffer-pool": {
+            "sonic-buffer-pool:BUFFER_POOL": {
+                "BUFFER_POOL_LIST": [
+                {
+                    "name": "ingress_lossless_pool",
+                    "mode": "dynamic",
+                    "percentage": "200",
+                    "type": "ingress"
+                }
+                ]
+            }
+        }
+    },
     "BUFFER_POOL_WRONG_PERCENTAGE_NEGATIVE_VALUE": {
         "sonic-buffer-pool:sonic-buffer-pool": {
             "sonic-buffer-pool:BUFFER_POOL": {

--- a/src/sonic-yang-models/yang-models/sonic-buffer-pool.yang
+++ b/src/sonic-yang-models/yang-models/sonic-buffer-pool.yang
@@ -2,6 +2,10 @@ module sonic-buffer-pool {
     namespace "http://github.com/sonic-net/sonic-buffer-pool";
     prefix bpl;
 
+    import sonic-device_metadata {
+        prefix device_metadata;
+    }
+
     organization
         "SONiC";
 
@@ -59,12 +63,13 @@ module sonic-buffer-pool {
                 }
 
                 leaf percentage {
-                    type uint8 {
-                        range "1..99";
-                    }
+                    type uint8;
                     description "Buffer Pool percentage";
                     must "(not(current()/../size))" {
                         error-message "Percentage should not be configured along with size";
+                    }
+                    must "/device_metadata:sonic-device_metadata/device_metadata:DEVICE_METADATA/device_metadata:localhost/device_metadata:buffer_model = 'dynamic'" {
+                        error-message "Percentage must be configured in dynamic buffer model";
                     }
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-buffer-pool.yang
+++ b/src/sonic-yang-models/yang-models/sonic-buffer-pool.yang
@@ -57,6 +57,16 @@ module sonic-buffer-pool {
                     type uint64;
                     description "Buffer Pool Xoff Threshold (in Bytes)";
                 }
+
+                leaf percentage {
+                    type uint8 {
+                        range "1..99";
+                    }
+                    description "Buffer Pool percentage";
+                    must "(not(current()/../size))" {
+                        error-message "Percentage should not be configured along with size";
+                    }
+                }
             }
         }
     }

--- a/src/sonic-yang-models/yang-models/sonic-buffer-pool.yang
+++ b/src/sonic-yang-models/yang-models/sonic-buffer-pool.yang
@@ -64,7 +64,10 @@ module sonic-buffer-pool {
 
                 leaf percentage {
                     type uint8;
-                    description "Buffer Pool percentage";
+                    description "
+                        Buffer Pool percentage.
+                        The buffer pool size will be available_buffer * percentage / 100 if percentage is provided.
+                        It is valid in dynamic buffer model only.";
                     must "(not(current()/../size))" {
                         error-message "Percentage should not be configured along with size";
                     }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Support yang model for `percentage` field in `BUFFER_POOL` table.
It is used in dynamic buffer model only and represents the percentage of a buffer pool's size compared to the available memory size

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

Unit test and manual test

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

