### PR TITLE
[YANG] Add `in_band_mgmt_enabled` field in `MGMT_VRF_CONFIG` table.

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -408,7 +408,7 @@ ASIC/SDK health event related configuration is defined in **SUPPRESS_ASIC_SDK_HE
 
 ### BGP Device Global
 
-The **BGP_DEVICE_GLOBAL** table contains device-level BGP global state.  
+The **BGP_DEVICE_GLOBAL** table contains device-level BGP global state.
 It has a STATE object containing device state like **tsa_enabled**, **wcmp_enabled** and **idf_isolation_state**.
 
 When **tsa_enabled** is set to true, the device is isolated using traffic-shift-away (TSA) route-maps in BGP.
@@ -422,7 +422,7 @@ When **tsa_enabled** is set to true, the device is isolated using traffic-shift-
 }
 ```
 
-When **wcmp_enabled** is set to true, the device is configured to use BGP Link Bandwidth Extended Community.  
+When **wcmp_enabled** is set to true, the device is configured to use BGP Link Bandwidth Extended Community.
 Weighted ECMP load balances traffic between the equal cost paths in proportion to the capacity of the local links.
 
 ```json
@@ -1523,8 +1523,9 @@ instead of data network.
 {
 "MGMT_VRF_CONFIG": {
     "vrf_global": {
-        "mgmtVrfEnabled": "true"
-     }
+        "mgmtVrfEnabled": "true",
+        "in_band_mgmt_enabled": "false"
+    }
   }
 }
 ```

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -486,7 +486,8 @@
         },
         "MGMT_VRF_CONFIG": {
             "vrf_global": {
-                "mgmtVrfEnabled": "true"
+                "mgmtVrfEnabled": "true",
+                "in_band_mgmt_enabled": "false"
             }
         },
         "NTP": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mgmt_vrf.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mgmt_vrf.json
@@ -2,7 +2,10 @@
     "MGMT_VRF_TEST": {
         "desc": "LOAD MGMT VRF TABLE WITH mgmtVrfEnabled SET TO TRUE SUCCESSFULLY."
     },
+    "MGMT_VRF_IN_BAND_MGMT_TEST": {
+        "desc": "LOAD MGMT VRF TABLE WITH both mgmtVrfEnabled and in_band_mgmt_enabled SET TO TRUE SUCCESSFULLY."
+    },
     "MGMT_VRF_TEST_WITH_DEFAULT_VALUE": {
-	"desc": "LOAD MGMT VRF TABLE WITH DEFAULT mgmtVrfEnabled SUCCESSFULLY."
+	    "desc": "LOAD MGMT VRF TABLE WITH DEFAULT mgmtVrfEnabled SUCCESSFULLY."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mgmt_vrf.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mgmt_vrf.json
@@ -8,6 +8,16 @@
             }
         }
     },
+    "MGMT_VRF_IN_BAND_MGMT_TEST": {
+        "sonic-mgmt_vrf:sonic-mgmt_vrf": {
+            "sonic-mgmt_vrf:MGMT_VRF_CONFIG": {
+                "sonic-mgmt_vrf:vrf_global": {
+                    "mgmtVrfEnabled": true,
+                    "in_band_mgmt_enabled": true
+                }
+            }
+        }
+    },
     "MGMT_VRF_TEST_WITH_DEFAULT_VALUE": {
         "sonic-mgmt_vrf:sonic-mgmt_vrf": {
             "sonic-mgmt_vrf:MGMT_VRF_CONFIG": {

--- a/src/sonic-yang-models/yang-models/sonic-mgmt_vrf.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mgmt_vrf.yang
@@ -23,6 +23,11 @@ module sonic-mgmt_vrf {
                     default false;
                 }
 
+                leaf in_band_mgmt_enabled {
+                    type boolean;
+                    default false;
+                }
+
             } /* end of container vrf_global */
 
         } /* end of container MGMT_VRF_CONFIG */


### PR DESCRIPTION
#### Why I did it
in_band_mgmt_enabled is supported in mgmt vrf function

#### How I did it
Add `in_band_mgmt_enabled` field in `MGMT_VRF_CONFIG` table.

#### How to verify it
Unit test