### PR TITLE
[FRR] Fix isisd crash in list_delete

### DIFF
--- a/src/sonic-frr/patch/0030-isis-list-delete-safe-wrapper.patch
+++ b/src/sonic-frr/patch/0030-isis-list-delete-safe-wrapper.patch
@@ -1,0 +1,82 @@
+diff --git a/isisd/isisd.h b/isisd/isisd.h
+old mode 100644
+new mode 100755
+index 7f8474a5f..27f0248a5
+--- a/isisd/isisd.h
++++ b/isisd/isisd.h
+@@ -25,6 +25,7 @@
+ 
+ #include "vty.h"
+ #include "memory.h"
++#include "linklist.h"
+ 
+ #include "isisd/isis_constants.h"
+ #include "isisd/isis_common.h"
+@@ -73,6 +74,9 @@ extern void isis_cli_init(void);
+ 		all_vrf = strmatch(vrf_name, "all");                           \
+ 	}
+ 
++// ISU2024032541096, Use list_delete wrapper func point to list_delete_safe
++#define list_delete(LIST_A) list_delete_safe(LIST_A)
++
+ extern struct zebra_privs_t isisd_privs;
+ 
+ /* uncomment if you are a developer in bug hunt */
+diff --git a/lib/linklist.c b/lib/linklist.c
+old mode 100644
+new mode 100755
+index 8137b68d8..ad8246e73
+--- a/lib/linklist.c
++++ b/lib/linklist.c
+@@ -304,6 +304,33 @@ void *listnode_head(struct list *list)
+ 	return NULL;
+ }
+ 
++// ISU2024032541096, Use list_delete wrapper func point to list_delete_safe
++void list_delete_all_node_safe(struct list *list)
++{
++	struct listnode *node;
++	struct listnode *next;
++
++	assert(list);
++	for (node = list->head; node; node = next) {
++		next = node->next;
++		if (*list->del)
++			(*list->del)(node->data);
++		listnode_free(list, node);
++		list->head = next;
++		list->count--;
++	}
++	list->head = list->tail = NULL;
++	list->count = 0;
++}
++
++void list_delete_safe(struct list **list)
++{
++	assert(*list);
++	list_delete_all_node_safe(*list);
++	list_free_internal(*list);
++	*list = NULL;
++}
++
+ void list_delete_all_node(struct list *list)
+ {
+ 	struct listnode *node;
+diff --git a/lib/linklist.h b/lib/linklist.h
+old mode 100644
+new mode 100755
+index 145214521..0e75e5e83
+--- a/lib/linklist.h
++++ b/lib/linklist.h
+@@ -258,6 +258,11 @@ extern void list_sort(struct list *list,
+  */
+ void **list_to_array(struct list *list, void **arr, size_t arrlen);
+ 
++
++// ISU2024032541096, Use list_delete wrapper func point to list_delete_safe
++extern void list_delete_all_node_safe(struct list *list);
++extern void list_delete_safe(struct list **plist);
++
+ /*
+  * Delete a list and NULL its pointer.
+  *

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -27,3 +27,4 @@
 0027-lib-Do-not-convert-EVPN-prefixes-into-IPv4-IPv6-if-n.patch
 0028-zebra-fix-parse-attr-problems-for-encap.patch
 0029-zebra-nhg-fix-on-intf-up.patch
+0030-isis-list-delete-safe-wrapper.patch


### PR DESCRIPTION
Fixing issue
isisd circut down will trigget list_delete, the isisd state change hooker func call the list in the same time

- Waht I did
Use list_delete_safe wrapper function to replace list_delete

- How to verify it 2 device connected directly, and setup isis session via direct interface, execute interface shutdown/no shutdown many times

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [X] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

