### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202311.1.0.2
+ref=202311.1.0.3


### PR DESCRIPTION
Release notes for Cisco 8102-64H-O, 8101-32FH, and 8111-32EH-O

- Enable IP for flow cache
- Fix arp reply delay
- Update default graphene pfc scrubber state 
- Enable l2 ecn for 8111
- Code drop update for SAI 1.13.0

How I did it
Update platform version to 202311.1.0.3