### PR TITLE
Add a patch for scapy to fix fd leak issue in AsyncSniffer

### DIFF
--- a/src/scapy.patch/0004-Fix-fd-leak-in-worker-thread.patch
+++ b/src/scapy.patch/0004-Fix-fd-leak-in-worker-thread.patch
@@ -1,0 +1,47 @@
+diff --git a/scapy/sendrecv.py b/scapy/sendrecv.py
+index f97fc415..dbcc372f 100644
+--- a/scapy/sendrecv.py
++++ b/scapy/sendrecv.py
+@@ -1111,17 +1111,19 @@ class AsyncSniffer(object):
+             # The _RL2 function resolves the L2socket of an iface
+             _RL2 = lambda i: L2socket or resolve_iface(i).l2listen()  # type: Callable[[_GlobInterfaceType], Callable[..., SuperSocket]]  # noqa: E501
+             if isinstance(iface, list):
+-                sniff_sockets.update(
+-                    (_RL2(ifname)(type=ETH_P_ALL, iface=ifname, **karg),
+-                     ifname)
+-                    for ifname in iface
+-                )
++                for ifname in iface:
++                    try:
++                        sniff_sockets.update({_RL2(ifname)(type=ETH_P_ALL, iface=ifname, **karg): ifname})
++                    except OSError:
++                        # Ignore OSError when opening the socket
++                        # The error can happen when the port goes down during the creation of the socket
++                        pass
+             elif isinstance(iface, dict):
+-                sniff_sockets.update(
+-                    (_RL2(ifname)(type=ETH_P_ALL, iface=ifname, **karg),
+-                     iflabel)
+-                    for ifname, iflabel in six.iteritems(iface)
+-                )
++                for ifname, iflabel in six.iteritems(iface):
++                    try:
++                        sniff_sockets.update({_RL2(ifname)(type=ETH_P_ALL, iface=ifname, **karg): iflabel})
++                    except OSError:
++                        pass
+             else:
+                 iface = iface or conf.iface
+                 sniff_sockets[_RL2(iface)(type=ETH_P_ALL, iface=iface,
+@@ -1221,7 +1223,11 @@ class AsyncSniffer(object):
+         self.running = False
+         if opened_socket is None:
+             for s in sniff_sockets:
+-                s.close()
++                try:
++                    s.close()
++                except Exception:
++                    # Ignore exceptions to ensure all sockets are closed
++                    pass
+         elif close_pipe:
+             close_pipe.close()
+         self.results = session.toPacketList()

--- a/src/scapy.patch/series
+++ b/src/scapy.patch/series
@@ -1,3 +1,4 @@
 0001-Fix-version-string-generation-when-scapy-is-a-submod.patch
 0002-Check-if-the-network-interface-still-exists.patch
 0003-Do-not-resolve-the-interface-name-globally.patch
+0004-Fix-fd-leak-in-worker-thread.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR is to add a patch to fix potential fd leak issue in `AsyncSniffer` in `scapy` python library.
There are two fd leak scenarios.
1. When starting worker thread `_run`, if an interface is down, an `OSError` is thrown, and the sockets that have been created will  be leaked as it never got a chance to be closed.
2. When stopping the worker thread, same error can happen when calling `close`. The sockets not closed will be leaked.

Test code:
```
from scapy.all import *
import time


sniffing_iface = ["PortChannel101", "PortChannel102", "PortChannel106", "PortChannel1024"]
sniffstring = "udp"

sniffer = None

def process_packet(packet):
    print("Got a packet {}".format(len(packet)))

while True:
    sniffer = AsyncSniffer(iface=sniffing_iface, filter=sniffstring, prn=process_packet, store=False)
    try:
        sniffer.start()
        RETRY = 30
        while RETRY >= 0 and not hasattr(sniffer, 'stop_cb'):
            time.sleep(0.1)
            RETRY -= 1
        if RETRY < 0:
            print("Sniffer failed to start")
        else:
            print("Sniffer started")
        try:
            sniffer.stop()
            time.sleep(1)
            print("Sniffer stopped")
        except:
            pass
    except:
        time.sleep(1)
        pass
```
Run above code while toggling portchannels on the device. The opened fd is increasing.


##### Work item tracking
- Microsoft ADO **29735068**:

#### How I did it
Catch `OSError` when creating sockets, and catch any exception when closing socket to ensure all sockets are closed.

#### How to verify it
Verified by the testing code above. No fd leak happened.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311
- [x] 202405 

#### Tested branch (Please provide the tested image version)
The change is tested on 202311 and 202405 branches.
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
 fix potential fd leak issue in `AsyncSniffer` in `scapy` python library.
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
No config change.
#### A picture of a cute animal (not mandatory but encouraged)

