### PR TITLE
[finalize-warmboot.sh] reset cpufreq governor to default

### DIFF
--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -116,7 +116,7 @@ function finalize_common() {
 
     if [[ "$asic_type" == "mellanox" ]]; then
         # Read default governor from kernel config
-        local -r default_governor=$(cat "/boot/config-$(uname -r)" | grep -o 'CONFIG_CPU_FREQ_DEFAULT_GOV_[^=]*=y')
+        local -r default_governor=$(cat "/boot/config-$(uname -r)" | grep -E 'CONFIG_CPU_FREQ_DEFAULT_GOV_.*=y' | sed -E 's/CONFIG_CPU_FREQ_DEFAULT_GOV_(.*)=y/\1/')
         set_cpufreq_governor "$default_governor"
     fi
 }

--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -102,15 +102,15 @@ function check_list()
 }
 
 function set_cpufreq_governor() {
-    governor="$1"
-    echo "$governor" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor \
+    local -r governor="$1"
+    echo "$governor" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor 1> /dev/null \
         && debug "Set CPUFreq scaling governor to $governor" \
         || debug "Failed to set CPUFreq scaling governor to $governor"
 }
 
 function finalize_common() {
     # Read default governor from kernel config
-    default_governor=$(cat "/boot/config-$(uname -r)" | grep -E 'CONFIG_CPU_FREQ_DEFAULT_GOV_.*=y' | sed -E 's/CONFIG_CPU_FREQ_DEFAULT_GOV_(.*)=y/\1/')
+    local -r default_governor=$(cat "/boot/config-$(uname -r)" | grep -o 'CONFIG_CPU_FREQ_DEFAULT_GOV_[^=]*=y')
     set_cpufreq_governor "$default_governor"
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Set cpufreq.default_governor to *performance* for faster boot time. We observe consistent 1 sec improvement across several devices.

The change in finalize-warmboot.sh restores the default governor after fast or warm boot is finished.

**NOTE**: This will apply to upgrades starting from 202405 since this is set in shutdown path to avoid any extra scripts running at boot time. Upgrade from older versions/branches will require a runtime patch to fast-reboot and warm-reboot script.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

After fast or warm boot is finished restore to default governor.

#### How to verify it


Run fast-reboot or warm-reboot. Check:
```
admin@sonic:~$ cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
performance
```

After boot is finalized check that it is reset back to default:
```
admin@sonic:~$ cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
schedutil
```

Tested with https://github.com/sonic-net/sonic-utilities/pull/3435

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

