### PR TITLE
Add to support the pmon.service restart when when syncd.service restart

### DIFF
--- a/files/build_templates/pmon.service.j2
+++ b/files/build_templates/pmon.service.j2
@@ -4,6 +4,9 @@ Requires=database.service config-setup.service
 After=database.service config-setup.service
 {% if sonic_asic_platform == 'mellanox' %}
 After=syncd.service
+{% elif sonic_asic_platform == 'broadcom' %}
+Requires=syncd.service
+After=syncd.service
 {% endif %}
 BindsTo=sonic.target
 After=sonic.target

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -95,7 +95,7 @@ function startplatform() {
 function waitplatform() {
 
     BOOT_TYPE=`getBootType`
-    if [[ x"$sonic_asic_platform" == x"mellanox" ]]; then
+    if [[ x"$sonic_asic_platform" == x"mellanox" ]] || [[ x"$sonic_asic_platform" == x"broadcom" ]]; then
         PLATFORM=`$SONIC_DB_CLI CONFIG_DB hget 'DEVICE_METADATA|localhost' platform`
         PMON_IMMEDIATE_START="/usr/share/sonic/device/$PLATFORM/pmon_immediate_start"
         if [[ x"$BOOT_TYPE" = @(x"fast"|x"warm"|x"fastfast") ]] && [[ ! -f $PMON_IMMEDIATE_START ]]; then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The pmon.service is not restarted after restarting syncd.service. 
The pmon.service need to set the preemphasis and media-type after the syncd.service restart. It is needed to add supporting the pmon.service restart after the syncd.service restart.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Adds a condition into syncd.sh to restart the pmon.service when syncd restart.

#### How to verify it
Restart syncd.service and confirm the pmon.service is also restart.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [X] 202305
- [X] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

