### PR TITLE
Start startup_tsa_tsb.service only if services.conf file exists

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/services.conf
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/services.conf
@@ -1,0 +1,1 @@
+startup_tsa_tsb.service

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -1029,7 +1029,6 @@ sudo LANG=C cp $SCRIPTS_DIR/write_standby.py $FILESYSTEM_ROOT/usr/local/bin/writ
 sudo LANG=C cp $SCRIPTS_DIR/mark_dhcp_packet.py $FILESYSTEM_ROOT/usr/local/bin/mark_dhcp_packet.py
 
 sudo cp files/build_templates/startup_tsa_tsb.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/
-echo "startup_tsa_tsb.service" | sudo tee -a $GENERATED_SERVICE_FILE
 
 sudo cp $BUILD_TEMPLATES/sonic.target $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable sonic.target

--- a/files/build_templates/startup_tsa_tsb.service
+++ b/files/build_templates/startup_tsa_tsb.service
@@ -3,7 +3,6 @@ Description= STARTUP TSA-TSB SERVICE
 Requires=config-setup.service database.service
 After=config-setup.service database.service
 Before=bgp.service
-ConditionPathExists=!/etc/sonic/chassisdb.conf
 
 [Service]
 Environment="STARTED_BY_TSA_TSB_SERVICE=1"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix https://github.com/sonic-net/sonic-buildimage/issues/20049

Currently, the startup_tsa_tsb.service is started for all the platforms and the service exists if startup-tsa-tsb.conf doesn't exist for the platform.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Don't add startup_tsa_tsb.service to /etc/sonic/generated_services.conf.
Instead add it to services.conf if the platform supports startup_tsa_tsb.service.
#### How to verify it
1)Verified in Nokia platform that the startup_tsa_tsb.service starts only when the services.conf file exists
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

