### PR TITLE
[SNMP] Fix config template issue when setting snmpagentaddress

### DIFF
--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -26,7 +26,7 @@
 
 {% if SNMP_AGENT_ADDRESS_CONFIG %}
 {% for (agentip, port, vrf) in SNMP_AGENT_ADDRESS_CONFIG %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if port %}:{{ port }}{% endif %}{% if vrf %}%{{ vrf }}{% endif %}{{ "" }}
+agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if vrf %}@{{ vrf }}{% endif %}{% if port %}:{{ port }}{% endif %}{{ "" }}
 {% endfor %}
 {% else %}
 agentAddress udp:161


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Related to [PR#16187](https://github.com/sonic-net/sonic-buildimage/issues/16187)

#### Why I did it

When you configure an SNMP agent address with a VRF, the snmpd service will fail to properly start after the configuration has been applied. The snmpd service shows a status of "FATAL."

```
sudo config snmpagentaddress add 1.1.1.1 -p 161 -v mgmt

docker exec -it snmp supervisorctl status | awk '{print $1, $2}'
dependent-startup RUNNING
rsyslogd RUNNING
snmp-subagent STOPPED
snmpd FATAL
start EXITED
supervisor-proc-exit-listener RUNNING
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Corrected syntax in the jinja template used to generate the snmpd.conf within the SNMP docker container.

#### How to verify it
```
sudo config snmpagentaddress add 1.1.1.1 -p 161 -v mgmt

docker exec -it snmp supervisorctl status | awk '{print $1, $2}'
dependent-startup EXITED
rsyslogd RUNNING
snmp-subagent RUNNING
snmpd RUNNING
start EXITED
supervisor-proc-exit-listener RUNNING
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] SONiC.master.634739-2ff111cb9
- [x] SONiC.202405.565256-4d6d808b8
- [x] SONiC-OS-202311.634628-3cc3e1a11

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->


#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

