### PR TITLE
Fix optional hwsku params not applying to all interfaces

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -430,7 +430,8 @@ def parse_platform_json_file(hwsku_json_file, platform_json_file):
             if child_port in hwsku_entry:
                 for key, item in hwsku_entry[child_port].items():
                     if key in OPTIONAL_HWSKU_ATTRIBUTES:
-                        child_ports.get(child_port)[key] = item
+                        for child in child_ports:
+                            child_ports.get(child)[key] = item
 
         ports.update(child_ports)
 

--- a/src/sonic-config-engine/tests/sample_output/platform_output.json
+++ b/src/sonic-config-engine/tests/sample_output/platform_output.json
@@ -976,7 +976,8 @@
     "alias": "Eth36/1",
     "pfc_asym": "off",
     "subport": "1",
-    "speed": "25000"
+    "speed": "25000",
+    "role": "Dpc"
   },
   "Ethernet141": {
     "index": "36",
@@ -987,7 +988,8 @@
     "alias": "Eth36/2",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "2"
+    "subport": "2",
+    "role": "Dpc"
   },
   "Ethernet142": {
     "index": "36",


### PR DESCRIPTION
Currently optional params only get applied to the first child port in group. We want optional parameters to apply to all child ports in group.

For example:
```
        "Ethernet0": {
            "default_brkout_mode": "2x400G",
            "autoneg": "on"
        },
```
In this scenario we want autoneg on to be in the config_db entry for
both interfaces that belong to the group; Ethernet0 and Ethernet4.

Currently this only gets applied to Ethernet0:
```
(Pdb++) pp child_ports
{'Ethernet0': {'alias': 'Ethernet1/1',
               'autoneg': 'on',
               'index': '1',
               'lanes': '17,18,19,20',
               'speed': '400000',
               'subport': '1'},
 'Ethernet4': {'alias': 'Ethernet1/5',
               'index': '1',
               'lanes': '21,22,23,24',
               'speed': '400000',
               'subport': '2'}}
```

With this change it now gets applied to all interfaces in the group as expected
```
(Pdb) pp child_ports
{'Ethernet0': {'alias': 'Ethernet1/1',
               'autoneg': 'on',
               'index': '1',
               'lanes': '17,18,19,20',
               'speed': '400000',
               'subport': '1'},
 'Ethernet4': {'alias': 'Ethernet1/5',
               'autoneg': 'on',
               'index': '1',
               'lanes': '21,22,23,24',
               'speed': '400000',
               'subport': '2'}}
```
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
I need to apply optional hwsku params for a group of interfaces.

#### How I did it
Just changed to iterate over every child port in group.

#### How to verify it
Introduction to the problem shows verification of the solution. Check the output manually and also fixed the unit test to correspond and pass.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 202405

#### Tested branch (Please provide the tested image version)
master and 202405

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

#### Description for the changelog
fix optional hwsku params not applying to all interfaces in defined group.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

