### PR TITLE
Add received_bandwidth to BGP

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -33,7 +33,7 @@
             "tsa_enabled": "false",
             "wcmp_enabled": "false",
             "idf_isolation_state": "unisolated",
-            "bestpath_bandwidth": "ignore"
+            "received_bandwidth": "ignore"
         }
     },
 {%- set features = [("bgp", "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}", false, "enabled"),

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -32,7 +32,8 @@
         "STATE": {
             "tsa_enabled": "false",
             "wcmp_enabled": "false",
-            "idf_isolation_state": "unisolated"
+            "idf_isolation_state": "unisolated",
+            "bestpath_bandwidth": "ignore"
         }
     },
 {%- set features = [("bgp", "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}", false, "enabled"),

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -33,7 +33,7 @@
             "tsa_enabled": "false",
             "wcmp_enabled": "false",
             "idf_isolation_state": "unisolated",
-            "received_bandwidth": "ignore"
+            "received_bandwidth": "allow"
         }
     },
 {%- set features = [("bgp", "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}", false, "enabled"),

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
@@ -12,7 +12,7 @@ class DeviceGlobalCfgMgr(Manager):
     TSA_DEFAULTS = "false"
     WCMP_DEFAULTS = "false"
     IDF_DEFAULTS = "unisolated"
-    BANDWIDTH_DEFAULTS = "ignore"
+    RECEIVED_DEFAULTS = "ignore"
 
     def __init__(self, common_objs, db, table):
         """
@@ -50,7 +50,7 @@ class DeviceGlobalCfgMgr(Manager):
             self.directory.put(self.db_name, self.table_name, "idf_isolation_state", self.IDF_DEFAULTS)
         # By default received bandwidth for W-ECMP feature is ignore
         if not self.directory.path_exist(self.db_name, self.table_name, "received_bandwidth"):
-            self.directory.put(self.db_name, self.table_name, "received_bandwidth", self.BANDWIDTH_DEFAULTS)
+            self.directory.put(self.db_name, self.table_name, "received_bandwidth", self.RECEIVED_DEFAULTS)
 
     def on_switch_type_change(self):
         log_debug("DeviceGlobalCfgMgr:: Switch type update handler")
@@ -74,8 +74,8 @@ class DeviceGlobalCfgMgr(Manager):
         self.configure_wcmp(data)
         # IDF configuration
         self.configure_idf(data)
-        # Bandwidth configuration
-        self.configure_bandwidth(data)
+        # Received Bandwidth configuration
+        self.configure_received_bandwidth(data)
 
         return True
 
@@ -88,8 +88,8 @@ class DeviceGlobalCfgMgr(Manager):
         self.configure_wcmp()
         # IDF configuration
         self.configure_idf()
-        # Bandwidth configuration
-        self.configure_bandwidth()
+        # Reveived Bandwidth configuration
+        self.configure_received_bandwidth()
 
         return True
 
@@ -150,22 +150,22 @@ class DeviceGlobalCfgMgr(Manager):
         else:
             log_notice("DeviceGlobalCfgMgr:: IDF configuration is up-to-date")
     
-    def configure_bandwidth(self, data=None):
+    def configure_received_bandwidth(self, data=None):
         """Configure received bandwidth for W-ECMP feature"""
         
-        state = self.BANDWIDTH_DEFAULTS
+        state = self.RECEIVED_DEFAULTS
         
         if data is not None:
             if "received_bandwidth" in data:
                 state = data["received_bandwidth"]
         
         if self.is_update_required("received_bandwidth", state):
-            if self.set_bandwidth(state):
+            if self.set_received_bandwidth(state):
                 self.directory.put(self.db_name, self.table_name, "received_bandwidth", state)
         else:
             log_notice("DeviceGlobalCfgMgr:: received bandwidth for W-ECMP configuration is up-to-date")
             
-    def set_bandwidth(self, status):
+    def set_received_bandwidth(self, status):
         """API to configure received bandwidth for W-ECMP"""
         
         bgp_asn = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]["bgp_asn"]

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
@@ -48,9 +48,9 @@ class DeviceGlobalCfgMgr(Manager):
         # By default IDF feature is unisolated
         if not self.directory.path_exist(self.db_name, self.table_name, "idf_isolation_state"):
             self.directory.put(self.db_name, self.table_name, "idf_isolation_state", self.IDF_DEFAULTS)
-        # By default bestpath for bandwidth feature is ignore
-        if not self.directory.path_exist(self.db_name, self.table_name, "bestpath_bandwidth"):
-            self.directory.put(self.db_name, self.table_name, "bestpath_bandwidth", self.BANDWIDTH_DEFAULTS)
+        # By default received bandwidth for W-ECMP feature is ignore
+        if not self.directory.path_exist(self.db_name, self.table_name, "received_bandwidth"):
+            self.directory.put(self.db_name, self.table_name, "received_bandwidth", self.BANDWIDTH_DEFAULTS)
 
     def on_switch_type_change(self):
         log_debug("DeviceGlobalCfgMgr:: Switch type update handler")
@@ -151,35 +151,35 @@ class DeviceGlobalCfgMgr(Manager):
             log_notice("DeviceGlobalCfgMgr:: IDF configuration is up-to-date")
     
     def configure_bandwidth(self, data=None):
-        """Configure bestpath for bandwidth feature"""
+        """Configure received bandwidth for W-ECMP feature"""
         
         state = self.BANDWIDTH_DEFAULTS
         
         if data is not None:
-            if "bestpath_bandwidth" in data:
-                state = data["bestpath_bandwidth"]
+            if "received_bandwidth" in data:
+                state = data["received_bandwidth"]
         
-        if self.is_update_required("bestpath_bandwidth", state):
+        if self.is_update_required("received_bandwidth", state):
             if self.set_bandwidth(state):
-                self.directory.put(self.db_name, self.table_name, "bestpath_bandwidth", state)
+                self.directory.put(self.db_name, self.table_name, "received_bandwidth", state)
         else:
-            log_notice("DeviceGlobalCfgMgr:: Bestpath for bandwidth configuration is up-to-date")
+            log_notice("DeviceGlobalCfgMgr:: received bandwidth for W-ECMP configuration is up-to-date")
             
     def set_bandwidth(self, status):
-        """API to configure bestpath for bandwidth"""
+        """API to configure received bandwidth for W-ECMP"""
         
         bgp_asn = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]["bgp_asn"]
         cmd_list = []
         
-        if status not in ["ignore", "active", "skip_missing", "default_weight_for_missing"]:
-            log_err("Bestpath for bandwidth: invalid value({}) is provided".format(status))
+        if status not in ["ignore", "allow", "skip_missing", "default_weight_for_missing"]:
+            log_err("Received bandwidth for W-ECMP: invalid value({}) is provided".format(status))
             return False
         
         cmd_list.append("router bgp %s" % bgp_asn)
         
         if status == "ignore":
             cmd_list.append(" bgp bestpath bandwidth ignore")
-        elif status == "active":
+        elif status == "allow":
             cmd_list.append(" no bgp bestpath bandwidth")
         elif status == "skip_missing":
             cmd_list.append(" bgp bestpath bandwidth skip-missing")

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
@@ -172,7 +172,7 @@ class DeviceGlobalCfgMgr(Manager):
         cmd_list = []
         
         if status not in ["ignore", "allow", "skip_missing", "default_weight_for_missing"]:
-            log_err("Received bandwidth for W-ECMP: invalid value({}) is provided".format(status))
+            log_err("Received Bandwidth for W-ECMP: invalid value({}) is provided".format(status))
             return False
         
         cmd_list.append("router bgp %s" % bgp_asn)

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
@@ -12,7 +12,7 @@ class DeviceGlobalCfgMgr(Manager):
     TSA_DEFAULTS = "false"
     WCMP_DEFAULTS = "false"
     IDF_DEFAULTS = "unisolated"
-    RECEIVED_DEFAULTS = "ignore"
+    RECEIVED_DEFAULTS = "allow"
 
     def __init__(self, common_objs, db, table):
         """
@@ -48,7 +48,7 @@ class DeviceGlobalCfgMgr(Manager):
         # By default IDF feature is unisolated
         if not self.directory.path_exist(self.db_name, self.table_name, "idf_isolation_state"):
             self.directory.put(self.db_name, self.table_name, "idf_isolation_state", self.IDF_DEFAULTS)
-        # By default received bandwidth for W-ECMP feature is ignore
+        # By default received bandwidth for W-ECMP feature is allow
         if not self.directory.path_exist(self.db_name, self.table_name, "received_bandwidth"):
             self.directory.put(self.db_name, self.table_name, "received_bandwidth", self.RECEIVED_DEFAULTS)
 

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
@@ -171,7 +171,7 @@ class DeviceGlobalCfgMgr(Manager):
         bgp_asn = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]["bgp_asn"]
         cmd_list = []
         
-        if status not in ["ignore", "active", "skip-missing", "default-weight-for-missing"]:
+        if status not in ["ignore", "active", "skip_missing", "default_weight_for_missing"]:
             log_err("Bestpath for bandwidth: invalid value({}) is provided".format(status))
             return False
         
@@ -181,9 +181,9 @@ class DeviceGlobalCfgMgr(Manager):
             cmd_list.append(" bgp bestpath bandwidth ignore")
         elif status == "active":
             cmd_list.append(" no bgp bestpath bandwidth")
-        elif status == "skip-missing":
+        elif status == "skip_missing":
             cmd_list.append(" bgp bestpath bandwidth skip-missing")
-        elif status == "default-weight-for-missing":
+        elif status == "default_weight_for_missing":
             cmd_list.append(" bgp bestpath bandwidth default-weight-for-missing")
         else:
             return False

--- a/src/sonic-bgpcfgd/tests/test_device_global.py
+++ b/src/sonic-bgpcfgd/tests/test_device_global.py
@@ -350,9 +350,9 @@ def test_idf_neg(mocked_log_err, value):
 def test_received_bandwidth(mocked_log_info, value, result):
     m = constructor(bgp_asn=True)
     m.cfg_mgr.changes = ""
-    if value == "ignore":
-        # By default feature is ignore. Simulate allow state
-        m.directory.put(m.db_name, m.table_name, "received_bandwidth", "allow")
+    if value == "allow":
+        # By default feature is allow. Simulate ignore state
+        m.directory.put(m.db_name, m.table_name, "received_bandwidth", "ignore")
         
     res = m.set_handler("STATE", {"received_bandwidth": value})
     assert res, "Expect True return value for set_handler"

--- a/src/sonic-bgpcfgd/tests/test_device_global.py
+++ b/src/sonic-bgpcfgd/tests/test_device_global.py
@@ -319,7 +319,7 @@ def test_idf_neg(mocked_log_err, value):
     mocked_log_err.assert_called_with("IDF: invalid value({}) is provided".format(value))
     
 #
-# Bestpath for Bandwidth -----------------------------------------------------------------------------------------------------------------
+# Received Bandwidth for W-ECMP -----------------------------------------------------------------------------------------------------------------
 #
 
 @pytest.mark.parametrize(
@@ -330,9 +330,9 @@ def test_idf_neg(mocked_log_err, value):
             id="ignore"
         ),
         pytest.param(
-            "active",
+            "allow",
             ["router bgp 65100", " no bgp bestpath bandwidth"],
-            id="active"
+            id="allow"
         ),
         pytest.param(
             "skip_missing",
@@ -351,10 +351,10 @@ def test_bandwidth(mocked_log_info, value, result):
     m = constructor(bgp_asn=True)
     m.cfg_mgr.changes = ""
     if value == "ignore":
-        # By default feature is ignore. Simulate active state
-        m.directory.put(m.db_name, m.table_name, "bestpath_bandwidth", "active")
+        # By default feature is ignore. Simulate allow state
+        m.directory.put(m.db_name, m.table_name, "received_bandwidth", "allow")
         
-    res = m.set_handler("STATE", {"bestpath_bandwidth": value})
+    res = m.set_handler("STATE", {"received_bandwidth": value})
     assert res, "Expect True return value for set_handler"
     mocked_log_info.assert_called_with("DeviceGlobalCfgMgr::Done")
     assert m.cfg_mgr.get_config() == result
@@ -366,7 +366,7 @@ def test_bandwidth(mocked_log_info, value, result):
 def test_bandwidth_neg(mocked_log_err, value):
     m = constructor(bgp_asn=True)
     m.cfg_mgr.changes = ""
-    res = m.set_handler("STATE", {"bestpath_bandwidth": value})
+    res = m.set_handler("STATE", {"received_bandwidth": value})
     assert res, "Expect True return value for set_handler"
-    mocked_log_err.assert_called_with("Bestpath for bandwidth: invalid value({}) is provided".format(value))
+    mocked_log_err.assert_called_with("Received Bandwidth for W-ECMP: invalid value({}) is provided".format(value))
 

--- a/src/sonic-bgpcfgd/tests/test_device_global.py
+++ b/src/sonic-bgpcfgd/tests/test_device_global.py
@@ -335,14 +335,14 @@ def test_idf_neg(mocked_log_err, value):
             id="active"
         ),
         pytest.param(
-            "skip-missing",
+            "skip_missing",
             ["bgp router 65100", " bgp bestpath bandwidth skip-missing"],
-            id="skip-missing"
+            id="skip_missing"
         ),
         pytest.param(
-            "default-weight-for-missing",
+            "default_weight_for_missing",
             ["bgp router 65100", " bgp bestpath bandwidth default-weight-for-missing"],
-            id="default-weight-for-missing"
+            id="default_weight_for_missing"
         ),
     ]
 )

