### PR TITLE
Adds blkinfo for use by stormond to instantiate UsbUtil object

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -54,6 +54,10 @@ RUN pip3 install libpci
 # Install psutil for process and system monitoring operations
 RUN pip3 install psutil
 
+# Install blkinfo for block device information gathering operations
+RUN pip3 install blkinfo
+
+
 {% if docker_platform_monitor_debs.strip() -%}
 # Copy locally-built Debian package dependencies
 {{ copy_files("debs/", docker_platform_monitor_debs.split(' '), "/debs/") }}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This module is required in the pmon container for Storage Monitoring Daemon (stormond) to instantiate objects of type (UsbUtil)[https://github.com/sonic-net/sonic-platform-common/pull/493].

##### Work item tracking
- Microsoft ADO **(number only)**: 29203991

#### How I did it
Added config to pmon Dockerfile.j2 to install blkinfo

#### How to verify it
On an image containing this change, verify following output:

```
root@str2-7050qx-32s-acs-03:/# pip3 list | grep -i blkinfo
blkinfo                       0.2.0

```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] <!-- image version 1 -->SONiC.20240531.beta.09
- [ ] <!-- image version 2 -->

#### Description for the changelog
Added blkinfo module to PMON container

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

