### PR TITLE
arista: Add chassis temperature sensors

### DIFF
--- a/device/arista/x86_64-arista_7800_sup/platform.json
+++ b/device/arista/x86_64-arista_7800_sup/platform.json
@@ -210,7 +210,40 @@
                 ]
             }
         ],
-        "thermals": [],
+        "thermals": [
+            {
+                "name": "Supervisor front",
+                "controllable": false
+            },
+            {
+                "name": "Physical id 0",
+                "controllable": false
+            },
+            {
+                "name": "CPU core0",
+                "controllable": false
+            },
+            {
+                "name": "CPU core1",
+                "controllable": false
+            },
+            {
+                "name": "CPU core2",
+                "controllable": false
+            },
+            {
+                "name": "CPU core3",
+                "controllable": false
+            },
+            {
+                "name": "CPU core4",
+                "controllable": false
+            },
+            {
+                "name": "CPU core5",
+                "controllable": false
+            }
+        ],
         "sfps": []
     },
     "interfaces": {}


### PR DESCRIPTION
#### Why I did it

This allows the chassis temperature sensor sonic-mgmt tests to pass on Arista 7800 chassis platform.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

I added the sensor info to the corresponding `platform.json` file.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Run the `platforms/api/test_thermal.py` sonic-mgmt test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202405
This is required for the corresponding sonic-mgmt tests to pass on 202405.

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

