### PR TITLE
Restart NTP only if there is server information present in configuration

### DIFF
--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -31,4 +31,13 @@ get_database_reboot_type
 echo "Disabling NTP long jump for reboot type ${reboot_type} ..."
 modify_ntp_default "s/NTPD_OPTS=\"-g -N\"/NTPD_OPTS=\"-x -N\"/"
 
-systemctl --no-block restart ntp
+#Check for NTP_KEYS or NTP_SERVERS in CONFIG_DB 
+ntp_config=$(redis-cli -n 4 keys *NTP_*)
+if [ -n "$ntp_config" ]; then
+    echo "Server information present in CONFIG_DB, NTP is restarted"
+    systemctl --no-block restart ntp
+else
+    echo "No server information present in CONFIG_DB, NTP is not restarted"
+fi
+    
+

--- a/files/image_config/ntp/sonic-target.conf
+++ b/files/image_config/ntp/sonic-target.conf
@@ -1,3 +1,2 @@
 [Unit]
-BindsTo=sonic.target
 After=sonic.target


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR aims to restart NTP only if there is server information present in the CONFIG_DB on config reload / reboot, as dhcp will restart ntpsec if there is any change in NTP servers and this can cause multiple restarts if a reboot/reload is happening concurrently leading to the error logs. The issue is described in https://github.com/sonic-net/sonic-buildimage/issues/19859


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

