### PR TITLE
Fix flaky capture service start

### DIFF
--- a/src/sonic-eventd/src/eventd.cpp
+++ b/src/sonic-eventd/src/eventd.cpp
@@ -419,7 +419,7 @@ capture_service::do_capture()
             zmq_msg_close(&msg);
         } else if (rc > 1) { // If there are events already published to XSUB when XSUB connects to XPUB, we can receive events before subscription message
             string event_source((const char*)zmq_msg_data(&msg), zmq_msg_size(&msg));
-            SWSS_LOG_INFO("Receiving event from source: %s, will read second part of event", event_source.c_str());
+            SWSS_LOG_DEBUG("Receiving event from source: %s, will read second part of event", event_source.c_str());
             zmq_msg_close(&msg);
             int more = 0;
             size_t more_size = sizeof(more);
@@ -431,7 +431,7 @@ capture_service::do_capture()
                 rc = zmq_msg_recv(&msg_part, cap_sub_sock, 0);
                 if(rc > 0) {
                     string event_data((const char*)zmq_msg_data(&msg_part),zmq_msg_size(&msg_part));
-                    SWSS_LOG_INFO("Received second part of event: %s", event_data.c_str());
+                    SWSS_LOG_DEBUG("Received second part of event: %s", event_data.c_str());
                     zmq_msg_close(&msg_part);
                     internal_event_t event;
                     if(deserialize(event_data, event) == 0) {
@@ -442,25 +442,18 @@ capture_service::do_capture()
                             m_pre_exist_id[rid] = seq;
                             m_events.push_back(event_data);
                         }
-                        rc = 1;
                     } else {
-                        SWSS_LOG_ERROR("Unable to deserialize first event");
-                        rc = -1;
+                        SWSS_LOG_DEBUG("Unable to deserialize first event");
                     }
                 } else {
-                    SWSS_LOG_ERROR("Unable to read second part of first event, rc=%d", rc);
+                    SWSS_LOG_DEBUG("Unable to read second part of first event, rc=%d", rc);
                     zmq_msg_close(&msg_part);
-                    rc = -1;
                 }
-            } else { // No second part to read
-                rc = 1;
             }
         } else {
             zmq_msg_close(&msg);
             SWSS_LOG_ERROR("Error reading from ZMQ socket, rc=%d", rc);
         }
-
-        RET_ON_ERR(rc == 1, "Failed to read subscription message when XSUB connects to XPUB");
         init_done = true;
     }
 

--- a/src/sonic-eventd/tests/eventd_ut.cpp
+++ b/src/sonic-eventd/tests/eventd_ut.cpp
@@ -150,9 +150,8 @@ static const test_data_t ldata[] = {
     },
 };
 
-
 void run_cap(void *zctx, bool &term, string &read_source,
-        int &cnt, bool &should_read_control)
+        int &cnt)
 {
     void *mock_cap = zmq_socket (zctx, ZMQ_SUB);
     string source;
@@ -165,11 +164,10 @@ void run_cap(void *zctx, bool &term, string &read_source,
     EXPECT_EQ(0, zmq_setsockopt(mock_cap, ZMQ_SUBSCRIBE, "", 0));
     EXPECT_EQ(0, zmq_setsockopt(mock_cap, ZMQ_RCVTIMEO, &block_ms, sizeof (block_ms)));
 
-    if(should_read_control) {
-        zmq_msg_t msg;
-        zmq_msg_init(&msg);
-        EXPECT_NE(1, zmq_msg_recv(&msg, mock_cap, 0)); // Subscription message should be read by do_capture
-    }
+    zmq_msg_t msg;
+    zmq_msg_init(&msg);
+    int rc = zmq_msg_recv(&msg, mock_cap, 0);
+    EXPECT_EQ(1, rc); // read control character
 
     while(!term) {
         string source;
@@ -228,7 +226,6 @@ void run_pub(void *mock_pub, const string wr_source, internal_events_lst_t &lst)
 TEST(eventd, proxy)
 {
     printf("Proxy TEST started\n");
-    bool should_read_control = false;
     bool term_sub = false;
     bool term_cap = false;
     string rd_csource, rd_source, wr_source("hello");
@@ -246,7 +243,7 @@ TEST(eventd, proxy)
     EXPECT_EQ(0, pxy->init());
 
     /* capture in a thread */
-    thread thrc(&run_cap, zctx, ref(term_cap), ref(rd_csource), ref(rd_cevts_sz), ref(should_read_control));
+    thread thrc(&run_cap, zctx, ref(term_cap), ref(rd_csource), ref(rd_cevts_sz));
 
     /* subscriber in a thread */
     thread thr(&run_sub, zctx, ref(term_sub), ref(rd_source), ref(rd_evts), ref(rd_evts_sz));
@@ -283,17 +280,9 @@ TEST(eventd, proxy)
 
     zmq_close(mock_pub);
 
-    /* Do control test */
-
-    should_read_control = true;
-
-    /* capture in a thread */
-    thread thrcc(&run_cap, zctx, ref(term_cap), ref(rd_csource), ref(rd_cevts_sz), ref(should_read_control));
-
     delete pxy;
     pxy = NULL;
 
-    thrcc.join();
     zmq_ctx_term(zctx);
 
     /* Provide time for async proxy removal to complete */


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Dropping control character (message sent when XSUB connects to XPUB as part of ZMQ Proxy setup to notify that subscription has been made) in do capture has been flaky since control character is not guaranteed to be the first message sent if there are events (like event-down-ctr) being published to XSUB.

Scenarios

1) Control character is sent and is first message when starting capture service

`eventd#eventd#eventd: :- heartbeat_ctrl: Set heartbeat_ctrl pause=1`
`eventd#eventd#eventd: :- do_capture: Received subscription message when XSUB connects to XPUB`

2) Events like event-down ctr is sent before control character

`eventd#eventd#eventd: :- run: Dropping Message: 22 serialization::archive 18 17 sonic-events-host`
`eventd#eventd#eventd: :- run: Dropping Message: 22 serialization::archive 18 0 0 4 0 0 0 1 d 103 {"sonic-events-host:event-stopped-ctr":{"ctr_name":"EVENTD","timestamp":"2024-08-27T00:02:51.407518Z"}} 1 r 36 3357542f-bae1-458f-a804-660e620d21f5 1 s 1 9 1 t 19 1724716971407591080`
`heartbeat_ctrl: Set heartbeat_ctrl pause=1`
`do_capture: Received subscription message when XSUB connects to XPUB`

3) Control character is not sent at all

`eventd#eventd#eventd: :- heartbeat_ctrl: Set heartbeat_ctrl pause=1`

4) Control character is delayed and not caught when starting capture service, but is then caught after causing deserialize error.

`do_capture: Receiving event from source: 22 serialization::archive 18 17 sonic-events-host, will read second part of event`
`deserialize: deserialize Failed: input stream errorstr[0:64]:(#001) data type: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&`
`zmq_read_part: Failed to deserialize part rc=-2`
`zmq_read_part: last:errno=11`
`zmq_message_read: Failure to read part1 rc=-2`
`zmq_message_read: last:errno=11`

We can cover these scenarios by just dropping the control character inside zmq_message_read as part of events_common in swsscommon (different PR). In this PR we will remove such handling logic and make sure that empty events that will be sent by control character are ignored.

##### Work item tracking
- Microsoft ADO **(number only)**:28728116

#### How I did it

Remove logic for handling control character

#### How to verify it

UT and sonic-mgmt test cases.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

