### PR TITLE
[chassis] add condition is yang model to make lanes not mandatory for chassis

### DIFF
--- a/src/sonic-config-engine/tests/sample-chassis-packet-lc-graph.xml
+++ b/src/sonic-config-engine/tests/sample-chassis-packet-lc-graph.xml
@@ -146,11 +146,6 @@
         </SubInterface>
       </SubInterfaces>
       <IPInterfaces>
-        <IPInterface>
-          <Name i:nil="true"/>
-          <AttachTo>Eth1/1/47</AttachTo>
-          <Prefix>27.1.1.1/24</Prefix>
-        </IPInterface>
       </IPInterfaces>
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
@@ -206,11 +201,6 @@
       <PortChannelInterfaces>
       </PortChannelInterfaces>
       <IPInterfaces>
-        <IPInterface>
-          <Name i:nil="true"/>
-          <AttachTo>Eth1/1/47</AttachTo>
-          <Prefix>27.1.1.1/24</Prefix>
-        </IPInterface>
         </IPInterfaces>
        <VlanInterfaces>
        </VlanInterfaces>
@@ -261,13 +251,6 @@
   </LinkMetadataDeclaration>
   <PngDec>
     <DeviceInterfaceLinks>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>IXIA-EBGP</EndDevice>
-        <EndPort>Ethernet1</EndPort>
-        <StartDevice>str2-8808-lc2-1</StartDevice>
-        <StartPort>Eth1/1/47</StartPort>
-      </DeviceLinkBase>
       <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <Bandwidth>100000</Bandwidth>
@@ -402,20 +385,6 @@
     <DeviceInfo>
       <AutoNegotiation>true</AutoNegotiation>
       <EthernetInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-        <a:EthernetInterface>
-          <ElementType>DeviceInterface</ElementType>
-          <AlternateSpeeds i:nil="true"/>
-          <EnableAutoNegotiation>true</EnableAutoNegotiation>
-          <EnableFlowControl>true</EnableFlowControl>
-          <Index>1</Index>
-          <InterfaceName>Ethernet1/1/47</InterfaceName>
-          <InterfaceType i:nil="true"/>
-          <MultiPortsInterface>false</MultiPortsInterface>
-          <PortName>47</PortName>
-          <Priority>0</Priority>
-          <Speed>100000</Speed>
-          <SonicName>Ethernet47</SonicName>
-        </a:EthernetInterface>
       </EthernetInterfaces>
       <FlowControl>true</FlowControl>
       <Height>0</Height>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -1020,8 +1020,25 @@ class TestCfgGen(TestCase):
                 "'Vlan2000': {'dhcpv6_servers': ['fc02:2000::3', 'fc02:2000::4']}}"
             )
         )
-        
-    def test_minigraph_packet_chassis_acl(self):
+
+    def test_minigraph_packet_chassis_acl_local_host(self):
+        # CFGGEN_UNIT_TESTING is set to '2' in the set_up function
+        # this causes the port_table to have ports from the previous test
+        # causing yang validation to fail
+
+        os.environ["CFGGEN_UNIT_TESTING"] = ""
+        argument = ['-m', self.packet_chassis_graph, '-v', "ACL_TABLE"]
+        output = self.run_script(argument)
+        print(output)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            utils.to_dict("{'SNMP_ACL': {'policy_desc': 'SNMP_ACL', 'type': 'CTRLPLANE', 'stage': 'ingress', 'services': ['SNMP']}, 'SSH_ONLY': {'policy_desc': 'SSH_ONLY', 'type': 'CTRLPLANE', 'stage': 'ingress', 'services': ['SSH']}}")
+        )
+
+        # set it back to the original value
+        os.environ["CFGGEN_UNIT_TESTING"] = "2"
+
+    def test_minigraph_packet_chassis_acl_namespace(self):
 
         argument = ['-m', self.packet_chassis_graph, '-p', self.packet_chassis_port_ini, '-n', "asic1", '-v', "ACL_TABLE"]
         output = self.run_script(argument)

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -1022,12 +1022,6 @@ class TestCfgGen(TestCase):
         )
         
     def test_minigraph_packet_chassis_acl(self):
-        argument = ['-m', self.packet_chassis_graph, '-p', self.packet_chassis_port_ini, '-v', "ACL_TABLE"]
-        output = self.run_script(argument)
-        self.assertEqual(
-            utils.to_dict(output.strip()),
-            utils.to_dict("{'SNMP_ACL': {'policy_desc': 'SNMP_ACL', 'type': 'CTRLPLANE', 'stage': 'ingress', 'services': ['SNMP']}, 'SSH_ONLY': {'policy_desc': 'SSH_ONLY', 'type': 'CTRLPLANE', 'stage': 'ingress', 'services': ['SSH']}}")
-        )
 
         argument = ['-m', self.packet_chassis_graph, '-p', self.packet_chassis_port_ini, '-n', "asic1", '-v', "ACL_TABLE"]
         output = self.run_script(argument)
@@ -1045,20 +1039,13 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_bgp_packet_chassis_static_route(self):
-        argument = ['-m', self.packet_chassis_graph, '-p', self.packet_chassis_port_ini, '-v', "STATIC_ROUTE"]
-        output = self.run_script(argument)
-        self.assertEqual(
-            utils.to_dict(output.strip()),
-            utils.to_dict("{'8.0.0.1/32': {'nexthop': '192.168.1.2,192.168.2.2', 'ifname': 'PortChannel40,PortChannel50', 'advertise':'false', 'bfd':'true'}}")
-        )
-
         argument = ['-m', self.packet_chassis_graph, '-p', self.packet_chassis_port_ini, '-n', "asic1", '-v', "STATIC_ROUTE"]
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict("{'8.0.0.1/32': {'nexthop': '192.168.1.2,192.168.2.2', 'ifname': 'PortChannel40,PortChannel50', 'advertise':'false', 'bfd':'true'}}")
         )
