### PR TITLE
[isc-dhcp-relay] Add patch to init io obj before creating fd watch

### DIFF
--- a/src/isc-dhcp/patch/0017-Register-IO-obj-before-create-fd-watch.patch
+++ b/src/isc-dhcp/patch/0017-Register-IO-obj-before-create-fd-watch.patch
@@ -1,0 +1,61 @@
+From 7331cc3b6d5d092079b6430dead83e5b3e6b2e10 Mon Sep 17 00:00:00 2001
+From: yaqiangz <zyq1512099831@gmail.com>
+Date: Mon, 26 Aug 2024 02:18:52 +0000
+Subject: [PATCH] Register IO obj before create fd watch
+
+---
+ omapip/dispatch.c | 31 +++++++++++++++----------------
+ 1 file changed, 15 insertions(+), 16 deletions(-)
+
+diff --git a/omapip/dispatch.c b/omapip/dispatch.c
+index ba99889..0beb393 100644
+--- a/omapip/dispatch.c
++++ b/omapip/dispatch.c
+@@ -255,6 +255,21 @@ isc_result_t omapi_register_io_object (omapi_object_t *h,
+ 		fd = writefd(h);
+ 	}
+ 
++	/* Find the last I/O state, if there are any. */
++	for (p = omapi_io_states.next;
++	     p && p -> next; p = p -> next)
++		;
++	if (p)
++		omapi_io_reference (&p -> next, obj, MDL);
++	else
++		omapi_io_reference (&omapi_io_states.next, obj, MDL);
++
++	obj -> readfd = readfd;
++	obj -> writefd = writefd;
++	obj -> reader = reader;
++	obj -> writer = writer;
++	obj -> reaper = reaper;
++
+ 	if (fd_flags != 0) {
+ 		status = isc_socket_fdwatchcreate(dhcp_gbl_ctx.socketmgr,
+ 						  fd, fd_flags,
+@@ -274,22 +289,6 @@ isc_result_t omapi_register_io_object (omapi_object_t *h,
+ 		}
+ 	}
+ 
+-
+-	/* Find the last I/O state, if there are any. */
+-	for (p = omapi_io_states.next;
+-	     p && p -> next; p = p -> next)
+-		;
+-	if (p)
+-		omapi_io_reference (&p -> next, obj, MDL);
+-	else
+-		omapi_io_reference (&omapi_io_states.next, obj, MDL);
+-
+-	obj -> readfd = readfd;
+-	obj -> writefd = writefd;
+-	obj -> reader = reader;
+-	obj -> writer = writer;
+-	obj -> reaper = reaper;
+-
+ 	omapi_io_dereference(&obj, MDL);
+ 	return ISC_R_SUCCESS;
+ }
+-- 
+2.25.1
+

--- a/src/isc-dhcp/patch/0017-Register-IO-obj-before-create-fd-watch.patch
+++ b/src/isc-dhcp/patch/0017-Register-IO-obj-before-create-fd-watch.patch
@@ -1,17 +1,66 @@
-From 7331cc3b6d5d092079b6430dead83e5b3e6b2e10 Mon Sep 17 00:00:00 2001
+From 449a90a20967a3fa33535662ecd259793ad078ae Mon Sep 17 00:00:00 2001
 From: yaqiangz <zyq1512099831@gmail.com>
 Date: Mon, 26 Aug 2024 02:18:52 +0000
 Subject: [PATCH] Register IO obj before create fd watch
 
 ---
- omapip/dispatch.c | 31 +++++++++++++++----------------
- 1 file changed, 15 insertions(+), 16 deletions(-)
+ omapip/dispatch.c | 44 +++++++++++++++++++++++++++-----------------
+ 1 file changed, 27 insertions(+), 17 deletions(-)
 
 diff --git a/omapip/dispatch.c b/omapip/dispatch.c
-index ba99889..0beb393 100644
+index ba99889..7f21c9a 100644
 --- a/omapip/dispatch.c
 +++ b/omapip/dispatch.c
