### PR TITLE
[chassis][multiasic][sonic-db-cli] No need to access chassis_app_db from namespace in swss.sh

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -132,7 +132,7 @@ function clean_up_chassis_db_tables()
         return
     fi
 
-    until [[ $($SONIC_DB_CLI CHASSIS_APP_DB PING | grep -c True) -gt 0 ]]; do
+    until [[ $(sonic-db-cli CHASSIS_APP_DB PING | grep -c True) -gt 0 ]]; do
         sleep 1
     done
 
@@ -151,7 +151,7 @@ function clean_up_chassis_db_tables()
     debug "Chassis db clean up for ${SERVICE}$DEV. asic=$asic"
 
     # First, delete SYSTEM_NEIGH entries
-    num_neigh=`$SONIC_DB_CLI CHASSIS_APP_DB EVAL "
+    num_neigh=`sonic-db-cli CHASSIS_APP_DB EVAL "
     local nn = 0
     local host = string.gsub(ARGV[1], '%-', '%%-')
     local dev = ARGV[2]
@@ -178,7 +178,7 @@ function clean_up_chassis_db_tables()
     fi
 
     # Next, delete SYSTEM_INTERFACE entries
-    num_sys_intf=`$SONIC_DB_CLI CHASSIS_APP_DB EVAL "
+    num_sys_intf=`sonic-db-cli CHASSIS_APP_DB EVAL "
     local nsi = 0
     local host = string.gsub(ARGV[1], '%-', '%%-')
     local dev = ARGV[2]
@@ -195,7 +195,7 @@ function clean_up_chassis_db_tables()
     debug "Chassis db clean up for ${SERVICE}$DEV. Number of SYSTEM_INTERFACE entries deleted: $num_sys_intf"
 
     # Next, delete SYSTEM_LAG_MEMBER_TABLE entries
-    num_lag_mem=`$SONIC_DB_CLI CHASSIS_APP_DB EVAL "
+    num_lag_mem=`sonic-db-cli CHASSIS_APP_DB EVAL "
     local nlm = 0
     local host = string.gsub(ARGV[1], '%-', '%%-')
     local dev = ARGV[2]
@@ -220,7 +220,7 @@ function clean_up_chassis_db_tables()
     fi
 
     # Finally, delete SYSTEM_LAG_TABLE entries and deallot LAG IDs
-    num_sys_lag=`$SONIC_DB_CLI CHASSIS_APP_DB EVAL "
+    num_sys_lag=`sonic-db-cli CHASSIS_APP_DB EVAL "
     local nsl = 0
     local host = string.gsub(ARGV[1], '%-', '%%-')
     local dev = ARGV[2]


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently, in the multiaisc linecard, the sonic-db-cli is not able access from CHASSIS_APP_DB from namespace.  The swss,sh call SONIC_DB_CLI to ping and access the CHASSIS_APP_DB.  There is also a PR (https://github.com/sonic-net/sonic-swss-common/pull/896) try to address it.  Since sonic-db-cli  can access the CHASSIS_APP_DB from host instead of the namespace,  we modify the swss.sh to use sonic-db-cli instead of SONIC_DB_CLI which use the sonic-db-cli -n asic#.
 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modify the swss.sh to use sonic_db_cli instead of "SONIC_DB_CLI" to access the CHASSIS_APP_DB since there is no need to access the CHASSIS_APP_DB from namespace in the swss.sh.  Comparing to PR https://github.com/sonic-net/sonic-swss-common/pull/896,  this PR is more straight forward to address the issue based on the swss.sh implementation.  Anyway, both PRs have no conflict. 

#### How to verify it
The mutilasic swss# container should be able to be UP and running without any issue.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)
[x] 202405
[x] master

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

