### PR TITLE
[Supervisor][fabric] Fix the error message for non-present fabric card during config reload on SUP

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -731,23 +731,20 @@ stop() {
     if [[ "$DEV" && $DATABASE_TYPE != "dpudb" ]]; then
         ip netns delete "$NET_NS"
     fi
-    {%- elif docker_container_name == "teamd" %}
-    # Longer timeout of 60 sec to wait for Portchannels to be cleaned.
-    /usr/local/bin/container stop -t 60 $DOCKERNAME
-    {%- elif docker_container_name in ["swss", "syncd"] and enable_asan == "y" %}
-    /usr/local/bin/container stop -t 60 $DOCKERNAME
-    {%- elif docker_container_name in ["swss", "syncd"] %}
-    if [[ -f /etc/sonic/chassisdb.conf ]]; then
-        asic_key=$(sonic-db-cli CHASSIS_STATE_DB keys "CHASSIS_FABRIC_ASIC_TABLE|asic$DEV")
-        container_id=$(docker ps -a -q -f name="$DOCKERNAME")
-        if [[ ! -z "$container_id" ]] || [[ ! -z "$asic_key" ]]; then
-            /usr/local/bin/container stop $DOCKERNAME
-        fi
-    else
-        /usr/local/bin/container stop $DOCKERNAME
-    fi
     {%- else %}
-    /usr/local/bin/container stop $DOCKERNAME
+    container_id=$(docker ps --filter "name=$DOCKERNAME" --quiet)
+    if [ -z "$container_id" ]; then
+        echo "container stop $DOCKERNAME - No such container: $DOCKERNAME"
+    else
+    {%- if docker_container_name == "teamd" %}
+        # Longer timeout of 60 sec to wait for Portchannels to be cleaned.
+        /usr/local/bin/container stop -t 60 $DOCKERNAME
+    {%- elif docker_container_name in ["swss", "syncd"] and enable_asan == "y" %}
+        /usr/local/bin/container stop -t 60 $DOCKERNAME
+    {%- else %}
+        /usr/local/bin/container stop $DOCKERNAME
+    {%- endif %}
+    fi
     {%- endif %}
 }
 

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -736,6 +736,16 @@ stop() {
     /usr/local/bin/container stop -t 60 $DOCKERNAME
     {%- elif docker_container_name in ["swss", "syncd"] and enable_asan == "y" %}
     /usr/local/bin/container stop -t 60 $DOCKERNAME
+    {%- elif docker_container_name in ["swss", "syncd"] %}
+    if [[ -f /etc/sonic/chassisdb.conf ]]; then
+        asic_key=$(sonic-db-cli CHASSIS_STATE_DB keys "CHASSIS_FABRIC_ASIC_TABLE|asic$DEV")
+        container_id=$(docker ps -a -q -f name="$DOCKERNAME")
+        if [[ ! -z "$container_id" ]] || [[ ! -z "$asic_key" ]]; then
+            /usr/local/bin/container stop $DOCKERNAME
+        fi
+    else
+        /usr/local/bin/container stop $DOCKERNAME
+    fi
     {%- else %}
     /usr/local/bin/container stop $DOCKERNAME
     {%- endif %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
After a config reload or a config load_minigraph we see the following error messages in the syslog for non existing fabric cards:
```
ixre-cpm-chassis19 ERR container: docker cmd: stop for syncd0 failed with 404 Client Error for http+docker://localhost/v1.43/containers/syncd0/json: Not Found ("No such container: syncd0")
ixre-cpm-chassis19 ERR container: docker cmd: stop for syncd1 failed with 404 Client Error for http+docker://localhost/v1.43/containers/syncd1/json: Not Found ("No such container: syncd1")
```
On Sup, for non-existing Fabric slot, its related swss and syncd containers have not been created yet although its related services have been started.  

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added checking to the  docker_image_ctrl.j2 stop() method.  This change adds code to check if related container exists, then call container stop.  Otherwise, just log a message to indicate that "No such container".  Fixes https://github.com/sonic-net/sonic-buildimage/issues/19765

#### How to verify it
1) execute "config reload" on SUP which contains empty Fabric slot.
2) The following related error message should not be seen in syslog
```
ixre-cpm-chassis19 ERR container: docker cmd: stop for syncd0 failed with 404 Client Error for http+docker://localhost/v1.43/containers/syncd0/json: Not Found ("No such container: syncd0")
ixre-cpm-chassis19 ERR container: docker cmd: stop for syncd1 failed with 404 Client Error for http+docker://localhost/v1.43/containers/syncd1/json: Not Found ("No such container: syncd1")
```
3) Instead, the following message should be shown for the related empty Fabric slot
```
2024 Sep 19 17:45:18.339106 ixre-cpm-chassis15 INFO swss.sh[2024819]: container stop swss0 -- No such container: swss0
2024 Sep 19 17:45:20.633519 ixre-cpm-chassis15 INFO syncd.sh[2025664]: container stop syncd0 -- No such container: syncd0
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master 
- [x] 2022405

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

