### PR TITLE
Strip null bytes from parsed eeprom data before writing to db on S6000 platform

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/eeprom.py
@@ -429,7 +429,7 @@ class EepromS6000(EepromDecoder):
                     data = ":".join(["{:02x}".format(T) for T in e[offset:offset+f[1]]]).upper()
                 else:
                     data = e[offset:offset+f[1]].decode('ascii')
-                client.hset('EEPROM_INFO|{}'.format(f[0]), 'Value', data)
+                client.hset('EEPROM_INFO|{}'.format(f[0]), 'Value', data.strip('\x00'))
                 offset += f[1]
 
             if not self._is_valid_block_checksum(e[blk_start:blk_end]):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This was failing sonic-mgmt test [test_syseepromd](https://github.com/sonic-net/sonic-mgmt/blob/master/tests/platform_tests/daemon/test_syseepromd.py) due to a setup error on account of null bytes being parsed from the S6000 eeprom.

This is due to differences in the way sonic-db-cli handles null values in the part number as parsed by the EEPROM in the 202012 image vs 202205+ image versions:

**202305 image**

```
admin@dell-s6000-device:~$ sudo sonic-installer list
Current: SONiC-OS-20230531.38
Next: SONiC-OS-20230531.38
Available:
SONiC-OS-20230531.38
admin@dell-s6000-device:~$
admin@dell-s6000-device:~$ redis-cli -n 6 HGETALL "EEPROM_INFO|Part Number"
1) "Value"
2) "00NX1V\x00\x00\x00\x00"
admin@dell-s6000-device:~$ sonic-db-cli STATE_DB  HGETALL "EEPROM_INFO|Part Number"
{'Value': '00NX1V'}
admin@dell-s6000-device:~$ sonic-db-cli STATE_DB  HGETALL "EEPROM_INFO|Part Number" | cat --show-nonprinting
{'Value': '00NX1V^@^@^@^@'}
admin@dell-s6000-device:~$
```

**202012 image**

```
admin@dell-s6000-device:~$ sudo sonic-installer list
Current: SONiC-OS-20201231.119
Next: SONiC-OS-20201231.119
Available:
SONiC-OS-20201231.119
SONiC-OS-20230531.38
admin@dell-s6000-device:~$
admin@dell-s6000-device:~$ redis-cli -n 6 HGETALL "EEPROM_INFO|Part Number"
1) "Value"
2) "00NX1V\x00\x00\x00\x00"
admin@dell-s6000-device:~$
admin@dell-s6000-device:~$ sonic-db-cli STATE_DB HGETALL "EEPROM_INFO|Part Number"
{'Value': '00NX1V\x00\x00\x00\x00'}
admin@dell-s6000-device:~$
admin@dell-s6000-device:~$ sonic-db-cli STATE_DB HGETALL "EEPROM_INFO|Part Number" | cat --show-nonprinting
{'Value': '00NX1V\x00\x00\x00\x00'}
admin@dell-s6000-device:~$

```

##### Work item tracking
- Microsoft ADO **(number only)**: 29720798

#### How I did it
Added logic to strip null bytes from parsed data before writing to database.

#### How to verify it
Run the aforementioned sonic-mgmt test before and after making the change in this PR -- note that test fails on setup without the change. See attached logs.
[s6000_test_syseepromd_logs.txt](https://github.com/user-attachments/files/17386540/s6000_test_syseepromd_logs.txt)


Flashed image with this change on an S6000 device and ran the above sonic-mgmt test:

**Image info:**
```
admin@sonic-device:~$ show ver

SONiC Software Version: SONiC.master-20512.669582-5884dfa4f
SONiC OS Version: 12
Distribution: Debian 12.6
Kernel: 6.1.0-22-2-amd64
Build commit: 5884dfa4f
Build date: Tue Oct 15 23:44:02 UTC 2024
Built by: redacted

Platform: x86_64-dell_s6000_s1220-r0
HwSKU: Force10-S6000
ASIC: broadcom
ASIC Count: 1
Serial Number: NA
Model Number: NA
Hardware Revision: NA
Uptime: 21:43:14 up 12 min,  1 user,  load average: 11.27, 10.11, 5.95
Date: Wed 16 Oct 2024 21:43:14

```

**Relevant sonic-mgmt test logs:**
```
------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------
21:47:19 sonic.get_pmon_daemon_status             L0914 INFO   | Daemon 'syseepromd' in the 'RUNNING' state with pid 36
21:47:19 test_syseepromd.test_pmon_syseepromd_sto L0139 INFO   | syseepromd daemon is RUNNING with pid 36
21:47:34 sonic.get_pmon_daemon_status             L0914 INFO   | Daemon 'syseepromd' in the 'STOPPED' state with pid -1
21:48:06 sonic.get_pmon_daemon_status             L0914 INFO   | Daemon 'syseepromd' in the 'RUNNING' state with pid 130
PASSED
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 202205
- [x] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [20220531.51 ] <!-- image version 1 -->
- [ 20230531.38] <!-- image version 2 -->
- [ 20230531.39] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Strip null bytes from parsed eeprom data before writing to db

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

