### PR TITLE
[202405] Revert "Always set sai_tunnel_support on Arista-7260cx3"

### DIFF
--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
@@ -14,7 +14,8 @@
 {%-         set switch_subtype = DEVICE_METADATA['localhost']['subtype'] -%}
 {%-         if 'dualtor' in switch_subtype.lower() %}
 {%-             set IPinIP_sock =
-'sai_tunnel_underlay_route_mode=1
+'sai_tunnel_support=1
+sai_tunnel_underlay_route_mode=1
 host_as_route_disable=1
 l3_ecmp_levels=2' -%}
 {%-             set map_prio = 'sai_remap_prio_on_tnl_egress=1' -%}
@@ -1048,6 +1049,5 @@ serdes_preemphasis_116=0x103706
 serdes_preemphasis_117=0x133c06
 
 {{ mmu_sock }}
-sai_tunnel_support=1
 {{ IPinIP_sock }}
 phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C10/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C10/config.bcm.j2
@@ -6,7 +6,8 @@
 {%-     set switch_subtype = DEVICE_METADATA['localhost']['subtype'] -%}
 {%-     if 'dualtor' in switch_subtype.lower() %}
 {%-         set IPinIP_sock =
-'sai_tunnel_underlay_route_mode=1
+'sai_tunnel_support=1
+sai_tunnel_underlay_route_mode=1
 host_as_route_disable=1
 l3_ecmp_levels=2' -%}
 {%-         set map_prio = 'sai_remap_prio_on_tnl_egress=1' -%}
@@ -955,6 +956,5 @@ serdes_preemphasis_130=0x580c
 serdes_preemphasis_131=0x580c
 
 mmu_init_config="MSFT-TH2-Tier0"
-sai_tunnel_support=1
 {{ IPinIP_sock }}
 phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
@@ -6,7 +6,8 @@
 {%-     set switch_subtype = DEVICE_METADATA['localhost']['subtype'] -%}
 {%-     if 'dualtor' in switch_subtype.lower() %}
 {%-         set IPinIP_sock =
-'sai_tunnel_underlay_route_mode=1
+'sai_tunnel_support=1
+sai_tunnel_underlay_route_mode=1
 host_as_route_disable=1
 l3_ecmp_levels=2' -%}
 {%-         set map_prio = 'sai_remap_prio_on_tnl_egress=1' -%}
@@ -959,6 +960,5 @@ serdes_preemphasis_130=0x580c
 serdes_preemphasis_131=0x580c
 
 mmu_init_config="MSFT-TH2-Tier0"
-sai_tunnel_support=1
 {{ IPinIP_sock }}
 phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
@@ -14,7 +14,8 @@
 {%-         set switch_subtype = DEVICE_METADATA['localhost']['subtype'] -%}
 {%-         if 'dualtor' in switch_subtype.lower() %}
 {%-             set IPinIP_sock =
-'sai_tunnel_underlay_route_mode=1
+'sai_tunnel_support=1
+sai_tunnel_underlay_route_mode=1
 host_as_route_disable=1
 l3_ecmp_levels=2' -%}
 {%-             set map_prio = 'sai_remap_prio_on_tnl_egress=1' -%}
@@ -1047,6 +1048,5 @@ serdes_preemphasis_116=0x105004
 serdes_preemphasis_117=0x105004
 
 {{ mmu_sock }}
-sai_tunnel_support=1
 {{ IPinIP_sock }}
 phy_an_lt_msft=1

--- a/src/sonic-config-engine/tests/data/j2_template/config.bcm.j2
+++ b/src/sonic-config-engine/tests/data/j2_template/config.bcm.j2
@@ -14,7 +14,8 @@
 {%-         set switch_subtype = DEVICE_METADATA['localhost']['subtype'] -%}
 {%-         if 'dualtor' in switch_subtype.lower() %}
 {%-             set IPinIP_sock =
-'sai_tunnel_underlay_route_mode=1
+'sai_tunnel_support=1
+sai_tunnel_underlay_route_mode=1
 host_as_route_disable=1
 l3_ecmp_levels=2' -%}
 {%-             set map_prio = 'sai_remap_prio_on_tnl_egress=1' -%}
@@ -32,6 +33,5 @@ sai_pfc_dlr_init_capability=1' -%}
 l3_alpm_hit_skip=1
 {{ map_prio }}
 {{ mmu_sock }}
-sai_tunnel_support=1
 {{ IPinIP_sock }}
 {{ pfcwd_sock }}

--- a/src/sonic-config-engine/tests/sample_output/py3/arista7260-t1.config.bcm
+++ b/src/sonic-config-engine/tests/sample_output/py3/arista7260-t1.config.bcm
@@ -2,7 +2,6 @@
 l3_alpm_hit_skip=1
 
 mmu_init_config="MSFT-TH2-Tier1"
-sai_tunnel_support=1
 
 hybrid_pfc_deadlock_enable=1
 pfc_deadlock_seq_control=1


### PR DESCRIPTION
Reverts https://github.com/sonic-net/sonic-buildimage/pull/16097 from 202405 branch

The change has to be reverted as warm-reboot is broken.
MSFT ADO: 27996281