### PR TITLE
Enable runtime config log level

### DIFF
--- a/src/sonic-py-common/sonic_py_common/daemon_base.py
+++ b/src/sonic-py-common/sonic_py_common/daemon_base.py
@@ -35,10 +35,10 @@ def db_connect(db_name, namespace=EMPTY_NAMESPACE):
 
 
 class DaemonBase(Logger):
-    def __init__(self, log_identifier, use_syslogger=True):
+    def __init__(self, log_identifier, use_syslogger=True, enable_runtime_log_config=False):
         super().__init__()
         if use_syslogger:
-            self.logger_instance = SysLogger(log_identifier)
+            self.logger_instance = SysLogger(log_identifier, enable_runtime_config=enable_runtime_log_config)
         else:
             self.logger_instance = Logger(
                 log_identifier=log_identifier,

--- a/src/sonic-py-common/sonic_py_common/syslogger.py
+++ b/src/sonic-py-common/sonic_py_common/syslogger.py
@@ -3,6 +3,12 @@ from logging.handlers import SysLogHandler
 import os
 import socket
 import sys
+import threading
+
+CONFIG_DB = 'CONFIG_DB'
+FIELD_LOG_LEVEL = 'LOGLEVEL'
+FIELD_REQUIRE_REFRESH = 'require_manual_refresh'
+
 
 # customize python logging to support notice logger
 logging.NOTICE = logging.INFO + 1
@@ -14,11 +20,14 @@ class SysLogger:
     """
     SysLogger class for Python applications using SysLogHandler
     """
+    
+    log_registry = {}
+    lock = threading.Lock()
 
     DEFAULT_LOG_FACILITY = SysLogHandler.LOG_USER
     DEFAULT_LOG_LEVEL = logging.NOTICE
 
-    def __init__(self, log_identifier=None, log_facility=DEFAULT_LOG_FACILITY, log_level=DEFAULT_LOG_LEVEL):
+    def __init__(self, log_identifier=None, log_facility=DEFAULT_LOG_FACILITY, log_level=DEFAULT_LOG_LEVEL, enable_runtime_config=False):
         if log_identifier is None:
             log_identifier = os.path.basename(sys.argv[0])
 
@@ -35,6 +44,113 @@ class SysLogger:
         self.logger.addHandler(handler)
 
         self.set_min_log_priority(log_level)
+        
+        if enable_runtime_config:
+            self.register_for_runtime_config(log_identifier)
+            
+    def register_for_runtime_config(self, log_identifier):
+        """Register current log instance to log registry. If DB entry exists, 
+        update log level according to DB configuration; otherwise, save current
+        log level to DB.
+
+        Args:
+            log_identifier (str): key of LOGGER table
+        """
+        with SysLogger.lock:
+            if log_identifier not in SysLogger.log_registry:
+                SysLogger.log_registry[log_identifier] = [self]
+            else:
+                SysLogger.log_registry[log_identifier].append(self)
+            
+        from swsscommon import swsscommon
+        try:
+            config_db = swsscommon.SonicV2Connector(use_unix_socket_path=True)
+            config_db.connect(CONFIG_DB)
+            log_level_in_db = config_db.get(CONFIG_DB, f'{swsscommon.CFG_LOGGER_TABLE_NAME}|{log_identifier}', FIELD_LOG_LEVEL)
+            if log_level_in_db:
+                self.set_min_log_priority(self.log_priority_from_str(log_level_in_db))
+            else:
+                data = {
+                    FIELD_LOG_LEVEL: self.log_priority_to_str(self._min_log_level),
+                    FIELD_REQUIRE_REFRESH: 'true'
+                }
+                config_db.hmset(CONFIG_DB, f'{swsscommon.CFG_LOGGER_TABLE_NAME}|{log_identifier}', data)
+        except Exception as e:
+            self.log_notice(f'DB is not available when initialize logger instance - {e}')
+                
+    @classmethod
+    def update_log_level(cls):
+        """Refresh log level for each log instances registered to cls.log_registry.
+
+        Returns:
+            tuple: (refresh result, fail reason)
+        """
+        with cls.lock:
+            if not cls.log_registry:
+                return True, ''
+            
+            from swsscommon import swsscommon
+            try:
+                config_db = swsscommon.SonicV2Connector(use_unix_socket_path=True)
+                config_db.connect(CONFIG_DB)
+                for log_identifier, log_instances in cls.log_registry.items():
+                    log_level_in_db = config_db.get(CONFIG_DB, f'{swsscommon.CFG_LOGGER_TABLE_NAME}|{log_identifier}', FIELD_LOG_LEVEL)
+                    if log_level_in_db:
+                        for log_instance in log_instances:
+                            log_instance.set_min_log_priority(log_instance.log_priority_from_str(log_level_in_db))
+                    else:
+                        for log_instance in log_instances:
+                            data = {
+                                FIELD_LOG_LEVEL: log_instance.log_priority_to_str(log_instance._min_log_level),
+                                FIELD_REQUIRE_REFRESH: 'true'
+                            }
+                            config_db.hmset(CONFIG_DB, f'{swsscommon.CFG_LOGGER_TABLE_NAME}|{log_identifier}', data)
+                            break
+                return True, ''
+            except Exception as e:
+                return False, f'Failed to refresh log configuration - {e}'
+
+    def log_priority_to_str(self, priority):
+        """Convert log priority to string.
+        Args:
+            priority (int): log priority.
+        Returns:
+            str: log priority in string.
+        """
+        if priority == logging.INFO:
+            return 'INFO'
+        elif priority == logging.NOTICE:
+            return 'NOTICE'
+        elif priority == logging.DEBUG:
+            return 'DEBUG'
+        elif priority == logging.WARNING:
+            return 'WARN'
+        elif priority == logging.ERROR:
+            return 'ERROR'
+        else:
+            self.log_error(f'Invalid log priority: {priority}')
+            return 'NOTICE'
+
+    def log_priority_from_str(self, priority_in_str):
+        """Convert log priority from string.
+        Args:
+            priority_in_str (str): log priority in string.
+        Returns:
+            _type_: log priority.
+        """
+        if priority_in_str == 'DEBUG':
+            return logging.DEBUG
+        elif priority_in_str == 'INFO':
+            return logging.INFO
+        elif priority_in_str == 'NOTICE':
+            return logging.NOTICE
+        elif priority_in_str == 'WARN':
+            return logging.WARNING
+        elif priority_in_str == 'ERROR':
+            return logging.ERROR
+        else:
+            self.log_error(f'Invalid log priority string: {priority_in_str}')
+            return logging.NOTICE
 
     def set_min_log_priority(self, priority):
         """

--- a/src/sonic-py-common/sonic_py_common/syslogger.py
+++ b/src/sonic-py-common/sonic_py_common/syslogger.py
@@ -19,18 +19,15 @@ class SysLogger:
     """
     SysLogger class for Python applications using SysLogHandler
     """
-    
-    log_registry = {}
 
     DEFAULT_LOG_FACILITY = SysLogHandler.LOG_USER
     DEFAULT_LOG_LEVEL = logging.NOTICE
 
     def __init__(self, log_identifier=None, log_facility=DEFAULT_LOG_FACILITY, log_level=DEFAULT_LOG_LEVEL, enable_runtime_config=False):
-        if log_identifier is None:
-            log_identifier = os.path.basename(sys.argv[0])
+        self.log_identifier = log_identifier if log_identifier else os.path.basename(sys.argv[0]) 
 
         # Initialize SysLogger
-        self.logger = logging.getLogger(log_identifier)
+        self.logger = logging.getLogger(self.log_identifier)
 
         # Reset all existing handlers
         for handler in self.logger.handlers[:]:
@@ -44,26 +41,19 @@ class SysLogger:
         self.set_min_log_priority(log_level)
         
         if enable_runtime_config:
-            self.register_for_runtime_config(log_identifier)
-            
-    def register_for_runtime_config(self, log_identifier):
-        """Register current log instance to log registry. If DB entry exists, 
-        update log level according to DB configuration; otherwise, save current
-        log level to DB.
+            self.update_log_level()
+                            
+    def update_log_level(self):
+        """Refresh log level.
 
-        Args:
-            log_identifier (str): key of LOGGER table
-        """
-        if log_identifier not in SysLogger.log_registry:
-            SysLogger.log_registry[log_identifier] = [self]
-        else:
-            SysLogger.log_registry[log_identifier].append(self)
-            
+        Returns:
+            tuple: (refresh result, fail reason)
+        """        
         from swsscommon import swsscommon
         try:
             config_db = swsscommon.SonicV2Connector(use_unix_socket_path=True)
             config_db.connect(CONFIG_DB)
-            log_level_in_db = config_db.get(CONFIG_DB, f'{swsscommon.CFG_LOGGER_TABLE_NAME}|{log_identifier}', FIELD_LOG_LEVEL)
+            log_level_in_db = config_db.get(CONFIG_DB, f'{swsscommon.CFG_LOGGER_TABLE_NAME}|{self.log_identifier}', FIELD_LOG_LEVEL)
             if log_level_in_db:
                 self.set_min_log_priority(self.log_priority_from_str(log_level_in_db))
             else:
@@ -71,37 +61,7 @@ class SysLogger:
                     FIELD_LOG_LEVEL: self.log_priority_to_str(self._min_log_level),
                     FIELD_REQUIRE_REFRESH: 'true'
                 }
-                config_db.hmset(CONFIG_DB, f'{swsscommon.CFG_LOGGER_TABLE_NAME}|{log_identifier}', data)
-        except Exception as e:
-            self.log_notice(f'DB is not available when initialize logger instance - {e}')
-                
-    @classmethod
-    def update_log_level(cls):
-        """Refresh log level for each log instances registered to cls.log_registry.
-
-        Returns:
-            tuple: (refresh result, fail reason)
-        """
-        if not cls.log_registry:
-            return True, ''
-        
-        from swsscommon import swsscommon
-        try:
-            config_db = swsscommon.SonicV2Connector(use_unix_socket_path=True)
-            config_db.connect(CONFIG_DB)
-            for log_identifier, log_instances in cls.log_registry.items():
-                log_level_in_db = config_db.get(CONFIG_DB, f'{swsscommon.CFG_LOGGER_TABLE_NAME}|{log_identifier}', FIELD_LOG_LEVEL)
-                if log_level_in_db:
-                    for log_instance in log_instances:
-                        log_instance.set_min_log_priority(log_instance.log_priority_from_str(log_level_in_db))
-                else:
-                    for log_instance in log_instances:
-                        data = {
-                            FIELD_LOG_LEVEL: log_instance.log_priority_to_str(log_instance._min_log_level),
-                            FIELD_REQUIRE_REFRESH: 'true'
-                        }
-                        config_db.hmset(CONFIG_DB, f'{swsscommon.CFG_LOGGER_TABLE_NAME}|{log_identifier}', data)
-                        break
+                config_db.hmset(CONFIG_DB, f'{swsscommon.CFG_LOGGER_TABLE_NAME}|{self.log_identifier}', data)
             return True, ''
         except Exception as e:
             return False, f'Failed to refresh log configuration - {e}'

--- a/src/sonic-py-common/sonic_py_common/syslogger.py
+++ b/src/sonic-py-common/sonic_py_common/syslogger.py
@@ -125,7 +125,7 @@ class SysLogger:
             return 'ERROR'
         else:
             self.log_error(f'Invalid log priority: {priority}')
-            return 'NOTICE'
+            return 'WARN'
 
     def log_priority_from_str(self, priority_in_str):
         """Convert log priority from string.
@@ -146,7 +146,7 @@ class SysLogger:
             return logging.ERROR
         else:
             self.log_error(f'Invalid log priority string: {priority_in_str}')
-            return logging.NOTICE
+            return logging.WARNING
 
     def set_min_log_priority(self, priority):
         """

--- a/src/sonic-py-common/tests/test_syslogger.py
+++ b/src/sonic-py-common/tests/test_syslogger.py
@@ -32,3 +32,70 @@ class TestSysLogger:
         log.log_notice('this is a message')
         captured = capsys.readouterr() 
         assert 'NOTICE' in captured.out
+
+    def test_basic(self):
+        log = syslogger.SysLogger()
+        log.logger.log = mock.MagicMock()
+        log.log_error('error message')
+        log.log_warning('warning message')
+        log.log_notice('notice message')
+        log.log_info('info message')
+        log.log_debug('debug message')
+        log.log(logging.ERROR, 'error msg', also_print_to_console=True)
+
+    def test_log_priority(self):
+        log = syslogger.SysLogger()
+        log.set_min_log_priority(logging.ERROR)
+        assert log.logger.level == logging.ERROR
+
+    def test_log_priority_from_str(self):
+        log = syslogger.SysLogger()
+        assert log.log_priority_from_str('ERROR') == logging.ERROR
+        assert log.log_priority_from_str('INFO') == logging.INFO
+        assert log.log_priority_from_str('NOTICE') == logging.NOTICE
+        assert log.log_priority_from_str('WARN') == logging.WARN
+        assert log.log_priority_from_str('DEBUG') == logging.DEBUG
+        assert log.log_priority_from_str('invalid') == logging.NOTICE
+
+    def test_log_priority_to_str(self):
+        log = syslogger.SysLogger()
+        assert log.log_priority_to_str(logging.NOTICE) == 'NOTICE'
+        assert log.log_priority_to_str(logging.INFO) == 'INFO'
+        assert log.log_priority_to_str(logging.DEBUG) == 'DEBUG'
+        assert log.log_priority_to_str(logging.WARN) == 'WARN'
+        assert log.log_priority_to_str(logging.ERROR) == 'ERROR'
+        assert log.log_priority_to_str(-1) == 'NOTICE'
+
+    @mock.patch('swsscommon.swsscommon.SonicV2Connector')
+    def test_runtime_config(self, mock_connector):
+        mock_db = mock.MagicMock()
+        mock_db.get = mock.MagicMock(return_value='DEBUG')
+        mock_connector.return_value = mock_db
+        log1 = syslogger.SysLogger(log_identifier='log1', enable_runtime_config=True, log_level=logging.INFO)
+        assert 'log1' in syslogger.SysLogger.log_registry
+        assert log1.logger.level == logging.DEBUG
+
+        mock_db.get.return_value = None
+        mock_db.hmset = mock.MagicMock()
+        log2 = syslogger.SysLogger(log_identifier='log2', enable_runtime_config=True, log_level=logging.INFO)
+        assert 'log2' in syslogger.SysLogger.log_registry
+        mock_db.hmset.assert_called_once()
+
+        mock_db.get.return_value = 'ERROR'
+        ret, msg = syslogger.SysLogger.update_log_level()
+        assert ret
+        assert not msg
+        assert log1.logger.level == logging.ERROR
+        assert log2.logger.level == logging.ERROR
+
+    @mock.patch('swsscommon.swsscommon.SonicV2Connector')
+    def test_runtime_config_negative(self, mock_connector):
+        mock_db = mock.MagicMock()
+        mock_db.get = mock.MagicMock(side_effect=Exception(''))
+        mock_connector.return_value = mock_db
+        syslogger.SysLogger(log_identifier='log', enable_runtime_config=True)
+        assert 'log' in syslogger.SysLogger.log_registry
+
+        ret, msg = syslogger.SysLogger.update_log_level()
+        assert not ret
+        assert msg

--- a/src/sonic-py-common/tests/test_syslogger.py
+++ b/src/sonic-py-common/tests/test_syslogger.py
@@ -55,7 +55,7 @@ class TestSysLogger:
         assert log.log_priority_from_str('NOTICE') == logging.NOTICE
         assert log.log_priority_from_str('WARN') == logging.WARN
         assert log.log_priority_from_str('DEBUG') == logging.DEBUG
-        assert log.log_priority_from_str('invalid') == logging.NOTICE
+        assert log.log_priority_from_str('invalid') == logging.WARN
 
     def test_log_priority_to_str(self):
         log = syslogger.SysLogger()
@@ -64,7 +64,7 @@ class TestSysLogger:
         assert log.log_priority_to_str(logging.DEBUG) == 'DEBUG'
         assert log.log_priority_to_str(logging.WARN) == 'WARN'
         assert log.log_priority_to_str(logging.ERROR) == 'ERROR'
-        assert log.log_priority_to_str(-1) == 'NOTICE'
+        assert log.log_priority_to_str(-1) == 'WARN'
 
     @mock.patch('swsscommon.swsscommon.SonicV2Connector')
     def test_runtime_config(self, mock_connector):

--- a/src/sonic-py-common/tests/test_syslogger.py
+++ b/src/sonic-py-common/tests/test_syslogger.py
@@ -84,8 +84,8 @@ class TestSysLogger:
         mock_db = mock.MagicMock()
         mock_db.get = mock.MagicMock(side_effect=Exception(''))
         mock_connector.return_value = mock_db
-        syslogger.SysLogger(log_identifier='log', enable_runtime_config=True)
+        log = syslogger.SysLogger(log_identifier='log', enable_runtime_config=True)
 
-        ret, msg = syslogger.SysLogger.update_log_level()
+        ret, msg = log.update_log_level()
         assert not ret
         assert msg

--- a/src/sonic-py-common/tests/test_syslogger.py
+++ b/src/sonic-py-common/tests/test_syslogger.py
@@ -71,22 +71,13 @@ class TestSysLogger:
         mock_db = mock.MagicMock()
         mock_db.get = mock.MagicMock(return_value='DEBUG')
         mock_connector.return_value = mock_db
-        log1 = syslogger.SysLogger(log_identifier='log1', enable_runtime_config=True, log_level=logging.INFO)
-        assert 'log1' in syslogger.SysLogger.log_registry
-        assert log1.logger.level == logging.DEBUG
-
-        mock_db.get.return_value = None
-        mock_db.hmset = mock.MagicMock()
-        log2 = syslogger.SysLogger(log_identifier='log2', enable_runtime_config=True, log_level=logging.INFO)
-        assert 'log2' in syslogger.SysLogger.log_registry
-        mock_db.hmset.assert_called_once()
+        log = syslogger.SysLogger(log_identifier='log1', enable_runtime_config=True, log_level=logging.INFO)
+        assert log.logger.level == logging.DEBUG
 
         mock_db.get.return_value = 'ERROR'
-        ret, msg = syslogger.SysLogger.update_log_level()
+        ret, msg = log.update_log_level()
         assert ret
         assert not msg
-        assert log1.logger.level == logging.ERROR
-        assert log2.logger.level == logging.ERROR
 
     @mock.patch('swsscommon.swsscommon.SonicV2Connector')
     def test_runtime_config_negative(self, mock_connector):
@@ -94,7 +85,6 @@ class TestSysLogger:
         mock_db.get = mock.MagicMock(side_effect=Exception(''))
         mock_connector.return_value = mock_db
         syslogger.SysLogger(log_identifier='log', enable_runtime_config=True)
-        assert 'log' in syslogger.SysLogger.log_registry
 
         ret, msg = syslogger.SysLogger.update_log_level()
         assert not ret


### PR DESCRIPTION
HLD link: https://github.com/sonic-net/SONiC/pull/1522
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

SONiC provides two Python logger implementations: `sonic_py_common.logger.Logger` and `sonic_py_common.syslogger.SysLogger`. Both of them do not provide the ability to change log level at real time. Sometimes, in order to get more debug information, developer has to manually change the log level in code on a running switch and restart the Python daemon. This is not convenient.

SONiC also provides a C/C++ logger implementation in `sonic-platform-common.common.logger.cpp`. This C/C++ logger implementation is also a wrapper of Linux standard `syslog` which is widely used by swss/syncd. It provides the ability to set log level on fly by starting a thread to listen to CONFIG DB LOGGER table change. SONiC infrastructure also provides the Python wrapper for `sonic-platform-common.common.logger.cpp` which is `swsscommon.Logger`. However, this logger implementation also has some drawbacks:


1. `swsscommon.Logger` assumes redis DB is ready to connect. This is a valid assumption for swss/syncd. But it is not good for a Python logger implementation because some Python script may be called before redis server starting.
2. `swsscommon.Logger` wraps Linux syslog which only support single log identifier for a daemon. 

So, `swsscommon.Logger` is not an option too.

This PR is a Python logger enhancement which allows user setting log level at run time.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

`swsscommon.Logger` depends on a thread to listen to CONFIG DB LOGGER table change. It refreshes log level for each logger instances once the thread detects a DB entry change. A thread is considered heavy in a python script, especially that there are many short and simple python scripts which also use logger. To keep python logger light weight, it uses a different design than `swsscommon.Logger`:

- A class level logger registry shall be added to `SysLogger`class
- Each logger instance shall register itself to logger register if enables runtime configuration
- Logger configuration shall be refreshed by CLI which send a SIGHUP signal to the daemon

#### How to verify it

Manual test
New unit test cases

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