-
+        os.environ["CFGGEN_UNIT_TESTING_TOPOLOGY"] = ""
     def test_minigraph_bgp_packet_chassis_vlan_subintf(self):
         argument = ['-m', self.packet_chassis_graph, '-p', self.packet_chassis_port_ini, '-n', "asic1", '-v', "VLAN_SUB_INTERFACE"]
         output = self.run_script(argument)

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
@@ -151,7 +151,27 @@
         "eStrKey" : "InvalidValue",
         "eStr": ["dom_polling"]
     },
-     "PORT_AUTO_FEC_TEST": {
-         "desc": "PORT_AUTO_FEC_TEST validate auto mode in fec."
-     }
+    "PORT_AUTO_FEC_TEST": {
+        "desc": "PORT_AUTO_FEC_TEST validate auto mode in fec."
+    },
+    "PORT_NO_LANES_NEGATIVE_TEST": {
+        "desc": "PORT_NO_LANES_NEGATIVE_TEST no lanes.",
+        "eStrKey": "Mandatory",
+        "eStr": ["Missing"]
+    },
+    "PORT_VOQ_CHASSIS_WITH_NO_LANES": {
+        "desc": "PORT_VOQ_CHASSIS_WITH_NO_LANES no failure."
+    },
+    "PORT_PACKET_CHASSIS_WITH_NO_LANES": {
+        "desc": "PORT_PACKET_CHASSIS_WITH_NO_LANES no failure."
+    },
+    "PORT_FABRIC_WITH_NO_LANES": {
+        "desc": "PORT_FABRIC_WITH_NO_LANES no failure."
+    },
+    "PORT_VOQ_CHASSIS_WITH_LANES": {
+        "desc": "PORT_VOQ_CHASSIS_WITH_LANES no failure."
+    }
+
+
+
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -804,5 +804,107 @@
                 ]
             }
         }
+    },
+    "PORT_NO_LANES_NEGATIVE_TEST": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet0",
+                        "alias": "etp1a",
+                        "speed": 100000,
+                        "role": "Ext"
+                    }
+                ]
+            }
+        }
+    },
+    "PORT_VOQ_CHASSIS_WITH_NO_LANES": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "switch_type": "voq"
+                }
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet0",
+                        "alias": "etp1a",
+                        "speed": 100000,
+                        "role": "Ext"
+                    }
+                ]
+            }
+        }
+    },
+    "PORT_VOQ_CHASSIS_WITH_LANES": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "switch_type": "voq",
+                    "asic_name": "asic0"
+                }
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet0",
+                        "alias": "etp1a",
+                        "speed": 100000,
+                        "role": "Ext",
+                        "lanes": "60, 61"
+                    }
+                ]
+            }
+        }
+    },
+    "PORT_PACKET_CHASSIS_WITH_NO_LANES": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "switch_type": "chassis-packet"
+                }
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet0",
+                        "alias": "etp1a",
+                        "speed": 100000,
+                        "role": "Ext"
+                        
+                    }
+                ]
+            }
+        }
+    },
+    "PORT_FABRIC_WITH_NO_LANES": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "switch_type": "fabric"
+                }
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet0",
+                        "alias": "etp1a",
+                        "speed": 100000,
+                        "role": "Int"
+                        
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -13,9 +13,9 @@ module sonic-port{
 		prefix ext;
 	}
 
-    import sonic-device_metadata {
-        prefix sdm;
-    }
+	import sonic-device_metadata {
+		prefix sdm;
+	}
 
 	import sonic-macsec {
 		prefix macsec;
@@ -72,11 +72,11 @@ module sonic-port{
 
 				leaf lanes {
 					when "not(not(/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:asic_name) and
-					((/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type ='voq') or 
-					(/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type  = 'chassis-packet') or
-					(/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type ='fabric')))";
+					((/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type='voq') or 
+					(/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type='chassis-packet') or
+					(/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type='fabric')))";
 
-					description "Number of hardware lanes for the port. This is mandoatory for all devices except for chassis devices";
+					description "Number of hardware lanes for the port. This is mandatory for all devices except for chassis devices";
 					mandatory true;
 					type string {
 						length 1..128;

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -13,6 +13,10 @@ module sonic-port{
 		prefix ext;
 	}
 
+    import sonic-device_metadata {
+        prefix sdm;
+    }
+
 	import sonic-macsec {
 		prefix macsec;
 	}
@@ -67,6 +71,12 @@ module sonic-port{
 				}
 
 				leaf lanes {
+					when "not(not(/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:asic_name) and
+					((/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type ='voq') or 
+					(/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type  = 'chassis-packet') or
+					(/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type ='fabric')))";
+
+					description "Number of hardware lanes for the port. This is mandoatory for all devices except for chassis devices";
 					mandatory true;
 					type string {
 						length 1..128;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In the sonic chassis the port table on the host does not lanes. Add conditions in the lab chassis to make lanes not mandatory for chassis devices

##### Work item tracking
- Microsoft ADO **29108681**:

#### How I did it
Add the check in `sonic-port.yang` to make lanes are mandatory in the host config_db only for non-chassis devices.

#### How to verify it
UT.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

