### PR TITLE
Fix TH5 egress pool creation failure with BCM YAML file and SAI update on 07/16.

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-256x200G/BALANCED/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-256x200G/BALANCED/buffers_defaults_t0.j2
@@ -5,13 +5,13 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "165660324",
+            "size": "165603428",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "29520896"
         },
         "egress_lossless_pool": {
-            "size": "165660324",
+            "size": "165603428",
             "type": "egress",
             "mode": "dynamic"
         }


### PR DESCRIPTION
#### Why I did it

The latest TH5 mmu configuration has some issues where egress pool creation fails with the latest BCM SAI updates.

> Jul 20 12:04:58.163923 str3-7060x6-64pe-2 ERR syncd#syncd: [none] SAI_API_BUFFER:driverEgressPoolSharedLimitSet:3476 configure egress itm 0 buffer pool 0 with size 82830162, gport 0x 800000b COS 0 current reserved size 21805392 shared size 60996322, requested shared size 61024770 failed with error -1
> Jul 20 12:04:58.163923 str3-7060x6-64pe-2 ERR syncd#syncd: [none] SAI_API_BUFFER:ltsw_driverDBLimitSet:3197 set egress buffer pool 0 limit to 82830162 using port 11 queue 0 failed with error -1


##### Work item tracking
- Microsoft ADO **(number only)**: 28775282

#### How I did it

This PR fixes the issue by updating the egress pool size to match with the one in the ASIC.

#### How to verify it

Tested on local testbed

> Jul 20 19:45:35.767569 str3-7060x6-64pe-2 NOTICE swss#orchagent: :- processQueue: Set buffer queue Ethernet0:0-2 to BUFFER_PROFILE_TABLE:egress_lossy_profile
> Jul 20 19:45:35.823139 str3-7060x6-64pe-2 INFO syncd#syncd: [none] SAI_API_BUFFER:ltsw_driverDBLimitSet:3204 Created egress buffer pool 0 with size 82801714 bytes
> Jul 20 19:45:35.823139 str3-7060x6-64pe-2 INFO syncd#syncd: [none] SAI_API_BUFFER:ltsw_driverEgressQueueFieldSet:4099 Programming cosq 0 for port 11 control 81 with value 1
> Jul 20 19:45:35.823166 str3-7060x6-64pe-2 INFO syncd#syncd: [none] 
> ...
> Jul 20 19:45:38.214661 str3-7060x6-64pe-2 INFO syncd#syncd: [none] SAI_API_BUFFER:driverPGAttributeSet:1158 Programming ing cosq 3 for port 70 control 128 with value 3556
> Jul 20 19:45:38.216275 str3-7060x6-64pe-2 INFO syncd#rsyslogd: imuxsock[pid: 33, name: /usr/bin/syncd] from <str3-7060x6-64pe-2:syncd>: begin to drop messages due to rate-limiting
> Jul 20 19:45:38.279834 str3-7060x6-64pe-2 NOTICE swss#orchagent: :- processPriorityGroup: Set buffer PG Ethernet106:0 to BUFFER_PROFILE_TABLE:ingress_lossy_profile

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [X] 202311
- [X] 202405

#### Tested branch (Please provide the tested image version)

- [x] 20231110.17

#### Description for the changelog

Fix TH5 egress pool creation failure with BCM YAML file and SAI update on 07/16.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

