### PR TITLE
Fix the reference of variables for PR testing template

### DIFF
--- a/.azure-pipelines/run-test-scheduler-template.yml
+++ b/.azure-pipelines/run-test-scheduler-template.yml
@@ -117,7 +117,7 @@ steps:
       set -e
       pip install PyYAML
       rm -f new_test_plan_id.txt
-      
+
       python ./.azure-pipelines/test_plan.py create \
       -t ${{ parameters.TOPOLOGY }} \
       -o new_test_plan_id.txt \
@@ -130,17 +130,14 @@ steps:
       --mgmt-branch ${{ parameters.MGMT_BRANCH }} \
       --vm-type ${{ parameters.VM_TYPE }} \
       --num-asic ${{ parameters.NUM_ASIC }}
-      
+
       TEST_PLAN_ID=`cat new_test_plan_id.txt`
 
       echo "Created test plan $TEST_PLAN_ID"
       echo "Check $(FRONTEND_URL)/scheduler/testplan/$TEST_PLAN_ID for test plan status"
       echo "##vso[task.setvariable variable=TEST_PLAN_ID]$TEST_PLAN_ID"
     env:
-      TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
-      TENANT_ID: $(TESTBED_TOOLS_MSAL_TENANT_ID)
-      CLIENT_ID: $(TESTBED_TOOLS_MSAL_CLIENT_ID)
-      CLIENT_SECRET: $(TESTBED_TOOLS_MSAL_CLIENT_SECRET)
+      ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
     displayName: Trigger test
 
   - script: |
@@ -151,7 +148,7 @@ steps:
       # When "LOCK_TESTBED" finish, it changes into "PREPARE_TESTBED"
       python ./.azure-pipelines/test_plan.py poll -i "$(TEST_PLAN_ID)" --expected-state LOCK_TESTBED
     env:
-      TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
+      ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
     displayName: Lock testbed
 
   - script: |
@@ -163,7 +160,7 @@ steps:
       # When "PREPARE_TESTBED" finish, it changes into "EXECUTING"
       python ./.azure-pipelines/test_plan.py poll -i "$(TEST_PLAN_ID)" --expected-state PREPARE_TESTBED
     env:
-      TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
+      ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
     displayName: Prepare testbed
 
   - script: |
@@ -174,7 +171,7 @@ steps:
       # When "EXECUTING" finish, it changes into "KVMDUMP", "FAILED", "CANCELLED" or "FINISHED"
       python ./.azure-pipelines/test_plan.py poll -i "$(TEST_PLAN_ID)" --expected-state EXECUTING
     env:
-      TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
+      ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
     displayName: Run test
     timeoutInMinutes: ${{ parameters.MAX_RUN_TEST_MINUTES }}
 
@@ -188,7 +185,7 @@ steps:
         python ./.azure-pipelines/test_plan.py poll -i "$(TEST_PLAN_ID)" --expected-state KVMDUMP
       condition: succeededOrFailed()
       env:
-        TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
+        ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
       displayName: KVM dump
 
   - script: |
@@ -197,8 +194,5 @@ steps:
       python ./.azure-pipelines/test_plan.py cancel -i "$(TEST_PLAN_ID)"
     condition: always()
     env:
-      TESTBED_TOOLS_URL: $(TESTBED_TOOLS_URL)
-      TENANT_ID: $(TESTBED_TOOLS_MSAL_TENANT_ID)
-      CLIENT_ID: $(TESTBED_TOOLS_MSAL_CLIENT_ID)
-      CLIENT_SECRET: $(TESTBED_TOOLS_MSAL_CLIENT_SECRET)
+      ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
     displayName: Finalize running test plan


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the reference of variable in variable group in PR testing template.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

