### PR TITLE
[Mellanox] Disable Auto Negotiation by default for SN4700

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/hwsku.json
@@ -2,227 +2,283 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet4": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet8": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet12": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet16": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet20": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet24": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet28": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet32": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet36": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet40": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet44": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet48": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet52": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet56": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet60": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet64": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet68": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet72": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet76": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet80": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet84": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet88": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet92": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet96": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet104": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet112": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet120": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet128": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet136": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet144": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet152": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet160": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet164": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet168": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet172": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet176": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet180": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet184": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet188": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet192": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet196": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet200": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet204": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet208": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet212": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet216": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet220": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet224": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet228": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet232": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet236": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet240": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet244": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet248": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet252": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         }
     }
 }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/hwsku.json
@@ -2,227 +2,283 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet4": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet8": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet12": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet16": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet20": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet24": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet28": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet32": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet36": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet40": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet44": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet48": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet52": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet56": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet60": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet64": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet68": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet72": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet76": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet80": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet84": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet88": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet92": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet96": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet104": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet112": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet120": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet128": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet136": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet144": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet152": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet160": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet164": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet168": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet172": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet176": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet180": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet184": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet188": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet192": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet196": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet200": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet204": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet208": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet212": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet216": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet220": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet224": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet228": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet232": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet236": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet240": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet244": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         },
         "Ethernet248": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "subport": "1",
+            "autoneg": "off"
         },
         "Ethernet252": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "subport": "2",
+            "autoneg": "off"
         }
     }
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When CMIS host mgmt is enabled, CMIS active cables' autoneg must be disabled. 
Here, it will generate config_db with autoneg:off by default for all ports. 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
deploy/sonic-cfggem
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

