### PR TITLE
Fix the issue of monit service socket connection is not ready

### DIFF
--- a/src/system-health/health_checker/service_checker.py
+++ b/src/system-health/health_checker/service_checker.py
@@ -56,6 +56,9 @@ class ServiceChecker(HealthChecker):
         'Program': 'Status ok'
     }
 
+    # monit service socket path
+    SOCKET_PATH = '/var/run/monit.sock'
+
     def __init__(self):
         HealthChecker.__init__(self)
         self.container_critical_processes = {}
@@ -264,6 +267,11 @@ class ServiceChecker(HealthChecker):
         :param config: Health checker configuration.
         :return:
         """
+
+        if not os.path.exists(ServiceChecker.SOCKET_PATH):
+            logger.log_warning('monit service socket connection is not ready ...')
+            return
+
         output = utils.run_command(ServiceChecker.CHECK_MONIT_SERVICE_CMD)
         if not output or output.strip() != 'active':
             self.set_object_not_ok('Service', 'monit', 'monit service is not running')


### PR DESCRIPTION
#### Why I did it
    system-healthd obtains the status of relevant services through "monit summary," which may result in error messages, when rebooting DUT

#### How I did it
    The monit service will start monitoring only after a delay of 5 minutes. system-healthd checks whether the monit service socket is established.
#### How to verify it
    Reboot DUT and check the logs