### PR TITLE
[S6000] Fix 'show interface status' CLI needs sudo permission

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/eeprom.py
@@ -17,6 +17,7 @@
 
 
 try:
+    import os
     import binascii
     import redis
     import struct
@@ -304,7 +305,7 @@ class EepromS6000(EepromDecoder):
         super(EepromS6000, self).__init__(self.eeprom_path, None, 0, '', True)
 
         if not is_plugin:
-            self.eeprom_data = self.read_eeprom()
+            self.eeprom_data = "N/A"  if os.geteuid() != 0 else self.read_eeprom()
 
     def _is_valid_block_checksum(self, e):
         crc = self.compute_dell_crc(e[:-2])


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
CLI crashes without `sudo` permission on Dell 6000 platform

```
sonic@sonic-dev:~$ show interfaces status
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform_base/sonic_eeprom/eeprom_base.py", line 244, in read_eeprom_bytes
    F = self.open_eeprom()
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform_base/sonic_eeprom/eeprom_base.py", line 232, in open_eeprom
    return io.open(eeprom_file, "rb")
PermissionError: [Errno 13] Permission denied: '/sys/bus/i2c/devices/i2c-10/10-0053/eeprom'
 
During handling of the above exception, another exception occurred:
 
Traceback (most recent call last):
  File "/usr/local/bin/intfutil", line 836, in <module>
    main()
  File "/usr/local/bin/intfutil", line 819, in main
    interface_stat.display_intf_status()
  File "/usr/local/bin/intfutil", line 448, in display_intf_status
    self.get_intf_status()
  File "/usr/local/lib/python3.9/dist-packages/utilities_common/multi_asic.py", line 157, in wrapped_run_on_all_asics
    func(self,  *args, **kwargs)
  File "/usr/local/bin/intfutil", line 535, in get_intf_status
    self.table += self.generate_intf_status()
  File "/usr/local/bin/intfutil", line 479, in generate_intf_status
    port_oper_speed_get(self.db, key),
  File "/usr/local/bin/intfutil", line 202, in port_oper_speed_get
    return appl_db_port_status_get(db, intf_name, PORT_SPEED)
  File "/usr/local/bin/intfutil", line 167, in appl_db_port_status_get
    optics_type = port_optics_get(appl_db, intf_name, PORT_OPTICS_TYPE)
  File "/usr/local/bin/intfutil", line 224, in port_optics_get
    if is_rj45_port(intf_name):
  File "/usr/local/lib/python3.9/dist-packages/utilities_common/platform_sfputil_helper.py", line 120, in is_rj45_port
    platform_chassis = sonic_platform.platform.Platform().get_chassis()
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform/platform.py", line 24, in __init__
    self._chassis = Chassis()
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform/chassis.py", line 93, in __init__
    self._eeprom = EepromS6000()
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform/eeprom.py", line 307, in __init__
    self.eeprom_data = self.read_eeprom()
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform/eeprom.py", line 374, in read_eeprom
    return self.read_eeprom_bytes(self._EEPROM_MAX_LEN)
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform_base/sonic_eeprom/eeprom_base.py", line 267, in read_eeprom_bytes
    raise IOError("Failed to read eeprom : %s" % (str(e)))
OSError: Failed to read eeprom : [Errno 13] Permission denied: '/sys/bus/i2c/devices/i2c-10/10-0053/eeprom'
```

##### Work item tracking
- Microsoft ADO **(number only)**:29676167

#### How I did it
Add check to read eeprom only if user has root permission

#### How to verify it
Verified  the CLI "show interface status" does not crash if user is not root

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305
- [x] 202311
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

