### PR TITLE
Add an artificial dependency between two modules for centec-arm64

### DIFF
--- a/platform/centec-arm64/platform-modules-fs.mk
+++ b/platform/centec-arm64/platform-modules-fs.mk
@@ -9,4 +9,8 @@ FS_S5800_48T4S_PLATFORM_MODULE = platform-modules-s5800-48t4s_$(FS_S5800_48T4S_P
 $(FS_S5800_48T4S_PLATFORM_MODULE)_SRC_PATH = $(PLATFORM_PATH)/sonic-platform-modules-fs
 $(FS_S5800_48T4S_PLATFORM_MODULE)_DEPENDS += $(LINUX_HEADERS) $(LINUX_HEADERS_COMMON)
 $(FS_S5800_48T4S_PLATFORM_MODULE)_PLATFORM = arm64-fs_s5800_48t4s-r0
+# Both this and the e530 modules compile ../centec/centec-dal/, which causes a problem
+# if both are being compiled at the same time. To get around that, add an artificial
+# dependency here so that this part is serialized.
+$(FS_S5800_48T4S_PLATFORM_MODULE)_AFTER = $(CENTEC_E530_48T4X_P_PLATFORM_MODULE)
 SONIC_DPKG_DEBS += $(FS_S5800_48T4S_PLATFORM_MODULE)


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

For centec-arm64, both platform-modules-fs and platform-modules-e530 try to compile the same directory of kernel sources. If both compilations are running at the same time, then this is going to lead to errors.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Fix this by introducing an artificial dependency between the two so that the compilations are forced to be serialized.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

