### PR TITLE
Add NODE_CFG in init_cfg.json to bring up p4rt properly.

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -177,6 +177,12 @@
             "num_dumps": "3"
         }
     },
+{%- if include_p4rt == "y" %}
+    "NODE_CFG": {
+        "integrated_circuit0": {
+            "node-id": "1"
+        }
+    },{% endif %}
     "NTP": {
         "global": {
             "authentication": "disabled",

--- a/platform/vs/docker-sonic-vs/init_cfg.json.j2
+++ b/platform/vs/docker-sonic-vs/init_cfg.json.j2
@@ -6,6 +6,11 @@
             "buffer_model": "traditional"
         }
     },
+    "NODE_CFG": {
+        "integrated_circuit0": {
+            "node-id": "1"
+        }
+    },
 {% if switch_type != "dpu" %}
 {% set features = ({"swss": "enabled", "bgp": "enabled", "teamd": "enabled", "nat": "enabled", "database": "enabled", "lldp": "enabled", "dhcp_relay": "enabled", "macsec": "enabled"}) %}
 {% else %}


### PR DESCRIPTION
#### Why I did it
Fix [19328](https://github.com/sonic-net/sonic-buildimage/issues/19328)

#### How I did it

Add `NODE_CFG` in docker-sonic-vs/sonic-vs.img.gz initial CONFIG DB.

#### How to verify it

```
INCLUDE_P4RT = y
make configure PLATFORM=vs
make target/docker-sonic-vs.gz
make target/sonic-vs.img.gz
```

```
docker run --privileged -id --name sw debian bash
sudo ./platform/vs/create_vnet.sh -n 32 sw
docker image rm docker-sonic-vs:latest
docker load -i ./target/docker-sonic-vs.gz
docker run --privileged -v /var/run/redis-vs/sw:/var/run/redis --network container:sw -d --name vs docker-sonic-vs:latest
docker exec -it vs bash

root@306b22890506:/# redis-cli
127.0.0.1:6379> select 4
OK
127.0.0.1:6379[4]> keys NODE_CFG*
1) "NODE_CFG|integrated_circuit0"
127.0.0.1:6379[4]> hgetall "NODE_CFG|integrated_circuit0"
1) "node-id"
2) "1"
127.0.0.1:6379[4]> 


root@306b22890506:/# cat /etc/sonic/init_cfg.json 
{
    ...
    "NODE_CFG": {
        "integrated_circuit0": {
            "node-id": "1"
        }
    },
    ...
}
```


#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

