### PR TITLE
[Bug Fix] Route map for BGP profile FROM_SDN_APPLIANCE_ROUTES

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_rm.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_rm.py
@@ -2,7 +2,7 @@ from .manager import Manager
 from swsscommon import swsscommon
 from .log import log_err, log_debug
 
-ROUTE_MAPS = ["FROM_SDN_SLB_ROUTES"]
+ROUTE_MAPS = ["FROM_SDN_SLB_ROUTES", "FROM_COM_SDN_APPLIENCE_ROUTES"]
 FROM_SDN_SLB_DEPLOYMENT_ID = '2'
 
 class RouteMapMgr(Manager):
@@ -83,7 +83,7 @@ class RouteMapMgr(Manager):
 
     def __update_rm(self, rm, data):
         cmds = []
-        if rm == "FROM_SDN_SLB_ROUTES":
+        if rm in ROUTE_MAPS :
             cmds.append("route-map %s permit 100" % ("%s_RM" % rm))
             bgp_asn = self.__read_asn()
             if bgp_asn is None or bgp_asn is '':

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_rm.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_rm.py
@@ -2,7 +2,7 @@ from .manager import Manager
 from swsscommon import swsscommon
 from .log import log_err, log_debug
 
-ROUTE_MAPS = ["FROM_SDN_SLB_ROUTES", "FROM_COM_SDN_APPLIENCE_ROUTES"]
+ROUTE_MAPS = ["FROM_SDN_SLB_ROUTES", "FROM_SDN_APPLIANCE_ROUTES"]
 FROM_SDN_SLB_DEPLOYMENT_ID = '2'
 
 class RouteMapMgr(Manager):

--- a/src/sonic-bgpcfgd/tests/test_rm.py
+++ b/src/sonic-bgpcfgd/tests/test_rm.py
@@ -104,8 +104,6 @@ def test_set_del_com_sdn_apl():
 
 def test_set_del_com_sdn_apl_and_slb():
     mgr = constructor()
