### PR TITLE
Disable host-resource MIB in snmpd

### DIFF
--- a/src/snmpd/patch-5.9+dfsg/0014-exclude-host-mibs.patch
+++ b/src/snmpd/patch-5.9+dfsg/0014-exclude-host-mibs.patch
@@ -1,0 +1,14 @@
+diff --git a/debian/rules b/debian/rules
+index 0eeaeda..674950b 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -31,7 +31,8 @@ endif
+ ifeq (hurd,$(DEB_BUILD_ARCH_OS))
+ EXCL_MIB_MODULES += mibII
+ else
+-MIB_MODULES += host
++#MIB_MODULES += host
++EXCL_MIB_MODULES += host
+ endif
+
+ %:

--- a/src/snmpd/patch-5.9+dfsg/series
+++ b/src/snmpd/patch-5.9+dfsg/series
@@ -9,3 +9,4 @@
 0012-agent-Makefile.in-Unbreak-the-enable-minimalist-buil.patch
 0013-enable-parallel-build-for-net-snmp.patch
 cross-compile-changes.patch
+0014-exclude-host-mibs.patch


### PR DESCRIPTION
Why I did it
Disable host-resource-v2 SNMP MIB implementation in snmpd
snmpd is currently returning the data based on the overlay FS inside a container

How it was done
Configuring snmpd to exclude host MIB

How to verify
snmpwalk on a host-resource MIB OID