--- a/src/sonic-bgpcfgd/tests/test_device_global.py
+++ b/src/sonic-bgpcfgd/tests/test_device_global.py
@@ -326,22 +326,22 @@ def test_idf_neg(mocked_log_err, value):
     "value,result", [
         pytest.param(
             "ignore",
-            ["bgp router 65100", " bgp bestpath bandwidth ignore"],
+            ["router bgp 65100", " bgp bestpath bandwidth ignore"],
             id="ignore"
         ),
         pytest.param(
             "active",
-            ["bgp router 65100", " no bgp bestpath bandwidth"],
+            ["router bgp 65100", " no bgp bestpath bandwidth"],
             id="active"
         ),
         pytest.param(
             "skip_missing",
-            ["bgp router 65100", " bgp bestpath bandwidth skip-missing"],
+            ["router bgp 65100", " bgp bestpath bandwidth skip-missing"],
             id="skip_missing"
         ),
         pytest.param(
             "default_weight_for_missing",
-            ["bgp router 65100", " bgp bestpath bandwidth default-weight-for-missing"],
+            ["router bgp 65100", " bgp bestpath bandwidth default-weight-for-missing"],
             id="default_weight_for_missing"
         ),
     ]

--- a/src/sonic-bgpcfgd/tests/test_device_global.py
+++ b/src/sonic-bgpcfgd/tests/test_device_global.py
@@ -347,7 +347,7 @@ def test_idf_neg(mocked_log_err, value):
     ]
 )
 @patch('bgpcfgd.managers_device_global.log_debug')
