### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202305.1.0.17
+ref=202305.1.0.18


### PR DESCRIPTION
Release notes for Cisco 8111-32EH-O, 8102-64H-O and 8101-32FH:

* Fix for Orchagent crash due to ECC Corr error – threshold removal
* Fix for Orchagent crash due to BFD session timeout

Update platform version to 202305.1.0.18



