### PR TITLE
Revert "[Marvell] Update SAI debian version to 1.13.3-2"

### DIFF
--- a/platform/marvell-armhf/sai.mk
+++ b/platform/marvell-armhf/sai.mk
@@ -1,6 +1,6 @@
 # Marvell SAI
 
-export MRVL_SAI_VERSION = 1.13.3-2
+export MRVL_SAI_VERSION = 1.13.3-1
 export MRVL_SAI = mrvllibsai_$(MRVL_SAI_VERSION)_$(PLATFORM_ARCH).deb
 
 $(MRVL_SAI)_SRC_PATH = $(PLATFORM_PATH)/sai


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#19966 due to sonic-net/sonic-buildimage#20255