### PR TITLE
Create Yang Model for originate-bandwidth

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -31,7 +31,7 @@
     "BGP_DEVICE_GLOBAL": {
         "STATE": {
             "tsa_enabled": "false",
-            "wcmp_enabled": "false",
+            "originate_bandwidth": "disabled",
             "idf_isolation_state": "unisolated"
         }
     },

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -409,7 +409,7 @@ ASIC/SDK health event related configuration is defined in **SUPPRESS_ASIC_SDK_HE
 ### BGP Device Global
 
 The **BGP_DEVICE_GLOBAL** table contains device-level BGP global state.  
-It has a STATE object containing device state like **tsa_enabled**, **wcmp_enabled** and **idf_isolation_state**.
+It has a STATE object containing device state like **tsa_enabled**, **originate_bandwidth** and **idf_isolation_state**.
 
 When **tsa_enabled** is set to true, the device is isolated using traffic-shift-away (TSA) route-maps in BGP.
 
@@ -423,13 +423,13 @@ When **tsa_enabled** is set to true, the device is isolated using traffic-shift-
 ```
   
 Weighted ECMP load balances traffic between the equal cost paths in proportion to the capacity of the local links.
-The W-ECMP state **wcmp_enabled** could be one of cumulative, num_multipaths, disabled, or [WEIGHT].
+The W-ECMP state for originating bandwidth **originate_bandwidth** could be one of cumulative, num_multipaths, disabled, or [WEIGHT].
 
 ```json
 {
 "BGP_DEVICE_GLOBAL": {
     "STATE": {
-        "wcmp_enabled": "cumulative"
+        "originate_bandwidth": "cumulative"
     }
 }
 ```

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -421,15 +421,15 @@ When **tsa_enabled** is set to true, the device is isolated using traffic-shift-
     }
 }
 ```
-
-When **wcmp_enabled** is set to true, the device is configured to use BGP Link Bandwidth Extended Community.  
+  
 Weighted ECMP load balances traffic between the equal cost paths in proportion to the capacity of the local links.
+The W-ECMP state **wcmp_enabled** could be one of cumulative, num_multipaths, disabled, or [WEIGHT].
 
 ```json
 {
 "BGP_DEVICE_GLOBAL": {
     "STATE": {
-        "wcmp_enabled": "true"
+        "wcmp_enabled": "cumulative"
     }
 }
 ```

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1710,7 +1710,7 @@
         "BGP_DEVICE_GLOBAL": {
             "STATE": {
                 "tsa_enabled": "false",
-                "originate_bandwidth": "false",
+                "originate_bandwidth": "disabled",
                 "idf_isolation_state": "unisolated"
             }
         },

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1710,7 +1710,7 @@
         "BGP_DEVICE_GLOBAL": {
             "STATE": {
                 "tsa_enabled": "false",
-                "wcmp_enabled": "false",
+                "originate_bandwidth": "false",
                 "idf_isolation_state": "unisolated"
             }
         },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
@@ -25,7 +25,7 @@
         "verify": {
             "xpath": "/sonic-bgp-device-global:sonic-bgp-device-global/BGP_DEVICE_GLOBAL/STATE/originate_bandwidth",
             "key": "sonic-bgp-device-global:originate_bandwidth",
-            "value": "false"
+            "value": "disabled"
         }
     },
     "BGP_DEVICE_GLOBAL_WITH_ORIGINATE_BANDWIDTH_CUMULATIVE": {
@@ -38,7 +38,7 @@
         "desc": "Load bgp device global table with originate_bandwidth set to a weight of 5"
     },
     "BGP_DEVICE_GLOBAL_WITH_ORIGINATE_BANDWIDTH_DISABLED": {
-        "desc": "Load bgp device global table with originate_bandwidth set to false"
+        "desc": "Load bgp device global table with originate_bandwidth set to disabled"
     },
     "BGP_DEVICE_GLOBAL_WITH_ORIGINATE_BANDWIDTH_INVALID_VALUE": {
         "desc": "Configure invalid originate_bandwidth in BGP_DEVICE_GLOBAL.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
@@ -28,23 +28,17 @@
             "value": false
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_ENABLED": {
-        "desc": "Verify value for WCMP_ENABLED in BGP_DEVICE_GLOBAL is set to true.",
-        "eStrKey": "Verify",
-        "verify": {
-            "xpath": "/sonic-bgp-device-global:sonic-bgp-device-global/BGP_DEVICE_GLOBAL/STATE/wcmp_enabled",
-            "key": "sonic-bgp-device-global:wcmp_enabled",
-            "value": true
-        }
+    "BGP_DEVICE_GLOBAL_WITH_WCMP_CUMMULATIVE": {
+        "desc": "Load bgp device global table with wcmp_enabled set to cummulative"
+    },
+    "BGP_DEVICE_GLOBAL_WITH_WCMP_MULTIPATH": {
+        "desc": "Load bgp device global table with wcmp_enabled set to num_multipaths"
+    },
+    "BGP_DEVICE_GLOBAL_WITH_WCMP_WEIGHT": {
+        "desc": "Load bgp device global table with wcmp_enabled set to a weight of 5"
     },
     "BGP_DEVICE_GLOBAL_WITH_WCMP_DISABLED": {
-        "desc": "Verify value for WCMP_ENABLED in BGP_DEVICE_GLOBAL is set to false.",
-        "eStrKey": "Verify",
-        "verify": {
-            "xpath": "/sonic-bgp-device-global:sonic-bgp-device-global/BGP_DEVICE_GLOBAL/STATE/wcmp_enabled",
-            "key": "sonic-bgp-device-global:wcmp_enabled",
-            "value": false
-        }
+        "desc": "Load bgp device global table with wcmp_enabled set to false"
     },
     "BGP_DEVICE_GLOBAL_WITH_WCMP_INVALID_VALUE": {
         "desc": "Configure invalid WCMP_ENABLED in BGP_DEVICE_GLOBAL.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
@@ -19,31 +19,31 @@
         "eStrKey": "InvalidValue",
         "eStr": ["tsa_enabled"]
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_DEFAULT_VALUE": {
-        "desc": "Verify default value for WCMP_ENABLED field in BGP_DEVICE_GLOBAL.",
+    "BGP_DEVICE_GLOBAL_WITH_ORIGINATE_BANDWIDTH_DEFAULT_VALUE": {
+        "desc": "Verify default value for originate_bandwidth field in BGP_DEVICE_GLOBAL.",
         "eStrKey": "Verify",
         "verify": {
-            "xpath": "/sonic-bgp-device-global:sonic-bgp-device-global/BGP_DEVICE_GLOBAL/STATE/wcmp_enabled",
-            "key": "sonic-bgp-device-global:wcmp_enabled",
+            "xpath": "/sonic-bgp-device-global:sonic-bgp-device-global/BGP_DEVICE_GLOBAL/STATE/originate_bandwidth",
+            "key": "sonic-bgp-device-global:originate_bandwidth",
             "value": "false"
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_CUMULATIVE": {
-        "desc": "Load bgp device global table with wcmp_enabled set to cumulative"
+    "BGP_DEVICE_GLOBAL_WITH_ORIGINATE_BANDWIDTH_CUMULATIVE": {
+        "desc": "Load bgp device global table with originate_bandwidth set to cumulative"
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_MULTIPATH": {
-        "desc": "Load bgp device global table with wcmp_enabled set to num_multipaths"
+    "BGP_DEVICE_GLOBAL_WITH_ORIGINATE_BANDWIDTH_MULTIPATH": {
+        "desc": "Load bgp device global table with originate_bandwidth set to num_multipaths"
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_WEIGHT": {
-        "desc": "Load bgp device global table with wcmp_enabled set to a weight of 5"
+    "BGP_DEVICE_GLOBAL_WITH_ORIGINATE_BANDWIDTH_WEIGHT": {
+        "desc": "Load bgp device global table with originate_bandwidth set to a weight of 5"
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_DISABLED": {
-        "desc": "Load bgp device global table with wcmp_enabled set to false"
+    "BGP_DEVICE_GLOBAL_WITH_ORIGINATE_BANDWIDTH_DISABLED": {
+        "desc": "Load bgp device global table with originate_bandwidth set to false"
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_INVALID_VALUE": {
-        "desc": "Configure invalid WCMP_ENABLED in BGP_DEVICE_GLOBAL.",
+    "BGP_DEVICE_GLOBAL_WITH_ORIGINATE_BANDWIDTH_INVALID_VALUE": {
+        "desc": "Configure invalid originate_bandwidth in BGP_DEVICE_GLOBAL.",
         "eStrKey": "InvalidValue",
-        "eStr": ["wcmp_enabled"]
+        "eStr": ["originate_bandwidth"]
     },
     "BGP_DEVICE_GLOBAL_WITH_IDF_ISOLATION_DEFAULT_VALUE": {
         "desc": "Load bgp device global table with idf_isolation_state set to default value",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
@@ -25,7 +25,7 @@
         "verify": {
             "xpath": "/sonic-bgp-device-global:sonic-bgp-device-global/BGP_DEVICE_GLOBAL/STATE/wcmp_enabled",
             "key": "sonic-bgp-device-global:wcmp_enabled",
-            "value": false
+            "value": "false"
         }
     },
     "BGP_DEVICE_GLOBAL_WITH_WCMP_CUMULATIVE": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
@@ -28,8 +28,8 @@
             "value": false
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_CUMMULATIVE": {
-        "desc": "Load bgp device global table with wcmp_enabled set to cummulative"
+    "BGP_DEVICE_GLOBAL_WITH_WCMP_CUMULATIVE": {
+        "desc": "Load bgp device global table with wcmp_enabled set to cumulative"
     },
     "BGP_DEVICE_GLOBAL_WITH_WCMP_MULTIPATH": {
         "desc": "Load bgp device global table with wcmp_enabled set to num_multipaths"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
@@ -73,7 +73,7 @@
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE": {
-                    "originate_bandwidth": "false"
+                    "originate_bandwidth": "disabled"
                 }
             }
         }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
@@ -34,7 +34,7 @@
             }
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_DEFAULT_VALUE": {
+    "BGP_DEVICE_GLOBAL_WITH_ORIGINATE_BANDWIDTH_DEFAULT_VALUE": {
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE": {
@@ -42,47 +42,47 @@
             }
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_CUMULATIVE": {
+    "BGP_DEVICE_GLOBAL_WITH_ORIGINATE_BANDWIDTH_CUMULATIVE": {
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE": {
-                    "wcmp_enabled": "cumulative"
+                    "originate_bandwidth": "cumulative"
                 }
             }
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_MULTIPATH": {
+    "BGP_DEVICE_GLOBAL_WITH_ORIGINATE_BANDWIDTH_MULTIPATH": {
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE": {
-                    "wcmp_enabled": "num_multipaths"
+                    "originate_bandwidth": "num_multipaths"
                 }
             }
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_WEIGHT": {
+    "BGP_DEVICE_GLOBAL_WITH_ORIGINATE_BANDWIDTH_WEIGHT": {
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE": {
-                    "wcmp_enabled": "5"
+                    "originate_bandwidth": "5"
                 }
             }
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_DISABLED": {
+    "BGP_DEVICE_GLOBAL_WITH_ORIGINATE_BANDWIDTH_DISABLED": {
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE": {
-                    "wcmp_enabled": "false"
+                    "originate_bandwidth": "false"
                 }
             }
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_INVALID_VALUE": {
+    "BGP_DEVICE_GLOBAL_WITH_ORIGINATE_BANDWIDTH_INVALID_VALUE": {
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE": {
-                    "wcmp_enabled": "invalid_value"
+                    "originate_bandwidth": "invalid_value"
                 }
             }
         }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
