### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202305.1.0.15
+ref=202305.1.0.17


### PR DESCRIPTION
Release notes for Cisco 8111-32EH-O, 8102-64H-O and 8101-32FH:
• [8111] IOFPGA version upgrade to 1.8 for fixing transceiver EEPROM access issue
• Platform workaround for PSU Status "Not Ok"​

Update platform version to 202305.1.0.17
• Skipping 202305.1.0.16 due to it missing a key fix.