### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202311.1.0.4
+ref=202311.1.0.5


### PR DESCRIPTION
Release notes for Cisco 8102-64H-O, 8101-32FH, and 8111-32EH-O
 
Fix Orchagent crash due to ECC Corr error - threshold check removal
Fix Orchagent crash due to BFD session timeout
Platform workaround for PSU Status "Not Ok"​
[8111] IOFPGA version upgrade to 1.8 for fixing transceiver EEPROM access issue
[8111] Fix for ECN L3 Counter not incrementing issue
[8111] Fix for i2c mux is not detected on BT0s

How I did it:
Update platform version to 202311.1.0.5
