### PR TITLE
[Nvidia-bluefield] Extend BFB installer script to reset DPU after image installation

### DIFF
--- a/platform/mellanox/sonic-bfb-installer.sh
+++ b/platform/mellanox/sonic-bfb-installer.sh
@@ -16,6 +16,12 @@
 # limitations under the License.
 #
 
+declare -A rshim2dpu
+rshim2dpu["rshim0"]="dpu0"
+rshim2dpu["rshim1"]="dpu1"
+rshim2dpu["rshim2"]="dpu2"
+rshim2dpu["rshim3"]="dpu3"
+
 command_name="sonic-bfb-installer.sh"
 usage(){
     echo "Syntax: $command_name -b|--bfb <BFB_Image_Path> --rshim|-r <rshim1,..rshimN> --verbose|-v --config|-c <Options> --help|h"
@@ -30,20 +36,30 @@ WORK_DIR=`mktemp -d -p "$DIR"`
 
 bfb_install_call(){
     #Example:sudo bfb-install -b <full path to image> -r rshim<id>
-    local result_file=$(mktemp "${WORK_DIR}/result_file.XXXXX")
-    local cmd="timeout 600s bfb-install -b $2 -r $1 $appendix"
-    echo "Installing bfb image on DPU connected to $1 using $cmd"
-    local indicator="$1:"
+    local -r rshim=$1
+    local result_file=$(mktemp "/tmp/result_file.XXXXX")
+    local cmd="timeout 600s bfb-install -b $2 -r $rshim $appendix"
+    echo "Installing bfb image on DPU connected to $rshim using $cmd"
+    local indicator="$rshim:"
     eval "$cmd" > "$result_file" 2>&1 > >(while IFS= read -r line; do echo "$indicator $line"; done > "$result_file")
     local exit_status=$?
     if [ $exit_status  -ne 0 ]; then
-        echo "$1: Error: Installation failed on connected DPU!"
+        echo "$rshim: Error: Installation failed on connected DPU!"
     else
-        echo "$1: Installation Successful"
+        echo "$rshim: Installation Successful"
     fi
     if [ $exit_status -ne 0 ] ||[ $verbose = true ]; then
         cat "$result_file"
     fi
+
+    dpu=${rshim2dpu[$rshim]}
+    echo "$rshim: Resetting DPU $dpu"
+    cmd="dpuctl dpu-reset --force $dpu"
+    if [[ $verbose == true ]]; then
+        cmd="$cmd -v"
+    fi
+
+    eval $cmd
 }
 
 file_cleanup(){


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The DPU reset after the image installation is required to boot the DPU with the new NIC FW

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Trigger DPU reset with the `dpuctl` utility after the image isntallation

#### How to verify it
Build and install the image

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

