### PR TITLE
Fix lldpmgrd traceback when hostname is not available

### DIFF
--- a/dockers/docker-lldp/lldpmgrd
+++ b/dockers/docker-lldp/lldpmgrd
@@ -68,7 +68,7 @@ class LldpManager(daemon_base.DaemonBase):
                                               False)
         
         self.pending_cmds = {}
-        self.hostname = "None"
+        self.hostname = None
         self.mgmt_ip = "None"
 
         self.device_table = swsscommon.Table(self.config_db, swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
We see below backtrace when hostname is not available during boot and lldpmgrd exits
```
Oct 11 03:25:29.131847 sonic INFO lldp#supervisord: lldpmgrd Traceback (most recent call last):
Oct 11 03:25:29.131847 sonic INFO lldp#supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 369, in <module>
Oct 11 03:25:29.132038 sonic INFO lldp#supervisord: lldpmgrd     main()
Oct 11 03:25:29.132038 sonic INFO lldp#supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 351, in main
Oct 11 03:25:29.132209 sonic INFO lldp#supervisord: lldpmgrd     lldpmgr.run()
Oct 11 03:25:29.132209 sonic INFO lldp#supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 319, in run
Oct 11 03:25:29.132333 sonic INFO lldp#supervisord: lldpmgrd     self.lldp_process_device_table_event(op, dict(fvp), key)
Oct 11 03:25:29.132347 sonic INFO lldp#supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 253, in lldp_process_device_table_event
Oct 11 03:25:29.132347 sonic INFO lldp#supervisord: lldpmgrd     self.update_hostname(hostname)
Oct 11 03:25:29.132356 sonic INFO lldp#supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 88, in update_hostname
Oct 11 03:25:29.132461 sonic INFO lldp#supervisord: lldpmgrd     proc = subprocess.Popen(cmd,stdout=subprocess.PIPE, stderr=subprocess.PIPE)
Oct 11 03:25:29.132461 sonic INFO lldp#supervisord: lldpmgrd   File "/usr/lib/python3.9/subprocess.py", line 951, in __init__
Oct 11 03:25:29.132611 sonic INFO lldp#supervisord: lldpmgrd     self._execute_child(args, executable, preexec_fn, close_fds,
Oct 11 03:25:29.132622 sonic INFO lldp#supervisord: lldpmgrd   File "/usr/lib/python3.9/subprocess.py", line 1756, in _execute_child
Oct 11 03:25:29.132929 sonic INFO lldp#supervisord: lldpmgrd     self.pid = _posixsubprocess.fork_exec(
```
This is because string `self.hostname` is initialized to *string* `'None'`. It is not of `NoneType`
In the code hostname which has a value of `None(NoneType)` is compared with `'None'(str object)` and it fails.
It then attempts to run lldpcli with hostname as `None(NoneType)` which results in traceback and exit of lldpmgrd.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Initialize `self.hostname` to `None` of `NoneType`

#### How to verify it
1. Removed hostname from config, reboot. Verified that no Traceback seen
2. set hostname using config CLI and verified that lldpcli is run with correct hostname

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

