### PR TITLE
Secure boot: Bump shim-unsigned package from debian repo

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -682,9 +682,18 @@ if [[ $SECURE_UPGRADE_MODE == 'dev' || $SECURE_UPGRADE_MODE == "prod" ]]; then
     echo "Secure Boot support build stage: Starting .."
 
     # debian secure boot dependecies
-    sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install      \
-        shim-unsigned \
-        grub-efi
+    sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install grub-efi
+
+    # TEMP: Remove after merging SONiC 202311. Instead of that piece of code we
+    # must install shim-unsigned using apt-get
+    if [[ $CONFIGURED_ARCH == armhf ]]; then
+        sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install shim-unsigned
+    else
+        wget http://ftp.debian.org/debian/pool/main/s/shim/shim-unsigned_15.8-1~deb11u1_$CONFIGURED_ARCH.deb -O shim-unsigned.deb
+        sudo mv shim-unsigned.deb $FILESYSTEM_ROOT/tmp/
+        sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT dpkg -i /tmp/shim-unsigned.deb
+        sudo rm -f $FILESYSTEM_ROOT/tmp/shim-unsigned.deb
+    fi
 
     if [ ! -f $SECURE_UPGRADE_SIGNING_CERT ]; then
         echo "Error: SONiC SECURE_UPGRADE_SIGNING_CERT=$SECURE_UPGRADE_SIGNING_CERT key missing"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Due to the following chnage added during the last weeks, conflict was appeared.

https://www.techpowerup.com/325849/dual-boot-linux-users-need-to-update-systems-due-to-grub-sbat-policy-changes-in-windows

Dual-Boot Linux Users Need to Update Systems Due to GRUB/SBAT Policy Changes in Windows

Multiple users have recently reported that the August 13 Windows 11 update causes issues with dual-boot Linux/Windows configurations. 

However, the issues are actually related to changes in UEFI Sec.

This PR is for updating the shim version to a newer so SBAT list not revoke it. Otherwise, secured boot system may be stuck.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

