### PR TITLE
[Mellanox] update buffers and align QoS to add support for DSCP remapping (for Dual-Tor on t1) for Mellanox-SN4700-O8C48

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/buffers_defaults_t0.j2
@@ -1,5 +1,5 @@
 {#
-    Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES.
+    Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES.
     Apache-2.0
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -12,10 +12,17 @@
     limitations under the License.
 #}
 {% set default_cable = '5m' %}
+{%- if ((SYSTEM_DEFAULTS is defined) and ('tunnel_qos_remap' in SYSTEM_DEFAULTS) and (SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled')) -%}
+{% set ingress_lossless_pool_size =  '45088768' %}
+{% set ingress_lossless_pool_xoff  =  '8298496' %}
+{% set egress_lossless_pool_size =  '60817392' %}
+{% set egress_lossy_pool_size =  '45088768' %}
+{%- else -%}
 {% set ingress_lossless_pool_size =  '44433408' %}
 {% set ingress_lossless_pool_xoff  =  '9576448' %}
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '44433408' %}
+{%- endif -%}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 
@@ -23,8 +30,16 @@
 {{ defs.generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) }}
 {%- endmacro %}
 
+{%- macro generate_queue_buffers_with_extra_lossless_queues_with_inactive_ports(port_names_active, port_names_extra_queues, port_names_inactive) %}
+{{ defs.generate_queue_buffers_with_extra_lossless_queues(port_names_active, port_names_extra_queues, port_names_inactive) }}
+{%- endmacro %}
+
 {%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
 {{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_pg_profiles_with_extra_lossless_pgs_with_inactive_ports(port_names_active, port_names_extra_pgs, port_names_inactive) %}
+{{ defs.generate_pg_profiles_with_extra_lossless_pgs(port_names_active, port_names_extra_pgs, port_names_inactive) }}
 {%- endmacro %}
 
 {%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/buffers_defaults_t0.j2
@@ -13,15 +13,15 @@
 #}
 {% set default_cable = '5m' %}
 {%- if ((SYSTEM_DEFAULTS is defined) and ('tunnel_qos_remap' in SYSTEM_DEFAULTS) and (SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled')) -%}
-{% set ingress_lossless_pool_size =  '45088768' %}
-{% set ingress_lossless_pool_xoff  =  '8298496' %}
+{% set ingress_lossless_pool_size =  '50397184' %}
+{% set ingress_lossless_pool_xoff  =  '2990080' %}
 {% set egress_lossless_pool_size =  '60817392' %}
-{% set egress_lossy_pool_size =  '45088768' %}
+{% set egress_lossy_pool_size =  '50397184' %}
 {%- else -%}
-{% set ingress_lossless_pool_size =  '44433408' %}
-{% set ingress_lossless_pool_xoff  =  '9576448' %}
+{% set ingress_lossless_pool_size =  '51748864' %}
+{% set ingress_lossless_pool_xoff  =  '2260992' %}
 {% set egress_lossless_pool_size =  '60817392' %}
-{% set egress_lossy_pool_size =  '44433408' %}
+{% set egress_lossy_pool_size =  '51748864' %}
 {%- endif -%}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/buffers_defaults_t1.j2
@@ -1,5 +1,5 @@
 {#
-    Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES.
+    Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES.
     Apache-2.0
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -12,10 +12,17 @@
     limitations under the License.
 #}
 {% set default_cable = '300m' %}
+{%- if ((SYSTEM_DEFAULTS is defined) and ('tunnel_qos_remap' in SYSTEM_DEFAULTS) and (SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled')) -%}
+{% set ingress_lossless_pool_size =  '39026688' %}
+{% set ingress_lossless_pool_xoff  =  '13115392' %}
+{% set egress_lossless_pool_size =  '60817392' %}
+{% set egress_lossy_pool_size =  '39026688' %}
+{%- else -%}
 {% set ingress_lossless_pool_size =  '44089344' %}
 {% set ingress_lossless_pool_xoff  =  '9920512' %}
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '44089344' %}
+{%- endif -%}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 
@@ -27,8 +34,16 @@
 {{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
+{%- macro generate_queue_buffers_with_extra_lossless_queues_with_inactive_ports(port_names_active, port_names_extra_queues, port_names_inactive) %}
+{{ defs.generate_queue_buffers_with_extra_lossless_queues(port_names_active, port_names_extra_queues, port_names_inactive) }}
+{%- endmacro %}
+
 {%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
 {{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_pg_profiles_with_extra_lossless_pgs_with_inactive_ports(port_names_active, port_names_extra_pgs, port_names_inactive) %}
+{{ defs.generate_pg_profiles_with_extra_lossless_pgs(port_names_active, port_names_extra_pgs, port_names_inactive) }}
 {%- endmacro %}
 
 {%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/buffers_defaults_t1.j2
@@ -13,15 +13,15 @@
 #}
 {% set default_cable = '300m' %}
 {%- if ((SYSTEM_DEFAULTS is defined) and ('tunnel_qos_remap' in SYSTEM_DEFAULTS) and (SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled')) -%}
-{% set ingress_lossless_pool_size =  '39026688' %}
-{% set ingress_lossless_pool_xoff  =  '13115392' %}
+{% set ingress_lossless_pool_size =  '43859968' %}
+{% set ingress_lossless_pool_xoff  =  '8282112' %}
 {% set egress_lossless_pool_size =  '60817392' %}
-{% set egress_lossy_pool_size =  '39026688' %}
+{% set egress_lossy_pool_size =  '43859968' %}
 {%- else -%}
-{% set ingress_lossless_pool_size =  '44089344' %}
-{% set ingress_lossless_pool_xoff  =  '9920512' %}
+{% set ingress_lossless_pool_size =  '47792128' %}
+{% set ingress_lossless_pool_xoff  =  '6217728 ' %}
 {% set egress_lossless_pool_size =  '60817392' %}
-{% set egress_lossy_pool_size =  '44089344' %}
+{% set egress_lossy_pool_size =  '47792128 ' %}
 {%- endif -%}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/pg_profile_lookup.ini
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/pg_profile_lookup.ini
@@ -1,1 +1,53 @@
-../Mellanox-SN4700-C128/pg_profile_lookup.ini
+##
+## Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+## Apache-2.0
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+#  PG lossless profiles.
+# speed cable  size   xon    xoff   threshold
+  10000    5m 19456  19456  16384          0
+  25000    5m 19456  19456  17408          0
+  40000    5m 19456  19456  19456          0
+  50000    5m 19456  19456  21504          0
+ 100000    5m 19456  19456  37888          0
+ 200000    5m 19456  19456  43008          0
+ 400000    5m 38912  38912  73728          0
+  10000   40m 19456  19456  16384          0
+  25000   40m 19456  19456  18432          0
+  40000   40m 19456  19456  21504          0
+  50000   40m 19456  19456  23552          0
+ 100000   40m 19456  19456  43008          0
+ 200000   40m 19456  19456  51200          0
+ 400000   40m 38912  38912  91136          0
+  10000  300m 19456  19456  19456          0
+  25000  300m 19456  19456  26624          0
+  40000  300m 19456  19456  34816          0
+  50000  300m 19456  19456  40960          0
+ 100000  300m 19456  19456  75776          0
+ 200000  300m 19456  19456  118784         0
+ 400000  300m 38912  38912  225280         0
+  10000 1500m 19456  19456  35840          0
+  25000 1500m 19456  19456  65536          0
+  40000 1500m 19456  19456  96256          0
+  50000 1500m 19456  19456  117760         0
+ 100000 1500m 19456  19456  230400         0
+ 200000 1500m 19456  19456  427008         0
+ 400000 1500m 38912  38912  427008         0
+  10000 2000m 19456  19456  41984          0
+  25000 2000m 19456  19456  80896          0
+  40000 2000m 19456  19456  121856         0
+  50000 2000m 19456  19456  149504         0
+ 100000 2000m 19456  19456  293888         0
+ 200000 2000m 19456  19456  555008         0
+ 400000 2000m 38912  38912  555008         0

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/qos.json.j2
@@ -1,1 +1,1 @@
-../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/qos.json.j2
+../../x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/qos.json.j2


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- update buffers and align QoS to add support for DSCP remapping (for Dual-Tor on t1) for Mellanox-SN4700-O8C48
- use latest pg_profile_lookup.ini file

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
run related QoS/DSCP remapping test

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

