### PR TITLE
[Nokia][snmpwalk] Fix the snmpwalk cefcFruPowerStatusTable on Nokia LC platform

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/pmon_daemon_control.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/pmon_daemon_control.json
@@ -1,3 +1,2 @@
 {
-    "skip_psud": true
 }


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Executes "docker exec -it snmp snmpwalk -v2c -c 127.0.0.1 1.3.6.1.4.1.9.9.117.1.1.2.1"  Nokia LC - Nokia_IXR7250E_36x400G will get the following error in the syslog:
Jul 30 02:03:21.836386 ixre-egl-board9 ERR snmp#snmp-subagent [sonic_ax_impl] ERROR: PowerStatusHandler._get_psu_index() caught an unexpected exception during _get_num_psus()#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.9/dist-packages/sonic_ax_impl/mibs/vendor/cisco/ciscoEntityFruControlMIB.py", line 101, in _get_psu_index#012    num_psus = self._get_num_psus()#012  File "/usr/local/lib/python3.9/dist-packages/sonic_ax_impl/mibs/vendor/cisco/ciscoEntityFruControlMIB.py", line 66, in _get_num_psus#012    return int(num_psus[0])#012ValueError: invalid literal for int() with base 10: ''

This PR will enable to Psud in LC to address this issue.  Fixes https://github.com/sonic-net/sonic-buildimage/issues/19535

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Based on the snmp_agent common handling, it requires to enable the Pusd on the LC to set the "psu_num": 0 (as in the below entry) to allow the mibwalk handle the return value correctly.  Enable the Psud on the LC although there is no PSU in LC.  
 
#### How to verify it
1) Executes "docker exec -it snmp snmpwalk -v2c -c 127.0.0.1 1.3.6.1.4.1.9.9.117.1.1.2.1"
2) Check the syslog, there should not any error in the syslog which is related to this MIBwalk.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master <!-- image version 1 -->
- [x] 202405 <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

