### PR TITLE
[ntp] Add support for ntp to listen ipv4/ipv6 address depends on server config

### DIFF
--- a/files/image_config/ntp/ntp.conf.j2
+++ b/files/image_config/ntp/ntp.conf.j2
@@ -18,6 +18,7 @@ leapfile /usr/share/zoneinfo/leap-seconds.list
 {# Adding NTP servers. We need to know if we have some pools, to set proper
 config -#}
 {% set ns = namespace(is_pools=false) %}
+{% set ip_ver_ns = namespace(ipv4_server=false, ipv6_server=false) %}
 {% for server in NTP_SERVER if NTP_SERVER[server].admin_state != 'disabled' -%}
     {% set config = NTP_SERVER[server] -%}
     {# Server options -#}
@@ -55,6 +56,13 @@ config -#}
 {% if global.server_role == 'disabled' %}
 restrict {{ resolve_as }} kod limited nomodify noquery
 {% endif %}
+
+{% if resolve_as | ipv4 -%}
+    {% set ip_ver_ns.ipv4_server = true %}
+{% elif resolve_as | ipv6 %}
+    {% set ip_ver_ns.ipv6_server = true %}
+{% endif -%}
+
 
 {% endfor -%}
 
@@ -125,8 +133,10 @@ interface listen {{ mgmt_prefix | ip }}
 {% endfor %}
 {% elif LOOPBACK_INTERFACE %}
 {% for (name, prefix) in LOOPBACK_INTERFACE|pfx_filter %}
-{% if prefix | ipv4 and name == 'Loopback0' %}
+{% if name == 'Loopback0' %}
+{% if prefix | ipv4 and ip_ver_ns.ipv4_server or prefix | ipv6 and ip_ver_ns.ipv6_server %}
 interface listen {{ prefix | ip }}
+{% endif %}
 {% endif %}
 {% endfor %}
 {% else %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Switch cannot connect to NTP server with Loopback ipv6 in Loopback ipv6 only scenario.

##### Work item tracking
- Microsoft ADO **(number only)**: 29415265

#### How I did it
Add support for ntp to listen ipv4/ipv6 address depends on server config

#### How to verify it
Run ntp test with new template
```
generic_config_updater/test_ntp.py::test_ntp_server_tc1_suite PASSED                                                                                                                                                                                                                                                          [100%]
```
```
ntp/test_ntp.py::test_ntp_long_jump_enabled[False] PASSED                                                                                                                                                                                                                                                                     [ 16%]
ntp/test_ntp.py::test_ntp_long_jump_disabled[False] PASSED                                                                                                                                                                                                                                                                    [ 33%]
ntp/test_ntp.py::test_ntp[False] PASSED                                                                                                                                                                                                                                                                                       [ 50%]
ntp/test_ntp.py::test_ntp_long_jump_enabled[True] PASSED                                                                                                                                                                                                                                                                      [ 66%]
ntp/test_ntp.py::test_ntp_long_jump_disabled[True] PASSED                                                                                                                                                                                                                                                                     [ 83%]
ntp/test_ntp.py::test_ntp[True] PASSED                                                                                                                                                                                                                                                                                        [100%]
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

