### PR TITLE
Enhance IPMI raw cmd and custom pmon object names

### DIFF
--- a/platform/pddf/i2c/utils/pddfparse.py
+++ b/platform/pddf/i2c/utils/pddfparse.py
@@ -1837,12 +1837,32 @@ class PddfParse():
         cmd = bmc_attr['bmc_cmd'] + " 2>/dev/null"
         if bmc_attr['type'] == 'raw':
             try:
-                value = subprocess.check_output(cmd, shell=True).strip()
+                value = subprocess.check_output(cmd, shell=True, universal_newlines=True).strip()
+
+                if 'index' in bmc_attr.keys():
+                    offset = int(bmc_attr['index'])
+                    #Assuming value is a string of bytes seperated by space
+                    value = value[offset * 3 : (offset * 3) + 2]
+
+                value = int(value, 16)
+
+                for attr in bmc_attr.keys():
+                    if attr == 'mask' :
+                        mask = int(bmc_attr['mask'], 16)
+                        value = value & mask
+                    elif attr == 'offset':
+                        inc = float(bmc_attr['offset'])
+                        value = int(value + inc)
+                    elif attr =='multiplier':
+                        mult = float(bmc_attr['multiplier'])
+                        value = int(value * mult)
+
             except Exception as e:
                 pass
 
             if value != 'N/A':
-                value = str(int(value, 16))
+                value = str(value)
+
             return value
 
         if bmc_attr['type'] == 'mask':

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_fan_drawer.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_fan_drawer.py
@@ -41,6 +41,9 @@ class PddfFanDrawer(FanDrawerBase):
         Retrieves the fan drawer name
         Returns: String containing fan-drawer name
         """
+        if 'drawer_name' in self.plugin_data['FAN']:
+            return self.plugin_data['FAN']['drawer_name'][str(self.fantray_index)]
+
         return "Fantray{0}".format(self.fantray_index)
 
     def get_presence(self):

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
@@ -196,7 +196,7 @@ class PddfSfp(SfpOptoeBase):
                 lpmode = True
             else:
                 lpmode = False
-        else:
+        elif self.get_presence():
             xcvr_id = self._xcvr_api_factory._get_id()
             if xcvr_id is not None:
                 if xcvr_id == 0x18 or xcvr_id == 0x19 or xcvr_id == 0x1e:

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_thermal.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_thermal.py
@@ -42,6 +42,9 @@ class PddfThermal(ThermalBase):
 
     def get_name(self):
         if self.is_psu_thermal:
+            if 'thermal_name' in self.plugin_data['PSU']:
+                return self.plugin_data['PSU']['thermal_name'][str(self.thermals_psu_index)]
+
             return "PSU{}_TEMP{}".format(self.thermals_psu_index, self.thermal_index)
         else:
             if 'dev_attr' in self.thermal_obj.keys():

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
@@ -909,11 +909,31 @@ class PddfApi():
         if bmc_attr['type'] == 'raw':
             try:
                 value = subprocess.check_output(cmd, shell=True, universal_newlines=True).strip()
+
+                if 'index' in bmc_attr.keys():
+                    offset = int(bmc_attr['index'])
+                    #Assuming value is a string of bytes seperated by space
+                    value = value[offset * 3 : (offset * 3) + 2]
+
+                value = int(value, 16)
+
+                for attr in bmc_attr.keys():
+                    if attr == 'mask' :
+                        mask = int(bmc_attr['mask'], 16)
+                        value = value & mask
+                    elif attr == 'offset':
+                        inc = float(bmc_attr['offset'])
+                        value = int(value + inc)
+                    elif attr =='multiplier':
+                        mult = float(bmc_attr['multiplier'])
+                        value = int(value * mult)
+
             except Exception as e:
                 pass
 
             if value != 'N/A':
-                value = str(int(value, 16))
+                value = str(value)
+
             return value
 
         if bmc_attr['type'] == 'mask':


### PR DESCRIPTION
#### Why I did it
- IPMI raw commands require some post processing which can be achieved only with method override
- Custom names for PMON objects is only possible with get_name method override
- LP mode is attempted to read from EEPROM even when transceiver is not present

#### How I did it
- Add below post processing parameters for IPMI raw command
1. index - byte position
2. mask - masking the values
3. offset - to increment or decrement
4. multiplier - to multiply
- Specifiy custom names for the PMON objects in pd-plugin.json
- LPMode is read from the EEPROM of the transceiver only when presence is true

#### How to verify it
Verified using the Celestica platforms DS2000, DS3000, DS4000

#### A picture of a cute animal (not mandatory but encouraged)
<img width="90" alt="image" src="https://github.com/sonic-net/sonic-buildimage/assets/29372802/58d9cc92-26cb-47d2-9b4b-bf56e5069f85">

