### PR TITLE
Add received_bandwidth to BGP

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
@@ -12,6 +12,7 @@ class DeviceGlobalCfgMgr(Manager):
     TSA_DEFAULTS = "false"
     WCMP_DEFAULTS = "false"
     IDF_DEFAULTS = "unisolated"
+    RECEIVED_DEFAULTS = "ignore"
 
     def __init__(self, common_objs, db, table):
         """
@@ -47,6 +48,9 @@ class DeviceGlobalCfgMgr(Manager):
         # By default IDF feature is unisolated
         if not self.directory.path_exist(self.db_name, self.table_name, "idf_isolation_state"):
             self.directory.put(self.db_name, self.table_name, "idf_isolation_state", self.IDF_DEFAULTS)
+        # By default received bandwidth for W-ECMP feature is ignore
+        if not self.directory.path_exist(self.db_name, self.table_name, "received_bandwidth"):
+            self.directory.put(self.db_name, self.table_name, "received_bandwidth", self.RECEIVED_DEFAULTS)
 
     def on_switch_type_change(self):
         log_debug("DeviceGlobalCfgMgr:: Switch type update handler")
@@ -70,6 +74,8 @@ class DeviceGlobalCfgMgr(Manager):
         self.configure_wcmp(data)
         # IDF configuration
         self.configure_idf(data)
+        # Received Bandwidth configuration
+        self.configure_received_bandwidth(data)
 
         return True
 
@@ -82,6 +88,8 @@ class DeviceGlobalCfgMgr(Manager):
         self.configure_wcmp()
         # IDF configuration
         self.configure_idf()
+        # Received Bandwidth configuration
+        self.configure_received_bandwidth()
 
         return True
 
@@ -142,6 +150,51 @@ class DeviceGlobalCfgMgr(Manager):
         else:
             log_notice("DeviceGlobalCfgMgr:: IDF configuration is up-to-date")
 
+    def configure_received_bandwidth(self, data=None):
+        """Configure received bandwidth for W-ECMP feature"""
+        
+        state = self.RECEIVED_DEFAULTS
+        
+        if data is not None:
+            if "received_bandwidth" in data:
+                state = data["received_bandwidth"]
+        
+        if self.is_update_required("received_bandwidth", state):
+            if self.set_received_bandwidth(state):
+                self.directory.put(self.db_name, self.table_name, "received_bandwidth", state)
+        else:
+            log_notice("DeviceGlobalCfgMgr:: received bandwidth for W-ECMP configuration is up-to-date")
+     
+    def set_received_bandwidth(self, status):
+        """API to configure received bandwidth for W-ECMP"""
+        
+        bgp_asn = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]["bgp_asn"]
+        cmd_list = []
+        
+        if status not in ["ignore", "allow", "skip_missing", "default_weight_for_missing"]:
+            log_err("Received Bandwidth for W-ECMP: invalid value({}) is provided".format(status))
+            return False
+        
+        cmd_list.append("router bgp %s" % bgp_asn)
+        
+        if status == "ignore":
+            cmd_list.append(" bgp bestpath bandwidth ignore")
+        elif status == "allow":
+            cmd_list.append(" no bgp bestpath bandwidth")
+        elif status == "skip_missing":
+            cmd_list.append(" bgp bestpath bandwidth skip-missing")
+        elif status == "default_weight_for_missing":
+            cmd_list.append(" bgp bestpath bandwidth default-weight-for-missing")
+        else:
+            return False
+        
+        
+        self.cfg_mgr.push_list(cmd_list)
+        
+        log_debug("DeviceGlobalCfgMgr::Done")
+        
+        return True 
+    
     def set_wcmp(self, status):
         """ API to set/unset W-ECMP """
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Associated PR:
https://github.com/sonic-net/sonic-buildimage/pull/19532
https://github.com/sonic-net/sonic-utilities/pull/3411
#### Why I did it

The update enhances the BGP device global configuration to listen for changes in the "received_bandwidth" setting within the BGP device global table.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Updated bgpcfgd/managers_device_global.py to handle changes in the "received_bandwidth" field.
- Added the "received_bandwidth" field to the initialization configuration.
- Modified unit tests to cover the new functionality and ensure it works as expected.

#### How to verify it

- Created unit tests to test the new functionality.
- Verified that the changes work as intended by running the updated unit tests.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

