### PR TITLE
Limit auditd service CPU usage.

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -398,6 +398,9 @@ LogsDirectory=audit
 LogsDirectoryMode=0750
 EOF
 
+# Limit auditd CPU max usage to 10%
+sudo sed -t '/\[Service\]/a CPUQuota=10%' $FILESYSTEM_ROOT/lib/systemd/system/auditd.service
+
 # latest tcpdump control resource access with AppArmor.
 # override tcpdump profile to allow tcpdump access TACACS config file.
 sudo cp files/apparmor/usr.bin.tcpdump $FILESYSTEM_ROOT/etc/apparmor.d/local/usr.bin.tcpdump

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -399,7 +399,7 @@ LogsDirectoryMode=0750
 EOF
 
 # Limit auditd CPU max usage to 10%
-sudo sed -t '/\[Service\]/a CPUQuota=10%' $FILESYSTEM_ROOT/lib/systemd/system/auditd.service
+sudo sed -i '/\[Service\]/a CPUQuota=10%' $FILESYSTEM_ROOT/lib/systemd/system/auditd.service
 
 # latest tcpdump control resource access with AppArmor.
 # override tcpdump profile to allow tcpdump access TACACS config file.


### PR DESCRIPTION
Limit auditd service CPU usage.

#### Why I did it
To enhance SONiC security, need rollout auditd with more rules, this may mpact system performance, so need limit CPU usage

##### Work item tracking
- Microsoft ADO: 29882616

#### How I did it
Add CPUQuota setting to limit CPU usage.

#### How to verify it
Pass all UT.

Manually verified that the configuration file and service cgroup settings have been updated:

admin@vlab-01:~$ cat /lib/systemd/system/auditd.service
...
[Service]
CPUQuota=10%
...

admin@vlab-01:~$ cat /sys/fs/cgroup/cpu,cpuacct/system.slice/auditd.service/cpu.cfs_quota_us
10000
admin@vlab-01:~$ cat /sys/fs/cgroup/cpu,cpuacct/system.slice/auditd.service/cpu.cfs_period_us
100000



<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [] 

#### Description for the changelog
Limit auditd service CPU usage.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