-def test_bandwidth(mocked_log_info, value, result):
+def test_received_bandwidth(mocked_log_info, value, result):
     m = constructor(bgp_asn=True)
     m.cfg_mgr.changes = ""
     if value == "ignore":
@@ -363,7 +363,7 @@ def test_bandwidth(mocked_log_info, value, result):
     "value", [ "invalid_value" ]
 )
 @patch('bgpcfgd.managers_device_global.log_err')
-def test_bandwidth_neg(mocked_log_err, value):
+def test_received_bandwidth_neg(mocked_log_err, value):
     m = constructor(bgp_asn=True)
     m.cfg_mgr.changes = ""
     res = m.set_handler("STATE", {"received_bandwidth": value})

--- a/src/sonic-bgpcfgd/tests/test_device_global.py
+++ b/src/sonic-bgpcfgd/tests/test_device_global.py
@@ -357,7 +357,7 @@ def test_bandwidth(mocked_log_info, value, result):
     res = m.set_handler("STATE", {"bestpath_bandwidth": value})
     assert res, "Expect True return value for set_handler"
     mocked_log_info.assert_called_with("DeviceGlobalCfgMgr::Done")
-    assert m.cfg_mgr.get_config() in result
+    assert m.cfg_mgr.get_config() == result
 
 @pytest.mark.parametrize(
     "value", [ "invalid_value" ]

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -445,7 +445,7 @@ The IDF isolation state **idf_isolation_state** could be one of isolated_no_expo
 }
 ```
 
-The bestpath for bandwidth state **bestpath_bandwidth** could be one of ignore, active, skip_missing, or default_weight_for_missing.
+The bestpath for bandwidth state **bestpath_bandwidth** could be one of ignore, allow, skip_missing, or default_weight_for_missing.
 
 ```json
 {

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -445,7 +445,7 @@ The IDF isolation state **idf_isolation_state** could be one of isolated_no_expo
 }
 ```
 
-The bestpath for bandwidth state **received_bandwidth** could be one of ignore, allow, skip_missing, or default_weight_for_missing.
+The received bandwidth for W-ECMP state **received_bandwidth** could be one of ignore, allow, skip_missing, or default_weight_for_missing.
 
 ```json
 {

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -445,13 +445,13 @@ The IDF isolation state **idf_isolation_state** could be one of isolated_no_expo
 }
 ```
 
-The bestpath for bandwidth state **bestpath_bandwidth** could be one of ignore, allow, skip_missing, or default_weight_for_missing.
+The bestpath for bandwidth state **received_bandwidth** could be one of ignore, allow, skip_missing, or default_weight_for_missing.
 
 ```json
 {
 "BGP_DEVICE_GLOBAL": {
     "STATE": {
-        "bestpath_bandwidth": "ignore"
+        "received_bandwidth": "ignore"
     }
 }
 ```

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -445,6 +445,17 @@ The IDF isolation state **idf_isolation_state** could be one of isolated_no_expo
 }
 ```
 
+The bestpath for bandwidth state **bestpath_bandwidth** could be one of ignore, active, skip_missing, or default_weight_for_missing.
+
+```json
+{
+"BGP_DEVICE_GLOBAL": {
+    "STATE": {
+        "bestpath_bandwidth": "ignore"
+    }
+}
+```
+
 ### BGP Sessions
 
 BGP session configuration is defined in **BGP_NEIGHBOR** table. BGP

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1712,7 +1712,7 @@
                 "tsa_enabled": "false",
                 "wcmp_enabled": "false",
                 "idf_isolation_state": "unisolated",
-                "bestpath_bandwidth": "ignore"
+                "received_bandwidth": "ignore"
             }
         },
         "BGP_PEER_RANGE": {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1712,7 +1712,7 @@
                 "tsa_enabled": "false",
                 "wcmp_enabled": "false",
                 "idf_isolation_state": "unisolated",
-                "received_bandwidth": "ignore"
+                "received_bandwidth": "active"
             }
         },
         "BGP_PEER_RANGE": {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1712,7 +1712,7 @@
                 "tsa_enabled": "false",
                 "wcmp_enabled": "false",
                 "idf_isolation_state": "unisolated",
-                "received_bandwidth": "active"
+                "received_bandwidth": "allow"
             }
         },
         "BGP_PEER_RANGE": {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1711,7 +1711,8 @@
             "STATE": {
                 "tsa_enabled": "false",
                 "wcmp_enabled": "false",
-                "idf_isolation_state": "unisolated"
+                "idf_isolation_state": "unisolated",
+                "bestpath_bandwidth": "ignore"
             }
         },
         "BGP_PEER_RANGE": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
