### PR TITLE
[System-Health] Add to support ignoring the health check for the required feature.

### DIFF
--- a/src/system-health/health_checker/config.py
+++ b/src/system-health/health_checker/config.py
@@ -41,6 +41,7 @@ class Config(object):
         self._last_mtime = None
         self.config_data = None
         self.interval = Config.DEFAULT_INTERVAL
+        self.ignore_features = None
         self.ignore_services = None
         self.ignore_devices = None
         self.user_defined_checkers = None
@@ -69,6 +70,7 @@ class Config(object):
                     self.config_data = json.load(f)
 
                 self.interval = self.config_data.get('polling_interval', Config.DEFAULT_INTERVAL)
+                self.ignore_features = self._get_list_data('features_to_ignore')
                 self.ignore_services = self._get_list_data('services_to_ignore')
                 self.ignore_devices = self._get_list_data('devices_to_ignore')
                 self.user_defined_checkers = self._get_list_data('user_defined_checkers')
@@ -83,6 +85,7 @@ class Config(object):
         self._last_mtime = None
         self.config_data = None
         self.interval = Config.DEFAULT_INTERVAL
+        self.ignore_features = None
         self.ignore_services = None
         self.ignore_devices = None
         self.user_defined_checkers = None

--- a/src/system-health/health_checker/service_checker.py
+++ b/src/system-health/health_checker/service_checker.py
@@ -378,6 +378,10 @@ class ServiceChecker(HealthChecker):
         """
         feature_name = self.container_feature_dict[container_name]
         if feature_name in feature_table:
+            # We check the feature ignore list. 
+            # If the feature is in that list, we skip its health check. 
+            if (config and config.ignore_features and feature_name in config.ignore_features):
+                return
             # We look into the 'FEATURE' table to verify whether the container is disabled or not.
             # If the container is diabled, we exit.
             if ("state" in feature_table[feature_name]

--- a/src/system-health/health_checker/system_health_monitoring_config.json
+++ b/src/system-health/health_checker/system_health_monitoring_config.json
@@ -1,4 +1,5 @@
 {
+    "features_to_ignore": [],
     "services_to_ignore": [],
     "devices_to_ignore": [],
     "user_defined_checkers": [],

--- a/src/system-health/tests/system_health_monitoring_config.json
+++ b/src/system-health/tests/system_health_monitoring_config.json
@@ -1,4 +1,5 @@
 {
+    "features_to_ignore": ["dummy_feature"],
     "services_to_ignore": ["dummy_service"],
     "devices_to_ignore": ["psu.voltage"],
     "user_defined_checkers": [],

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -528,6 +528,7 @@ def test_config():
     assert config.config_file_exists()
     config.load_config()
     assert config.interval == 60
+    assert 'dummy_feature' in config.ignore_features
     assert 'dummy_service' in config.ignore_services
     assert 'psu.voltage' in config.ignore_devices
     assert len(config.user_defined_checkers) == 0
@@ -538,6 +539,7 @@ def test_config():
     assert config.get_bootup_timeout() == 300
 
     config._reset()
+    assert not config.ignore_features
     assert not config.ignore_services
     assert not config.ignore_devices
     assert not config.user_defined_checkers


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently, the system-health supports ignore the health check for services and devices by 
user-defined. 

However, more support must be needed to ignore some features during the health check. 

This PR implements the related functions to system-health so that users can skip the 
feature's health check by adding the feature name into the new field "features_to_ignore" 
at the system_health_monitoring_config.json.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
 - A new field, "features_to_ignore," was added to the system_health_monitoring_config.json.
 - Update the config.py to read the new field from the JSON file. 
 - Update the service_checker.py to check if the feature is not in the features ignore list, then start the health check. 

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [X] 202111
- [X] 202205
- [X] 202211
- [X] 202305
- [X] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

