### PR TITLE
Initialize BBR from config_db first

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
@@ -48,17 +48,20 @@ class BBRMgr(Manager):
         if self.directory.path_exist("CONFIG_DB", "BGP_BBR", "all/status"):
             config_db_bbr = self.directory.get_slot("CONFIG_DB", "BGP_BBR")
             log_info("BBRMgr::Initialize from CONFIG_DB")
-            self.bbr_enabled_pgs = self.__read_pgs()
-            if self.bbr_enabled_pgs:
-                self.enabled = True
-                self.default_state = config_db_bbr["all"]["status"]
-                log_info("BBRMgr::Initialized from CONFIG_DB and Enabled. Default state: '%s'" % self.default_state)
+            if 'bgp' in self.constants:
+                self.bbr_enabled_pgs = self.__read_pgs()
+                if self.bbr_enabled_pgs:
+                    self.enabled = True
+                    self.default_state = config_db_bbr["all"]["status"]
+                    log_info("BBRMgr::Initialized and Enabled. Default state: '%s'" % self.default_state)
+                else:
+                    log_info("BBRMgr::Initialized and Disabled: no BBR enabled peers in constants")
             else:
-                log_info("BBRMgr::Initialized from CONFIG_DB and Disabled: no BBR enabled peers")
+                log_info("BBRMgr::Initialized and Disabled: 'bgp' key is not found in constants")
         else:
             log_info("BBRMgr::Initialize from constants")
             if not 'bgp' in self.constants:
-                log_err("BBRMgr::Initialized from constants and Disabled: 'bgp' key is not found in constants")
+                log_err("BBRMgr::Initialized and Disabled: 'bgp' key is not found in constants")
             elif 'bbr' in self.constants['bgp'] \
                     and 'enabled' in self.constants['bgp']['bbr'] \
                     and self.constants['bgp']['bbr']['enabled']:
@@ -72,11 +75,11 @@ class BBRMgr(Manager):
                         self.default_state = "enabled"
                     else:
                         self.default_state = "disabled"
-                    log_info("BBRMgr::Initialized from constants and Enabled. Default state: '%s'" % self.default_state)
+                    log_info("BBRMgr::Initialized and Enabled. Default state: '%s'" % self.default_state)
                 else:
-                    log_info("BBRMgr::Initialized from constants and Disabled: no BBR enabled peers")
+                    log_info("BBRMgr::Initialized nd Disabled: no BBR enabled peers in constants")
             else:
-                log_info("BBRMgr::Initialized from constants and Disabled: no bgp.bbr.enabled in the constants")
+                log_info("BBRMgr::Initialized and Disabled: no bgp.bbr.enabled in the constants")
         self.directory.put(self.db_name, self.table_name, "all", {"status": self.default_state})
 
     def __read_pgs(self):

--- a/src/sonic-bgpcfgd/tests/test_bbr.py
+++ b/src/sonic-bgpcfgd/tests/test_bbr.py
@@ -124,26 +124,26 @@ def __init_common(constants,
         mocked_log_info.assert_called_with(expected_log_info)
 
 def test___init_1():
-    __init_common({}, None, "BBRMgr::Initialized from constants and Disabled: 'bgp' key is not found in constants", {}, "disabled")
+    __init_common({}, None, "BBRMgr::Initialized and Disabled: 'bgp' key is not found in constants", {}, "disabled")
 
 def test___init_2():
     constants = deepcopy(global_constants)
-    __init_common(constants, "BBRMgr::Initialized from constants and Disabled: no bgp.bbr.enabled in the constants", None, {}, "disabled")
+    __init_common(constants, "BBRMgr::Initialized and Disabled: no bgp.bbr.enabled in the constants", None, {}, "disabled")
 
 def test___init_3():
     constants = deepcopy(global_constants)
     constants["bgp"]["bbr"] = { "123" : False }
-    __init_common(constants, "BBRMgr::Initialized from constants and Disabled: no bgp.bbr.enabled in the constants", None, {}, "disabled")
+    __init_common(constants, "BBRMgr::Initialized and Disabled: no bgp.bbr.enabled in the constants", None, {}, "disabled")
 
 def test___init_4():
     constants = deepcopy(global_constants)
     constants["bgp"]["bbr"] = { "enabled" : False }
-    __init_common(constants, "BBRMgr::Initialized from constants and Disabled: no bgp.bbr.enabled in the constants", None, {}, "disabled")
+    __init_common(constants, "BBRMgr::Initialized and Disabled: no bgp.bbr.enabled in the constants", None, {}, "disabled")
 
 def test___init_5():
     constants = deepcopy(global_constants)
     constants["bgp"]["bbr"] = { "enabled" : True }
-    __init_common(constants, "BBRMgr::Initialized from constants and Disabled: no BBR enabled peers", None, {}, "disabled")
+    __init_common(constants, "BBRMgr::Initialized and Disabled: no BBR enabled peers", None, {}, "disabled")
 
 def test___init_6():
     expected_bbr_entries = {
@@ -157,7 +157,7 @@ def test___init_6():
             "bbr": expected_bbr_entries,
         }
     }