@@ -80,7 +80,7 @@
         "verify": {
             "xpath": "/sonic-bgp-device-global:sonic-bgp-device-global/BGP_DEVICE_GLOBAL/STATE/received_bandwidth",
             "key": "sonic-bgp-device-global:received_bandwidth",
-            "value": "active"
+            "value": "allow"
         }
     },
     "BGP_DEVICE_GLOBAL_WITH_RECEIVED_BANDWIDTH_TEST_1": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
@@ -74,30 +74,30 @@
         "eStrKey": "InvalidValue",
         "eStr": ["idf_isolation_state"]
     },
-    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_DEFAULT_VALUE": {
-        "desc": "Load bgp device global table with bestpath_bandwidth set to default value",
+    "BGP_DEVICE_GLOBAL_WITH_RECEIVED_BANDWIDTH_DEFAULT_VALUE": {
+        "desc": "Load bgp device global table with received_bandwidth set to default value",
         "eStrKey": "Verify",
         "verify": {
-            "xpath": "/sonic-bgp-device-global:sonic-bgp-device-global/BGP_DEVICE_GLOBAL/STATE/bestpath_bandwidth",
-            "key": "sonic-bgp-device-global:bestpath_bandwidth",
+            "xpath": "/sonic-bgp-device-global:sonic-bgp-device-global/BGP_DEVICE_GLOBAL/STATE/received_bandwidth",
+            "key": "sonic-bgp-device-global:received_bandwidth",
             "value": "ignore"
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_1": {
-        "desc": "Load bgp device global table with bestpath_bandwidth set to ignore"
+    "BGP_DEVICE_GLOBAL_WITH_RECEIVED_BANDWIDTH_TEST_1": {
+        "desc": "Load bgp device global table with received_bandwidth set to ignore"
     },
-    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_2": {
-        "desc": "Load bgp device global table with bestpath_bandwidth set to allow"
+    "BGP_DEVICE_GLOBAL_WITH_RECEIVED_BANDWIDTH_TEST_2": {
+        "desc": "Load bgp device global table with received_bandwidth set to allow"
     },
-    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_3": {
-        "desc": "Load bgp device global table with bestpath_bandwidth set to skip_missing"
+    "BGP_DEVICE_GLOBAL_WITH_RECEIVED_BANDWIDTH_TEST_3": {
+        "desc": "Load bgp device global table with received_bandwidth set to skip_missing"
     },
-    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_4": {
-        "desc": "Load bgp device global table with bestpath_bandwidth set to default_weight_for_missing"
+    "BGP_DEVICE_GLOBAL_WITH_RECEIVED_BANDWIDTH_TEST_4": {
+        "desc": "Load bgp device global table with received_bandwidth set to default_weight_for_missing"
     },
-    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_INVALID_VALUE": {
-        "desc": "Load bgp device global table with bestpath_bandwidth set to invalid value",
+    "BGP_DEVICE_GLOBAL_WITH_RECEIVED_BANDWIDTH_INVALID_VALUE": {
+        "desc": "Load bgp device global table with received_bandwidth set to invalid value",
         "eStrKey": "InvalidValue",
-        "eStr": ["bestpath_bandwidth"]
+        "eStr": ["received_bandwidth"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
@@ -80,7 +80,7 @@
         "verify": {
             "xpath": "/sonic-bgp-device-global:sonic-bgp-device-global/BGP_DEVICE_GLOBAL/STATE/received_bandwidth",
             "key": "sonic-bgp-device-global:received_bandwidth",
-            "value": "ignore"
+            "value": "active"
         }
     },
     "BGP_DEVICE_GLOBAL_WITH_RECEIVED_BANDWIDTH_TEST_1": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
@@ -87,7 +87,7 @@
         "desc": "Load bgp device global table with bestpath_bandwidth set to ignore"
     },
     "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_2": {
-        "desc": "Load bgp device global table with bestpath_bandwidth set to active"
+        "desc": "Load bgp device global table with bestpath_bandwidth set to allow"
     },
     "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_3": {
         "desc": "Load bgp device global table with bestpath_bandwidth set to skip_missing"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
@@ -73,5 +73,31 @@
         "desc": "Load bgp device global table with idf_isolation_state set to invalid value",
         "eStrKey": "InvalidValue",
         "eStr": ["idf_isolation_state"]
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_DEFAULT_VALUE": {
+        "desc": "Load bgp device global table with bestpath_bandwidth set to default value",
+        "eStrKey": "Verify",
+        "verify": {
+            "xpath": "/sonic-bgp-device-global:sonic-bgp-device-global/BGP_DEVICE_GLOBAL/STATE/bestpath_bandwidth",
+            "key": "sonic-bgp-device-global:bestpath_bandwidth",
+            "value": "ignore"
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_1": {
+        "desc": "Load bgp device global table with bestpath_bandwidth set to ignore"
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_2": {
+        "desc": "Load bgp device global table with bestpath_bandwidth set to active"
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_3": {
+        "desc": "Load bgp device global table with bestpath_bandwidth set to skip_missing"
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_4": {
+        "desc": "Load bgp device global table with bestpath_bandwidth set to default_weight_for_missing"
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_INVALID_VALUE": {
+        "desc": "Load bgp device global table with bestpath_bandwidth set to invalid value",
+        "eStrKey": "InvalidValue",
+        "eStr": ["bestpath_bandwidth"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
@@ -112,5 +112,58 @@
                 }
             }
         }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_DEFAULT_VALUE": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE":{
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_1": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE":{
+                    "bestpath_bandwidth": "ignore"
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_2": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE":{
+                    "bestpath_bandwidth": "active"
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_3": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE":{
+                    "bestpath_bandwidth": "skip_missing"
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_4": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE":{
+                    "bestpath_bandwidth": "default_weight_for_missing"
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_INVALID_VALUE": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE":{
+                    "bestpath_bandwidth": "invalid_value"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
@@ -134,7 +134,7 @@
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE":{
-                    "bestpath_bandwidth": "active"
+                    "bestpath_bandwidth": "allow"
                 }
             }
         }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
@@ -113,7 +113,7 @@
             }
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_DEFAULT_VALUE": {
+    "BGP_DEVICE_GLOBAL_WITH_RECEIVED_BANDWIDTH_DEFAULT_VALUE": {
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE":{
@@ -121,47 +121,47 @@
             }
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_1": {
+    "BGP_DEVICE_GLOBAL_WITH_RECEIVED_BANDWIDTH_TEST_1": {
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE":{
-                    "bestpath_bandwidth": "ignore"
+                    "received_bandwidth": "ignore"
                 }
             }
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_2": {
+    "BGP_DEVICE_GLOBAL_WITH_RECEIVED_BANDWIDTH_TEST_2": {
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE":{
-                    "bestpath_bandwidth": "allow"
+                    "received_bandwidth": "allow"
                 }
             }
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_3": {
+    "BGP_DEVICE_GLOBAL_WITH_RECEIVED_BANDWIDTH_TEST_3": {
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE":{
-                    "bestpath_bandwidth": "skip_missing"
+                    "received_bandwidth": "skip_missing"
                 }
             }
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_4": {
+    "BGP_DEVICE_GLOBAL_WITH_RECEIVED_BANDWIDTH_TEST_4": {
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE":{
-                    "bestpath_bandwidth": "default_weight_for_missing"
+                    "received_bandwidth": "default_weight_for_missing"
                 }
             }
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_INVALID_VALUE": {
+    "BGP_DEVICE_GLOBAL_WITH_RECEIVED_BANDWIDTH_INVALID_VALUE": {
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE":{
-                    "bestpath_bandwidth": "invalid_value"
+                    "received_bandwidth": "invalid_value"
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -65,7 +65,7 @@ module sonic-bgp-device-global {
                         enum ignore {
                             description "Ignore link bandwidth (i.e., do regular ECMP, not weighted)";
                         }
-                        enum active {
+                        enum allow {
                             description "Allow for normal behavior without bestpath for bandwidth";
                         }
                         enum skip_missing {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -66,7 +66,7 @@ module sonic-bgp-device-global {
                             description "Ignore link bandwidth (i.e., do regular ECMP, not weighted)";
                         }
                         enum allow {
-                            description "Allow for normal behavior without bestpath for bandwidth";
+                            description "Allow for normal behavior without bgp bestpath bandwidth";
                         }
                         enum skip_missing {
                             description "Ignore paths without link bandwidth for W-ECMP (if other paths have it)";

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -75,7 +75,7 @@ module sonic-bgp-device-global {
                             description "Assign a low default weight (value 1) to paths not having link bandwidth";
                         }
                     }
-                    default "ignore";
+                    default "active";
                 }
 
             }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -59,8 +59,8 @@ module sonic-bgp-device-global {
                     default "unisolated";
                 }
 
-                leaf bestpath_bandwidth {
-                    description "Configures device bestpath for bandwidth state";
+                leaf received_bandwidth {
+                    description "Configures device received-bandwidth state";
                     type enumeration {
                         enum ignore {
                             description "Ignore link bandwidth (i.e., do regular ECMP, not weighted)";

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -59,6 +59,25 @@ module sonic-bgp-device-global {
                     default "unisolated";
                 }
 
+                leaf bestpath_bandwidth {
+                    description "Configures device bestpath for bandwidth state";
+                    type enumeration {
+                        enum ignore {
+                            description "Ignore link bandwidth (i.e., do regular ECMP, not weighted)";
+                        }
+                        enum active {
+                            description "Allow for normal behavior without bestpath for bandwidth";
+                        }
+                        enum skip_missing {
+                            description "Ignore paths without link bandwidth for W-ECMP (if other paths have it)";
+                        }
+                        enum default_weight_for_missing {
+                            description "Assign a low default weight (value 1) to paths not having link bandwidth";
+                        }
+                    }
+                    default "ignore";
+                }
+
             }
             /* end of STATE container */
         }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -75,7 +75,7 @@ module sonic-bgp-device-global {
                             description "Assign a low default weight (value 1) to paths not having link bandwidth";
                         }
                     }
-                    default "active";
+                    default "allow";
                 }
 
             }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Associated PR:
https://github.com/sonic-net/sonic-buildimage/pull/19532
https://github.com/sonic-net/sonic-utilities/pull/3411
#### Why I did it

The update enhances the BGP device global configuration to listen for changes in the "received_bandwidth" setting within the BGP device global table.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Updated bgpcfgd/managers_device_global.py to handle changes in the "received_bandwidth" field.
- Added the "received_bandwidth" field to the initialization configuration.
- Modified unit tests to cover the new functionality and ensure it works as expected.

#### How to verify it

- Created unit tests to test the new functionality.
- Verified that the changes work as intended by running the updated unit tests.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

