### PR TITLE
Prioritize configuration from config_db over constants.yml during BBR status initialization

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
@@ -45,26 +45,39 @@ class BBRMgr(Manager):
 
     def __init(self):
         """ Initialize BBRMgr. Extracted from constructor """
-        if not 'bgp' in self.constants:
-            log_err("BBRMgr::Disabled: 'bgp' key is not found in constants")
-            return
-        if 'bbr' in self.constants['bgp'] \
-                and 'enabled' in self.constants['bgp']['bbr'] \
-                and self.constants['bgp']['bbr']['enabled']:
+        # Check BGP_BBR table from config_db first
+        bbr_status_from_config_db = self._get_bbr_status_from_config_db()
+
+        if bbr_status_from_config_db is None:
+            if not 'bgp' in self.constants:
+                log_err("BBRMgr::Disabled: 'bgp' key is not found in constants")
+                return
+            if 'bbr' in self.constants['bgp'] \
+                    and 'enabled' in self.constants['bgp']['bbr'] \
+                    and self.constants['bgp']['bbr']['enabled']:
+                self.bbr_enabled_pgs = self.__read_pgs()
+                if self.bbr_enabled_pgs:
+                    self.enabled = True
+                    if 'default_state' in self.constants['bgp']['bbr'] \
+                            and self.constants['bgp']['bbr']['default_state'] == 'enabled':
+                        default_status = "enabled"
+                    else:
+                        default_status = "disabled"
+                    self.directory.put(self.db_name, self.table_name, 'status', default_status)
+                    log_info("BBRMgr::Initialized and enabled from constants. Default state: '%s'" % default_status)
+                else:
+                    log_info("BBRMgr::Disabled: no BBR enabled peers")
+            else:
+                log_info("BBRMgr::Disabled: no bgp.bbr.enabled in the constants")
+        else:
             self.bbr_enabled_pgs = self.__read_pgs()
             if self.bbr_enabled_pgs:
                 self.enabled = True
-                if 'default_state' in self.constants['bgp']['bbr'] \
-                        and self.constants['bgp']['bbr']['default_state'] == 'enabled':
-                    default_status = "enabled"
-                else:
-                    default_status = "disabled"
-                self.directory.put(self.db_name, self.table_name, 'status', default_status)
-                log_info("BBRMgr::Initialized and enabled. Default state: '%s'" % default_status)
+                self.directory.put(self.db_name, self.table_name, 'status', bbr_status_from_config_db)
+                log_info("BBRMgr::Initialized and enabled from config_db. Default status: '%s'" % bbr_status_from_config_db)
             else:
                 log_info("BBRMgr::Disabled: no BBR enabled peers")
-        else:
-            log_info("BBRMgr::Disabled: no bgp.bbr.enabled in the constants")
+
 
     def __read_pgs(self):
         """
@@ -81,6 +94,22 @@ class BBRMgr(Manager):
             for pg_name, pg_afs in value['bbr'].items():
                 res[pg_name] = pg_afs
         return res
+
+
+    def _get_bbr_status_from_config_db(self):
+        """
+        Read BBR status from CONFIG_DB
+        :return: BBR status from CONFIG_DB or None if not found
+        """
+        config_db = swsscommon.ConfigDBConnector()
+        if config_db is None:
+            return None
+        config_db.connect()
+        bbr_table_data = config_db.get_table(self.table_name)
+        if bbr_table_data and 'all' in bbr_table_data:
+            return bbr_table_data["all"]
+        return None
+
 
     def __set_validation(self, key, data):
         """ Validate set-command arguments

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
@@ -99,17 +99,29 @@ class BBRMgr(Manager):
         Read BBR status from CONFIG_DB
         :return: BBR status from CONFIG_DB or None if not found
         """
-        config_db = swsscommon.ConfigDBConnector()
-        if config_db is None:
+        try:
+            config_db = swsscommon.ConfigDBConnector()
+            if config_db is None:
+                log_info("BBRMgr::Failed to connect to CONFIG_DB, get BBR default state from constants.yml")
+                return None
+            config_db.connect()
+        except Exception as e:
+            log_info("BBRMgr::Failed to connect to CONFIG_DB with exception %s, get BBR default state from constants.yml" % str(e))
             return None
-        config_db.connect()
-        bbr_table_data = config_db.get_table(self.table_name)
-        if bbr_table_data and 'all' in bbr_table_data and 'status' in bbr_table_data["all"]:
-            if bbr_table_data["all"]["status"] == "enabled":
-                return "enabled"
+
+        try:
+            bbr_table_data = config_db.get_table(self.table_name)
+            if bbr_table_data and 'all' in bbr_table_data and 'status' in bbr_table_data["all"]:
+                if bbr_table_data["all"]["status"] == "enabled":
+                    return "enabled"
+                else:
+                    return "disabled"
             else:
-                return "disabled"
-        return None
+                log_info("BBRMgr::BBR status is not found in CONFIG_DB, get BBR default state from constants.yml")
+                return None
+        except Exception as e:
+            log_info("BBRMgr::Failed to read BBR status from CONFIG_DB with exception %s, get BBR default state from constants.yml" % str(e))
+            return None
 
     def __set_validation(self, key, data):
         """ Validate set-command arguments

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
@@ -74,7 +74,7 @@ class BBRMgr(Manager):
             if self.bbr_enabled_pgs:
                 self.enabled = True
                 self.directory.put(self.db_name, self.table_name, 'status', bbr_status_from_config_db)
