### PR TITLE
[FRR] Adding patch to fix ospfd vty json memory leak

### DIFF
--- a/src/sonic-frr/patch/0030-ospf-vty-json-obj-free.patch
+++ b/src/sonic-frr/patch/0030-ospf-vty-json-obj-free.patch
@@ -1,0 +1,63 @@
+diff --git a/ospfd/ospf_vty.c b/ospfd/ospf_vty.c
+index 387472454..122d8525e 100755
+--- a/ospfd/ospf_vty.c
++++ b/ospfd/ospf_vty.c
+@@ -3927,15 +3927,15 @@ static int show_ip_ospf_interface_common(struct vty *vty, struct ospf *ospf,
+ 		/* Interface name is specified. */
+ 		ifp = if_lookup_by_name(intf_name, ospf->vrf_id);
+ 		if (ifp == NULL) {
+-			if (use_json)
++			if (use_json) {
+ 				json_object_boolean_true_add(json_vrf,
+ 							     "noSuchIface");
+-			else
++				json_object_free(json_interface);
++			} else
+ 				vty_out(vty, "No such interface name\n");
+ 		} else {
+ 			if (use_json) {
+ 				json_interface_sub = json_object_new_object();
+-				json_interface = json_object_new_object();
+ 			}
+ 
+ 			show_ip_ospf_interface_sub(
+@@ -4070,6 +4070,10 @@ static int show_ip_ospf_interface_traffic_common(
+ 				vty_out(vty,
+ 					"  OSPF not enabled on this interface %s\n",
+ 					ifp->name);
++				if (use_json) {
++					if (use_vrf)
++						json_object_free(json_vrf);
++				}
+ 				return CMD_SUCCESS;
+ 			}
+ 
+@@ -7024,8 +7028,13 @@ static int show_ip_ospf_database_common(struct vty *vty, struct ospf *ospf,
+ 		type = OSPF_OPAQUE_AREA_LSA;
+ 	else if (strncmp(argv[arg_base + idx_type]->text, "opaque-as", 9) == 0)
+ 		type = OSPF_OPAQUE_AS_LSA;
+-	else
++	else {
++		if (uj) {
++			if (use_vrf)
++				json_object_free(json_vrf);
++		}
+ 		return CMD_WARNING;
++	}
+ 
+ 	/* `show ip ospf database LSA'. */
+ 	if ((argc == arg_base + 5) || (uj && (argc == arg_base + 6)))
+@@ -11028,7 +11037,12 @@ static int show_ip_ospf_route_common(struct vty *vty, struct ospf *ospf,
+ 	ospf_show_vrf_name(ospf, vty, json_vrf, use_vrf);
+ 
+ 	if (ospf->new_table == NULL) {
+-		vty_out(vty, "No OSPF routing information exist\n");
++		if (json) {
++			if (use_vrf)
++				json_object_free(json_vrf);
++		} else {
++			vty_out(vty, "No OSPF routing information exist\n");
++		}
+ 		return CMD_SUCCESS;
+ 	}
+ 

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -27,3 +27,4 @@
 0027-lib-Do-not-convert-EVPN-prefixes-into-IPv4-IPv6-if-n.patch
 0028-zebra-fix-parse-attr-problems-for-encap.patch
 0029-zebra-nhg-fix-on-intf-up.patch
+0030-ospf-vty-json-obj-free.patch


### PR DESCRIPTION
Fixing issue
Use json_object_new_object, but some json missing json_object_object_add to add into parent node,

- Waht I did
Force lost json obj child nodes to use json_object_free

- How to verify it
Execute vtysh "show ip ospf interface Ethernet5 json", "show ip ospf vrf default interface Ethernet5 json" ..related commands Check ospfd memory usage

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [X] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

