### PR TITLE
[202311] Pin pip to version 24.2, and update disable-non-manylinux.patch

### DIFF
--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -487,7 +487,7 @@ RUN wget -O golang-go.deb 'https://sonicstorage.blob.core.windows.net/public/fip
  && rm golang-go.deb golang-src.deb
 {%- endif %}
 
-RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade pip==24.2
 RUN apt-get purge -y python3-pip python3-yaml
 
 # For building Python packages

--- a/sonic-slave-bullseye/disable-non-manylinux.patch
+++ b/sonic-slave-bullseye/disable-non-manylinux.patch
@@ -1,10 +1,16 @@
+Disable any type of wheel besides manylinux wheels. This is to work around an issue where the architecture-specific
+wheel might be built with a newer glibc version than what is supported on the system.
+
+(This patch gets applied only on armhf.)
+
 --- a/tags.py	2022-07-12 00:07:22.710207780 +0000
 +++ b/tags.py	2022-07-12 00:07:13.185890659 +0000
-@@ -424,7 +424,6 @@
-     _, arch = linux.split("_", 1)
-     yield from _manylinux.platform_tags(linux, arch)
-     yield from _musllinux.platform_tags(arch)
--    yield linux
+@@ -498,8 +498,6 @@
+     archs = {"armv8l": ["armv8l", "armv7l"]}.get(arch, [arch])
+     yield from _manylinux.platform_tags(archs)
+     yield from _musllinux.platform_tags(archs)
+-    for arch in archs:
+-        yield f"linux_{arch}"
  
  
  def _generic_platforms() -> Iterator[str]:


### PR DESCRIPTION
Cherry-pick of #19510

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Pip has been recently updated to 24.2. For armhf, there is a patch file that gets applied to disable the use of manylinux wheels, to avoid the use of packages that might be using a newer glibc version than what is available on the system. This patch file was designed for 24.0, but can't be applied to 24.2.

##### Work item tracking
- Microsoft ADO **(number only)**: 28835746

#### How I did it

Update the patch file to apply on 24.2, and make sure version 24.2 of pip gets installed.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

