### PR TITLE
[Mellanox] SN4280 Platform pcie changes

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn4280-r0/pcie.yaml
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/pcie.yaml
@@ -52,6 +52,18 @@
   name: 'PCI bridge: Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh)
     PCIe GPP Bridge'
 - bus: '00'
+  dev: '01'
+  fn: '5'
+  id: '1453'
+  name: 'PCI bridge: Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh)
+    PCIe GPP Bridge'
+- bus: '00'
+  dev: '01'
+  fn: '6'
+  id: '1453'
+  name: 'PCI bridge: Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh)
+    PCIe GPP Bridge'
+- bus: '00'
   dev: '02'
   fn: '0'
   id: '1452'
@@ -217,73 +229,55 @@
   id: '1467'
   name: 'Host bridge: Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh)
     Data Fabric: Device 18h; Function 7'
-- bus: '01'
-  dev: '00'
-  fn: '0'
-  id: c2d5
-  name: 'DMA controller: Mellanox Technologies MT43244 BlueField-3 SoC Management
-    Interface (rev 01)'
-- bus: '02'
-  dev: '00'
-  fn: '0'
-  id: c2d5
-  name: 'DMA controller: Mellanox Technologies MT43244 BlueField-3 SoC Management
-    Interface (rev 01)'
 - bus: '03'
   dev: '00'
   fn: '0'
   id: '5765'
-  name: 'Non-Volatile memory controller: Device 1f9f:5765 (rev 01)'
-- bus: '04'
+  name: 'Non-Volatile memory controller: Realtek Semiconductor Co., Ltd. RTS5765DL
+    NVMe SSD Controller (DRAM-less) (rev 01)'
+- bus: '06'
   dev: '00'
   fn: '0'
   id: cf70
   name: 'Ethernet controller: Mellanox Technologies Spectrum-3'
-- bus: '05'
-  dev: '00'
-  fn: '0'
-  id: c2d5
-  name: 'DMA controller: Mellanox Technologies MT43244 BlueField-3 SoC Management
-    Interface (rev 01)'
-- bus: '06'
-  dev: '00'
-  fn: '0'
-  id: c2d5
-  name: 'DMA controller: Mellanox Technologies MT43244 BlueField-3 SoC Management
-    Interface (rev 01)'
-- bus: '07'
+- bus: 09
   dev: '00'
   fn: '0'
   id: 145a
   name: 'Non-Essential Instrumentation [1300]: Advanced Micro Devices, Inc. [AMD]
     Zeppelin/Raven/Raven2 PCIe Dummy Function'
-- bus: '07'
+- bus: 09
   dev: '00'
   fn: '2'
   id: '1456'
   name: 'Encryption controller: Advanced Micro Devices, Inc. [AMD] Family 17h (Models
     00h-0fh) Platform Security Processor (PSP) 3.0 Device'
-- bus: '07'
+- bus: 09
   dev: '00'
   fn: '3'
   id: 145f
   name: 'USB controller: Advanced Micro Devices, Inc. [AMD] Zeppelin USB 3.0 xHCI
     Compliant Host Controller'
-- bus: 08
+- bus: 0a
   dev: '00'
   fn: '0'
   id: '1455'
   name: 'Non-Essential Instrumentation [1300]: Advanced Micro Devices, Inc. [AMD]
     Zeppelin/Renoir PCIe Dummy Function'
-- bus: 08
+- bus: 0a
   dev: '00'
   fn: '1'
   id: '1468'
   name: 'Encryption controller: Advanced Micro Devices, Inc. [AMD] Zeppelin Cryptographic
     Coprocessor NTBCCP'
-- bus: 08
+- bus: 0a
   dev: '00'
   fn: '4'
+  id: '1458'
+  name: 'Ethernet controller: Advanced Micro Devices, Inc. [AMD] XGMAC 10GbE Controller'
+- bus: 0a
+  dev: '00'
+  fn: '5'
   id: '1458'
   name: 'Ethernet controller: Advanced Micro Devices, Inc. [AMD] XGMAC 10GbE Controller'
 - bus: '40'

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/sensors.conf
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/sensors.conf
@@ -561,5 +561,5 @@ chip "nvme-pci-*"
     ignore temp2
     ignore temp3
 
-chip "00000400400-mdio-*"
+chip "00000a00400-mdio-*"
    label temp1 "PHY TEMP"

--- a/platform/mellanox/rshim/files/rshim.sh
+++ b/platform/mellanox/rshim/files/rshim.sh
@@ -24,8 +24,8 @@ fi
 dpu_id=$1
 
 declare -A dpu2pcie
-dpu2pcie[0]="06:00.0"
-dpu2pcie[1]="05:00.0"
+dpu2pcie[0]="08:00.0"
+dpu2pcie[1]="07:00.0"
 dpu2pcie[2]="01:00.0"
 dpu2pcie[3]="02:00.0"
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The pcie ids of some specific devices is updated for the SN4280 device. Due to this there are some changes to be updated in the platform specific code for mellanox
`sensors.conf` - This change is due to pci id change for a sensor
`rshim..sh` - This change is due to the pci id changes for the dpus, which have to be aligned to the platform
`pcie.yaml` - This change is due to pci id change for the devices
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

