### PR TITLE
Bandwidth yang models

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -445,6 +445,17 @@ The IDF isolation state **idf_isolation_state** could be one of isolated_no_expo
 }
 ```
 
+The bestpath for bandwidth state **bestpath_bandwidth** could be one of ignore, active, skip-missing, or default-weight-for-missing.
+
+```json
+{
+"BGP_DEVICE_GLOBAL": {
+    "STATE": {
+        "bestpath_bandwidth": "ignore"
+    }
+}
+```
+
 ### BGP Sessions
 
 BGP session configuration is defined in **BGP_NEIGHBOR** table. BGP

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -445,7 +445,7 @@ The IDF isolation state **idf_isolation_state** could be one of isolated_no_expo
 }
 ```
 
-The bestpath for bandwidth state **bestpath_bandwidth** could be one of ignore, active, skip-missing, or default-weight-for-missing.
+The bestpath for bandwidth state **bestpath_bandwidth** could be one of ignore, active, skip_missing, or default_weight_for_missing.
 
 ```json
 {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1711,7 +1711,8 @@
             "STATE": {
                 "tsa_enabled": "false",
                 "wcmp_enabled": "false",
-                "idf_isolation_state": "unisolated"
+                "idf_isolation_state": "unisolated",
+                "bestpath_bandwidth": "ignore"
             }
         },
         "BGP_PEER_RANGE": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
@@ -90,10 +90,10 @@
         "desc": "Load bgp device global table with bestpath_bandwidth set to active"
     },
     "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_3": {
-        "desc": "Load bgp device global table with bestpath_bandwidth set to skip-missing"
+        "desc": "Load bgp device global table with bestpath_bandwidth set to skip_missing"
     },
     "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_4": {
-        "desc": "Load bgp device global table with bestpath_bandwidth set to default-weight-for-missing"
+        "desc": "Load bgp device global table with bestpath_bandwidth set to default_weight_for_missing"
     },
     "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_INVALID_VALUE": {
         "desc": "Load bgp device global table with bestpath_bandwidth set to invalid value",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
@@ -73,5 +73,31 @@
         "desc": "Load bgp device global table with idf_isolation_state set to invalid value",
         "eStrKey": "InvalidValue",
         "eStr": ["idf_isolation_state"]
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_DEFAULT_VALUE": {
+        "desc": "Load bgp device global table with bestpath_bandwidth set to default value",
+        "eStrKey": "Verify",
+        "verify": {
+            "xpath": "/sonic-bgp-device-global:sonic-bgp-device-global/BGP_DEVICE_GLOBAL/STATE/bestpath_bandwidth",
+            "key": "sonic-bgp-device-global:bestpath_bandwidth",
+            "value": "ignore"
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_1": {
+        "desc": "Load bgp device global table with bestpath_bandwidth set to ignore"
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_2": {
+        "desc": "Load bgp device global table with bestpath_bandwidth set to active"
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_3": {
+        "desc": "Load bgp device global table with bestpath_bandwidth set to skip-missing"
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_4": {
+        "desc": "Load bgp device global table with bestpath_bandwidth set to default-weight-for-missing"
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_INVALID_VALUE": {
+        "desc": "Load bgp device global table with bestpath_bandwidth set to invalid value",
+        "eStrKey": "InvalidValue",
+        "eStr": ["bestpath_bandwidth"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
@@ -143,7 +143,7 @@
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE":{
-                    "bestpath_bandwidth": "skip-missing"
+                    "bestpath_bandwidth": "skip_missing"
                 }
             }
         }
@@ -152,7 +152,7 @@
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE":{
-                    "bestpath_bandwidth": "default-weight-for-missing"
+                    "bestpath_bandwidth": "default_weight_for_missing"
                 }
             }
         }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
@@ -112,5 +112,58 @@
                 }
             }
         }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_DEFAULT_VALUE": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE":{
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_1": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE":{
+                    "bestpath_bandwidth": "ignore"
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_2": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE":{
+                    "bestpath_bandwidth": "active"
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_3": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE":{
+                    "bestpath_bandwidth": "skip-missing"
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_TEST_4": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE":{
+                    "bestpath_bandwidth": "default-weight-for-missing"
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_BESTPATH_BANDWIDTH_INVALID_VALUE": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE":{
+                    "bestpath_bandwidth": "invalid_value"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -68,10 +68,10 @@ module sonic-bgp-device-global {
                         enum active {
                             description "Allow for normal behavior without bestpath for bandwidth";
                         }
-                        enum skip-missing {
+                        enum skip_missing {
                             description "Ignore paths without link bandwidth for W-ECMP (if other paths have it)";
                         }
-                        enum default-weight-for-missing {
+                        enum default_weight_for_missing {
                             description "Assign a low default weight (value 1) to paths not having link bandwidth";
                         }
                     }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -59,6 +59,25 @@ module sonic-bgp-device-global {
                     default "unisolated";
                 }
 
+                leaf bestpath_bandwidth {
+                    description "Configures device bestpath for bandwidth state";
+                    type enumeration {
+                        enum ignore {
+                            description "Ignore link bandwidth (i.e., do regular ECMP, not weighted)";
+                        }
+                        enum active {
+                            description "Allow for normal behavior without bestpath for bandwidth";
+                        }
+                        enum skip-missing {
+                            description "Ignore paths without link bandwidth for W-ECMP (if other paths have it)";
+                        }
+                        enum default-weight-for-missing {
+                            description "Assign a low default weight (value 1) to paths not having link bandwidth";
+                        }
+                    }
+                    default "ignore";
+                }
+
             }
             /* end of STATE container */
         }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

