### PR TITLE
[FRR] Adding patch to fix isisd memory leak

### DIFF
--- a/src/sonic-frr/patch/0014-isisd-Fix-memory-leak.patch
+++ b/src/sonic-frr/patch/0014-isisd-Fix-memory-leak.patch
@@ -1,0 +1,25 @@
+From 45f5ba53f94d97c4b1cf31fd0bca01167cd727cb Mon Sep 17 00:00:00 2001
+From: Tyler Li <litiezheng@inspur.com>
+Date: Tue, 9 Apr 2024 14:43:19 +0800
+Subject: [PATCH] isisd: Fix memory leak
+
+Signed-off-by: Tyler Li <litiezheng@inspur.com>
+---
+ isisd/isis_lfa.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/isisd/isis_lfa.c b/isisd/isis_lfa.c
+index 84aac24d5..e99c4b805 100644
+--- a/isisd/isis_lfa.c
++++ b/isisd/isis_lfa.c
+@@ -255,6 +255,7 @@ void isis_lfa_excluded_ifaces_clear(struct isis_circuit *circuit, int level)
+ {
+ 	hash_clean(circuit->lfa_excluded_ifaces[level - 1],
+ 		   lfa_excl_interface_hash_free);
++	hash_free(circuit->lfa_excluded_ifaces[level - 1]);
+ }
+ 
+ /**
+-- 
+2.37.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -13,3 +13,4 @@ cross-compile-changes.patch
 0011-bgpd-enhanced-capability-is-always-turned-on-for-int.patch
 0012-Ensure-ospf_apiclient_lsa_originate-cannot-accidently-write-into-stack.patch
 0013-zebra-fix-dplane-fpm-nl-to-allow-for-fast-configuration.patch
+0014-isisd-Fix-memory-leak.patch


### PR DESCRIPTION
Fixing issue
Repeat command "ip router isis 5" and "no ip router isis 5", there is memory leak in isisd

- How I did it Root cause of the problem:

The isis_lfa_excluded_ifaces_clear function in isis_lfa.c only clears the elements when clearing the hash table, but does not release the table itself.

Release memory in hash_free:

MTYPE_HASH*2
MTYPE_HASH_INDEX * 1
MTYPE_LINK_NODE * 1

Modification method:

Add hash_free after hash_clean, and there is no need to empty it after release.

- How to verify it Repeat command "ip router isis 5" and "no ip router isis 5", no memory leak in isisd

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

