### PR TITLE
[frrcfgd] Support configuring source IP for routes

### DIFF
--- a/dockers/docker-fpm-frr/frr/zebra/zebra.interfaces.conf.j2
+++ b/dockers/docker-fpm-frr/frr/zebra/zebra.interfaces.conf.j2
@@ -9,6 +9,26 @@ exit
 {%   endfor %}
 {%  endif %}
 {% endblock vrf %}
+{% block setsrc %}
+{%  if BGP_GLOBALS is defined and BGP_GLOBALS|length > 0 %}
+{%   for vrf, bgp_sess in BGP_GLOBALS.items() %}
+{%    if 'route_map' in bgp_sess %}
+!
+vrf {{ vrf }}
+ ip protocol bgp route-map {{ bgp_sess['route_map'] }}
+{%    endif %}
+{%   endfor %}
+{%  endif %}
+{%  if ROUTE_MAP is defined and ROUTE_MAP|length > 0 %}
+{%   for rm_key, rm_val in ROUTE_MAP.items() %}
+{%    if 'route_operation' in rm_val and 'set_src' in rm_val %}
+!
+route-map {{rm_key[0]}} {{rm_val['route_operation']}} {{rm_key[1]}}
+ set src {{rm_val['set_src']}}
+{%    endif %}
+{%   endfor %}
+{%  endif %}
+{% endblock setsrc %}
 !
 {% block interfaces %}
 ! Enable nht through default route

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1754,7 +1754,8 @@ class BGPConfigDaemon:
                       ('confed_id',                                     '{no:no-prefix}bgp confederation identifier {}'),
                       ('confed_peers',                                  '{no:no-prefix}bgp confederation peers {}', hdl_confed_peers),
                       (['keepalive', 'holdtime'],                       '{no:no-prefix}timers bgp {} {}'),
-                      (['max_med_admin', '+max_med_admin_val'],         '{no:no-prefix}bgp max-med administrative {}', ['true', 'false'])
+                      (['max_med_admin', '+max_med_admin_val'],         '{no:no-prefix}bgp max-med administrative {}', ['true', 'false']),
+                      ('route_map',                                     '{no:no-prefix}ip protocol bgp route-map {}'),
     ]
 
     global_af_key_map = [(['ebgp_route_distance',
@@ -1877,6 +1878,7 @@ class BGPConfigDaemon:
                          ('call_route_map',                 '{no:no-prefix}call {:enable-only}'),
                          ('set_origin',                     '[bgpd]{no:no-prefix}set origin {:tolower}'),
                          ('set_local_pref',                 '[bgpd]{no:no-prefix}set local-preference {}'),
+                         ('set_src',                        '{no:no-prefix}set src {}'),
                          ('set_next_hop',                   '{no:no-prefix}set ip next-hop {}'),
                          ('set_ipv6_next_hop_global',       '[bgpd]{no:no-prefix}set ipv6 next-hop global {}'),
                          ('set_ipv6_next_hop_prefer_global', '[bgpd]{no:no-prefix}set ipv6 next-hop prefer-global', ['true', 'false']),
@@ -2642,6 +2644,12 @@ class BGPConfigDaemon:
                     if local_asn is None:
                         syslog.syslog(syslog.LOG_ERR, 'local ASN for VRF %s was not configured' % vrf)
                         continue
+                    if 'route_map' in data:
+                        # Route maps are configured in a different context, so they need a different cmd_prefix
+                        cmd_prefix = ['configure terminal', 'vrf {}'.format(vrf)]
+                        if not key_map.run_command(self, table, {'route_map': data['route_map']}, cmd_prefix):
+                            syslog.syslog(syslog.LOG_ERR, 'failed running BGP global config command')
+                        del data['route_map']
                     cmd_prefix = ['configure terminal', 'router bgp {} vrf {}'.format(local_asn, vrf)]
                     if not key_map.run_command(self, table, data, cmd_prefix):
                         syslog.syslog(syslog.LOG_ERR, 'failed running BGP global config command')

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
@@ -180,6 +180,7 @@
                     "set_metric_action": "METRIC_SET_VALUE",
                     "set_metric": 50,
                     "set_next_hop": "10.10.10.10",
+                    "set_src": "10.10.10.10",
                     "set_ipv6_next_hop_global": "1000::1",
                     "set_ipv6_next_hop_prefer_global": true,
                     "set_repeat_asn": 5,

--- a/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
@@ -317,6 +317,11 @@ module sonic-bgp-global {
                     type uint16;
                     description "Hold time";
                 }
+
+                leaf route_map {
+                    type string;
+                    description "Route map to apply to BGP-learned routes in Zebra";
+                }
             }
         }
 

--- a/src/sonic-yang-models/yang-models/sonic-route-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-route-map.yang
@@ -294,6 +294,11 @@ module sonic-route-map {
                     description "Set metric value";
                 }
 
+                leaf set_src{
+                    type string;
+                    description "Set route source address";
+                }
+
                 leaf set_next_hop{
                     type string;
                     description "Set IP nexthop";


### PR DESCRIPTION
#### Why I did it

Fixes #14195 (or at least provides a config workaround).

#### How I did it

Add support for configuring a route map to set the source IP for routes pushed into the kernel by FRR.

#### How to verify it

- Run BGP config with frrcfgd
- Check `ip route`
- Observe that routes don't have their source set
- Add `BGP_GLOBALS|default|route_map` to e.g. `FIX_SOURCE`
- Add `ROUTE_MAP|FIX_SOURCE|100` with `route_operation: permit` and `set_src: <your IP>`
- Load the config
- Check `ip route` again
- Observe that routes have `src <your IP>` set

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

- [x] 202305 (We've been running this in our production fork for ~2 years now)

#### Description for the changelog

Support configuring source IP for BGP routes

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

