### PR TITLE
Change of W-ECMP template 

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
@@ -50,6 +50,7 @@ route-map FROM_BGP_PEER_V6 permit 11
 route-map FROM_BGP_PEER_V4 permit 100
 !
 route-map TO_BGP_PEER_V4 permit 100
+  call CHECK_WCMP_ENABLED
 !
 !
 route-map FROM_BGP_PEER_V6 permit 1
@@ -59,6 +60,7 @@ route-map FROM_BGP_PEER_V6 permit 1
 route-map FROM_BGP_PEER_V6 permit 100
 !
 route-map TO_BGP_PEER_V6 permit 100
+  call CHECK_WCMP_ENABLED
 !
 ! end of template: bgpd/templates/general/policies.conf.j2
 !

--- a/dockers/docker-fpm-frr/frr/bgpd/wcmp/bgpd.wcmp.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/wcmp/bgpd.wcmp.conf.j2
@@ -1,15 +1,7 @@
 !
 ! template: bgpd/wcmp/bgpd.wcmp.conf.j2
 !
-route-map TO_BGP_PEER_V4 permit 100
-{%- if wcmp_enabled == 'true' %}
-  set extcommunity bandwidth num-multipaths
-{%- else %}
-  no set extcommunity bandwidth
-{%- endif %}
-exit
-!
-route-map TO_BGP_PEER_V6 permit 100
+route-map CHECK_WCMP_ENABLED permit 100
 {%- if wcmp_enabled == 'true' %}
   set extcommunity bandwidth num-multipaths
 {%- else %}

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all.conf
@@ -31,6 +31,7 @@ route-map FROM_BGP_PEER_V6 permit 11
 route-map FROM_BGP_PEER_V4 permit 100
 !
 route-map TO_BGP_PEER_V4 permit 100
+  call CHECK_WCMP_ENABLED
 !
 route-map FROM_BGP_PEER_V6 permit 1
  on-match next
@@ -39,6 +40,7 @@ route-map FROM_BGP_PEER_V6 permit 1
 route-map FROM_BGP_PEER_V6 permit 100
 !
 route-map TO_BGP_PEER_V6 permit 100
+  call CHECK_WCMP_ENABLED
 !
 ! end of template: bgpd/templates/general/policies.conf.j2
 !

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_base.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_base.conf
@@ -4,6 +4,7 @@
 route-map FROM_BGP_PEER_V4 permit 100
 !
 route-map TO_BGP_PEER_V4 permit 100
+  call CHECK_WCMP_ENABLED
 !
 route-map FROM_BGP_PEER_V6 permit 1
  on-match next
@@ -12,6 +13,7 @@ route-map FROM_BGP_PEER_V6 permit 1
 route-map FROM_BGP_PEER_V6 permit 100
 !
 route-map TO_BGP_PEER_V6 permit 100
+  call CHECK_WCMP_ENABLED
 !
 ! end of template: bgpd/templates/general/policies.conf.j2
 !

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_deny.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_deny.conf
@@ -31,6 +31,7 @@ route-map FROM_BGP_PEER_V6 permit 11
 route-map FROM_BGP_PEER_V4 permit 100
 !
 route-map TO_BGP_PEER_V4 permit 100
+  call CHECK_WCMP_ENABLED
 !
 route-map FROM_BGP_PEER_V6 permit 1
  on-match next
@@ -39,6 +40,7 @@ route-map FROM_BGP_PEER_V6 permit 1
 route-map FROM_BGP_PEER_V6 permit 100
 !
 route-map TO_BGP_PEER_V6 permit 100
+  call CHECK_WCMP_ENABLED
 !
 ! end of template: bgpd/templates/general/policies.conf.j2
 !

--- a/src/sonic-bgpcfgd/tests/data/wcmp/wcmp.set.conf
+++ b/src/sonic-bgpcfgd/tests/data/wcmp/wcmp.set.conf
@@ -2,11 +2,7 @@
 !
 ! template: bgpd/wcmp/bgpd.wcmp.conf.j2
 !
-route-map TO_BGP_PEER_V4 permit 100
-  set extcommunity bandwidth num-multipaths
-exit
-!
-route-map TO_BGP_PEER_V6 permit 100
+route-map CHECK_WCMP_ENABLED permit 100
   set extcommunity bandwidth num-multipaths
 exit
 !

--- a/src/sonic-bgpcfgd/tests/data/wcmp/wcmp.unset.conf
+++ b/src/sonic-bgpcfgd/tests/data/wcmp/wcmp.unset.conf
@@ -2,11 +2,7 @@
 !
 ! template: bgpd/wcmp/bgpd.wcmp.conf.j2
 !
-route-map TO_BGP_PEER_V4 permit 100
-  no set extcommunity bandwidth
-exit
-!
-route-map TO_BGP_PEER_V6 permit 100
+route-map CHECK_WCMP_ENABLED permit 100
   no set extcommunity bandwidth
 exit
 !


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The update enables W-ECMP in outbound route-maps by calling the template w-ecmp route-map.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Changed the naming convention and updated TO_BGP_PEER_V4 and TO_BGP_PEER_V6 to call CHECK_WCMP_ENABLED.
- Modified the configuration templates to include the necessary CHECK_WCMP_ENABLED calls.

#### How to verify it

- Updated the unit tests to reflect these changes.
- Reran the unit tests to ensure they pass and verify the new functionality.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

