### PR TITLE
[docker-ptf] sflowtool requires autoconf 2.71+

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -28,7 +28,6 @@ RUN apt-get update          \
     && apt-get upgrade -y   \
     && apt-get dist-upgrade -y  \
     && apt-get install -y   \
-        autoconf            \
         openssh-server      \
         vim                 \
         telnet              \
@@ -96,6 +95,20 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
     && update-alternatives --install /usr/bin/pydoc pydoc /usr/bin/pydoc3 1 \
     && update-alternatives --install /usr/bin/pygettext pygettext /usr/bin/pygettext3 1
 {% endif %}
+
+# sflow requires autoconf 2.71; This step builds autoconf from source
+RUN apt-get update \
+    && apt-get install -y \
+        m4 \
+        texinfo \
+        help2man
+# get autoconf, build and install
+RUN git clone http://git.sv.gnu.org/r/autoconf.git \
+    && cd autoconf \
+    && ./bootstrap \
+    && ./configure \
+    && make \
+    && make install
 
 # Install all python modules from pypi. python-scapy is exception, ptf debian package requires python-scapy
 # TODO: Clean up this step

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -108,7 +108,9 @@ RUN git clone http://git.sv.gnu.org/r/autoconf.git \
     && ./bootstrap \
     && ./configure \
     && make \
-    && make install
+    && make install \
+    && cd .. \
+    && rm -rf autoconf
 
 # Install all python modules from pypi. python-scapy is exception, ptf debian package requires python-scapy
 # TODO: Clean up this step


### PR DESCRIPTION
#### Why I did it

Latest changes to sflowtool [source](https://github.com/sflow/sflowtool/blob/master/configure.ac#L4) mandates autoconf 2.71+ to build it. Bullseye is at autoconf 2.69. This PR builds autoconf from source in the docker-ptf image.

##### Work item tracking
- Microsoft ADO **(number only)**: Not applicable

#### How I did it

Modified dockers/docker-ptf/Dockerfile.j2 to -

- Install dependencies to build autoconf
- Build and install autoconf

#### How to verify it

docker-ptf image is built successfully.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

Not applicable.

#### Description for the changelog

Sflowtool requires autoconf 2.71; Build autoconf from source

#### Link to config_db schema for YANG module changes

Not applicable