### PR TITLE
Add CHASIS_COUNTERS_DB for aggregated stats in a chassis based system

### DIFF
--- a/dockers/docker-database/database_config.json.j2
+++ b/dockers/docker-database/database_config.json.j2
@@ -105,6 +105,11 @@
             "id" : 14,
             "separator": ":",
             "instance" : "redis"
+        },
+        "CHASSIS_COUNTERS_DB" : {
+            "id" : 21,
+            "separator": ":",
+            "instance" : "redis_chassis"
         }
 {% if DATABASE_TYPE is defined and DATABASE_TYPE == "dpudb" %}
         ,

--- a/files/scripts/update_chassisdb_config
+++ b/files/scripts/update_chassisdb_config
@@ -7,7 +7,7 @@ import syslog
 
 database_config_file = "/var/run/redis/sonic-db/database_config.json"
 redis_chassis = 'redis_chassis'
-chassis_db_list = ['CHASSIS_APP_DB', 'CHASSIS_STATE_DB']
+chassis_db_list = ['CHASSIS_APP_DB', 'CHASSIS_STATE_DB', "CHASSIS_COUNTERS_DB"]
 
 
 def main():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### What I did
Added a new CHASSIS_COUNTERS_DB in redis_chassis instance of SSI for chassis based systems.

Tracked by [#1543](https://github.com/sonic-net/SONiC/issues/1543)

HLD: [#1587](https://github.com/sonic-net/SONiC/pull/1587)
