### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202305.1.0.13
+ref=202305.1.0.14


### PR DESCRIPTION
Release notes for Cisco 8111-32EH-O, 8102-64H-O and 8101-32FH:
[8111] Fix for BT0 switch in a problematic state and sending out PFCs on all the ports carrying traffic
[8111] Fix for OIR issue: of all 16 AEC supported ports, removal+insertion is getting detected only for 8 to 10 ports
[8111] During Tput tests, packet drops are not getting listed under 'show interface counters'/'show queue counters'
          - Partial fix to account for drops related to invalid destination
Show platform npu CLI support for displaying LPM and CEM report

Addressed the following test case failures:
          - Fix for ERR log on get_sms_wred_mark_probability
          - Fix various errors in SAI that are triggering log analyzer to fail
          - Expediting the code drop for [8111].  Will upload test results to Kusto once run analysis completed for all platforms

Update platform version to 202305.1.0.14

