### PR TITLE
Add wrapper around logger command to always pass id/pid argument

### DIFF
--- a/dockers/docker-base-bookworm/Dockerfile.j2
+++ b/dockers/docker-base-bookworm/Dockerfile.j2
@@ -120,6 +120,9 @@ RUN apt-get clean -y                     && \
 COPY ["etc/rsyslog.conf", "/etc/rsyslog.conf"]
 COPY ["etc/rsyslog.d/*", "/etc/rsyslog.d/"]
 COPY ["root/.vimrc", "/root/.vimrc"]
+COPY ["bin/wrapper_logger.sh", "/usr/local/bin/logger"]
+RUN chmod +x /usr/bin/logger
+
 
 RUN ln /usr/bin/vim.tiny /usr/bin/vim
 

--- a/dockers/docker-base-bookworm/bin/wrapper_logger.sh
+++ b/dockers/docker-base-bookworm/bin/wrapper_logger.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# This is a wrapper script for logger to take -i option as the default
+# If user provides -id or --id then that option takes precedence
+
+/usr/bin/logger -i "$@"

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -231,6 +231,10 @@ sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/bash_*.deb || \
 sudo cp -f $IMAGE_CONFIGS/bash/bash.bashrc $FILESYSTEM_ROOT/etc/
 sudo cp -f $IMAGE_CONFIGS/bash/bash.bash_logout $FILESYSTEM_ROOT/etc/
 
+# Add wrapper script for logger command
+sudo cp -f $IMAGE_CONFIGS/bash/wrapper_logger.sh $FILESYSTEM_ROOT/usr/local/bin/logger
+sudo chmod 755 $FILESYSTEM_ROOT/usr/local/bin/logger
+
 # Install readline's initialization file
 sudo cp -f $IMAGE_CONFIGS/readline/inputrc $FILESYSTEM_ROOT/etc/
 

--- a/files/image_config/bash/wrapper_logger.sh
+++ b/files/image_config/bash/wrapper_logger.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# This is a wrapper script for logger to take -i option as the default
+# If user provides -id or --id then that option takes precedence
+
+/usr/bin/logger -i "$@"


### PR DESCRIPTION

#### Why I did it
Rsyslogd daemon installs rate limiting per process id. If a process calls `logger` to log syslog messages, then if the process becomes too chatty, then rsyslogd memory usage increases over time because each logger message is generated with new PID. To prevent this increase of rsyslogd memory over time due to flooding of syslog messages, a wrapper script is installed which invokes `/usr/bin/logger` with `-i` so that the logger logs the message with same process id and hence rate limit will be done per process and not per log message.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add wrapper around /usr/bin/logger 

#### How to verify it
1. Generate flood of syslog message in a script and see if rsyslogd memory is increasing
2. Ensure if the user passes `-id` or `--id` then this argument takes precd

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

- [x] 202305
- [x] 202311
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

