### PR TITLE
[202305] Fixed the failure to establish bfd session for ipv6 neighbors on sub-interface within vrf

### DIFF
--- a/src/sonic-frr/patch/0038-bfdd-Fix-malformed-session-with-vrf.patch
+++ b/src/sonic-frr/patch/0038-bfdd-Fix-malformed-session-with-vrf.patch
@@ -1,0 +1,48 @@
+From b17c179664da7331a4669a1cf548e4e9c48a5477 Mon Sep 17 00:00:00 2001
+From: anlan_cs <vic.lan@pica8.com>
+Date: Wed, 10 May 2023 22:04:33 +0800
+Subject: [PATCH 06972/10000] bfdd: Fix malformed session with vrf
+
+With this configuration:
+
+```
+bfd
+ peer 33:33::66 local-address 33:33::88 vrf vrf8 interface enp1s0
+ exit
+ !
+exit
+```
+
+The bfd session can't be established with error:
+
+```
+bfdd[18663]: [YA0Q5-C0BPV] control-packet: wrong vrfid. [mhop:no peer:33:33::66 local:33:33::88 port:2 vrf:61]
+```
+
+The vrf check should use the carefully adjusted `vrfid`, which is
+based on globally/reliable interface.  We can't believe the
+`bvrf->vrf->vrf_id` because the `/proc/sys/net/ipv4/udp_l3mdev_accept`
+maybe is set "1" in VRF-lite backend even with security drawback.
+
+Just correct the vrf check.
+
+Signed-off-by: anlan_cs <vic.lan@pica8.com>
+---
+ bfdd/bfd_packet.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bfdd/bfd_packet.c b/bfdd/bfd_packet.c
+index 311ce4d37..ea7a1038a 100644
+--- a/bfdd/bfd_packet.c
++++ b/bfdd/bfd_packet.c
+@@ -878,7 +878,7 @@ void bfd_recv_cb(struct event *t)
+ 	/*
+ 	 * We may have a situation where received packet is on wrong vrf
+ 	 */
+-	if (bfd && bfd->vrf && bfd->vrf != bvrf->vrf) {
++	if (bfd && bfd->vrf && bfd->vrf->vrf_id != vrfid) {
+ 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
+ 			 "wrong vrfid.");
+ 		return;
+-- 
+2.38.1

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -34,3 +34,4 @@ cross-compile-changes.patch
 0035-fpm-ignore-route-from-default-table.patch
 0036-Add-support-of-bgp-l3vni-evpn.patch
 0037-bgp-community-memory-leak-fix.patch
+0038-bfdd-Fix-malformed-session-with-vrf.patch


### PR DESCRIPTION
#### Why I did it

Fix [#20206](https://github.com/sonic-net/sonic-buildimage/issues/20206)

#### How I did it

The version of frr in the 202305 branch is 8.5.1, and the issue has been fixed in official later release. 
Porting bug fix from [FRRouting/frr#13506](https://github.com/FRRouting/frr/pull/13506)

#### How to verify it

Verify bfd session for the ipv6 neighbor on the sub-interface in the vrf works as expected.

We can verify this by following the steps below:
1.  Assign ipv6 addresses to both the main interface and sub-interface, ensuring the sub-interface is bound to a vrf.
2.  Configure bgp neighbors for both interfaces.
3.  Set up bfd sessions for the neighbors on both interfaces.
4.  Check bfd session status via vtysh.

Based on the following information, we can confirm that the bfd session for the ipv6 neighbor on the sub-interface in the vrf is established successfully.

[Configs]:  
Switch 1:

The configuration information is as follows.
```
router bgp 65100
 bgp router-id 10.1.0.115
 bgp log-neighbor-changes
 no bgp ebgp-requires-policy
 no bgp default ipv4-unicast
 bgp bestpath as-path multipath-relax
 no bgp network import-check
 neighbor PEER_V4 peer-group
 neighbor PEER_V6 peer-group
 neighbor 2444::10:108:115:1 remote-as 65102
 neighbor 2444::10:108:115:1 peer-group PEER_V6
 neighbor 2444::10:108:115:1 description 115-108
 neighbor 2444::10:108:115:1 bfd
 neighbor 2444::10:108:115:1 timers connect 10
 !
 address-family ipv6 unicast
  network 2409:100:100::2/128
  neighbor PEER_V6 soft-reconfiguration inbound
  neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
  neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
  neighbor 2444::10:108:115:1 activate
  maximum-paths 64
 exit-address-family
exit
!

router bgp 65100 vrf VrfDummy
 bgp router-id 10.1.0.115
 bgp log-neighbor-changes
 no bgp ebgp-requires-policy
 no bgp default ipv4-unicast
 bgp bestpath as-path multipath-relax
 no bgp network import-check
 neighbor PEER_V4 peer-group
 neighbor PEER_V6 peer-group
 neighbor 2444::10:108:115:9 remote-as 65102
 neighbor 2444::10:108:115:9 peer-group PEER_V6
 neighbor 2444::10:108:115:9 description 115-108
 neighbor 2444::10:108:115:9 bfd
 neighbor 2444::10:108:115:9 timers connect 10
 !
 address-family ipv6 unicast
  neighbor PEER_V6 soft-reconfiguration inbound
  neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
  neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
  neighbor 2444::10:108:115:9 activate
 exit-address-family
exit

```


[Result]:

Switch 1:

The bgp information and bfd information are as follows.
```
sonic# show bgp vrf all ipv6 summary

IPv6 Unicast Summary (VRF default):
BGP router identifier 10.1.0.115, local AS number 65100 vrf-id 0
BGP table version 39
RIB entries 3, using 576 bytes of memory
Peers 1, using 1449 KiB of memory
Peer groups 2, using 128 bytes of memory

Neighbor           V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
2444::10:108:115:1 4      65102      7076      5870        0    0    0 2d22h22m            1        2 115-108

Total number of neighbors 1

IPv6 Unicast Summary (VRF VrfDummy):
BGP router identifier 10.1.0.115, local AS number 65100 vrf-id 46
BGP table version 113
RIB entries 6, using 1152 bytes of memory
Peers 1, using 1449 KiB of memory
Peer groups 2, using 128 bytes of memory

Neighbor           V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
2444::10:108:115:9 4      65102      6997      5895        0    0    0 2d22h22m            4        4 115-108

Total number of neighbors 1


sonic# show bfd peer
BFD Peers:
        peer 2444::10:108:115:9 local-address 2444::10:108:115:a vrf VrfDummy interface Po0101.10
                ID: 3973009496
                Remote ID: 1251
                Active mode
                Status: ok
                Uptime: 18 hour(s), 12 minute(s), 59 second(s)
                Diagnostics: ok
                Remote diagnostics: ok
                Peer Type: dynamic
                RTT min/avg/max: 0/0/0 usec
                Local timers:
                        Detect-multiplier: 3
                        Receive interval: 300ms
                        Transmission interval: 300ms
                        Echo receive interval: 50ms
                        Echo transmission interval: disabled
                Remote timers:
                        Detect-multiplier: 3
                        Receive interval: 300ms
                        Transmission interval: 300ms
                        Echo receive interval: disabled

        peer 2444::10:108:115:1 local-address 2444::10:108:115:2 vrf default interface PortChannel0101
                ID: 800531739
                Remote ID: 1244
                Active mode
                Status: up
                Uptime: 2 day(s), 22 hour(s), 33 minute(s), 57 second(s)
                Diagnostics: ok
                Remote diagnostics: ok
                Peer Type: dynamic
                RTT min/avg/max: 0/0/0 usec
                Local timers:
                        Detect-multiplier: 3
                        Receive interval: 300ms
                        Transmission interval: 300ms
                        Echo receive interval: 50ms
                        Echo transmission interval: disabled
                Remote timers:
                        Detect-multiplier: 3
                        Receive interval: 300ms
                        Transmission interval: 300ms
                        Echo receive interval: disabled


```


#### Which release branch to backport (provide reason below if selected)

- [ ]  201811
- [ ]  201911
- [ ]  202006
- [ ]  202012
- [ ]  202106
- [ ]  202111
- [ ]  202205
- [ ] 202211
- [x]  202305
- [ ]  202405

