### PR TITLE
Revert "[action] [PR:18912] [swss]: Add default ECMP/LAG hash offset values for T0 and T1 (#18912)"

### DIFF
--- a/dockers/docker-orchagent/switch.json.j2
+++ b/dockers/docker-orchagent/switch.json.j2
@@ -2,15 +2,11 @@
 {# set default hash seed to 0 #}
 {% set hash_seed = 0 %}
 {% set hash_seed_offset = 0 %}
-{% set ecmp_hash_offset_value = 0 %}
-{% set lag_hash_offset_value = 0 %}
 {% if DEVICE_METADATA.localhost.type %}
 {% if "ToRRouter" in DEVICE_METADATA.localhost.type or DEVICE_METADATA.localhost.type in ["EPMS", "MgmtTsToR"] %}
 {% set hash_seed = 0 %}
 {% elif "LeafRouter" in DEVICE_METADATA.localhost.type %}
 {% set hash_seed = 10 %}
-{% set ecmp_hash_offset_value = 10 %}
-{% set lag_hash_offset_value = 10 %}
 {% elif "SpineRouter" in DEVICE_METADATA.localhost.type %}
 {% set hash_seed = 25 %}
 {% endif %}
@@ -25,8 +21,6 @@
             "ecmp_hash_seed": "{{ hash_seed_value }}",
             "lag_hash_seed": "{{ hash_seed_value }}",
             "fdb_aging_time": "600",
-            "ecmp_hash_offset": "{{ ecmp_hash_offset_value }}",
-            "lag_hash_offset": "{{ lag_hash_offset_value }}",
 {% if DEVICE_METADATA.localhost.type and "LeafRouter" in DEVICE_METADATA.localhost.type %}
             "ordered_ecmp": "true"
 {% else %}

--- a/src/sonic-config-engine/tests/sample_output/t0-switch-masic1.json
+++ b/src/sonic-config-engine/tests/sample_output/t0-switch-masic1.json
@@ -4,8 +4,6 @@
             "ecmp_hash_seed": "11",
             "lag_hash_seed": "11",
             "fdb_aging_time": "600",
-            "ecmp_hash_offset": "10",
-            "lag_hash_offset": "10",
             "ordered_ecmp": "true"
         },
         "OP": "SET"

--- a/src/sonic-config-engine/tests/sample_output/t0-switch-masic3.json
+++ b/src/sonic-config-engine/tests/sample_output/t0-switch-masic3.json
@@ -4,8 +4,6 @@
             "ecmp_hash_seed": "13",
             "lag_hash_seed": "13",
             "fdb_aging_time": "600",
-            "ecmp_hash_offset": "10",
-            "lag_hash_offset": "10",
             "ordered_ecmp": "true"
         },
         "OP": "SET"

--- a/src/sonic-config-engine/tests/sample_output/t0-switch.json
+++ b/src/sonic-config-engine/tests/sample_output/t0-switch.json
@@ -4,8 +4,6 @@
             "ecmp_hash_seed": "0",
             "lag_hash_seed": "0",
             "fdb_aging_time": "600",
-            "ecmp_hash_offset": "0",
-            "lag_hash_offset": "0",
             "ordered_ecmp": "false"
         },
         "OP": "SET"

--- a/src/sonic-config-engine/tests/sample_output/t1-switch.json
+++ b/src/sonic-config-engine/tests/sample_output/t1-switch.json
@@ -4,8 +4,6 @@
             "ecmp_hash_seed": "10",
             "lag_hash_seed": "10",
             "fdb_aging_time": "600",
-            "ecmp_hash_offset": "10",
-            "lag_hash_offset": "10",
             "ordered_ecmp": "true"
         },
         "OP": "SET"


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#19397

This change was taken too early. We need to wait for below swss change to be merged and submodule advanced first.

https://github.com/sonic-net/sonic-swss/pull/3204