### PR TITLE
Added a default forwarding template for rsyslog in 202305 images

### DIFF
--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -110,7 +110,7 @@ $RepeatedMsgReduction on
 
 {% set fmodifier = '!' if filter == 'exclude' else '' %}
 {% set device = vrf if vrf != '' and vrf != 'default' -%}
-{% set template = 'WelfRemoteFormat' if format == 'welf' else 'SONiCFileFormat' -%}
+{% set template = 'WelfRemoteFormat' if format == 'welf' else 'SONiCForwardFormat' -%}
 
 {# Server extra options -#}
 {% set options = '' -%}

--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -53,6 +53,8 @@ $UDPServerRun 514
 # Define a custom template
 $template SONiCFileFormat,"%timegenerated%.%timegenerated:::date-subseconds% %HOSTNAME% %syslogseverity-text:::uppercase% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
 $ActionFileDefaultTemplate SONiCFileFormat
+$template SONiCForwardFormat,"<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %syslogseverity-text:::uppercase% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
+$ActionForwardDefaultTemplate SONiCForwardFormat
 
 template(name="WelfRemoteFormat" type="string" string="%TIMESTAMP% id=firewall time=\"%timereported\
 :::date-year%-%timereported:::date-month%-%timereported:::date-day% %timereported:::date-hour%:%timereported:::date-minute%:%timereported\


### PR DESCRIPTION
#### Why I did it
Switches running SONiC 22305 versions do not show the severity when viewed via Streaming telemetry servers.

##### Work item tracking
- Microsoft ADO **(number only)**: 29362758

#### How I did it
Added the forwarding format template back to 202305 images.

#### How to verify it
Run build with this change on a device
Wait for logs to be forwarded to streaming telemetry and verify that severity is not "Unknown"

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] internal-202305

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->
Added a default forwarding template for rsyslog in 202305 images
