### PR TITLE
Fix Arista-7060X6-64DE-64x400G hwsku config.bcm file

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-64x400G/th5-a7060x6-64de.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-64x400G/th5-a7060x6-64de.config.bcm
@@ -1,1 +1,1160 @@
-../Arista-7060X6-64DE/th5-a7060x6-64de.config.bcm
+#
+# $Copyright: (c) 2022 Broadcom.
+# Broadcom Proprietary and Confidential. All rights reserved.$
+#
+# BCM78900 64x800g port configuration.
+#
+# configuration yaml file
+#   device:
+#       <unit>:
+#           <table>:
+#               ?
+#                   <key_fld_1>: <value>
+#                   <key_fld_2>: <value>
+#                   ...
+#                   <key_fld_n>: <value>
+#               :
+#                   <data_fld_1>: <value>
+#                   <data_fld_2>: <value>
+#                   ...
+#                   <data_fld_n>: <value>
+#
+
+---
+bcm_device:
+    0:
+        global:
+            pktio_mode: 1
+            default_cpu_tx_queue: 7
+            vlan_flooding_l2mc_num_reserved: 0
+            ipv6_lpm_128b_enable: 1
+            shared_block_mask_section: uc_bc
+            skip_protocol_default_entries: 1
+            # LTSW uses value 1 for ALPM combined mode
+            l3_alpm_template: 1
+            l3_alpm_hit_skip: 1
+            sai_feat_tail_timestamp : 1
+            sai_port_phy_time_sync_en : 1
+            sai_field_group_auto_prioritize: 1
+            #l3_intf_vlan_split_egress for MTU at L3IF
+            l3_intf_vlan_split_egress : 1
+            pfc_deadlock_seq_control : 1
+            sai_tunnel_support: 2
+            bcm_tunnel_term_compatible_mode: 1
+            l3_ecmp_member_first_lkup_mem_size: 12288
+---
+device:
+    0:
+        PC_PM_CORE:
+            ?
+                PC_PM_ID: 3
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x15047362
+                TX_LANE_MAP: 0x4152637
+                RX_POLARITY_FLIP: 0xc3
+                TX_POLARITY_FLIP: 0xcc
+            ?
+                PC_PM_ID: 1
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x17063524
+                TX_LANE_MAP: 0x60714253
+                RX_POLARITY_FLIP: 0x97
+                TX_POLARITY_FLIP: 0xcc
+            ?
+                PC_PM_ID: 2
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x6172435
+                TX_LANE_MAP: 0x71605342
+                RX_POLARITY_FLIP: 0x33
+                TX_POLARITY_FLIP: 0x69
+            ?
+                PC_PM_ID: 4
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x40516273
+                TX_LANE_MAP: 0x51403726
+                RX_POLARITY_FLIP: 0x33
+                TX_POLARITY_FLIP: 0xc3
+            ?
+                PC_PM_ID: 8
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x71630524
+                TX_LANE_MAP: 0x4371625
+                RX_POLARITY_FLIP: 0x47
+                TX_POLARITY_FLIP: 0xc9
+            ?
+                PC_PM_ID: 6
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x70625143
+                TX_LANE_MAP: 0x60534172
+                RX_POLARITY_FLIP: 0x1e
+                TX_POLARITY_FLIP: 0x2c
+            ?
+                PC_PM_ID: 5
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x17063524
+                TX_LANE_MAP: 0x60715243
+                RX_POLARITY_FLIP: 0x38
+                TX_POLARITY_FLIP: 0x4e
+            ?
+                PC_PM_ID: 7
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x36172405
+                TX_LANE_MAP: 0x73402516
+                RX_POLARITY_FLIP: 0xd2
+                TX_POLARITY_FLIP: 0xc9
+            ?
+                PC_PM_ID: 12
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x71630524
+                TX_LANE_MAP: 0x4371625
+                RX_POLARITY_FLIP: 0x47
+                TX_POLARITY_FLIP: 0xc9
+            ?
+                PC_PM_ID: 10
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x70625143
+                TX_LANE_MAP: 0x60534172
+                RX_POLARITY_FLIP: 0x1e
+                TX_POLARITY_FLIP: 0x6c
+            ?
+                PC_PM_ID: 9
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x62704351
+                TX_LANE_MAP: 0x53607241
+                RX_POLARITY_FLIP: 0xb4
+                TX_POLARITY_FLIP: 0x6c
+            ?
+                PC_PM_ID: 11
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x36172405
+                TX_LANE_MAP: 0x73402516
+                RX_POLARITY_FLIP: 0xd2
+                TX_POLARITY_FLIP: 0xc9
+            ?
+                PC_PM_ID: 16
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x71630524
+                TX_LANE_MAP: 0x4371625
+                RX_POLARITY_FLIP: 0x47
+                TX_POLARITY_FLIP: 0xc9
+            ?
+                PC_PM_ID: 14
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x70625143
+                TX_LANE_MAP: 0x60534172
+                RX_POLARITY_FLIP: 0x1e
+                TX_POLARITY_FLIP: 0x6c
+            ?
+                PC_PM_ID: 13
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x62704351
+                TX_LANE_MAP: 0x53607241
+                RX_POLARITY_FLIP: 0xb4
+                TX_POLARITY_FLIP: 0x6c
+            ?
+                PC_PM_ID: 15
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x36172405
+                TX_LANE_MAP: 0x73402516
+                RX_POLARITY_FLIP: 0xd2
+                TX_POLARITY_FLIP: 0xc9
+            ?
+                PC_PM_ID: 20
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x15347062
+                TX_LANE_MAP: 0x60734152
+                RX_POLARITY_FLIP: 0x3f
+                TX_POLARITY_FLIP: 0x76
+            ?
+                PC_PM_ID: 18
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x17360524
+                TX_LANE_MAP: 0x16270435
+                RX_POLARITY_FLIP: 0x7b
+                TX_POLARITY_FLIP: 0x9b
+            ?
+                PC_PM_ID: 17
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x36172405
+                TX_LANE_MAP: 0x27163504
+                RX_POLARITY_FLIP: 0x21
+                TX_POLARITY_FLIP: 0x91
+            ?
+                PC_PM_ID: 19
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x43516270
+                TX_LANE_MAP: 0x37065241
+                RX_POLARITY_FLIP: 0x30
+                TX_POLARITY_FLIP: 0x16
+            ?
+                PC_PM_ID: 24
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x15347062
+                TX_LANE_MAP: 0x60734152
+                RX_POLARITY_FLIP: 0x3f
+                TX_POLARITY_FLIP: 0x76
+            ?
+                PC_PM_ID: 22
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x17360524
+                TX_LANE_MAP: 0x16270435
+                RX_POLARITY_FLIP: 0x7b
+                TX_POLARITY_FLIP: 0x9b
+            ?
+                PC_PM_ID: 21
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x36172405
+                TX_LANE_MAP: 0x27163504
+                RX_POLARITY_FLIP: 0x21
+                TX_POLARITY_FLIP: 0x91
+            ?
+                PC_PM_ID: 23
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x43516270
+                TX_LANE_MAP: 0x37065241
+                RX_POLARITY_FLIP: 0x30
+                TX_POLARITY_FLIP: 0x16
+            ?
+                PC_PM_ID: 28
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x43612705
+                TX_LANE_MAP: 0x63507241
+                RX_POLARITY_FLIP: 0xfc
+                TX_POLARITY_FLIP: 0x8e
+            ?
+                PC_PM_ID: 26
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x17360524
+                TX_LANE_MAP: 0x16270435
+                RX_POLARITY_FLIP: 0x7b
+                TX_POLARITY_FLIP: 0x9b
+            ?
+                PC_PM_ID: 25
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x36172405
+                TX_LANE_MAP: 0x27163504
+                RX_POLARITY_FLIP: 0x21
+                TX_POLARITY_FLIP: 0x91
+            ?
+                PC_PM_ID: 27
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x43516270
+                TX_LANE_MAP: 0x37065241
+                RX_POLARITY_FLIP: 0x30
+                TX_POLARITY_FLIP: 0x36
+            ?
+                PC_PM_ID: 32
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x73621504
+                TX_LANE_MAP: 0x62734051
+                RX_POLARITY_FLIP: 0xf0
+                TX_POLARITY_FLIP: 0x00
+            ?
+                PC_PM_ID: 30
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x71605342
+                TX_LANE_MAP: 0x6172435
+                RX_POLARITY_FLIP: 0xa5
+                TX_POLARITY_FLIP: 0x00
+            ?
+                PC_PM_ID: 29
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x60714253
+                TX_LANE_MAP: 0x17063524
+                RX_POLARITY_FLIP: 0x21
+                TX_POLARITY_FLIP: 0x69
+            ?
+                PC_PM_ID: 31
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x26370415
+                TX_LANE_MAP: 0x37265140
+                RX_POLARITY_FLIP: 0x30
+                TX_POLARITY_FLIP: 0xc3
+            ?
+                PC_PM_ID: 35
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x15047362
+                TX_LANE_MAP: 0x4152637
+                RX_POLARITY_FLIP: 0xf0
+                TX_POLARITY_FLIP: 0xff
+            ?
+                PC_PM_ID: 33
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x17063524
+                TX_LANE_MAP: 0x60714253
+                RX_POLARITY_FLIP: 0xa5
+                TX_POLARITY_FLIP: 0xff
+            ?
+                PC_PM_ID: 34
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x6172435
+                TX_LANE_MAP: 0x71605342
+                RX_POLARITY_FLIP: 0xed
+                TX_POLARITY_FLIP: 0x69
+            ?
+                PC_PM_ID: 36
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x40516273
+                TX_LANE_MAP: 0x51403726
+                RX_POLARITY_FLIP: 0xfc
+                TX_POLARITY_FLIP: 0xc3
+            ?
+                PC_PM_ID: 40
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x70621534
+                TX_LANE_MAP: 0x14250637
+                RX_POLARITY_FLIP: 0x0c
+                TX_POLARITY_FLIP: 0x64
+            ?
+                PC_PM_ID: 38
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x71635042
+                TX_LANE_MAP: 0x61724053
+                RX_POLARITY_FLIP: 0x48
+                TX_POLARITY_FLIP: 0x9c
+            ?
+                PC_PM_ID: 37
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x6241537
+                TX_LANE_MAP: 0x51624073
+                RX_POLARITY_FLIP: 0x7b
+                TX_POLARITY_FLIP: 0x3a
+            ?
+                PC_PM_ID: 39
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x26073415
+                TX_LANE_MAP: 0x52413706
+                RX_POLARITY_FLIP: 0xfc
+                TX_POLARITY_FLIP: 0x9e
+            ?
+                PC_PM_ID: 44
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x70621534
+                TX_LANE_MAP: 0x14250637
+                RX_POLARITY_FLIP: 0x0c
+                TX_POLARITY_FLIP: 0x64
+            ?
+                PC_PM_ID: 42
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x71635042
+                TX_LANE_MAP: 0x61724053
+                RX_POLARITY_FLIP: 0x48
+                TX_POLARITY_FLIP: 0x98
+            ?
+                PC_PM_ID: 41
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x63714250
+                TX_LANE_MAP: 0x72615340
+                RX_POLARITY_FLIP: 0xed
+                TX_POLARITY_FLIP: 0x9d
+            ?
+                PC_PM_ID: 43
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x26073415
+                TX_LANE_MAP: 0x52413706
+                RX_POLARITY_FLIP: 0xfc
+                TX_POLARITY_FLIP: 0x9e
+            ?
+                PC_PM_ID: 48
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x70621534
+                TX_LANE_MAP: 0x14250637
+                RX_POLARITY_FLIP: 0x0c
+                TX_POLARITY_FLIP: 0x64
+            ?
+                PC_PM_ID: 46
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x71635042
+                TX_LANE_MAP: 0x61724053
+                RX_POLARITY_FLIP: 0x48
+                TX_POLARITY_FLIP: 0x98
+            ?
+                PC_PM_ID: 45
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x63714250
+                TX_LANE_MAP: 0x72615340
+                RX_POLARITY_FLIP: 0xed
+                TX_POLARITY_FLIP: 0x9d
+            ?
+                PC_PM_ID: 47
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x26073415
+                TX_LANE_MAP: 0x52413706
+                RX_POLARITY_FLIP: 0xfc
+                TX_POLARITY_FLIP: 0x9e
+            ?
+                PC_PM_ID: 52
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x5247163
+                TX_LANE_MAP: 0x61524073
+                RX_POLARITY_FLIP: 0x8b
+                TX_POLARITY_FLIP: 0x93
+            ?
+                PC_PM_ID: 50
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x7261534
+                TX_LANE_MAP: 0x6351427
+                RX_POLARITY_FLIP: 0xd2
+                TX_POLARITY_FLIP: 0x63
+            ?
+                PC_PM_ID: 49
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x26073415
+                TX_LANE_MAP: 0x35062714
+                RX_POLARITY_FLIP: 0x87
+                TX_POLARITY_FLIP: 0x63
+            ?
+                PC_PM_ID: 51
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x42506371
+                TX_LANE_MAP: 0x25167340
+                RX_POLARITY_FLIP: 0xe1
+                TX_POLARITY_FLIP: 0x63
+            ?
+                PC_PM_ID: 56
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x5247163
+                TX_LANE_MAP: 0x61524073
+                RX_POLARITY_FLIP: 0x8b
+                TX_POLARITY_FLIP: 0x93
+            ?
+                PC_PM_ID: 54
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x7261534
+                TX_LANE_MAP: 0x6351427
+                RX_POLARITY_FLIP: 0xd2
+                TX_POLARITY_FLIP: 0x63
+            ?
+                PC_PM_ID: 53
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x26073415
+                TX_LANE_MAP: 0x35062714
+                RX_POLARITY_FLIP: 0x87
+                TX_POLARITY_FLIP: 0x63
+            ?
+                PC_PM_ID: 55
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x42506371
+                TX_LANE_MAP: 0x25167340
+                RX_POLARITY_FLIP: 0xe1
+                TX_POLARITY_FLIP: 0x63
+            ?
+                PC_PM_ID: 60
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x62730415
+                TX_LANE_MAP: 0x73624150
+                RX_POLARITY_FLIP: 0x98
+                TX_POLARITY_FLIP: 0x1b
+            ?
+                PC_PM_ID: 58
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x7261534
+                TX_LANE_MAP: 0x6351427
+                RX_POLARITY_FLIP: 0xd2
+                TX_POLARITY_FLIP: 0x63
+            ?
+                PC_PM_ID: 57
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x26073415
+                TX_LANE_MAP: 0x35062714
+                RX_POLARITY_FLIP: 0x87
+                TX_POLARITY_FLIP: 0x63
+            ?
+                PC_PM_ID: 59
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x42506371
+                TX_LANE_MAP: 0x25167340
+                RX_POLARITY_FLIP: 0xe1
+                TX_POLARITY_FLIP: 0x62
+            ?
+                PC_PM_ID: 64
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x73621504
+                TX_LANE_MAP: 0x62734051
+                RX_POLARITY_FLIP: 0xc2
+                TX_POLARITY_FLIP: 0x33
+            ?
+                PC_PM_ID: 62
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x71605342
+                TX_LANE_MAP: 0x6172435
+                RX_POLARITY_FLIP: 0x96
+                TX_POLARITY_FLIP: 0x33
+            ?
+                PC_PM_ID: 61
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x60714253
+                TX_LANE_MAP: 0x17063524
+                RX_POLARITY_FLIP: 0xcc
+                TX_POLARITY_FLIP: 0x69
+            ?
+                PC_PM_ID: 63
+                CORE_INDEX: 0
+            :
+                RX_LANE_MAP_AUTO: 0
+                TX_LANE_MAP_AUTO: 0
+                RX_POLARITY_FLIP_AUTO: 0
+                TX_POLARITY_FLIP_AUTO: 0
+                RX_LANE_MAP: 0x26370415
+                TX_LANE_MAP: 0x37265140
+                RX_POLARITY_FLIP: 0xcc
+                TX_POLARITY_FLIP: 0xc3
+---
+device:
+    0:
+        PC_PORT_PHYS_MAP:
+            ?
+                PORT_ID: 1
+            :
+                PC_PHYS_PORT_ID: 1
+            ?
+                PORT_ID: 2
+            :
+                PC_PHYS_PORT_ID: 9
+            ?
+                PORT_ID: 11
+            :
+                PC_PHYS_PORT_ID: 17
+            ?
+                PORT_ID: 12
+            :
+                PC_PHYS_PORT_ID: 25
+            ?
+                PORT_ID: 22
+            :
+                PC_PHYS_PORT_ID: 33
+            ?
+                PORT_ID: 23
+            :
+                PC_PHYS_PORT_ID: 41
+            ?
+                PORT_ID: 33
+            :
+                PC_PHYS_PORT_ID: 49
+            ?
+                PORT_ID: 34
+            :
+                PC_PHYS_PORT_ID: 57
+            ?
+                PORT_ID: 44
+            :
+                PC_PHYS_PORT_ID: 65
+            ?
+                PORT_ID: 45
+            :
+                PC_PHYS_PORT_ID: 73
+            ?
+                PORT_ID: 55
+            :
+                PC_PHYS_PORT_ID: 81
+            ?
+                PORT_ID: 56
+            :
+                PC_PHYS_PORT_ID: 89
+            ?
+                PORT_ID: 66
+            :
+                PC_PHYS_PORT_ID: 97
+            ?
+                PORT_ID: 67
+            :
+                PC_PHYS_PORT_ID: 105
+            ?
+                PORT_ID: 77
+            :
+                PC_PHYS_PORT_ID: 113
+            ?
+                PORT_ID: 78
+            :
+                PC_PHYS_PORT_ID: 121
+            ?
+                PORT_ID: 88
+            :
+                PC_PHYS_PORT_ID: 129
+            ?
+                PORT_ID: 89
+            :
+                PC_PHYS_PORT_ID: 137
+            ?
+                PORT_ID: 99
+            :
+                PC_PHYS_PORT_ID: 145
+            ?
+                PORT_ID: 100
+            :
+                PC_PHYS_PORT_ID: 153
+            ?
+                PORT_ID: 110
+            :
+                PC_PHYS_PORT_ID: 161
+            ?
+                PORT_ID: 111
+            :
+                PC_PHYS_PORT_ID: 169
+            ?
+                PORT_ID: 121
+            :
+                PC_PHYS_PORT_ID: 177
+            ?
+                PORT_ID: 122
+            :
+                PC_PHYS_PORT_ID: 185
+            ?
+                PORT_ID: 132
+            :
+                PC_PHYS_PORT_ID: 193
+            ?
+                PORT_ID: 133
+            :
+                PC_PHYS_PORT_ID: 201
+            ?
+                PORT_ID: 143
+            :
+                PC_PHYS_PORT_ID: 209
+            ?
+                PORT_ID: 144
+            :
+                PC_PHYS_PORT_ID: 217
+            ?
+                PORT_ID: 154
+            :
+                PC_PHYS_PORT_ID: 225
+            ?
+                PORT_ID: 155
+            :
+                PC_PHYS_PORT_ID: 233
+            ?
+                PORT_ID: 165
+            :
+                PC_PHYS_PORT_ID: 241
+            ?
+                PORT_ID: 166
+            :
+                PC_PHYS_PORT_ID: 249
+            ?
+                PORT_ID: 176
+            :
+                PC_PHYS_PORT_ID: 257
+            ?
+                PORT_ID: 177
+            :
+                PC_PHYS_PORT_ID: 265
+            ?
+                PORT_ID: 187
+            :
+                PC_PHYS_PORT_ID: 273
+            ?
+                PORT_ID: 188
+            :
+                PC_PHYS_PORT_ID: 281
+            ?
+                PORT_ID: 198
+            :
+                PC_PHYS_PORT_ID: 289
+            ?
+                PORT_ID: 199
+            :
+                PC_PHYS_PORT_ID: 297
+            ?
+                PORT_ID: 209
+            :
+                PC_PHYS_PORT_ID: 305
+            ?
+                PORT_ID: 210
+            :
+                PC_PHYS_PORT_ID: 313
+            ?
+                PORT_ID: 220
+            :
+                PC_PHYS_PORT_ID: 321
+            ?
+                PORT_ID: 221
+            :
+                PC_PHYS_PORT_ID: 329
+            ?
+                PORT_ID: 231
+            :
+                PC_PHYS_PORT_ID: 337
+            ?
+                PORT_ID: 232
+            :
+                PC_PHYS_PORT_ID: 345
+            ?
+                PORT_ID: 242
+            :
+                PC_PHYS_PORT_ID: 353
+            ?
+                PORT_ID: 243
+            :
+                PC_PHYS_PORT_ID: 361
+            ?
+                PORT_ID: 253
+            :
+                PC_PHYS_PORT_ID: 369
+            ?
+                PORT_ID: 254
+            :
+                PC_PHYS_PORT_ID: 377
+            ?
+                PORT_ID: 264
+            :
+                PC_PHYS_PORT_ID: 385
+            ?
+                PORT_ID: 265
+            :
+                PC_PHYS_PORT_ID: 393
+            ?
+                PORT_ID: 275
+            :
+                PC_PHYS_PORT_ID: 401
+            ?
+                PORT_ID: 276
+            :
+                PC_PHYS_PORT_ID: 409
+            ?
+                PORT_ID: 286
+            :
+                PC_PHYS_PORT_ID: 417
+            ?
+                PORT_ID: 287
+            :
+                PC_PHYS_PORT_ID: 425
+            ?
+                PORT_ID: 297
+            :
+                PC_PHYS_PORT_ID: 433
+            ?
+                PORT_ID: 298
+            :
+                PC_PHYS_PORT_ID: 441
+            ?
+                PORT_ID: 308
+            :
+                PC_PHYS_PORT_ID: 449
+            ?
+                PORT_ID: 309
+            :
+                PC_PHYS_PORT_ID: 457
+            ?
+                PORT_ID: 319
+            :
+                PC_PHYS_PORT_ID: 465
+            ?
+                PORT_ID: 320
+            :
+                PC_PHYS_PORT_ID: 473
+            ?
+                PORT_ID: 330
+            :
+                PC_PHYS_PORT_ID: 481
+            ?
+                PORT_ID: 331
+            :
+                PC_PHYS_PORT_ID: 489
+            ?
+                PORT_ID: 341
+            :
+                PC_PHYS_PORT_ID: 497
+            ?
+                PORT_ID: 342
+            :
+                PC_PHYS_PORT_ID: 505
+            ?
+                PORT_ID: 76
+            :
+                PC_PHYS_PORT_ID: 513
+            ?
+                PORT_ID: 274
+            :
+                PC_PHYS_PORT_ID: 515
+...
+---
+device:
+    0:
+        PC_PORT:
+            ?
+                PORT_ID: [[1, 2],
+                          [11, 12],
+                          [22, 23],
+                          [33, 34],
+                          [44, 45],
+                          [55, 56],
+                          [66, 67],
+                          [77, 78],
+                          [88, 89],
+                          [99, 100],
+                          [110, 111],
+                          [121, 122],
+                          [132, 133],
+                          [143, 144],
+                          [154, 155],
+                          [165, 166],
+                          [176, 177],
+                          [187, 188],
+                          [198, 199],
+                          [209, 210],
+                          [220, 221],
+                          [231, 232],
+                          [242, 243],
+                          [253, 254],
+                          [264, 265],
+                          [275, 276],
+                          [286, 287],
+                          [297, 298],
+                          [308, 309],
+                          [319, 320],
+                          [330, 331],
+                          [341, 342]]
+            :
+                ENABLE: 0
+                SPEED: 400000
+                NUM_LANES: 8
+                FEC_MODE: PC_FEC_RS544_2XN
+                MAX_FRAME_SIZE: 9416
+            ?
+                PORT_ID: [[76, 76], [274, 274]]
+            :
+                ENABLE: 0
+                MAX_FRAME_SIZE: 9416
+                SPEED: 10000
+                NUM_LANES: 1
+...
+---
+bcm_device:
+    0:
+        global:
+            ftem_mem_entries: 65536
+...
+---
+device:
+    0:
+        # Per pipe flex counter configuration
+        CTR_EFLEX_CONFIG:
+            CTR_ING_EFLEX_OPERMODE_PIPEUNIQUE: 0
+            CTR_EGR_EFLEX_OPERMODE_PIPEUNIQUE: 0
+
+        # IFP mode
+        FP_CONFIG:
+            FP_ING_OPERMODE: GLOBAL_PIPE_AWARE
+...
+---
+device:
+    0:
+        DEVICE_CONFIG:
+            AUTOLOAD_BOARD_SETTINGS: 0
+...


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Without this change links will not come up at 400G-8 using this hwsku

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Previously the config.bcm file for this hwsku was simlinked to the default 800G-8 hwsku. This hwsku programs PC_PORT table at 800G-8. This file is no longer simlinked, it is now and exact copy except that the PC_PORT table programs the ports at 400G-8

#### How to verify it
Booted this hwsku on device and confirmed all links now come up as expected

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->


- [x] 202405
- [x] 202311

#### Tested branch (Please provide the tested image version)
202405

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

