### PR TITLE
[Mellanox] Add dpuctl services to support "dark mode".

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn4280-r0/services.conf
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/services.conf
@@ -1,1 +1,1 @@
-rshim-manager.service
+dpuctl.service

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -1095,6 +1095,14 @@ sudo install -m 755 platform/mellanox/rshim/files/rshim.sh $FILESYSTEM_ROOT/usr/
 # Install rshim services
 sudo cp platform/mellanox/rshim/files/rshim@.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/
 sudo cp platform/mellanox/rshim/files/rshim-manager.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/
+
+# Install dpuctl script and config file
+sudo install -m 755 platform/mellanox/smartswitch/dpuctl/dpuctl.sh $FILESYSTEM_ROOT/usr/bin/dpuctl.sh
+sudo install -m 755 platform/mellanox/smartswitch/dpuctl/dpu.conf $FILESYSTEM_ROOT_ETC/mlnx/
+
+# Install dpuctl services
+sudo cp platform/mellanox/smartswitch/dpuctl/dpuctl.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/
+
 {% endif %}
 
 {% if sonic_asic_platform == "nvidia-bluefield" %}

--- a/platform/mellanox/smartswitch/dpuctl/dpu.conf
+++ b/platform/mellanox/smartswitch/dpuctl/dpu.conf
@@ -1,0 +1,1 @@
+DARK_MODE=true

--- a/platform/mellanox/smartswitch/dpuctl/dpuctl.service
+++ b/platform/mellanox/smartswitch/dpuctl/dpuctl.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Controle DPUs state
+Requires=hw-management.service
+After=hw-management.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/dpuctl.sh start
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/mellanox/smartswitch/dpuctl/dpuctl.sh
+++ b/platform/mellanox/smartswitch/dpuctl/dpuctl.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# By default the dark mode is enabled
+DARK_MODE=true
+
+bf3_pci_id="15b3:c2d5"
+dpu2pcie[0]="08:00.0"
+dpu2pcie[1]="07:00.0"
+dpu2pcie[2]="01:00.0"
+dpu2pcie[3]="02:00.0"
+
+if [[ -f /etc/mlnx/dpu.conf ]]; then
+    . /etc/mlnx/dpu.conf
+fi
+
+do_start() {
+    if [[ $DARK_MODE == "true" ]]; then
+        # By default all the DPUs are on. Power off the DPUs when is dark mode is required.
+
+        for dpu_id in ${!dpu2pcie[@]}; do
+            pci_id=$(lspci -n | grep "${dpu2pcie[$dpu_id]}" | awk '{print $3}')
+            if [[ $pci_id == $bf3_pci_id ]]; then
+                dpuctl dpu-power-off dpu${dpu_id} &
+            fi
+        done
+
+        # Wait for all dpuctl processes to finish
+        wait
+    else
+        # Start RSHIM per each DPU to create interfaces
+        systemctl start rshim-manager.service
+    fi
+}
+
+case "$1" in
+    start)
+        do_start
+        ;;
+    *)
+        echo "Error: Invalid argument."
+        echo "Usage: $0 {start}"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Smart Switch Dark Mode allows disabling of all DPUs, removing any influence the DPU has on the system.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add the `dpuctl.service` that runs on system start and shuts down DPUs if needed.

#### How to verify it
Compile the image and run it on the Nvidia Smart Switch. Verify that all DPUs are down after the system starts.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

