### PR TITLE
Expand pattern for dhcp relay discarding interface

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/sonic-events-dhcp-relay.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/sonic-events-dhcp-relay.json
@@ -2,7 +2,7 @@
     "SONIC_EVENTS_DHCP_RELAY_DHCP_RELAY_DISCARD_INCORRECT_IFNAME": {
         "sonic-events-dhcp-relay:sonic-events-dhcp-relay": {
             "sonic-events-dhcp-relay:dhcp-relay-discard": {
-                "ifname": "Eth",
+                "ifname": "@@@!!!",
                 "timestamp": "1985-04-12T23:20:50.52Z"
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-events-dhcp-relay.yang
+++ b/src/sonic-yang-models/yang-models/sonic-events-dhcp-relay.yang
@@ -41,7 +41,7 @@ module sonic-events-dhcp-relay {
 
             leaf ifname {
                 type string {
-                    pattern 'Ethernet[0-9]{1,3}';
+                    pattern '[a-zA-Z0-9]+';
                 }
                 description "Name of the i/f discarding";
             }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Currently yang pattern is restricting interfaces to those that start with Ethernet however interfaces that discard can start with "eth", "Vlan", "PortChannel", and others as well.

##### Work item tracking
- Microsoft ADO **(number only)**: 27176810

#### How I did it

Update YANG file

Update yang file

#### How to verify it

sonic-mgmt test and UT


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