-    import pdb
-    pdb.set_trace()
     set_del_test(
         mgr,
         "SET",

--- a/src/sonic-bgpcfgd/tests/test_rm.py
+++ b/src/sonic-bgpcfgd/tests/test_rm.py
@@ -25,7 +25,7 @@ def constructor():
     mgr = RouteMapMgr(common_objs, "APPL_DB", "BGP_PROFILE_TABLE")
     return mgr
 
-def set_del_test(mgr, op, args, expected_ret, expected_cmds):
+def set_del_test(mgr, op, cfg_args, expected_ret, expected_cmds):
     set_del_test.push_list_called = False
     def push_list(cmds):
         set_del_test.push_list_called = True
@@ -34,10 +34,12 @@ def set_del_test(mgr, op, args, expected_ret, expected_cmds):
     mgr.cfg_mgr.push_list = push_list
 
     if op == "SET":
-        ret = mgr.set_handler(*args)
-        assert ret == expected_ret
+        for i in range(0, len(cfg_args)):
+            ret = mgr.set_handler(cfg_args[i][0], cfg_args[i][1])
+            assert ret == expected_ret
     elif op == "DEL":
-        mgr.del_handler(*args)
+        for i in range(0, len(cfg_args)):               
+            mgr.del_handler(cfg_args[i])
     else:
         assert False, "Wrong operation"
 
@@ -51,9 +53,9 @@ def test_set_del():
     set_del_test(
         mgr,
         "SET",
-        ("FROM_SDN_SLB_ROUTES", {
+        [("FROM_SDN_SLB_ROUTES", {
             "community_id": "1234:1234"
-        }),
+        })],
         True,
         [
             ["route-map FROM_SDN_SLB_ROUTES_RM permit 100",
@@ -72,3 +74,70 @@ def test_set_del():
             ["no route-map FROM_SDN_SLB_ROUTES_RM permit 100"]
         ]
     )
+
+def test_set_del_com_sdn_apl():
+    mgr = constructor()
+    set_del_test(
+        mgr,
+        "SET",
+        [("FROM_COM_SDN_APPLIENCE_ROUTES", {
+            "community_id": "1235:1235"
+        })],
+        True,
+        [
+            ["route-map FROM_COM_SDN_APPLIENCE_ROUTES_RM permit 100",
+             " set as-path prepend 12346 12346",
+             " set community 1235:1235",
+             " set origin incomplete"]
+        ]
+    )
+
+    set_del_test(
+        mgr,
+        "DEL",
+        ("FROM_COM_SDN_APPLIENCE_ROUTES",),
+        True,
+        [
+            ["no route-map FROM_COM_SDN_APPLIENCE_ROUTES_RM permit 100"]
+        ]
+    )
+
+def test_set_del_com_sdn_apl_and_slb():
+    mgr = constructor()
+    import pdb
+    pdb.set_trace()
+    set_del_test(
+        mgr,
+        "SET",
+        [("FROM_COM_SDN_APPLIENCE_ROUTES", {
+            "community_id": "1235:1235"
+        }),
+        ("FROM_SDN_SLB_ROUTES", {
+            "community_id": "1234:1234"
+        }
+        )],
+        True,
+        [
+            ["route-map FROM_COM_SDN_APPLIENCE_ROUTES_RM permit 100",
+             " set as-path prepend 12346 12346",
+             " set community 1235:1235",
+             " set origin incomplete"],
+           ["route-map FROM_SDN_SLB_ROUTES_RM permit 100",
+             " set as-path prepend 12346 12346",
+             " set community 1234:1234",
+             " set origin incomplete"]
+                   
+        ]
+    )
+
+    set_del_test(
+        mgr,
+        "DEL",
+        ("FROM_COM_SDN_APPLIENCE_ROUTES", "FROM_SDN_SLB_ROUTES",),
+        True,
+        [
+            ["no route-map FROM_COM_SDN_APPLIENCE_ROUTES_RM permit 100"],
+            ["no route-map FROM_SDN_SLB_ROUTES_RM permit 100"]
+        ]
+    )
+

--- a/src/sonic-bgpcfgd/tests/test_rm.py
+++ b/src/sonic-bgpcfgd/tests/test_rm.py
@@ -80,12 +80,12 @@ def test_set_del_com_sdn_apl():
     set_del_test(
         mgr,
         "SET",
-        [("FROM_COM_SDN_APPLIENCE_ROUTES", {
+        [("FROM_SDN_APPLIANCE_ROUTES", {
             "community_id": "1235:1235"
         })],
         True,
         [
-            ["route-map FROM_COM_SDN_APPLIENCE_ROUTES_RM permit 100",
+            ["route-map FROM_SDN_APPLIANCE_ROUTES_RM permit 100",
              " set as-path prepend 12346 12346",
              " set community 1235:1235",
              " set origin incomplete"]
@@ -95,10 +95,10 @@ def test_set_del_com_sdn_apl():
     set_del_test(
         mgr,
         "DEL",
-        ("FROM_COM_SDN_APPLIENCE_ROUTES",),
+        ("FROM_SDN_APPLIANCE_ROUTES",),
         True,
         [
-            ["no route-map FROM_COM_SDN_APPLIENCE_ROUTES_RM permit 100"]
+            ["no route-map FROM_SDN_APPLIANCE_ROUTES_RM permit 100"]
         ]
     )
 
@@ -107,7 +107,7 @@ def test_set_del_com_sdn_apl_and_slb():
     set_del_test(
         mgr,
         "SET",
-        [("FROM_COM_SDN_APPLIENCE_ROUTES", {
+        [("FROM_SDN_APPLIANCE_ROUTES", {
             "community_id": "1235:1235"
         }),
         ("FROM_SDN_SLB_ROUTES", {
@@ -116,7 +116,7 @@ def test_set_del_com_sdn_apl_and_slb():
         )],
         True,
         [
-            ["route-map FROM_COM_SDN_APPLIENCE_ROUTES_RM permit 100",
+            ["route-map FROM_SDN_APPLIANCE_ROUTES_RM permit 100",
              " set as-path prepend 12346 12346",
              " set community 1235:1235",
              " set origin incomplete"],
@@ -131,11 +131,11 @@ def test_set_del_com_sdn_apl_and_slb():
     set_del_test(
         mgr,
         "DEL",
-        ("FROM_COM_SDN_APPLIENCE_ROUTES", "FROM_SDN_SLB_ROUTES",),
+        ("FROM_SDN_APPLIANCE_ROUTES", "FROM_SDN_SLB_ROUTES",),
         True,
         [
-            ["no route-map FROM_COM_SDN_APPLIENCE_ROUTES_RM permit 100"],
+            ["no route-map FROM_SDN_APPLIANCE_ROUTES_RM permit 100"],
             ["no route-map FROM_SDN_SLB_ROUTES_RM permit 100"]
-        ]
+        ] 
     )
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is a bug fix and this change should go into 202305 brranch and onwards.
Added Route map support for BGP profile FROM_SDN_APPLIANCE_ROUTES
With this change the following route map should be added if the BGP profile is added
```
route-map FROM_SDN_APPLIANCE_ROUTES_RM permit 100
set as-path prepend <Prepend value of FROM_SDN_SLB_DEPLOYMENT_ID>
set community <community id>
set origin incomplete
```
##### Work item tracking
- Microsoft ADO **(number only)**:
28896695
#### How I did it

#### How to verify it
Added test to verify the rotue map creation.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [X] 202305
- [X] 202311
- [X] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
NO yang changes required.
#### A picture of a cute animal (not mandatory but encouraged)

