### PR TITLE
Set soc property `programmability_ucode_relative_path` for Arista DNX Devices

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -2,7 +2,7 @@ soc_family.BCM8869X=BCM8869X
 system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
-custom_feature_ucode_path=u_code_db2pem.txt
+programmability_ucode_relative_path.BCM8869X=pemla/ucode/standard_1/jer2pemla/u_code_db2pem.txt
 system_headers_mode=1
 suppress_unknown_prop_warnings=1
 l4_protocols_load_balancing_enable=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -2,6 +2,7 @@ soc_family=BCM8885X
 system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
+programmability_ucode_relative_path.BCM8885X=pemla/ucode/standard_1/jer2pemla/u_code_db2pem.txt
 
 ####################################################
 ##Reference applications related properties - Start

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -2,6 +2,7 @@ soc_family=BCM8885X
 system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
+programmability_ucode_relative_path.BCM8885X=pemla/ucode/standard_1/jer2pemla/u_code_db2pem.txt
 
 ####################################################
 ##Reference applications related properties - Start

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -2,6 +2,7 @@ soc_family=BCM8885X
 system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
+programmability_ucode_relative_path.BCM8885X=pemla/ucode/standard_1/jer2pemla/u_code_db2pem.txt
 
 ####################################################
 ##Reference applications related properties - Start

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -2,6 +2,7 @@ soc_family=BCM8885X
 system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
+programmability_ucode_relative_path.BCM8885X=pemla/ucode/standard_1/jer2pemla/u_code_db2pem.txt
 
 ####################################################
 ##Reference applications related properties - Start

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -2,6 +2,7 @@ soc_family=BCM8885X
 system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
+programmability_ucode_relative_path.BCM8885X=pemla/ucode/standard_1/jer2pemla/u_code_db2pem.txt
 
 ####################################################
 ##Reference applications related properties - Start

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -2,6 +2,7 @@ soc_family=BCM8885X
 system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
+programmability_ucode_relative_path.BCM8885X=pemla/ucode/standard_1/jer2pemla/u_code_db2pem.txt
 
 ####################################################
 ##Reference applications related properties - Start

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -346,3 +346,4 @@ sai_stats_support_mask
 sai_default_cpu_tx_tc
 oversubscribe_mixed_sister_25_50_enable
 sai_disable_srcmacqedstmac_ctrl
+programmability_ucode_relative_path


### PR DESCRIPTION
Broadcom requires that `programmability_ucode_relative_path` is set in SAI11.
This soc property replaces the legacy `custom_feature_ucode_path`

Without this we get the following error:
```
syncd#supervisord: syncd 0:dbx_file_get_db_location: DB Resource not defined#015
syncd#supervisord: syncd #015#015
syncd#supervisord: syncd 0:dnx_init_pemla_get_ucode_filepath:  Error 'Invalid parameter' indicated ; #015#015
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

