### PR TITLE
Fix set src frr

### DIFF
--- a/dockers/docker-fpm-frr/frr/zebra/zebra.interfaces.conf.j2
+++ b/dockers/docker-fpm-frr/frr/zebra/zebra.interfaces.conf.j2
@@ -9,6 +9,26 @@ exit
 {%   endfor %}
 {%  endif %}
 {% endblock vrf %}
+{% block setsrc %}
+{%  if BGP_GLOBALS is defined and BGP_GLOBALS|length > 0 %}
+{%   for vrf, bgp_sess in BGP_GLOBALS.items() %}
+{%    if 'route_map' in bgp_sess %}
+!
+vrf {{ vrf }}
+ ip protocol bgp route-map {{ bgp_sess['route_map'] }}
+{%    endif %}
+{%   endfor %}
+{%  endif %}
+{%  if ROUTE_MAP is defined and ROUTE_MAP|length > 0 %}
+{%   for rm_key, rm_val in ROUTE_MAP.items() %}
+{%    if 'route_operation' in rm_val and 'set_src' in rm_val %}
+!
+route-map {{rm_key[0]}} {{rm_val['route_operation']}} {{rm_key[1]}}
+ set src {{rm_val['set_src']}}
+{%    endif %}
+{%   endfor %}
+{%  endif %}
+{% endblock setsrc %}
 !
 {% block interfaces %}
 ! Enable nht through default route

--- a/dockers/docker-fpm-frr/frr/zebra/zebra.interfaces.conf.j2
+++ b/dockers/docker-fpm-frr/frr/zebra/zebra.interfaces.conf.j2
@@ -17,6 +17,11 @@ exit
 vrf {{ vrf }}
  ip protocol bgp route-map {{ bgp_sess['route_map'] }}
 {%    endif %}
+{%    if 'route_map_ipv6' in bgp_sess %}
+!
+vrf {{ vrf }}
+ ipv6 protocol bgp route-map {{ bgp_sess['route_map_ipv6'] }}
+{%    endif %}
 {%   endfor %}
 {%  endif %}
 {%  if ROUTE_MAP is defined and ROUTE_MAP|length > 0 %}

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1754,7 +1754,8 @@ class BGPConfigDaemon:
                       ('confed_id',                                     '{no:no-prefix}bgp confederation identifier {}'),
                       ('confed_peers',                                  '{no:no-prefix}bgp confederation peers {}', hdl_confed_peers),
                       (['keepalive', 'holdtime'],                       '{no:no-prefix}timers bgp {} {}'),
