### PR TITLE
[Chassis][Voq][Yang] Make asic_name case sensitive in yang models

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/system_port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/system_port.json
@@ -86,6 +86,82 @@
                 ]
             }
         }
+    },
+    "SYSTEM_ASIC_NAME_UPPERCASE": {
+        "sonic-system-port:sonic-system-port": {
+            "sonic-system-port:SYSTEM_PORT": {
+                "SYSTEM_PORT_LIST": [
+                    {
+                        "hostname": "host456",
+                        "asic_name": "ASIC0",
+                        "ifname": "Ethernet0",
+                        "core_index": "1",
+                        "core_port_index": "20",
+                        "num_voq": "8",
+                        "speed": "900000",
+                        "switch_id": "1",
+                        "system_port_id": "200"
+                    }
+                ]
+            }
+        }
+    },
+    "SYSTEM_ASIC_NAME_INVALID": {
+        "sonic-system-port:sonic-system-port": {
+            "sonic-system-port:SYSTEM_PORT": {
+                "SYSTEM_PORT_LIST": [
+                    {
+                        "hostname": "host456",
+                        "asic_name": "INVALIDASIC0",
+                        "ifname": "Ethernet0",
+                        "core_index": "1",
+                        "core_port_index": "20",
+                        "num_voq": "8",
+                        "speed": "900000",
+                        "switch_id": "1",
+                        "system_port_id": "200"
+                    }
+                ]
+            }
+        }
+    },
+    "SYSTEM_ASIC_NAME_SUP": {
+        "sonic-system-port:sonic-system-port": {
+            "sonic-system-port:SYSTEM_PORT": {
+                "SYSTEM_PORT_LIST": [
+                    {
+                        "hostname": "host456",
+                        "asic_name": "ASIC12",
+                        "ifname": "Ethernet0",
+                        "core_index": "1",
+                        "core_port_index": "20",
+                        "num_voq": "8",
+                        "speed": "900000",
+                        "switch_id": "1",
+                        "system_port_id": "200"
+                    }
+                ]
+            }
+        }
+    },
+    "SYSTEM_ASIC_NAME_MIXED_CASE": {
+        "sonic-system-port:sonic-system-port": {
+            "sonic-system-port:SYSTEM_PORT": {
+                "SYSTEM_PORT_LIST": [
+                    {
+                        "hostname": "host456",
+                        "asic_name": "Asic2",
+                        "ifname": "Ethernet0",
+                        "core_index": "1",
+                        "core_port_index": "20",
+                        "num_voq": "8",
+                        "speed": "900000",
+                        "switch_id": "1",
+                        "system_port_id": "200"
+                    }
+                ]
+            }
+        }
     }
 
 }

--- a/src/sonic-yang-models/yang-models/sonic-buffer-queue.yang
+++ b/src/sonic-yang-models/yang-models/sonic-buffer-queue.yang
@@ -84,9 +84,7 @@ module sonic-buffer-queue {
                 }
 
                 leaf asic_name {
-                    type string {
-                        pattern "[Aa]sic[0-4]";
-                    }
+                    type stypes:asic_name;
                 }
 
                 leaf port {

--- a/src/sonic-yang-models/yang-models/sonic-queue.yang
+++ b/src/sonic-yang-models/yang-models/sonic-queue.yang
@@ -105,9 +105,7 @@ module sonic-queue {
                 }
 
                 leaf asic_name {
-                    type string {
-                        pattern "[Aa]sic[0-4]";
-                    }
+                    type stypes:asic_name;
                 }
 
                 leaf ifname {

--- a/src/sonic-yang-models/yang-models/sonic-system-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-port.yang
@@ -34,9 +34,7 @@ module sonic-system-port {
                 }
 
                 leaf asic_name {
-                    type string {
-                        pattern "[Aa]sic[0-4]";
-                    }
+                    type stypes:asic_name;
                 }
 
                 leaf ifname {

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -385,6 +385,11 @@ module sonic-types {
             enum off;
         }
     }
+    typedef asic_name {
+        type string {
+            pattern '[Aa][Ss][Ii][Cc][0-9]{1,2}';
+        }
+    }
 
     {% if yang_model_type == "cvl" %}
     /* Required for CVL */

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -385,6 +385,7 @@ module sonic-types {
             enum off;
         }
     }
+
     typedef asic_name {
         type string {
             pattern '[Aa][Ss][Ii][Cc][0-9]{1,2}';


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes #19485 
##### Work item tracking
- Microsoft ADO ** 28529095**:

#### How I did it
Add a new typedef for `asic_name` and make the pattern case in sensitive
#### How to verify it
UT and test on voq linecards

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
202405 and 202205
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

