### PR TITLE
Enable iburst option for NTP servers loaded from minigraph

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2610,7 +2610,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         results['SYSLOG_SERVER'] = dict((item, {}) for item in syslog_servers)
         results['DHCP_SERVER'] = dict((item, {}) for item in dhcp_servers)
         results['DHCP_RELAY'] = dhcp_relay_table
-        results['NTP_SERVER'] = dict((item, {}) for item in ntp_servers)
+        results['NTP_SERVER'] = dict((item, {'iburst': 'true'}) for item in ntp_servers)
         # Set default DNS nameserver from dns.j2
         results['DNS_NAMESERVER'] = {}
         if os.environ.get("CFGGEN_UNIT_TESTING", "0") == "2":

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2610,7 +2610,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         results['SYSLOG_SERVER'] = dict((item, {}) for item in syslog_servers)
         results['DHCP_SERVER'] = dict((item, {}) for item in dhcp_servers)
         results['DHCP_RELAY'] = dhcp_relay_table
-        results['NTP_SERVER'] = dict((item, {'iburst': 'true'}) for item in ntp_servers)
+        results['NTP_SERVER'] = dict((item, {'iburst': 'on'}) for item in ntp_servers)
         # Set default DNS nameserver from dns.j2
         results['DNS_NAMESERVER'] = {}
         if os.environ.get("CFGGEN_UNIT_TESTING", "0") == "2":

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -696,7 +696,7 @@ class TestCfgGen(TestCase):
     def test_metadata_ntp(self):
         argument = ['-m', self.sample_graph_metadata, '-p', self.port_config, '-v', "NTP_SERVER"]
         output = self.run_script(argument)
-        self.assertEqual(utils.to_dict(output.strip()), utils.to_dict("{'10.0.10.1': {}, '10.0.10.2': {}}"))
+        self.assertEqual(utils.to_dict(output.strip()), utils.to_dict("{'10.0.10.1': {'iburst': 'on'}, '10.0.10.2': {'iburst': 'on'}}"))
 
     def test_dns_nameserver(self):
         argument = ['-m', self.sample_graph_metadata, '-p', self.port_config, '-v', "DNS_NAMESERVER"]

--- a/src/sonic-config-engine/tests/test_chassis_cfggen.py
+++ b/src/sonic-config-engine/tests/test_chassis_cfggen.py
@@ -104,7 +104,7 @@ class TestVoqChassisSingleAsic(TestChassis):
         argument = ['-m', self.sample_graph, '-p',
                     self.sample_port_config, '--var-json', 'NTP_SERVER']
         output = json.loads(self.run_script(argument))
-        self.assertDictEqual(output, {'17.39.1.130': {}, '17.39.1.129': {}})
+        self.assertDictEqual(output, {'17.39.1.130': {'iburst': 'on'}, '17.39.1.129': {'iburst': 'on'}})
         # NTP data is present only in the host config
         argument = ['-m', self.sample_graph, '--var-json', 'NTP_SERVER']
 
@@ -416,7 +416,7 @@ class TestVoqChassisMultiAsic(TestChassis):
         argument = ['-m', self.sample_graph, '-p',
                     self.sample_port_config, '--var-json', 'NTP_SERVER']
         output = json.loads(self.run_script(argument))
-        self.assertDictEqual(output, {'17.39.1.130': {}, '17.39.1.129': {}})
+        self.assertDictEqual(output, {'17.39.1.130': {'iburst': 'on'}, '17.39.1.129': {'iburst': 'on'}})
         # NTP data is present only in the host config
         argument = ['-m', self.sample_graph, '--var-json', 'NTP_SERVER']
 
@@ -885,7 +885,7 @@ class TestVoqChassisSup(TestChassis):
             '--var-json', 'NTP_SERVER'
         ]
         output = json.loads(self.run_script(argument))
-        self.assertDictEqual(output, {'17.39.1.130': {}, '17.39.1.129': {}})
+        self.assertDictEqual(output, {'17.39.1.130': {'iburst': 'on'}, '17.39.1.129': {'iburst': 'on'}})
 
 
     def test_mgmt_port(self):
@@ -1022,7 +1022,7 @@ class TestPacketChassisSup(TestChassis):
             '--var-json', 'NTP_SERVER'
         ]
         output = json.loads(self.run_script(argument))
-        self.assertDictEqual(output, {'17.39.1.130': {}, '17.39.1.129': {}})
+        self.assertDictEqual(output, {'17.39.1.130': {'iburst': 'on'}, '17.39.1.129': {'iburst': 'on'}})
         # NTP data is present only in the host config
         argument = ['-m', self.sample_graph, '--var-json', 'NTP_SERVER']
 

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -283,7 +283,7 @@ class TestCfgGenCaseInsensitive(TestCase):
     def test_metadata_ntp(self):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "NTP_SERVER"]
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'10.0.10.1': {}, '10.0.10.2': {}}")
+        self.assertEqual(output.strip(), "{'10.0.10.1': {'iburst': 'on'}, '10.0.10.2': {'iburst': 'on'}}")
 
     def test_minigraph_vnet(self):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "VNET"]

--- a/src/sonic-config-engine/tests/test_multinpu_cfggen.py
+++ b/src/sonic-config-engine/tests/test_multinpu_cfggen.py
@@ -151,7 +151,7 @@ class TestMultiNpuCfgGen(TestCase):
     def test_metadata_ntp(self):
         argument = ['-m', self.sample_graph, '-p', self.sample_port_config, '--var-json', "NTP_SERVER"]
         output = json.loads(self.run_script(argument))
-        self.assertDictEqual(output, {'17.39.1.130': {}, '17.39.1.129': {}})
+        self.assertDictEqual(output, {'17.39.1.130': {'iburst': 'on'}, '17.39.1.129': {'iburst': 'on'}})
         #NTP data is present only in the host config
         argument = ['-m', self.sample_graph, '--var-json', "NTP_SERVER"]
         for asic in range(NUM_ASIC):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

In #15058, the NTP server configuration was modified to add additional options, such as conditionally enabling iburst, specifying the association type, and specifying the NTP version. One side effect of this was that the iburst option which was previously always enabled now requires it to be explicitly enabled in the config_db.

Fixes #19425.

##### Work item tracking
- Microsoft ADO **(number only)**: 28623148

#### How I did it

To restore the old behavior, when loading from minigraph, add `"iburst": "true"` for each NTP server loaded from minigraph.

#### How to verify it

Tested on a KVM setup, verified that the generated `ntp.conf` file had the `iburst` option.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

