### PR TITLE
[Mellanox][202405] Remove DPU from SN4280 platform.json file

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn4280-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/platform.json
@@ -646,19 +646,5 @@
                 "1x400G": ["etp32"]
             }
         }
-    },
-    "DPUS": {
-        "dpu0": {
-            "midplane_interface":  "dpu0"
-        },
-        "dpu1": {
-            "midplane_interface":  "dpu1"
-        },
-        "dpu2": {
-            "midplane_interface":  "dpu2"
-        },
-        "dpu3": {
-            "midplane_interface":  "dpu3"
-        }
     }
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The presence of the DPUs definition in the `platform.json` file enables Smart Switch flows in SONiC, including the start of the per-DPU database, midplane bridge creation, etc. Since in 202405 release SONiC has run the DPUs in the "dark mode," and the DPUS are always in the power-down state, this is unnecessary. To disable the Smart Switch flows the DPUs definition should be excluded from the `platform.json`.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Exclude the DPUs definition from `platform.json` file.

#### How to verify it
Compile and run the. Verify that the per-DPU database containers are not started. Verify that the midplane bridge is not created.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

