### PR TITLE
[Ufispace] Update the transceiver control virtual address to avoid an address conflict with SPD

### DIFF
--- a/device/ufispace/x86_64-ufispace_s6301_56st-r0/pddf/pddf-device.json
+++ b/device/ufispace/x86_64-ufispace_s6301_56st-r0/pddf/pddf-device.json
@@ -1603,7 +1603,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0xA",
-                "dev_addr": "0x54",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -1702,7 +1702,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0xB",
-                "dev_addr": "0x54",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -1801,7 +1801,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0xC",
-                "dev_addr": "0x54",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -1900,7 +1900,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0xD",
-                "dev_addr": "0x54",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -1999,7 +1999,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0xE",
-                "dev_addr": "0x54",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2098,7 +2098,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0xF",
-                "dev_addr": "0x54",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2197,7 +2197,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x10",
-                "dev_addr": "0x54",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2296,7 +2296,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x11",
-                "dev_addr": "0x54",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [

--- a/device/ufispace/x86_64-ufispace_s7801_54xs-r0/pddf/pddf-device.json
+++ b/device/ufispace/x86_64-ufispace_s7801_54xs-r0/pddf/pddf-device.json
@@ -2594,7 +2594,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1a",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2693,7 +2693,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1b",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2792,7 +2792,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1c",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2891,7 +2891,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1d",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2990,7 +2990,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1e",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3089,7 +3089,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1f",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3188,7 +3188,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x20",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3287,7 +3287,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x21",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3386,7 +3386,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x22",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3485,7 +3485,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x23",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3584,7 +3584,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x24",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3683,7 +3683,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x25",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3782,7 +3782,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x26",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3881,7 +3881,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x27",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3980,7 +3980,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x28",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4079,7 +4079,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x29",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4178,7 +4178,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2a",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4277,7 +4277,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2b",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4376,7 +4376,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2c",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4475,7 +4475,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2d",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4574,7 +4574,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2e",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4673,7 +4673,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2f",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4772,7 +4772,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x30",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4871,7 +4871,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x31",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4970,7 +4970,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x32",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5069,7 +5069,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x33",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5168,7 +5168,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x34",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5267,7 +5267,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x35",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5366,7 +5366,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x36",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5465,7 +5465,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x37",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5564,7 +5564,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x38",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5663,7 +5663,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x39",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5762,7 +5762,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x3a",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5861,7 +5861,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x3b",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5960,7 +5960,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x3c",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6059,7 +6059,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x3d",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6158,7 +6158,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x3e",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6257,7 +6257,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x3f",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6356,7 +6356,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x40",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6455,7 +6455,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x41",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6554,7 +6554,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x42",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6653,7 +6653,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x43",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6752,7 +6752,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x44",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6851,7 +6851,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x45",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6950,7 +6950,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x46",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7049,7 +7049,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x47",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7148,7 +7148,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x48",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7247,7 +7247,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x49",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7346,7 +7346,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x4a",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7445,7 +7445,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x4b",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7544,7 +7544,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x4c",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7643,7 +7643,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x4d",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7742,7 +7742,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x4e",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7841,7 +7841,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x4f",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [

--- a/device/ufispace/x86_64-ufispace_s8901_54xc-r0/pddf/pddf-device.json
+++ b/device/ufispace/x86_64-ufispace_s8901_54xc-r0/pddf/pddf-device.json
@@ -2594,7 +2594,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1a",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2693,7 +2693,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1b",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2792,7 +2792,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1c",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2891,7 +2891,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1d",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2990,7 +2990,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1e",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3089,7 +3089,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1f",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3188,7 +3188,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x20",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3287,7 +3287,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x21",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3386,7 +3386,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x22",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3485,7 +3485,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x23",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3584,7 +3584,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x24",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3683,7 +3683,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x25",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3782,7 +3782,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x26",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3881,7 +3881,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x27",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3980,7 +3980,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x28",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4079,7 +4079,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x29",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4178,7 +4178,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2a",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4277,7 +4277,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2b",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4376,7 +4376,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2c",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4475,7 +4475,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2d",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4574,7 +4574,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2e",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4673,7 +4673,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2f",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4772,7 +4772,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x30",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4871,7 +4871,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x31",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4970,7 +4970,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x32",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5069,7 +5069,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x33",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5168,7 +5168,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x34",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5267,7 +5267,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x35",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5366,7 +5366,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x36",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5465,7 +5465,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x37",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5564,7 +5564,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x38",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5663,7 +5663,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x39",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5762,7 +5762,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x3a",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5861,7 +5861,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x3b",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -5960,7 +5960,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x3c",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6059,7 +6059,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x3d",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6158,7 +6158,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x3e",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6257,7 +6257,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x3f",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6356,7 +6356,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x40",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6455,7 +6455,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x41",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6554,7 +6554,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x42",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6653,7 +6653,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x43",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6752,7 +6752,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x44",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6851,7 +6851,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x45",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -6950,7 +6950,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x46",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7049,7 +7049,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x47",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7148,7 +7148,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x48",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7247,7 +7247,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x49",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7346,7 +7346,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x4a",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7445,7 +7445,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x4b",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7544,7 +7544,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x4c",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7643,7 +7643,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x4d",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7742,7 +7742,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x4e",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -7841,7 +7841,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x4f",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [

--- a/device/ufispace/x86_64-ufispace_s9110_32x-r0/pddf/pddf-device-beta.json
+++ b/device/ufispace/x86_64-ufispace_s9110_32x-r0/pddf/pddf-device-beta.json
@@ -1451,7 +1451,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x12",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -1550,7 +1550,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x13",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -1649,7 +1649,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x14",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -1748,7 +1748,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x15",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -1847,7 +1847,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x16",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -1946,7 +1946,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x17",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2045,7 +2045,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x18",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2144,7 +2144,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x19",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2243,7 +2243,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1A",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2342,7 +2342,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1B",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2441,7 +2441,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1C",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2540,7 +2540,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1D",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2639,7 +2639,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1E",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2738,7 +2738,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1F",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2837,7 +2837,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x20",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2936,7 +2936,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x21",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3035,7 +3035,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x22",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3134,7 +3134,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x23",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3233,7 +3233,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x24",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3332,7 +3332,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x25",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3431,7 +3431,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x26",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3530,7 +3530,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x27",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3629,7 +3629,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x28",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3728,7 +3728,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x29",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3827,7 +3827,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2A",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3926,7 +3926,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2B",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4025,7 +4025,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2C",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4124,7 +4124,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2D",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4223,7 +4223,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2E",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4322,7 +4322,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2F",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4421,7 +4421,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x30",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4520,7 +4520,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x31",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4619,7 +4619,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x33",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [

--- a/device/ufispace/x86_64-ufispace_s9110_32x-r0/pddf/pddf-device-pvt.json
+++ b/device/ufispace/x86_64-ufispace_s9110_32x-r0/pddf/pddf-device-pvt.json
@@ -1407,7 +1407,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x12",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -1506,7 +1506,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x13",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -1605,7 +1605,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x14",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -1704,7 +1704,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x15",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -1803,7 +1803,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x16",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -1902,7 +1902,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x17",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2001,7 +2001,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x18",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2100,7 +2100,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x19",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2199,7 +2199,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1A",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2298,7 +2298,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1B",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2397,7 +2397,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1C",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2496,7 +2496,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1D",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2595,7 +2595,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1E",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2694,7 +2694,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x1F",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2793,7 +2793,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x20",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2892,7 +2892,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x21",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -2991,7 +2991,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x22",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3090,7 +3090,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x23",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3189,7 +3189,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x24",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3288,7 +3288,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x25",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3387,7 +3387,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x26",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3486,7 +3486,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x27",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3585,7 +3585,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x28",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3684,7 +3684,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x29",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3783,7 +3783,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2A",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3882,7 +3882,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2B",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -3981,7 +3981,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2C",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4080,7 +4080,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2D",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4179,7 +4179,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2E",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4278,7 +4278,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x2F",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4377,7 +4377,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x30",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4476,7 +4476,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x31",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [
@@ -4575,7 +4575,7 @@
         "i2c": {
             "topo_info": {
                 "parent_bus": "0x33",
-                "dev_addr": "0x53",
+                "dev_addr": "0x5f",
                 "dev_type": "pddf_xcvr"
             },
             "attr_list": [


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Update the transceiver control virtual address to avoid an address conflict with SPD
* s6301-56st
* s7801-54xs
* s8901-54xc
* s9110-32x


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Update the PDDF config files.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Run the PDDF commands and show commands to check the sysfs and transceiver status.

[s6301-56st.txt](https://github.com/user-attachments/files/16450946/s6301-56st.txt)
[s7801-54xs.txt](https://github.com/user-attachments/files/16450947/s7801-54xs.txt)
[s8901-54xc.txt](https://github.com/user-attachments/files/16450944/s8901-54xc.txt)
[s9110-32x.txt](https://github.com/user-attachments/files/16450945/s9110-32x.txt)



#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

