### PR TITLE
[202311] use default (local) docker registry when available

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -71,7 +71,11 @@ SHELL = /bin/bash
 USER := $(shell id -un)
 PWD := $(shell pwd)
 USER_LC := $(shell echo $(USER) | tr A-Z a-z)
-DOCKER_MACHINE := $(shell docker run --rm debian:buster uname -m)
+ifneq ($(DEFAULT_CONTAINER_REGISTRY),)
+    DOCKER_MACHINE := $(shell docker run --rm $(DEFAULT_CONTAINER_REGISTRY)/debian:buster uname -m)
+    else
+    DOCKER_MACHINE := $(shell docker run --rm debian:buster uname -m)
+endif
 
 comma := ,
 


### PR DESCRIPTION
This PR is cherry-picking #19445

#### Why I did it
DEFAULT_CONTAINER_REGISTRY didn't work as expected in some scenario.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
When check for docker arch, use DEFAULT_CONTAINER_REGISTRY if it is not null.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

