### PR TITLE
[database-chassis][lagid] Initialize SYSTEM_LAG_IDS_FREE_LIST in CHASSIS_APP_DB

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/chassisdb.conf
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/chassisdb.conf
@@ -1,4 +1,4 @@
 start_chassis_db=1
 chassis_db_address=10.6.0.100
 lag_id_start=1
-lag_id_end=1024
+lag_id_end=1023

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -120,6 +120,12 @@ function setPlatformLagIdBoundaries()
 {
     docker exec -i ${DOCKERNAME} $SONIC_DB_CLI CHASSIS_APP_DB SET "SYSTEM_LAG_ID_START" "$lag_id_start"
     docker exec -i ${DOCKERNAME} $SONIC_DB_CLI CHASSIS_APP_DB SET "SYSTEM_LAG_ID_END" "$lag_id_end"
+    docker exec -i ${DOCKERNAME} $SONIC_DB_CLI CHASSIS_APP_DB EVAL "
+    local start_id = tonumber(ARGV[1])
+    local end_id = tonumber(ARGV[2])
+    for id = start_id,end_id do
+        redis.call('rpush','SYSTEM_LAG_IDS_FREE_LIST', tostring(id))
+    end" 0 $lag_id_start $lag_id_end
 }
 function waitForAllInstanceDatabaseConfigJsonFilesReady()
 {

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -233,6 +233,7 @@ function clean_up_chassis_db_tables()
             local lagid = redis.call('HGET', 'SYSTEM_LAG_ID_TABLE', lagname)
             redis.call('SREM', 'SYSTEM_LAG_ID_SET', lagid)
             redis.call('HDEL', 'SYSTEM_LAG_ID_TABLE', lagname)
+            redis.call('rpush', 'SYSTEM_LAG_IDS_FREE_LIST', lagid)
             nsl = nsl + 1
         end
     end


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To address the issue of the same lagid could be used by two Portchannels in two different linecards. This issue occurs when reboot many Linecards together with 20 seconds delay in each LC reboot.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
1) Modify database.sh to create a initial SYSTEM_LAG_IDS_FREE_LIST in the CHASSIS_APP_DB on SUP during database-chassis startup
2) Modify the database consistency check in swss.sh to append the lagid to the end of SYSTEM_LAG_IDS_FREE_LIST when lagid is released.
3) Modify the lag_id_end=1023 (not 1024) in chassisdb.conf since BCM supports the large lagid is 1023

This PR works with the following two PRs:
https://github.com/sonic-net/sonic-swss/pull/3303
https://github.com/sonic-net/sonic-platform-daemons/pull/542

Based on the dependency, the below order to merge these 3 PRs can help to avoid breaking the image run:
First:  PR https://github.com/sonic-net/sonic-buildimage/pull/20369 (This PR)
second:  https://github.com/sonic-net/sonic-swss/pull/3303
Third: https://github.com/sonic-net/sonic-platform-daemons/pull/542


#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

