### PR TITLE
Preserve permissions when copying

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -625,7 +625,7 @@ SONIC_TARGET_LIST += $(addprefix $(DEBS_PATH)/, $(SONIC_COPY_DEBS))
 #     SONIC_COPY_FILES += $(SOME_NEW_FILE)
 $(addprefix $(FILES_PATH)/, $(SONIC_COPY_FILES)) : $(FILES_PATH)/% : .platform
 	$(HEADER)
-	cp $($*_PATH)/$* $(FILES_PATH)/ $(LOG) || exit 1
+	cp -p $($*_PATH)/$* $(FILES_PATH)/ $(LOG) || exit 1
 	$(FOOTER)
 
 SONIC_TARGET_LIST += $(addprefix $(FILES_PATH)/, $(SONIC_COPY_FILES))


### PR DESCRIPTION
#### What I did

Fix for [#18695](https://github.com/sonic-net/sonic-buildimage/issues/18695)

#### How I did it

When using cp, add the -p option to preserve permissions


#### How to verify it

can make it

#### Previous command output (if the output of a command-line utility has changed)

Before this fix, you may find that you may not have permission when compiling arm

lin@lin-arm64:~/build$ ls -lrt sonic-buildimage.centec-arm64/target/files/bullseye/update_chassisdb_config
-rw-r--r-- 1 lin lin 2467 Jul 12 06:41 sonic-buildimage.centec-arm64/target/files/bullseye/update_chassisdb_config

#### New command output (if the output of a command-line utility has changed)

After the repair, the permissions can retain the previous execution permissions


lin@lin-arm64:~/build$ ls -lrt sonic-buildimage.centec-arm64/target/files/bullseye/update_chassisdb_config
-rwxr-xr-x 1 lin lin 2467 Jun  6 15:33 update_chassisdb_config