### PR TITLE
Fix for config replace issues seen with COPP configurations

### DIFF
--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -1,6 +1,7 @@
 {
     "COPP_GROUP": {
 	    "default": {
+		    "trap_action":"trap",
 		    "queue": "0",
 		    "meter_type":"packets",
 		    "mode":"sr_tcm",

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1848,7 +1848,9 @@
                 "mode":"sr_tcm",
                 "cir":"6000",
                 "cbs":"6000",
-                "red_action":"drop"
+                "red_action":"drop",
+		"genetlink_name":"psample",
+		"genetlink_mcgrp_name":"packets"
             }
         },
         "COPP_TRAP": {

--- a/src/sonic-yang-models/yang-models/sonic-copp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-copp.yang
@@ -11,6 +11,11 @@ module sonic-copp {
 
 	description "CoPP YANG Module for SONiC OS";
 
+	revision 2024-05-29 {
+		description
+			"Added genetlink name and mcgrp leaves";
+	}
+
 	revision 2021-03-31 {
 		description
 			"First Revision";
@@ -133,6 +138,16 @@ module sonic-copp {
 					default "forward";
 					description "Red action";
 				}
+
+                                leaf genetlink_name {
+                                        type string;
+                                        description "Genetlink name. [Optional] 'psample' for sFlow";
+                                }
+
+                                leaf genetlink_mcgrp_name {
+                                        type string;
+                                        description "multicast group name; ;[Optional] 'packets' for sFlow";
+                                }
 			}
 			/* end of list COPP_GROUP_LIST */
 		}


### PR DESCRIPTION
• Issue: config replace/yang-validation fails for COPP configurations.

• Root cause:
• COPP's device initial config copp_cfg.json has missing yang mandatory leaf "trap_action" for "default" COPP_GROUP.
• "genetlink_name" & "genetlink_mcgrp_name" nodes are not added in sonic-copp.yang, which are used for "queue2_group1" in copp_cfg.json

• Fix:
• In copp_cfg.json, mandatory leaf "trap_action" is added for "default" COPP_GROUP.

"COPP_GROUP": {
     "default": {
          + "trap_action":"trap", <<< this node needs to be added
              "queue": "0",
              "meter_type":"packets",

• "genetlink_name" and "genetlink_mcgrp_name" leaves are added in sonic-copp.yang.

• DB Migration script is updated to upgrade the DB config automatically.

Tests :
Config replace ->
i. Config load copp_cfg.json
ii. Config save
iii. Config replace -> Ensure no error seen

Upgrade ->
i. Save config in build without the fix
ii. upgrade to build with changes and ensure configurations are reflected in new config_db.json

PRs :
Sonic-buildimage :  https://github.com/sonic-net/sonic-buildimage/pull/19816
Sonic-utilities :  https://github.com/sonic-net/sonic-utilities/pull/3472