-                log_info("BBRMgr::Initialized and enabled from config_db. Default status: '%s'" % bbr_status_from_config_db)
+                log_info("BBRMgr::Initialized and enabled from config_db. Default state: '%s'" % bbr_status_from_config_db)
             else:
                 log_info("BBRMgr::Disabled: no BBR enabled peers")
 

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
@@ -105,7 +105,10 @@ class BBRMgr(Manager):
         config_db.connect()
         bbr_table_data = config_db.get_table(self.table_name)
         if bbr_table_data and 'all' in bbr_table_data and 'status' in bbr_table_data["all"]:
-            return bbr_table_data["all"]["status"]
+            if bbr_table_data["all"]["status"] == "enabled":
+                return "enabled"
+            else:
+                return "disabled"
         return None
 
     def __set_validation(self, key, data):

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
@@ -78,7 +78,6 @@ class BBRMgr(Manager):
             else:
                 log_info("BBRMgr::Disabled: no BBR enabled peers")
 
-
     def __read_pgs(self):
         """
         Read peer-group bbr settings from constants file
@@ -95,7 +94,6 @@ class BBRMgr(Manager):
                 res[pg_name] = pg_afs
         return res
 
-
     def _get_bbr_status_from_config_db(self):
         """
         Read BBR status from CONFIG_DB
@@ -109,7 +107,6 @@ class BBRMgr(Manager):
         if bbr_table_data and 'all' in bbr_table_data:
             return bbr_table_data["all"]
         return None
-
 
     def __set_validation(self, key, data):
         """ Validate set-command arguments

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
@@ -46,7 +46,7 @@ class BBRMgr(Manager):
     def __init(self):
         """ Initialize BBRMgr. Extracted from constructor """
         # Check BGP_BBR table from config_db first
-        bbr_status_from_config_db = self._get_bbr_status_from_config_db()
+        bbr_status_from_config_db = self.get_bbr_status_from_config_db()
 
         if bbr_status_from_config_db is None:
             if not 'bgp' in self.constants:
@@ -94,7 +94,7 @@ class BBRMgr(Manager):
                 res[pg_name] = pg_afs
         return res
 
-    def _get_bbr_status_from_config_db(self):
+    def get_bbr_status_from_config_db(self):
         """
         Read BBR status from CONFIG_DB
         :return: BBR status from CONFIG_DB or None if not found
@@ -104,8 +104,8 @@ class BBRMgr(Manager):
             return None
         config_db.connect()
         bbr_table_data = config_db.get_table(self.table_name)
-        if bbr_table_data and 'all' in bbr_table_data:
-            return bbr_table_data["all"]
+        if bbr_table_data and 'all' in bbr_table_data and 'status' in bbr_table_data["all"]:
+            return bbr_table_data["all"]["status"]
         return None
 
     def __set_validation(self, key, data):

--- a/src/sonic-bgpcfgd/tests/test_bbr.py
+++ b/src/sonic-bgpcfgd/tests/test_bbr.py
@@ -189,7 +189,7 @@ def test___init_8():
     __init_common(constants, "BBRMgr::Initialized and enabled from constants. Default state: 'enabled'", None, expected_bbr_entries, "enabled")
 
 @patch('bgpcfgd.managers_bbr.BBRMgr.get_bbr_status_from_config_db', return_value='enabled')
