### PR TITLE
[Mellanox] wait SFP ready when receive an insert event with module host management mode enabled

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -475,6 +475,8 @@ class Chassis(ChassisBase):
                 if fd_type == 'hw_present':
                     # event could be EVENT_NOT_PRESENT or EVENT_PRESENT
                     event = sfp.EVENT_NOT_PRESENT if fd_value == 0 else sfp.EVENT_PRESENT
+                    if fd_value == 1:
+                        s.processing_insert_event = True
                     s.on_event(event)
                 elif fd_type == 'present':
                     if str(fd_value) == sfp.SFP_STATUS_ERROR:

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -476,6 +476,7 @@ class SFP(NvidiaSFPCommon):
             self.state = STATE_DOWN
         else:
             self.state = STATE_FCP_DOWN
+        self.processing_insert_event = False
 
     def __str__(self):
         return f'SFP {self.sdk_index}'
@@ -1504,7 +1505,12 @@ class SFP(NvidiaSFPCommon):
                 sfp.set_hw_reset(1)
                 sfp.on_event(EVENT_RESET)
             else:
-                sfp.on_event(EVENT_POWER_ON)
+                if not sfp.processing_insert_event:
+                    sfp.on_event(EVENT_POWER_ON)
+                else:
+                    sfp.processing_insert_event = False
+                    logger.log_info(f'SFP {sfp.sdk_index} is processing insert event and needs to wait module ready')
+                    sfp.on_event(EVENT_RESET)
 
     @classmethod
     def action_fcp_on_start(cls, sfp):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/wait_sfp_ready_task.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/wait_sfp_ready_task.py
@@ -62,8 +62,8 @@ class WaitSfpReadyTask(threading.Thread):
         """
         logger.log_debug(f'SFP {sfp_index} is scheduled for waiting reset done')
         with self.lock:
-            if len(self._wait_dict) == 0:
-                is_empty = True
+            is_empty = len(self._wait_dict) == 0
+  
             # The item will be expired in 3 seconds
             self._wait_dict[sfp_index] = time.time() + self.WAIT_TIME
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

In dynamic module detection flow, sonic should wait module become ready.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

In dynamic module detection flow, sonic should wait module become ready.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
unit test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

