### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202311.1.0.3
+ref=202311.1.0.4


### PR DESCRIPTION

Release notes for Cisco 8102-64H-O, 8101-32FH, and 8111-32EH-O

* [8111] Fix for SDK Debug Shell (SDK CLI Server) Issue 
* [8111] Reduce XON rate to 12 kpps
* [8111] Fix for OIR issue: of all 16 AEC supported ports, removal+insertion is getting detected only for 8 to 10 ports
* [8111] Fix to account for drops related to invalid destination not getting listed under 'show interface counters'/'show queue counters'
* Fix for PortChannel interfaces go down after "config platform cisco trap-configuration -a restore-all”
* Remove extra 'syncd' in some syslog messages
* Addressed the following 202311 [sonic-mgmt] test case failures:
      - doCfgSensorsTable Task: ASIC sensors : unsupported operation for poller state 1
      - test_default_route_with_bgp_flap
      - syslog errors - test_broken_ip_header
      - Revert of “Add SAI support for SIP and DIP LINK LOCAL drop counters”

How I did it:
Update platform version to 202311.1.0.4