-def test___init_with_config_db(mocked_get_bbr_status_from_config_db):
+def test___init_with_config_db_1(mocked_get_bbr_status_from_config_db):
     expected_bbr_entries = {
         "PEER_V4": ["ipv4"],
         "PEER_V6": ["ipv6"],
@@ -216,6 +216,13 @@ def test___init_with_config_db(mocked_get_bbr_status_from_config_db):
     assert m.directory.get("CONFIG_DB", "BGP_BBR", "status") == "enabled"
     assert m.bbr_enabled_pgs == expected_bbr_entries
 
+@patch('bgpcfgd.managers_bbr.BBRMgr.get_bbr_status_from_config_db', return_value='enabled')
+def test___init_with_config_db_2(mocked_get_bbr_status_from_config_db):
+
+    constants = deepcopy(global_constants)
+    constants["bgp"]["bbr"] = {"enabled": True}
+
+    __init_common(constants, "BBRMgr::Disabled: no BBR enabled peers", None, {}, "disabled")
 
 @patch('bgpcfgd.managers_bbr.log_info')
 def read_pgs_common(constants, expected_log_info, expected_bbr_enabled_pgs, mocked_log_info):

--- a/src/sonic-bgpcfgd/tests/test_bbr.py
+++ b/src/sonic-bgpcfgd/tests/test_bbr.py
@@ -171,7 +171,7 @@ def test___init_7():
             "bbr": expected_bbr_entries,
         }
     }
-    __init_common(constants, "BBRMgr::Initialized and enabled. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
+    __init_common(constants, "BBRMgr::Initialized and from constants. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
 
 def test___init_8():
     expected_bbr_entries = {
@@ -185,7 +185,7 @@ def test___init_8():
             "bbr": expected_bbr_entries,
         }
     }
-    __init_common(constants, "BBRMgr::Initialized and enabled. Default state: 'enabled'", None, expected_bbr_entries, "enabled")
+    __init_common(constants, "BBRMgr::Initialized and enabled from constants. Default state: 'enabled'", None, expected_bbr_entries, "enabled")
 
 @patch('bgpcfgd.managers_bbr.log_info')
 def read_pgs_common(constants, expected_log_info, expected_bbr_enabled_pgs, mocked_log_info):

--- a/src/sonic-bgpcfgd/tests/test_bbr.py
+++ b/src/sonic-bgpcfgd/tests/test_bbr.py
@@ -102,8 +102,7 @@ def test_del_handler(mocked_log_err):
 
 @patch('bgpcfgd.managers_bbr.log_info')
 @patch('bgpcfgd.managers_bbr.log_err')
-@patch('bgpcfgd.managers_bbr.BBRMgr.get_bbr_status_from_config_db')
-def __init_common(constants, mocked_get_bbr_status_from_config_db,
+def __init_common(constants,
                   expected_log_info, expected_log_err, expected_bbr_enabled_pgs, expected_status,
                   mocked_log_err, mocked_log_info):
     cfg_mgr = MagicMock()
@@ -113,7 +112,6 @@ def __init_common(constants, mocked_get_bbr_status_from_config_db,
         'tf':        TemplateFabric(),
         'constants': constants,
     }
-    mocked_get_bbr_status_from_config_db.return_value = None
 
     m = BBRMgr(common_objs, "CONFIG_DB", "BGP_BBR")
     m._BBRMgr__init()
@@ -190,7 +188,7 @@ def test___init_8():
     }
     __init_common(constants, "BBRMgr::Initialized and enabled from constants. Default state: 'enabled'", None, expected_bbr_entries, "enabled")
 
-@patch('bgpcfgd.managers_bbr.BBRMgr.get_bbr_status_from_config_db', return_value={'all': {'status': 'enabled'}})
+@patch('bgpcfgd.managers_bbr.BBRMgr.get_bbr_status_from_config_db', return_value='enabled')
 def test___init_with_config_db(mocked_get_bbr_status_from_config_db):
     expected_bbr_entries = {
         "PEER_V4": ["ipv4"],

--- a/src/sonic-bgpcfgd/tests/test_bbr.py
+++ b/src/sonic-bgpcfgd/tests/test_bbr.py
@@ -188,33 +188,22 @@ def test___init_8():
     }
     __init_common(constants, "BBRMgr::Initialized and enabled from constants. Default state: 'enabled'", None, expected_bbr_entries, "enabled")
 
-@patch('bgpcfgd.managers_bbr.BBRMgr.get_bbr_status_from_config_db', return_value='enabled')
+@patch('bgpcfgd.managers_bbr.BBRMgr.get_bbr_status_from_config_db', return_value='disabled')
 def test___init_with_config_db_1(mocked_get_bbr_status_from_config_db):
     expected_bbr_entries = {
         "PEER_V4": ["ipv4"],
         "PEER_V6": ["ipv6"],
     }
     constants = deepcopy(global_constants)
-    constants["bgp"]["bbr"] = {"enabled": True, "default_state": "disabled"}
+    constants["bgp"]["bbr"] = {"enabled": True, "default_state": "enabled"}
     constants["bgp"]["peers"] = {
         "general": {
             "bbr": expected_bbr_entries,
         }
     }
-    cfg_mgr = MagicMock()
-    common_objs = {
-        'directory': Directory(),
-        'cfg_mgr': cfg_mgr,
-        'tf': TemplateFabric(),
-        'constants': constants,
-    }
-    m = BBRMgr(common_objs, "CONFIG_DB", "BGP_BBR")
-    m._BBRMgr__init()
 
     # BBR status from config_db should be prioritized over constants
-    assert m.enabled
-    assert m.directory.get("CONFIG_DB", "BGP_BBR", "status") == "enabled"
-    assert m.bbr_enabled_pgs == expected_bbr_entries
+    __init_common(constants, "BBRMgr::Initialized and enabled from config_db. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
 
 @patch('bgpcfgd.managers_bbr.BBRMgr.get_bbr_status_from_config_db', return_value='enabled')
 def test___init_with_config_db_2(mocked_get_bbr_status_from_config_db):

--- a/src/sonic-bgpcfgd/tests/test_bbr.py
+++ b/src/sonic-bgpcfgd/tests/test_bbr.py
@@ -171,7 +171,7 @@ def test___init_7():
             "bbr": expected_bbr_entries,
         }
     }
