### PR TITLE
YANG model for enabling fabric monitor attribute

### DIFF
--- a/src/sonic-config-engine/tests/test_cfggen_from_yang.py
+++ b/src/sonic-config-engine/tests/test_cfggen_from_yang.py
@@ -272,7 +272,9 @@ class TestCfgGen(object):
                 "monErrThreshCrcCells": "1",
                 "monErrThreshRxCells": "61035156",
                 "monPollThreshIsolation": "1",
-                "monPollThreshRecovery": "8"
+                "monPollThreshRecovery": "8",
+                "monCapacityThreshWarn": "10",
+                "monState": "enable"
             }
         })
 
@@ -283,6 +285,7 @@ class TestCfgGen(object):
             "Fabric0": {
                 "alias": "Fabric0",
                 "isolateStatus": "False",
-                "lanes": "0"
+                "lanes": "0",
+                "forceUnisolateStatus": "0"
             }
         })

--- a/src/sonic-config-engine/tests/test_yang_data.json
+++ b/src/sonic-config-engine/tests/test_yang_data.json
@@ -378,7 +378,9 @@
                 "monErrThreshCrcCells": "1",
                 "monErrThreshRxCells": "61035156",
                 "monPollThreshIsolation": "1",
-                "monPollThreshRecovery": "8"
+                "monPollThreshRecovery": "8",
+                "monCapacityThreshWarn": "10",
+                "monState": "enable"
             }
         }
     },
@@ -389,7 +391,8 @@
                     "name": "Fabric0",
                     "alias": "Fabric0",
                     "isolateStatus": "False",
-                    "lanes": "0"
+                    "lanes": "0",
+                    "forceUnisolateStatus": "0"
                 }
             ]
         }

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1197,7 +1197,9 @@ The FG_NHG_PREFIX table provides the FG_NHG_PREFIX for which FG behavior is desi
         "monErrThreshCrcCells": "1",
         "monErrThreshRxCells": "61035156",
         "monPollThreshIsolation": "1",
-        "monPollThreshRecovery": "8"
+        "monPollThreshRecovery": "8",
+        "monCapacityThreshWarn": "10",
+        "monState": "enable"
     }
   }
 }
@@ -1211,12 +1213,14 @@ The FG_NHG_PREFIX table provides the FG_NHG_PREFIX for which FG behavior is desi
     "Fabric0": {
         "alias": "Fabric0",
         "isolateStatus": "False",
-        "lanes": "0"
+        "lanes": "0",
+        "forceUnisolateStatus": "0"
     },
     "Fabric1": {
         "alias": "Fabric1",
         "isolateStatus": "False",
-        "lanes": "1"
+        "lanes": "1",
+        "forceUnisolateStatus": "0"
     }
   }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1378,19 +1378,23 @@
                 "monErrThreshCrcCells": "1",
                 "monErrThreshRxCells": "61035156",
                 "monPollThreshIsolation": "1",
-                "monPollThreshRecovery": "8"
+                "monPollThreshRecovery": "8",
+                "monCapacityThreshWarn": "10",
+                "monState": "enable"
             }
         },
         "FABRIC_PORT": {
             "Fabric0": {
                 "alias": "Fabric0",
                 "isolateStatus": "False",
-                "lanes": "0"
+                "lanes": "0",
+                "forceUnisolateStatus": "0"
             },
             "Fabric1": {
                 "alias": "Fabric1",
                 "isolateStatus": "False",
-                "lanes": "1"
+                "lanes": "1",
+                "forceUnisolateStatus": "0"
             }
         },
         "FLEX_COUNTER_TABLE": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/fabric_monitor_data.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/fabric_monitor_data.json
@@ -6,7 +6,9 @@
                     "monErrThreshCrcCells": "1",
                     "monErrThreshRxCells": "61035156",
                     "monPollThreshIsolation": "1",
-                    "monPollThreshRecovery": "8"
+                    "monPollThreshRecovery": "8",
+                    "monCapacityThreshWarn": "10",
+                    "monState": "enable"
                 }
             }
         }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/fabric_port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/fabric_port.json
@@ -7,7 +7,8 @@
                         "name": "Fabric0",
                         "alias": "Fabric0",
                         "isolateStatus": "False",