-    __init_common(constants, "BBRMgr::Initialized from constants and Enabled. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
+    __init_common(constants, "BBRMgr::Initialized and Enabled. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
 
 def test___init_7():
     expected_bbr_entries = {
@@ -171,7 +171,7 @@ def test___init_7():
             "bbr": expected_bbr_entries,
         }
     }
-    __init_common(constants, "BBRMgr::Initialized from constants and Enabled. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
+    __init_common(constants, "BBRMgr::Initialized and Enabled. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
 
 def test___init_8():
     expected_bbr_entries = {
@@ -185,7 +185,7 @@ def test___init_8():
             "bbr": expected_bbr_entries,
         }
     }
-    __init_common(constants, "BBRMgr::Initialized from constants and Enabled. Default state: 'enabled'", None, expected_bbr_entries, "enabled")
+    __init_common(constants, "BBRMgr::Initialized and Enabled. Default state: 'enabled'", None, expected_bbr_entries, "enabled")
 
 @patch('bgpcfgd.managers_bbr.log_info')
 def read_pgs_common(constants, expected_log_info, expected_bbr_enabled_pgs, mocked_log_info):

--- a/src/sonic-bgpcfgd/tests/test_bbr.py
+++ b/src/sonic-bgpcfgd/tests/test_bbr.py
@@ -36,7 +36,7 @@ def test_constructor():#m1, m2, m3):
     m = BBRMgr(common_objs, "CONFIG_DB", "BGP_BBR")
     assert not m.enabled
     assert len(m.bbr_enabled_pgs) == 0
-    assert m.directory.get("CONFIG_DB", "BGP_BBR", "status") == "disabled"
+    assert m.directory.get_slot("CONFIG_DB", "BGP_BBR")["all"]["status"] == "disabled"
 
 @patch('bgpcfgd.managers_bbr.log_info')
 def set_handler_common(key, value,
@@ -115,7 +115,7 @@ def __init_common(constants,
     m = BBRMgr(common_objs, "CONFIG_DB", "BGP_BBR")
     m._BBRMgr__init()
     assert m.bbr_enabled_pgs == expected_bbr_enabled_pgs
-    assert m.directory.get("CONFIG_DB", "BGP_BBR", "status") == expected_status
+    assert m.directory.get_slot("CONFIG_DB", "BGP_BBR")["all"]["status"] == expected_status
     if expected_status == "enabled":
         assert m.enabled
     if expected_log_err is not None:
@@ -124,26 +124,26 @@ def __init_common(constants,
         mocked_log_info.assert_called_with(expected_log_info)
 
 def test___init_1():
-    __init_common({}, None, "BBRMgr::Disabled: 'bgp' key is not found in constants", {}, "disabled")
+    __init_common({}, None, "BBRMgr::Initialized from constants and Disabled: 'bgp' key is not found in constants", {}, "disabled")
 
 def test___init_2():
     constants = deepcopy(global_constants)
-    __init_common(constants, "BBRMgr::Disabled: no bgp.bbr.enabled in the constants", None, {}, "disabled")
+    __init_common(constants, "BBRMgr::Initialized from constants and Disabled: no bgp.bbr.enabled in the constants", None, {}, "disabled")
 
 def test___init_3():
     constants = deepcopy(global_constants)
     constants["bgp"]["bbr"] = { "123" : False }
-    __init_common(constants, "BBRMgr::Disabled: no bgp.bbr.enabled in the constants", None, {}, "disabled")
+    __init_common(constants, "BBRMgr::Initialized from constants and Disabled: no bgp.bbr.enabled in the constants", None, {}, "disabled")
 
 def test___init_4():
     constants = deepcopy(global_constants)
     constants["bgp"]["bbr"] = { "enabled" : False }
-    __init_common(constants, "BBRMgr::Disabled: no bgp.bbr.enabled in the constants", None, {}, "disabled")
+    __init_common(constants, "BBRMgr::Initialized from constants and Disabled: no bgp.bbr.enabled in the constants", None, {}, "disabled")
 
 def test___init_5():
     constants = deepcopy(global_constants)
     constants["bgp"]["bbr"] = { "enabled" : True }
-    __init_common(constants, "BBRMgr::Disabled: no BBR enabled peers", None, {}, "disabled")
+    __init_common(constants, "BBRMgr::Initialized from constants and Disabled: no BBR enabled peers", None, {}, "disabled")
 
 def test___init_6():
     expected_bbr_entries = {
@@ -157,7 +157,7 @@ def test___init_6():
             "bbr": expected_bbr_entries,
         }
     }
-    __init_common(constants, "BBRMgr::Initialized and enabled. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
+    __init_common(constants, "BBRMgr::Initialized from constants and Enabled. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
 
 def test___init_7():
     expected_bbr_entries = {
@@ -171,7 +171,7 @@ def test___init_7():
             "bbr": expected_bbr_entries,
         }
     }
-    __init_common(constants, "BBRMgr::Initialized and enabled. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
+    __init_common(constants, "BBRMgr::Initialized from constants and Enabled. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
 
 def test___init_8():
     expected_bbr_entries = {
@@ -185,7 +185,7 @@ def test___init_8():
             "bbr": expected_bbr_entries,
         }
     }
-    __init_common(constants, "BBRMgr::Initialized and enabled. Default state: 'enabled'", None, expected_bbr_entries, "enabled")
+    __init_common(constants, "BBRMgr::Initialized from constants and Enabled. Default state: 'enabled'", None, expected_bbr_entries, "enabled")
 
 @patch('bgpcfgd.managers_bbr.log_info')
 def read_pgs_common(constants, expected_log_info, expected_bbr_enabled_pgs, mocked_log_info):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