-    __init_common(constants, "BBRMgr::Initialized and from constants. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
+    __init_common(constants, "BBRMgr::Initialized and enabled from constants. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
 
 def test___init_8():
     expected_bbr_entries = {

--- a/src/sonic-bgpcfgd/tests/test_bbr.py
+++ b/src/sonic-bgpcfgd/tests/test_bbr.py
@@ -157,7 +157,7 @@ def test___init_6():
             "bbr": expected_bbr_entries,
         }
     }
-    __init_common(constants, "BBRMgr::Initialized and enabled. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
+    __init_common(constants, "BBRMgr::Initialized and enabled from constants. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
 
 def test___init_7():
     expected_bbr_entries = {

--- a/src/sonic-bgpcfgd/tests/test_bbr.py
+++ b/src/sonic-bgpcfgd/tests/test_bbr.py
@@ -102,7 +102,8 @@ def test_del_handler(mocked_log_err):
 
 @patch('bgpcfgd.managers_bbr.log_info')
 @patch('bgpcfgd.managers_bbr.log_err')
-def __init_common(constants,
+@patch('bgpcfgd.managers_bbr.BBRMgr.get_bbr_status_from_config_db')
+def __init_common(constants, mocked_get_bbr_status_from_config_db,
                   expected_log_info, expected_log_err, expected_bbr_enabled_pgs, expected_status,
                   mocked_log_err, mocked_log_info):
     cfg_mgr = MagicMock()
@@ -112,6 +113,8 @@ def __init_common(constants,
         'tf':        TemplateFabric(),
         'constants': constants,
     }
+    mocked_get_bbr_status_from_config_db.return_value = None
+
     m = BBRMgr(common_objs, "CONFIG_DB", "BGP_BBR")
     m._BBRMgr__init()
     assert m.bbr_enabled_pgs == expected_bbr_enabled_pgs
@@ -187,13 +190,8 @@ def test___init_8():
     }
     __init_common(constants, "BBRMgr::Initialized and enabled from constants. Default state: 'enabled'", None, expected_bbr_entries, "enabled")
 
-@patch('bgpcfgd.managers_bbr.swsscommon.DBConnector')
-@patch('bgpcfgd.managers_bbr.swsscommon.Table')
-def test___init_with_config_db(mock_db_connector, mock_table):
-    mock_table_instance = MagicMock()
-    mock_table.return_value = mock_table_instance
-    mock_table_instance.get.return_value = (True, {'all': 'enabled'})
-
+@patch('bgpcfgd.managers_bbr.BBRMgr.get_bbr_status_from_config_db', return_value={'all': {'status': 'enabled'}})
+def test___init_with_config_db(mocked_get_bbr_status_from_config_db):
     expected_bbr_entries = {
         "PEER_V4": ["ipv4"],
         "PEER_V6": ["ipv6"],

--- a/src/sonic-bgpcfgd/tests/test_bbr.py
+++ b/src/sonic-bgpcfgd/tests/test_bbr.py
@@ -192,7 +192,7 @@ def test___init_8():
 def test___init_with_config_db(mock_db_connector, mock_table):
     mock_table_instance = MagicMock()
     mock_table.return_value = mock_table_instance
-    mock_table_instance.get.return_value = (True, {'status': 'enabled'})
+    mock_table_instance.get.return_value = (True, {'all': 'enabled'})
 
     expected_bbr_entries = {
         "PEER_V4": ["ipv4"],

--- a/src/sonic-bgpcfgd/tests/test_bbr.py
+++ b/src/sonic-bgpcfgd/tests/test_bbr.py
@@ -189,7 +189,7 @@ def test___init_8():
     __init_common(constants, "BBRMgr::Initialized and enabled from constants. Default state: 'enabled'", None, expected_bbr_entries, "enabled")
 
 @patch('bgpcfgd.managers_bbr.BBRMgr.get_bbr_status_from_config_db', return_value='disabled')
-def test___init_with_config_db_1(mocked_get_bbr_status_from_config_db):
+def test___init_with_config_db_overwirte_constants(mocked_get_bbr_status_from_config_db):
     expected_bbr_entries = {
         "PEER_V4": ["ipv4"],
         "PEER_V6": ["ipv6"],
@@ -206,7 +206,7 @@ def test___init_with_config_db_1(mocked_get_bbr_status_from_config_db):
     __init_common(constants, "BBRMgr::Initialized and enabled from config_db. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
 
 @patch('bgpcfgd.managers_bbr.BBRMgr.get_bbr_status_from_config_db', return_value='enabled')
-def test___init_with_config_db_2(mocked_get_bbr_status_from_config_db):
+def test___init_with_config_db_no_peers(mocked_get_bbr_status_from_config_db):
 
     constants = deepcopy(global_constants)
     constants["bgp"]["bbr"] = {"enabled": True}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
There are two places which we can configure the BBR disabled/enabled, one is constants.yml, the other is by config_db. During run time, config_db win. But at the init stage, constants.yml win. This is a wrong logic, constants.yml only win when there is no such config in the config_db.
##### Work item tracking
- Microsoft ADO **(number only)**: 28302790

#### How I did it
Initialize BBR status from constants.yml only when config_db doesn't have BBR entry.

#### How to verify it
Build image and run the following:
```
# bbr status in constants.yml is set to disabled
# change the bbr status in config_db to enabled and reload config
admin@str2-7050cx3-acs-01:~$ redis-cli -n 4 hset "BGP_BBR|all" "status" "enabled"
(integer) 0
admin@str2-7050cx3-acs-01:~$ redis-cli -n 4 hget "BGP_BBR|all" "status"
"enabled"
admin@str2-7050cx3-acs-01:~$ vtysh -c 'show run' | grep 'allowas'
  neighbor PEER_V4 allowas-in 1
  neighbor PEER_V6 allowas-in 1
admin@str2-7050cx3-acs-01:~$ sudo config save -y
Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
admin@str2-7050cx3-acs-01:~$ sudo config reload -y

# check bgpcfgd log, bbr default status is enabled
2024 Aug 14 05:42:47.653216 str2-7050cx3-acs-01 INFO bgp#bgpcfgd: BBRMgr::Initialized and enabled from config_db. Default state: 'enabled'
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [x] 202305
- [x] 202311
- [x] 202405  

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

