### PR TITLE
[ntp] Add interface existence check for eth0 in ntp configuration

### DIFF
--- a/files/image_config/ntp/ntp.conf.j2
+++ b/files/image_config/ntp/ntp.conf.j2
@@ -102,7 +102,7 @@ interface ignore wildcard
     {%- set ns.source_intf = global.src_intf %}
     {%- if ns.source_intf != "" %}
         {%- if ns.source_intf == "eth0" %}
-            {%- set ns.source_intf_ip = 'true' %}
+            {%- set ns.source_intf_ip = check_ip_on_interface(ns.source_intf, MGMT_INTERFACE) %}
         {%- elif ns.source_intf.startswith('Vlan') %}
             {%- set ns.source_intf_ip = check_ip_on_interface(ns.source_intf, VLAN_INTERFACE) %}
         {%- elif ns.source_intf.startswith('Ethernet') %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
NTP configuration wouldn't check existence of configured interface in config_db if it is `eth0`. This PR is to add this check

##### Work item tracking
- Microsoft ADO **(number only)**: 29385974

#### How I did it
Add interface existence check in config_db for ntp configuration

#### How to verify it
Generate NTP configuration and run ntp test in sonic-mgmt with new template
```
generic_config_updater/test_ntp.py::test_ntp_server_tc1_suite PASSED                                                                                                                                    [100%]
```
```
ntp/test_ntp.py::test_ntp_long_jump_enabled[False] PASSED                                                                                                                                               [ 16%]
ntp/test_ntp.py::test_ntp_long_jump_disabled[False] XFAIL (Known NTP bug)                                                                                                                               [ 33%]
ntp/test_ntp.py::test_ntp[False] PASSED                                                                                                                                                                 [ 50%]
ntp/test_ntp.py::test_ntp_long_jump_enabled[True] PASSED                                                                                                                                                [ 66%]
ntp/test_ntp.py::test_ntp_long_jump_disabled[True] XFAIL (Known NTP bug)                                                                                                                                [ 83%]
ntp/test_ntp.py::test_ntp[True] PASSED                                                                                                                                                                  [100%]
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

