### PR TITLE
Reliable TSA: Addressing review comments to use 'SpineRouter' in checks instead of 'voq' and fix few echo msgs.

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/TS
+++ b/dockers/docker-fpm-frr/base_image_files/TS
@@ -4,10 +4,10 @@
 [ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
 
 PLATFORM=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
-switch_type=`sonic-db-cli CONFIG_DB hget 'DEVICE_METADATA|localhost' 'switch_type'`
+type=`sonic-db-cli CONFIG_DB hget 'DEVICE_METADATA|localhost' 'type'`
 TSA_CHASSIS_STATE=false
 
-if [[ $switch_type == 'voq' ]]; then
+if [[ $type == *"SpineRouter"* ]]; then
  TSA_CHASSIS_STATE="$(sonic-db-cli CHASSIS_APP_DB HGET "BGP_DEVICE_GLOBAL|STATE" tsa_enabled)"
 fi
 

--- a/dockers/docker-fpm-frr/base_image_files/TSA
+++ b/dockers/docker-fpm-frr/base_image_files/TSA
@@ -19,7 +19,7 @@ if [ -f /etc/sonic/chassisdb.conf ]; then
     echo "Chassis Mode: Normal -> Maintenance"
     logger -t TSA -p user.info "Chassis Mode: Normal -> Maintenance"
   fi
-  echo "Please execute \"rexec all -c 'sudo config save -y'\" to preserve System mode in Maintenance after reboot\
+  echo "Please execute 'sudo config save' to preserve System mode in Maintenance after reboot\
   or config reload on all linecards"
   exit 0
 fi

--- a/dockers/docker-fpm-frr/base_image_files/TSB
+++ b/dockers/docker-fpm-frr/base_image_files/TSB
@@ -19,7 +19,7 @@ if [ -f /etc/sonic/chassisdb.conf ]; then
     echo "Chassis Mode: Maintenance -> Normal"
     logger -t TSB -p user.info "Chassis Mode: Maintenance -> Normal"
   fi
-  echo "Please execute \"rexec all -c 'sudo config save -y'\" to preserve System mode in Normal state after reboot\
+  echo "Please execute 'sudo config save' to preserve System mode in Normal state after reboot\
   or config reload on all linecards"
   exit 0
 fi


### PR DESCRIPTION
Addressing review comments to use 'SpineRouter' in checks instead of 'voq' and fix few echo msgs.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To address review comments
- https://github.com/sonic-net/sonic-buildimage/pull/19217#discussion_r1667199390
- https://github.com/sonic-net/sonic-buildimage/pull/19217#discussion_r1667199613
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
Ran reliable_tsa tests from https://github.com/sonic-net/sonic-mgmt/pull/13290 on a T2 chassis.
![image](https://github.com/sonic-net/sonic-buildimage/assets/169114916/e2a089e2-d53d-4ac4-9bea-a8ddb3e52929)

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