-                        "lanes": "0"
+                        "lanes": "0",
+                        "forceUnisolateStatus": "0"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
@@ -32,19 +32,19 @@ module sonic-fabric-monitor{
                 }
 
                 leaf monPollThreshIsolation {
-                    type uint32;
+                    type uint8;
                     default 1;
                     description "Consecutive polls with higher error rate for isolation.";
                 }
 
                 leaf monPollThreshRecovery {
-                    type uint32;
+                    type uint8;
                     default 8;
                     description "Consecutive polls with lesser error rate for inclusion.";
                 }
 
                 leaf monCapacityThreshWarn {
-                    type uint32;
+                    type uint8;
                     default 10;
                     description "Percentage of up fabric links.";
                 }
@@ -53,6 +53,7 @@ module sonic-fabric-monitor{
                     description "Configuration to set fabric link monitoring state: enable/disable";
                     type string {
                         length 1..32;
+                        pattern "enabled|disabled";
                     }
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
@@ -49,7 +49,7 @@ module sonic-fabric-monitor{
 
                 leaf monCapacityThreshWarn {
                     type uint8 {
-                        range 5..250;
+                        range 5..100;
                     }
                     default 10;
                     description "Percentage of up fabric links.";

--- a/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
@@ -51,10 +51,8 @@ module sonic-fabric-monitor{
 
                 leaf monState {
                     description "Configuration to set fabric link monitoring state: enable/disable";
-                    type string {
-                        length 1..32;
-                        pattern "enable|disable";
-                    }
+                    type stypes:mode-status;
+                    default disable;
                 }
 
             } /* end of container FABRIC_MONITOR_DATA */

--- a/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
@@ -48,7 +48,9 @@ module sonic-fabric-monitor{
                 }
 
                 leaf monCapacityThreshWarn {
-                    type uint8;
+                    type uint8 {
+                        range 5..250;
+                    }
                     default 10;
                     description "Percentage of up fabric links.";
                 }

--- a/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
@@ -5,6 +5,10 @@ module sonic-fabric-monitor{
     namespace "http://github.com/sonic-net/sonic-fabric-monitor";
     prefix fabric-monitor;
 
+    import sonic-types {
+        prefix stypes;
+    }
+
     description "FABRIC_MONITOR yang Module for SONiC OS";
 
     revision 2023-03-14 {

--- a/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
@@ -43,6 +43,19 @@ module sonic-fabric-monitor{
                     description "Consecutive polls with lesser error rate for inclusion.";
                 }
 
+                leaf monCapacityThreshWarn {
+                    type uint32;
+                    default 10;
+                    description "Percentage of up fabric links.";
+                }
+
+                leaf monState {
+                    description "Configuration to set fabric link monitoring state: enable/disable";
+                    type string {
+                        length 1..32;
+                    }
+                }
+
             } /* end of container FABRIC_MONITOR_DATA */
 
         } /* end of container FABRIC_MONITOR */

--- a/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
@@ -32,13 +32,17 @@ module sonic-fabric-monitor{
                 }
 
                 leaf monPollThreshIsolation {
-                    type uint8;
+                    type uint8 {
+                        range 1..10;
+                    }
                     default 1;
                     description "Consecutive polls with higher error rate for isolation.";
                 }
 
                 leaf monPollThreshRecovery {
-                    type uint8;
+                    type uint8 {
+                        range 1..10;
+                    }
                     default 8;
                     description "Consecutive polls with lesser error rate for inclusion.";
                 }

--- a/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
@@ -53,7 +53,7 @@ module sonic-fabric-monitor{
                     description "Configuration to set fabric link monitoring state: enable/disable";
                     type string {
                         length 1..32;
-                        pattern "enabled|disabled";
+                        pattern "enable|disable";
                     }
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-fabric-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fabric-port.yang
@@ -52,6 +52,12 @@ module sonic-fabric-port{
                     }
                 }
 
+                leaf forceUnisolateStatus {
+                    description "Force unisolate status of a fabric port";
+                    type uint32;
+                    default 0;
+                }
+
             } /* end of list FABRIC_PORT_LIST */
 
         } /* end of container FABRIC_PORT */


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The new added attributes related fabric link monitoring are missing YANG model. Adding them in this change. 

For fabric monitor table: 
> monCapacityThreshWarn
> monState

For fabric port:
> forceUnisolateStatus 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

