### PR TITLE
Make sure logrotate send rsyslog HUP signal only if it is already run…

### DIFF
--- a/files/image_config/logrotate/logrotateOverride.conf
+++ b/files/image_config/logrotate/logrotateOverride.conf
@@ -1,2 +1,4 @@
 [Unit]
 Requires=logrotate-config.service
+After=rsyslog.service
+Requires=rsyslog.service

--- a/files/image_config/logrotate/logrotateOverride.conf
+++ b/files/image_config/logrotate/logrotateOverride.conf
@@ -1,4 +1,2 @@
 [Unit]
 Requires=logrotate-config.service
-After=rsyslog.service
-Requires=rsyslog.service

--- a/files/image_config/logrotate/rsyslog.j2
+++ b/files/image_config/logrotate/rsyslog.j2
@@ -19,7 +19,9 @@
     delaycompress
     sharedscripts
     postrotate
-        /bin/kill -HUP $(cat /var/run/rsyslogd.pid)
+        if [ -f /var/run/rsyslogd.pid ]; then
+            /bin/kill -HUP $(cat /var/run/rsyslogd.pid)
+        fi
     endscript
 }
 
@@ -116,7 +118,9 @@
                 pgrep -x orchagent | xargs /bin/kill -HUP 2>/dev/null || true
             fi
         else
-            /bin/kill -HUP $(cat /var/run/rsyslogd.pid)
+            if [ -f /var/run/rsyslogd.pid ]; then
+                /bin/kill -HUP $(cat /var/run/rsyslogd.pid)
+            fi
         fi
     endscript
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
…ning

#### Why I did it
We encounter an error in the log, which came from the call to logrotate while rsyslog is not running.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Config logrotate to check that the HUP signal will only send when rsyslog is running.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

