### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202305.1.0.14
+ref=202305.1.0.15


### PR DESCRIPTION
Release notes for Cisco 8111-32EH-O, 8102-64H-O and 8101-32FH:
	•	[8111] ECN L3 Counter not incrementing issue
	•	[8111] Fix for i2c mux is not detected on BT0s
	•	Expediting the code drop with few tests still pending. Will share the results once becomes available:
                     - T1-800G nightly run still not complete
                     - 8111 full latency regression suite not run yet due to testbed issues.  
                     - Have manually verified latency for a few frame sizes and looks good.

Update platform version to 202305.1.0.15

