### PR TITLE
[NTP] Install ntpsec to fsroot. Align ntp-config.sh to ntpsec path

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -416,7 +416,7 @@ sudo cp -f $IMAGE_CONFIGS/cron.d/* $FILESYSTEM_ROOT/etc/cron.d/
 
 # Copy NTP configuration files and templates
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT \
-    apt-get -y install ntpdate
+    apt-get -y install ntpsec ntpdate
 sudo rm -f $FILESYSTEM_ROOT/etc/network/if-up.d/ntpsec-ntpdate
 sudo cp $IMAGE_CONFIGS/ntp/ntp-config.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
 echo "ntp-config.service" | sudo tee -a $GENERATED_SERVICE_FILE

--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -2,6 +2,8 @@
 
 ntp_default_file='/etc/default/ntpsec'
 ntp_temp_file='/tmp/ntp.orig'
+etc_ntpsec_dir='/etc/ntpsec'
+var_log_ntpsec_dir='/var/log/ntpsec'
 
 reboot_type='cold'
 
@@ -23,9 +25,12 @@ function modify_ntp_default
     sed -e "$1" ${ntp_temp_file} >${ntp_default_file}
 }
 
-sonic-cfggen -d -t /usr/share/sonic/templates/ntp.conf.j2 >/etc/ntpsec/ntp.conf
-sonic-cfggen -d -t /usr/share/sonic/templates/ntp.keys.j2 >/etc/ntpsec/ntp.keys
-chmod o-r /etc/ntp.keys
+mkdir -p ${var_log_ntpsec_dir}
+chmod a+rw ${var_log_ntpsec_dir}
+
+sonic-cfggen -d -t /usr/share/sonic/templates/ntp.conf.j2 > ${etc_ntpsec_dir}/ntp.conf
+sonic-cfggen -d -t /usr/share/sonic/templates/ntp.keys.j2 > ${etc_ntpsec_dir}/ntp.keys
+chmod o-r ${etc_ntpsec_dir}/ntp.keys
 
 get_database_reboot_type
 echo "Disabling NTP long jump for reboot type ${reboot_type} ..."


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
NTP service was broken because of PR - [Migrate from ntp to ntpsec](https://github.com/sonic-net/sonic-buildimage/commit/34a1ac1a0fcd8383ca7c9d43b2c825389aec0735)

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Install the `ntpsec` into SONiC fsroot.
Align the `ntp-config.sh` path to `ntpsec` instead of regular `ntp`.

#### How to verify it
- Execute the `systemctl status ntp`

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

