### PR TITLE
[FRR template]Add missing exit to avoid config nht via default route in vrf

### DIFF
--- a/dockers/docker-fpm-frr/frr/zebra/zebra.interfaces.conf.j2
+++ b/dockers/docker-fpm-frr/frr/zebra/zebra.interfaces.conf.j2
@@ -4,6 +4,7 @@
 {%   for vnet_name, vnet_metadata in VNET.items() %}
 vrf {{ vnet_name }}
 vni {{ vnet_metadata['vni'] }}
+exit
 !
 {%   endfor %}
 {%  endif %}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/zebra.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/zebra.conf
@@ -22,9 +22,11 @@ log facility local4
 !
 vrf First
 vni 10
+exit
 !
 vrf Second
 vni 20
+exit
 !
 ! Enable nht through default route
 ip nht resolve-via-default

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-vni-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-vni-zebra.conf
@@ -22,6 +22,7 @@ log facility local4
 !
 vrf VnetFE
 vni 9000
+exit
 !
 !
 ! Enable nht through default route

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-zebra.conf
@@ -22,6 +22,7 @@ log facility local4
 !
 vrf VnetFE
 vni 8000
+exit
 !
 !
 ! Enable nht through default route

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-vni-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-vni-zebra.conf
@@ -22,6 +22,7 @@ log facility local4
 !
 vrf VnetFE
 vni 9000
+exit
 !
 !
 ! Enable nht through default route

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-zebra.conf
@@ -22,6 +22,7 @@ log facility local4
 !
 vrf VnetFE
 vni 8000
+exit
 !
 !
 ! Enable nht through default route

--- a/src/sonic-config-engine/tests/sample_output/t2-chassis-fe-pc-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/t2-chassis-fe-pc-zebra.conf
@@ -10,6 +10,7 @@ enable password zebra
 !
 vrf VnetFE
 vni 8000
+exit
 !
 !
 ! Enable nht through default route


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The 'ip nht resolve-via-default' is configured in vrf config by mistake instead of the global setting when vrf is configured causing the bgpl cannot to be established.
##### Work item tracking
- Microsoft ADO **(number only)**: 28726407

#### How I did it
Add the missing 'exit' line in FRR zebra.interfaces.conf.j2 file to exit vrf config block and ensure the 'ip nht resolve-via-default' is configured in the global setting.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

