### PR TITLE
fix zebra crash when vrf delete

### DIFF
--- a/src/sonic-frr/patch/0030-fix-zebra-crash-when-vrf-delete.patch
+++ b/src/sonic-frr/patch/0030-fix-zebra-crash-when-vrf-delete.patch
@@ -1,0 +1,195 @@
+diff --git a/lib/queue.h b/lib/queue.h
+index dab43e3c5..2b999ee10 100644
+--- a/lib/queue.h
++++ b/lib/queue.h
+@@ -88,6 +88,18 @@ extern "C" {
+ 		TAILQ_FIRST(head) = TAILQ_NEXT((_elm), field);                 \
+ 	}; _elm; })
+ #endif
++#define PTR_POISON1  ((void *) 0x00100100)
++#define PTR_POISON2  ((void *) 0x00200200)
++
++#define TAILQ_ENTRY_NOLINK(elm, field)                                         \
++	(((elm)->field.tqe_next == PTR_POISON1) &&                             \
++	 ((elm)->field.tqe_prev == PTR_POISON2))
++
++#define TAILQ_ENTRY_POISON(elm, field)                                         \
++	do {                                                                   \
++		(elm)->field.tqe_next = PTR_POISON1;                           \
++		(elm)->field.tqe_prev = PTR_POISON2;                           \
++	} while (0)
+ 
+ #ifdef __cplusplus
+ }
+diff --git a/zebra/rib.h b/zebra/rib.h
+index 2e62148ea..d0797b7af 100644
+--- a/zebra/rib.h
++++ b/zebra/rib.h
+@@ -602,6 +602,10 @@ static inline void rib_tables_iter_cleanup(rib_tables_iter_t *iter)
+ 
+ DECLARE_HOOK(rib_update, (struct route_node * rn, const char *reason),
+ 	     (rn, reason));
++DECLARE_HOOK(fpm_write, (), ());
++DECLARE_HOOK(fpm_vrf_write, (), ());
++DECLARE_HOOK(dest_init, (rib_dest_t *dest), (dest));
++DECLARE_HOOK(dest_fini, (rib_dest_t *dest), (dest));
+ DECLARE_HOOK(rib_shutdown, (struct route_node * rn), (rn));
+ 
+ /*
+diff --git a/zebra/zebra_fpm.c b/zebra/zebra_fpm.c
+index f9f4ee476..3f41f8734 100644
+--- a/zebra/zebra_fpm.c
++++ b/zebra/zebra_fpm.c
+@@ -661,6 +661,7 @@ static void zfpm_conn_down_thread_cb(struct thread *thread)
+ 			if (CHECK_FLAG(dest->flags, RIB_DEST_UPDATE_FPM)) {
+ 				TAILQ_REMOVE(&zfpm_g->dest_q, dest,
+ 					     fpm_q_entries);
++				TAILQ_ENTRY_POISON(dest, fpm_q_entries);
+ 			}
+ 
+ 			UNSET_FLAG(dest->flags, RIB_DEST_UPDATE_FPM);
+@@ -1022,6 +1023,7 @@ static int zfpm_build_route_updates(void)
+ 		 */
+ 		UNSET_FLAG(dest->flags, RIB_DEST_UPDATE_FPM);
+ 		TAILQ_REMOVE(&zfpm_g->dest_q, dest, fpm_q_entries);
++		TAILQ_ENTRY_POISON(dest, fpm_q_entries);
+ 
+ 		if (is_add) {
+ 			SET_FLAG(dest->flags, RIB_DEST_SENT_TO_FPM);
+@@ -1236,7 +1238,7 @@ static void zfpm_write_cb(struct thread *thread)
+ 			break;
+ 		}
+ 
+-		if (zfpm_thread_should_yield(thread)) {
++		if (thread && zfpm_thread_should_yield(thread)) {
+ 			zfpm_g->stats.t_write_yields++;
+ 			break;
+ 		}
+@@ -1246,6 +1248,45 @@ static void zfpm_write_cb(struct thread *thread)
+ 		zfpm_write_on();
+ }
+ 
++/*
++ * zfpm_write_sync
++ */
++static int zfpm_write_sync()
++{
++	int num_writes = 0;
++
++	while (zfpm_g->t_write) {
++		zfpm_write_off();
++		zfpm_write_cb(NULL);
++		if (++num_writes >= ZFPM_MAX_WRITES_PER_RUN)
++			break;
++	}
++
++	return num_writes;
++}
++
++/*
++ * zfpm_dest_init
++ */
++static int zfpm_dest_init(rib_dest_t *dest)
++{
++	TAILQ_ENTRY_POISON(dest, fpm_q_entries);
++	return 1;
++}
++
++/*
++ * zfpm_dest_fini
++ */
++static int zfpm_dest_fini(rib_dest_t *dest)
++{
++	if (!TAILQ_ENTRY_NOLINK(dest, fpm_q_entries)) {
++		TAILQ_REMOVE(&zfpm_g->dest_q, dest, fpm_q_entries);
++		TAILQ_ENTRY_POISON(dest, fpm_q_entries);
++		return 1;
++	}
++	return 0;
++}
++
+ /*
+  * zfpm_connect_cb
+  */
+@@ -2071,6 +2112,11 @@ static int zebra_fpm_module_init(void)
+ 	hook_register(zebra_rmac_update, zfpm_trigger_rmac_update);
+ 	hook_register(frr_late_init, zfpm_init);
+ 	hook_register(frr_early_fini, zfpm_fini);
++	hook_register(fpm_write, zfpm_write_sync);
++	hook_register(fpm_vrf_write, zfpm_write_sync);
++	hook_register(dest_init, zfpm_dest_init);
++	hook_register(dest_fini, zfpm_dest_fini);
++
+ 	return 0;
+ }
+ 
+diff --git a/zebra/zebra_rib.c b/zebra/zebra_rib.c
+index 1ff3d9854..ebe990298 100644
+--- a/zebra/zebra_rib.c
++++ b/zebra/zebra_rib.c
+@@ -76,6 +76,9 @@ static struct dplane_ctx_list_head rib_dplane_q;
+ 
+ DEFINE_HOOK(rib_update, (struct route_node * rn, const char *reason),
+ 	    (rn, reason));
++DEFINE_HOOK(fpm_write, (), ());
++DEFINE_HOOK(dest_init, (rib_dest_t *dest), (dest));
++DEFINE_HOOK(dest_fini, (rib_dest_t *dest), (dest));
+ DEFINE_HOOK(rib_shutdown, (struct route_node * rn), (rn));
+ 
+ 
+@@ -946,6 +949,7 @@ int rib_gc_dest(struct route_node *rn)
+ 
+ 	dest->rnode = NULL;
+ 	rnh_list_fini(&dest->nht);
++	hook_call(dest_fini, dest);
+ 	XFREE(MTYPE_RIB_DEST, dest);
+ 	rn->info = NULL;
+ 
+@@ -972,6 +976,7 @@ void zebra_rtable_node_cleanup(struct route_table *table,
+ 		hook_call(rib_shutdown, node);
+ 
+ 		rnh_list_fini(&dest->nht);
++		hook_call(dest_fini, dest);
+ 		XFREE(MTYPE_RIB_DEST, node->info);
+ 	}
+ }
+@@ -3840,6 +3845,7 @@ rib_dest_t *zebra_rib_create_dest(struct route_node *rn)
+ 
+ 	dest = XCALLOC(MTYPE_RIB_DEST, sizeof(rib_dest_t));
+ 	rnh_list_init(&dest->nht);
++	hook_call(dest_init, dest);
+ 	re_list_init(&dest->routes);
+ 	route_lock_node(rn); /* rn route table reference */
+ 	rn->info = dest;
+diff --git a/zebra/zebra_vrf.c b/zebra/zebra_vrf.c
+index 9c5b38b96..4ac804d8e 100644
+--- a/zebra/zebra_vrf.c
++++ b/zebra/zebra_vrf.c
+@@ -54,6 +54,7 @@ static void zebra_rnhtable_node_cleanup(struct route_table *table,
+ 
+ DEFINE_MTYPE_STATIC(ZEBRA, ZEBRA_VRF, "ZEBRA VRF");
+ DEFINE_MTYPE_STATIC(ZEBRA, OTHER_TABLE, "Other Table");
++DEFINE_HOOK(fpm_vrf_write, (), ());
+ 
+ /* VRF information update. */
+ static void zebra_vrf_add_update(struct zebra_vrf *zvrf)
+@@ -215,6 +216,9 @@ static int zebra_vrf_disable(struct vrf *vrf)
+ 	FOR_ALL_INTERFACES (vrf, ifp)
+ 		if_nbr_ipv6ll_to_ipv4ll_neigh_del_all(ifp);
+ 
++	/* clean-up fpm queues */
++	hook_call(fpm_vrf_write);
++
+ 	/* clean-up work queues */
+ 	meta_queue_free(zrouter.mq, zvrf);
+ 
+@@ -250,6 +254,9 @@ static int zebra_vrf_delete(struct vrf *vrf)
+ 
+ 	table_manager_disable(zvrf);
+ 
++	/* clean-up fpm queues */
++	hook_call(fpm_vrf_write);
++
+ 	/* clean-up work queues */
+ 	meta_queue_free(zrouter.mq, zvrf);
+ 

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -27,3 +27,4 @@
 0027-lib-Do-not-convert-EVPN-prefixes-into-IPv4-IPv6-if-n.patch
 0028-zebra-fix-parse-attr-problems-for-encap.patch
 0029-zebra-nhg-fix-on-intf-up.patch
+0030-fix-zebra-crash-when-vrf-delete.patch


### PR DESCRIPTION
Fixing issue
when vnet is deleted, it will cause zebra crash because of non-deleted vrf pointer

- Waht I did when vrf is deleted, remove it from zfpm_g->dest_q too

- How to verify it create vent and remove it, the zebra will crash Please enter the commit message for your changes. Lines starting

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

