### PR TITLE
Fix no standalone lo_v6 entry which break YANG validation

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2831,9 +2831,9 @@ def parse_device_desc_xml(filename):
         'hwsku': hwsku,
         }}
 
-    results['LOOPBACK_INTERFACE'] = {('lo', lo_prefix): {}}
+    results['LOOPBACK_INTERFACE'] = {'lo': {}, ('lo', lo_prefix): {}}
     if lo_prefix_v6:
-        results['LOOPBACK_INTERFACE'] = {('lo_v6', lo_prefix_v6): {}}
+        results['LOOPBACK_INTERFACE'] = {'lo_v6': {}, ('lo_v6', lo_prefix_v6): {}}
 
     results['MGMT_INTERFACE'] = {}
     if mgmt_prefix:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The load_mgmt_config generated lo_v6 is missing standalone entry which fail YANG validation
##### Work item tracking
- Microsoft ADO **(number only)**:28665800

#### How I did it
Add the standalone entry
#### How to verify it
Manual test in DUT

Before change:
```
admin@str-msn2700a1-03:~$ sonic-cfggen -M /etc/sonic/device_desc.xml --print-data 
{
    "DEVICE_METADATA": {
        "localhost": {
            "hostname": "CPQ21-0101-0509-04T0",
            "hwsku": "Arista-7260CX3-D108C8"
        }
    },
    "LOOPBACK_INTERFACE": {
        "lo_v6|2603:10d0:e:5eb::/128": {}         <==== missing standalone entry which fail YANG
    },
    "MGMT_INTERFACE": {
        "eth0|100.84.101.139/26": {
            "gwaddr": "100.84.101.129"
        },
        "eth0|2603:10e2:f0:7478::b/64": {
            "gwaddr": "2603:10e2:f0:7478::1"
        }
    }
}
```
After change:
```
admin@str-msn2700a1-03:~$ sonic-cfggen -M /etc/sonic/device_desc.xml --print-data 
{
    "DEVICE_METADATA": {
        "localhost": {
            "hostname": "CPQ21-0101-0509-04T0",
            "hwsku": "Arista-7260CX3-D108C8"
        }
    },
    "LOOPBACK_INTERFACE": {
        "lo_v6": {},                                          <=== added standalone entry
        "lo_v6|2603:10d0:e:5eb::/128": {}
    },
    "MGMT_INTERFACE": {
        "eth0|100.84.101.139/26": {
            "gwaddr": "100.84.101.129"
        },
        "eth0|2603:10e2:f0:7478::b/64": {
            "gwaddr": "2603:10e2:f0:7478::1"
        }
    }
}
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

