### PR TITLE
[202205, build] When check for docker arch, use DEFAULT_CONTAINER_REGISTRY if it is not null (#19466)

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -62,7 +62,11 @@ SHELL = /bin/bash
 USER := $(shell id -un)
 PWD := $(shell pwd)
 USER_LC := $(shell echo $(USER) | tr A-Z a-z)
+ifneq ($(DEFAULT_CONTAINER_REGISTRY),)
+DOCKER_MACHINE := $(shell docker run --rm $(DEFAULT_CONTAINER_REGISTRY)/debian:buster uname -m)
+else
 DOCKER_MACHINE := $(shell docker run --rm debian:buster uname -m)
+endif
 
 comma := ,
 


### PR DESCRIPTION
Why I did it
DEFAULT_CONTAINER_REGISTRY didn't work as expected in some scenario.

How I did it
When check for docker arch, use DEFAULT_CONTAINER_REGISTRY if it is not null.

