### PR TITLE
Bind ZMQ to midplane mgmt interface on SmartSwitch DPU

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -77,13 +77,13 @@ fi
 # Enable ZMQ for SmartSwitch
 LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "subtype"`
 if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
-    midplane_mgmt_ip=$( ip -json -4 addr show eth0-midplane | jq -r ".[0].addr_info[0].local" )
+    midplane_mgmt_state=$( ip -json -4 addr show eth0-midplane | jq -r ".[0].operstate" )
     mgmt_ip=$( ip -json -4 addr show eth0 | jq -r ".[0].addr_info[0].local" )
-    if [[ $midplane_ip != "" ]]; then
-        # Enable ZMQ with eth0-midplane address
-        ORCHAGENT_ARGS+=" -q tcp://${midplane_mgmt_ip}:8100"
+    if [[ $midplane_mgmt_state == "UP" ]]; then
+        # Enable ZMQ with eth0-midplane interface name
+        ORCHAGENT_ARGS+=" -q tcp://eth0-midplane:8100"
     elif [[ $mgmt_ip != "" ]] && [[ $mgmt_ip != "null" ]]; then
-        # If eth0-midplane interface does not exist, enable ZMQ with eth0 address
+        # If eth0-midplane interface does not up, enable ZMQ with eth0 address
         ORCHAGENT_ARGS+=" -q tcp://${mgmt_ip}:8100"
     else
         ORCHAGENT_ARGS+=" -q tcp://127.0.0.1:8100"


### PR DESCRIPTION
Bind ZMQ to midplane mgmt interface on SmartSwitch DPU.

#### Why I did it
SmartSwitch DPU IP address may change after push config: https://github.com/sonic-net/sonic-buildimage/issues/20295

##### Work item tracking
- Microsoft ADO: 29628977

#### How I did it
Bind ZMQ to midplane mgmt interface on SmartSwitch DPU.

#### How to verify it
Pass all UT.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [] 

#### Description for the changelog
Bind ZMQ to midplane mgmt interface on SmartSwitch DPU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