-                      (['max_med_admin', '+max_med_admin_val'],         '{no:no-prefix}bgp max-med administrative {}', ['true', 'false'])
+                      (['max_med_admin', '+max_med_admin_val'],         '{no:no-prefix}bgp max-med administrative {}', ['true', 'false']),
+                      ('route_map',                                     '{no:no-prefix}ip protocol bgp route-map {}'),
     ]
 
     global_af_key_map = [(['ebgp_route_distance',
@@ -1877,6 +1878,7 @@ class BGPConfigDaemon:
                          ('call_route_map',                 '{no:no-prefix}call {:enable-only}'),
                          ('set_origin',                     '[bgpd]{no:no-prefix}set origin {:tolower}'),
                          ('set_local_pref',                 '[bgpd]{no:no-prefix}set local-preference {}'),
+                         ('set_src',                        '{no:no-prefix}set src {}'),
                          ('set_next_hop',                   '{no:no-prefix}set ip next-hop {}'),
                          ('set_ipv6_next_hop_global',       '[bgpd]{no:no-prefix}set ipv6 next-hop global {}'),
                          ('set_ipv6_next_hop_prefer_global', '[bgpd]{no:no-prefix}set ipv6 next-hop prefer-global', ['true', 'false']),
@@ -2642,6 +2644,12 @@ class BGPConfigDaemon:
                     if local_asn is None:
                         syslog.syslog(syslog.LOG_ERR, 'local ASN for VRF %s was not configured' % vrf)
                         continue
+                    if 'route_map' in data:
+                        # Route maps are configured in a different context, so they need a different cmd_prefix
+                        cmd_prefix = ['configure terminal', 'vrf {}'.format(vrf)]
+                        if not key_map.run_command(self, table, {'route_map': data['route_map']}, cmd_prefix):
+                            syslog.syslog(syslog.LOG_ERR, 'failed running BGP global config command')
+                        del data['route_map']
                     cmd_prefix = ['configure terminal', 'router bgp {} vrf {}'.format(local_asn, vrf)]
                     if not key_map.run_command(self, table, data, cmd_prefix):
                         syslog.syslog(syslog.LOG_ERR, 'failed running BGP global config command')

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
@@ -2,6 +2,9 @@
     "BGP_GLOBAL_VALID": {
         "desc": "Configure BGP global table."
     },
+    "BGP_GLOBAL_ROUTE_MAP_VALID": {
+        "desc": "Configure BGP global table with route map."
+    },
     "BGP_NEIGHBOR_ALL_VALID": {
         "desc": "Configure BGP neighbor table."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
@@ -82,6 +82,36 @@
         }
     },
 
+    "BGP_GLOBAL_ROUTE_MAP_VALID": {
+        "sonic-vrf:sonic-vrf":{
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [
+                {
+                    "name":"Vrf1"
+                }
+                ]
+            }
+        },
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001,
+                    "route_map": "RM_SET_SRC",
+                    "route_map_ipv6": "RM_SET_SRC6"
+                },
+                {
+                    "vrf_name":"Vrf1",
+                    "local_asn": 65001,
+                    "route_map": "RM_SET_SRC",
+                    "route_map_ipv6": "RM_SET_SRC6"
+                }
+                ]
+            }
+        }
+    },
+
     "BGP_NEIGHBOR_ALL_VALID": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
@@ -180,6 +180,7 @@
                     "set_metric_action": "METRIC_SET_VALUE",
                     "set_metric": 50,
                     "set_next_hop": "10.10.10.10",
+                    "set_src": "10.10.10.10",
                     "set_ipv6_next_hop_global": "1000::1",
                     "set_ipv6_next_hop_prefer_global": true,
                     "set_repeat_asn": 5,

--- a/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
@@ -317,6 +317,11 @@ module sonic-bgp-global {
                     type uint16;
                     description "Hold time";
                 }
+
+                leaf route_map {
+                    type string;
+                    description "Route map to apply to BGP-learned routes in Zebra";
+                }
             }
         }
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
@@ -320,7 +320,12 @@ module sonic-bgp-global {
 
                 leaf route_map {
                     type string;
-                    description "Route map to apply to BGP-learned routes in Zebra";
+                    description "IPv4 route map to apply to BGP-learned routes in Zebra";
+                }
+
+                leaf route_map_ipv6 {
+                    type string;
+                    description "IPv6 route map to apply to BGP-learned routes in Zebra";
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-route-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-route-map.yang
@@ -294,6 +294,11 @@ module sonic-route-map {
                     description "Set metric value";
                 }
 
+                leaf set_src{
+                    type string;
+                    description "Set route source address";
+                }
+
                 leaf set_next_hop{
                     type string;
                     description "Set IP nexthop";


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fixes https://github.com/sonic-net/sonic-buildimage/issues/14195

#### How I did it

Add support for configuring a route map to set the source IPv6 for routes pushed into the kernel by FRR.

#### How to verify it

- Run BGP config with frrcfgd
 - Check `ipv6 route`
 - Observe that routes don't have their source set
 - Add `BGP_GLOBALS|default|route_map_ipv6` to e.g. FIX_SOURCE
 - Add `ROUTE_MAP|FIX_SOURCE|100` with `route_operation: permit` and `set_src: <your IPv6>`
 -  Load the config
 -  Check `ipv6 route` again
 -  Observe that routes have `src <your IPv6>` set


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

- [x] master


#### Description for the changelog

Support configuring source IPv6 for BGP routes

#### Link to config_db schema for YANG module changes


#### A picture of a cute animal (not mandatory but encouraged)

