### PR TITLE
[BGP] Fix TCP MD5 authentication problem in VRF

### DIFF
--- a/src/sonic-frr/patch/0053-bgpd-Set-md5-TCP-socket-option-for-outgoing-connections-on-listener.patch
+++ b/src/sonic-frr/patch/0053-bgpd-Set-md5-TCP-socket-option-for-outgoing-connections-on-listener.patch
@@ -1,0 +1,14 @@
+diff --git a/bgpd/bgp_network.c b/bgpd/bgp_network.c
+index 76bb9949d..974a57ef2 100644
+--- a/bgpd/bgp_network.c
++++ b/bgpd/bgp_network.c
+@@ -774,6 +774,9 @@ int bgp_connect(struct peer *peer)
+ 					     ? IPV4_MAX_BITLEN
+ 					     : IPV6_MAX_BITLEN;
+ 
++		if (!BGP_PEER_SU_UNSPEC(peer))
++			bgp_md5_set(peer);
++
+ 		bgp_md5_set_connect(peer->fd, &peer->su, prefixlen,
+ 				    peer->password);
+ 	}

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -1,4 +1,3 @@
-0053-bgpd-Set-md5-TCP-socket-option-for-outgoing-connections-on-listener.patch
 0001-Reduce-severity-of-Vty-connected-from-message.patch
 0002-Allow-BGP-attr-NEXT_HOP-to-be-0.0.0.0-due-to-allevia.patch
 0003-nexthops-compare-vrf-only-if-ip-type.patch

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -1,3 +1,4 @@
+0053-bgpd-Set-md5-TCP-socket-option-for-outgoing-connections-on-listener.patch
 0001-Reduce-severity-of-Vty-connected-from-message.patch
 0002-Allow-BGP-attr-NEXT_HOP-to-be-0.0.0.0-due-to-allevia.patch
 0003-nexthops-compare-vrf-only-if-ip-type.patch
@@ -50,3 +51,4 @@
 0050-bgpd-backpressure-Avoid-use-after-free.patch
 0051-bgpd-backpressure-fix-ret-value-evpn_route_select_in.patch
 0052-bgpd-backpressure-log-error-for-evpn-when-route-inst.patch
+0053-bgpd-Set-md5-TCP-socket-option-for-outgoing-connections-on-listener.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix #19978 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Porting bug fix from https://github.com/FRRouting/frr/pull/13084

#### How to verify it
Verify BGP sessions in VRF with MD5 password works as expected.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305
- [x] 202405
#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

