### PR TITLE
[Marvell][Nokia-M0] Set custom create switch timeout

### DIFF
--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile
@@ -2,3 +2,4 @@ mode=1
 hwId=et6448m
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/profile.ini
 switchProfile=/usr/share/sonic/hwsku/SAI-M0-48x1G-4x10G.xml
+createSwitchTimeout=90

--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+HWSKU_DIR=/usr/share/sonic/hwsku
 SWSS_VARS_FILE=/usr/share/sonic/templates/swss_vars.j2
 
 # Retrieve SWSS vars from sonic-cfggen
@@ -69,6 +70,12 @@ elif [ "$platform" == "nvidia-bluefield" ]; then
 elif [ "$platform" == "pensando" ]; then
     MAC_ADDRESS=$(ip link property add dev oob_mnic0 altname eth0; ip link show oob_mnic0 | grep ether | awk '{print $2}')
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"
+elif [ "$platform" == "marvell" ]; then
+    ORCHAGENT_ARGS+="-m $MAC_ADDRESS"
+    CREATE_SWITCH_TIMEOUT=`cat $HWSKU_DIR/sai.profile | grep "createSwitchTimeout" | cut -d'=' -f 2`
+    if [[ ! -z $CREATE_SWITCH_TIMEOUT ]]; then
+        ORCHAGENT_ARGS+=" -t $CREATE_SWITCH_TIMEOUT"
+    fi
 else
     # Should we use the fallback MAC in case it is not found in Device.Metadata
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Migrating Nokia-M0 armhf platform from SONiC 202311 to master and 202405 branch, resulted in syncd create_switch timeout.
It is analyzed to see that SAI SDK code remains the same and time consume by SAI SDK during init when some(snmp mgmt-framework lldp gnmi dhcp_relay radv teamd pmon bgp) of the docker in sonic are disabled is same as running on 202311(with same environment).

Some of the other observations are:
* Switch create time varies from 50sec to 85 sec randomly depending on CPU load.
* Running bullseye based 5.10 sonic kernel yielded same result on latest master.
* Running docker ps -a in 202405 shows all dockers attempting to start, while in 202311 it delays most dockers.
* No single docker seems to have a significant impact.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added changes to support custom create_switch timeout value to orchagent from hwsku.
Orchagent changes are captured in PR https://github.com/sonic-net/sonic-swss/pull/3258

#### How to verify it
Verified by running SONIC PTF run on Nokia-M0.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

