### PR TITLE
[SAI 11] [Arista] Update phy-credo.mk

### DIFF
--- a/rules/phy-credo.mk
+++ b/rules/phy-credo.mk
@@ -1,3 +1,3 @@
 PHY_CREDO = phy-credo_1.0_amd64.deb
-$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/raw/9e34da2a2d2d1e7e972cda3064b7b73c0558b322/phy/phy-credo_1.0_amd64.deb"
+$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/raw/24716c4e03f223d8e18afff786ac427f6ac77fe0/phy/phy-credo_1.0_amd64.deb"
 SONIC_ONLINE_DEBS += $(PHY_CREDO)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
PR https://github.com/sonic-net/sonic-buildimage/pull/19891 is separated to
https://github.com/sonic-net/sonic-buildimage/pull/19854 and current PR

it's needed for Arista CW2 linecard for SAI11. 

There is system side mechanism in phy-credo.py to work around the links down issue on CW2 linecard.
This PR is changing $(PHY_CREDO)_URL to point to phy-credo_1.0_amd64.deb that is already merged with the fix in https://github.com/aristanetworks/sonic-firmware/pull/2

Verified links are all up with credo debian update, without this change, 1 portchannel is down on Arista CL2 LC.
#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
take this change locally and rebuilt the images, with this change, links are up on all LCs.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

