### PR TITLE
fix non canonical format of IPv6 address string in bgpcfgd

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
@@ -324,6 +324,15 @@ class BGPPeerMgrBase(Manager):
                  If the interface has not been set, return None
         """
         local_addresses = self.directory.get_slot("LOCAL", "local_addresses")
+
+        # Handle local_addr string that is not represented in canonical text format, especially for IPv6 addresses
+        try:
+            ip = netaddr.IPAddress(str(local_addr))
+        except (netaddr.NotRegisteredError, netaddr.AddrFormatError, netaddr.AddrConversionError):
+            log_warn("IP Address '%s' format is wrong" % (local_addr))
+            return None
+        local_addr = str(ip)
+
         # Check if the local address of this bgp session has been set
         if local_addr not in local_addresses:
             return None


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
IPv6 addresses text used in cfgdb may not follow the canonical IPv6 text format. When performing IPv6 addresses equivalent check with string, need to make sure that both of them are in the shortest form defined in rfc 5952
