### PR TITLE
[nvidia-bluefield] Fix pinctrl driver compilation under 6.1.94 Kernel.

### DIFF
--- a/platform/nvidia-bluefield/pinctrl-mlxbf3/Makefile
+++ b/platform/nvidia-bluefield/pinctrl-mlxbf3/Makefile
@@ -31,6 +31,8 @@ $(addprefix $(DEST)/, $(MLXBF3_PINCTRL_DRIVER)): $(DEST)/% :
 	${GET_PACKAGE} ${BSD_BASE_SOURCE_URL} ${MLXBF3_PINCTRL}
 
 	pushd ${MLXBF3_PINCTRL}
+	
+	sed -i 's/KERNEL_VERSION(6, 3, 0)/KERNEL_VERSION(6, 1, 0)/g' $(MODULE_DIR)/pinctrl-mlxbf3.c
 
 	# Build the package
 	make -C /lib/modules/$(KVERSION)/build M=$(MODULE_DIR)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