-@@ -255,6 +255,21 @@ isc_result_t omapi_register_io_object (omapi_object_t *h,
+@@ -123,6 +123,7 @@ omapi_iscsock_cb(isc_task_t   *task,
+ 		 int           flags)
+ {
+ 	omapi_io_object_t *obj;
++	omapi_io_object_t *temp_obj;
+ 	isc_result_t status;
+ 
+ 	/* Get the current time... */
+@@ -140,6 +141,9 @@ omapi_iscsock_cb(isc_task_t   *task,
+ 	}
+ 
+ 	if (obj == NULL) {
++		temp_obj = (omapi_io_object_t *) cbarg;
++		log_error ("Isc socket callback of fd %d return 0 because obj is NULL",
++		           temp_obj->fd->methods->getfd(temp_obj->fd));
+ 		return(0);
+ 	}
+ #else
+@@ -157,6 +161,8 @@ omapi_iscsock_cb(isc_task_t   *task,
+ 	 * close the socket.
+ 	 */
+ 	if (obj->closed == ISC_TRUE) {
++		log_error ("Isc socket callback of fd %d return 0 because fd closed",
++		           obj->fd->methods->getfd(obj->fd));
+ 		return(0);
+ 	}
+ #endif	  
+@@ -170,8 +176,11 @@ omapi_iscsock_cb(isc_task_t   *task,
+ 		 * read and got no bytes) we don't need to try
+ 		 * again.
+ 		 */
+-		if (status == ISC_R_SHUTTINGDOWN)
++		if (status == ISC_R_SHUTTINGDOWN) {
++			log_error ("Isc socket callback of fd %d return 0 because reader shutdown",
++		               obj->fd->methods->getfd(obj->fd));
+ 			return (0);
++		}
+ 		/* Otherwise We always ask for more when reading */
+ 		return (1);
+ 	} else if ((flags == ISC_SOCKFDWATCH_WRITE) &&
+@@ -190,6 +199,8 @@ omapi_iscsock_cb(isc_task_t   *task,
+ 	 * structures etc) or no more to write, tell the socket
+ 	 * lib we don't have more to do right now.
+ 	 */
++	log_error ("Isc socket callback of fd %d return 0 because unknown issue",
++			   obj->fd->methods->getfd(obj->fd));
+ 	return (0);
+ }
+ 
+@@ -255,6 +266,21 @@ isc_result_t omapi_register_io_object (omapi_object_t *h,
  		fd = writefd(h);
  	}
  
@@ -33,7 +82,7 @@ index ba99889..0beb393 100644
  	if (fd_flags != 0) {
  		status = isc_socket_fdwatchcreate(dhcp_gbl_ctx.socketmgr,
  						  fd, fd_flags,
-@@ -274,22 +289,6 @@ isc_result_t omapi_register_io_object (omapi_object_t *h,
+@@ -274,22 +300,6 @@ isc_result_t omapi_register_io_object (omapi_object_t *h,
  		}
  	}
  

--- a/src/isc-dhcp/patch/0017-Register-IO-obj-before-create-fd-watch.patch
+++ b/src/isc-dhcp/patch/0017-Register-IO-obj-before-create-fd-watch.patch
@@ -1,4 +1,4 @@
-From 449a90a20967a3fa33535662ecd259793ad078ae Mon Sep 17 00:00:00 2001
+From debe69ebc8df454f0fa7a8c6f3a7c9622ceaf3c2 Mon Sep 17 00:00:00 2001
 From: yaqiangz <zyq1512099831@gmail.com>
 Date: Mon, 26 Aug 2024 02:18:52 +0000
 Subject: [PATCH] Register IO obj before create fd watch
@@ -8,7 +8,7 @@ Subject: [PATCH] Register IO obj before create fd watch
  1 file changed, 27 insertions(+), 17 deletions(-)
 
 diff --git a/omapip/dispatch.c b/omapip/dispatch.c
-index ba99889..7f21c9a 100644
+index 644ab43..d9b9a57 100644
 --- a/omapip/dispatch.c
 +++ b/omapip/dispatch.c
 @@ -123,6 +123,7 @@ omapi_iscsock_cb(isc_task_t   *task,
@@ -37,7 +37,7 @@ index ba99889..7f21c9a 100644
 +		           obj->fd->methods->getfd(obj->fd));
  		return(0);
  	}
- #endif	  
+ #endif
 @@ -170,8 +176,11 @@ omapi_iscsock_cb(isc_task_t   *task,
  		 * read and got no bytes) we don't need to try
  		 * again.
@@ -45,7 +45,7 @@ index ba99889..7f21c9a 100644
 -		if (status == ISC_R_SHUTTINGDOWN)
 +		if (status == ISC_R_SHUTTINGDOWN) {
 +			log_error ("Isc socket callback of fd %d return 0 because reader shutdown",
-+		               obj->fd->methods->getfd(obj->fd));
++			           obj->fd->methods->getfd(obj->fd));
  			return (0);
 +		}
  		/* Otherwise We always ask for more when reading */

--- a/src/isc-dhcp/patch/series
+++ b/src/isc-dhcp/patch/series
@@ -14,3 +14,4 @@
 0014-enable-parallel-build.patch
 0015-option-to-set-primary-address-in-interface.patch
 0016-Don-t-look-up-the-ifindex-for-fallback.patch
+0017-Register-IO-obj-before-create-fd-watch.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In the scenario dhcrelay startup with DHCP packets come, there is possibility that dhcrelay try to attach FD wather to I/O handler before I/O handler initiated, which cause dhcrelay wouldn't read any packets from FD. This PR is to fix that issue.

##### Work item tracking
- Microsoft ADO **(number only)**: 29209311

#### How I did it
1. Move initialization part to place before attach FD watcher
2. Add log when it fails to attach FD watcher

#### How to verify it
Build image and run tests

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