@@ -42,11 +42,29 @@
             }
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_ENABLED": {
+    "BGP_DEVICE_GLOBAL_WITH_WCMP_CUMMULATIVE": {
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE": {
-                    "wcmp_enabled": "true"
+                    "wcmp_enabled": "cummulative"
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_WCMP_MULTIPATH": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE": {
+                    "wcmp_enabled": "num_multipaths"
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_WCMP_WEIGHT": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE": {
+                    "wcmp_enabled": "5"
                 }
             }
         }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
@@ -42,11 +42,11 @@
             }
         }
     },
-    "BGP_DEVICE_GLOBAL_WITH_WCMP_CUMMULATIVE": {
+    "BGP_DEVICE_GLOBAL_WITH_WCMP_CUMULATIVE": {
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
                 "STATE": {
-                    "wcmp_enabled": "cummulative"
+                    "wcmp_enabled": "cumulative"
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -37,8 +37,8 @@ module sonic-bgp-device-global {
                     "When set to true, Traffic is shifted away (TSA), i.e, BGP routes are not advertised to neighboring routers";
                 }
 
-                leaf wcmp_enabled {
-                    description "Configures device W-ECMP state either either weight or condition";
+                leaf originate_bandwidth {
+                    description "Configures state for device to send bandwidth for W-ECMP";
                     type union {
                         type enumeration {
                             enum cumulative {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -38,8 +38,24 @@ module sonic-bgp-device-global {
                 }
 
                 leaf wcmp_enabled {
-                    description "Enables/Disables Weighted-Equal Cost-Multipath using BGP link bandwidth";
-                    type boolean;
+                    description "Configures device W-ECMP state";
+                    type union {
+                        type enumeration {
+                            enum cummulative {
+                                description "Cumulative bandwidth of all multipaths";
+                            }
+                            enum num_multipaths {
+                                description "Internally computed bandwidth based on number of multipaths";
+                            }
+                            enum false {
+                                description "Disable W-ECMP using BGP link bandwidth";
+                            }
+                        }
+                        type uint16 {
+                            range "1..25600";
+                            description "A value between 1 and 25600 to be advertised through BGP link bandwidth";
+                        }
+                    }
                     default "false";
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -55,7 +55,7 @@ module sonic-bgp-device-global {
                             range "1..25600";
                         }
                     }
-                    default "false";
+                    default false;
                 }
 
                 leaf idf_isolation_state {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -47,7 +47,7 @@ module sonic-bgp-device-global {
                             enum num_multipaths {
                                 description "Internally computed bandwidth based on number of multipaths";
                             }
-                            enum false {
+                            enum disabled {
                                 description "Disable W-ECMP using BGP link bandwidth";
                             }
                         }
@@ -55,7 +55,7 @@ module sonic-bgp-device-global {
                             range "1..25600";
                         }
                     }
-                    default "false";
+                    default "disabled";
                 }
 
                 leaf idf_isolation_state {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -38,7 +38,7 @@ module sonic-bgp-device-global {
                 }
 
                 leaf wcmp_enabled {
-                    description "Configures device W-ECMP state";
+                    description "Configures device W-ECMP state either either weight or condition";
                     type union {
                         type enumeration {
                             enum cumulative {
@@ -53,7 +53,6 @@ module sonic-bgp-device-global {
                         }
                         type uint16 {
                             range "1..25600";
-                            description "A value between 1 and 25600 to be advertised through BGP link bandwidth";
                         }
                     }
                     default "false";

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -55,7 +55,7 @@ module sonic-bgp-device-global {
                             range "1..25600";
                         }
                     }
-                    default false;
+                    default "false";
                 }
 
                 leaf idf_isolation_state {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -41,7 +41,7 @@ module sonic-bgp-device-global {
                     description "Configures device W-ECMP state";
                     type union {
                         type enumeration {
-                            enum cummulative {
+                            enum cumulative {
                                 description "Cumulative bandwidth of all multipaths";
                             }
                             enum num_multipaths {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Associated PR: 
https://github.com/sonic-net/sonic-buildimage/pull/19662
https://github.com/sonic-net/sonic-utilities/pull/3410

#### Why I did it

Updated YANG models to include the originate-bandwidth field and its options for better management of BGP device global settings.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Created a new field originate-bandwidth in the YANG models for BGP device global.
- Updated the documentation to reflect the new field and its possible values.
- Modified the sample configuration files to include the originate-bandwidth field.
- Added unit tests to cover the new field and its functionality.

#### How to verify it

- Created unit tests to test the new functionality.
- Verified that the changes work as intended by running the updated unit tests.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

