### PR TITLE
Fix ICCPD make option

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -536,6 +536,7 @@ SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            INCLUDE_DHCP_RELAY=$(INCLUDE_DHCP_RELAY) \
                            INCLUDE_DHCP_SERVER=$(INCLUDE_DHCP_SERVER) \
                            INCLUDE_MACSEC=$(INCLUDE_MACSEC) \
+                           INCLUDE_ICCPD=$(INCLUDE_ICCPD) \
                            SONIC_INCLUDE_RESTAPI=$(INCLUDE_RESTAPI) \
                            SONIC_INCLUDE_MUX=$(INCLUDE_MUX) \
                            ENABLE_TRANSLIB_WRITE=$(ENABLE_TRANSLIB_WRITE) \


### PR DESCRIPTION
#### Why I did it
To optionally include "INCLUDE_ICCPD=y" in make command.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add the missing "INCLUDE_ICCPD" option in makefile.work

#### How to verify it
Build and verify ICCPD docker is created on the switch.

Build command used:
make configure PLATFORM=marvell PLATFORM_ARCH=arm64 INCLUDE_ICCPD=y
make INCLUDE_ICCPD=y target/sonic-marvell-arm64.bin

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)
master



#### Description for the changelog
#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

