### PR TITLE
dhcp_v4_relay_issue

### DIFF
--- a/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
@@ -19,7 +19,9 @@ command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /t
 {% if prefix | ipv4 and name != vlan_name %} -iu {{ name }}{% endif -%}
 {% endfor %}
 {% for (name, prefix) in INTERFACE|pfx_filter %}
-{% if prefix | ipv4 %} -iu {{ name }}{% endif -%}
+{%- if prefix | ipv4 %} -iu {{ name }}
+{%- elif prefix | ipv6 %} -ih {{ name }}
+{%- endif %}
 {% endfor %}
 {% for (name, prefix) in PORTCHANNEL_INTERFACE|pfx_filter %}
 {% if prefix | ipv4 %} -iu {{ name }}{% endif -%}

--- a/src/isc-dhcp/patch/0017-Allow-BOOTP-reply-on-rfc-5549-interfaces.patch
+++ b/src/isc-dhcp/patch/0017-Allow-BOOTP-reply-on-rfc-5549-interfaces.patch
@@ -1,0 +1,32 @@
+diff --git a/relay/dhcrelay.c b/relay/dhcrelay.c
+index ff0ad17..ec71600 100644
+--- a/relay/dhcrelay.c
++++ b/relay/dhcrelay.c
+@@ -507,6 +507,9 @@ main(int argc, char **argv) {
+ 			}
+ 
+ 			request_v4_interface(argv[i], INTERFACE_DOWNSTREAM);
++		} else if (!strcmp(argv[i], "-ih")) {
++			++i;
++			request_v4_interface(argv[i], INTERFACE_UPSTREAM);
+ 		} else if (!strcmp(argv[i], "-a")) {
+ #ifdef DHCPv6
+ 			if (local_family_set && (local_family == AF_INET6)) {
+@@ -907,9 +910,14 @@ do_relay4(struct interface_info *ip, struct dhcp_packet *packet,
+ 		return;
+ 	}
+ 	if (ip->address_count < 1 || ip->addresses == NULL) {
+-		log_info("Discarding packet received on %s interface that "
+-			 "has no IPv4 address assigned.", ip->name);
+-		return;
++		if (ip->flags & INTERFACE_UPSTREAM) {
++			log_info("Processing packet received on %s interface that "
++				 "has only IPv6 address assigned.", ip->name);
++		} else {
++			log_info("Discarding packet received on %s interface that "
++				 "has no IPv4 address assigned.", ip->name);
++			return;
++		}
+ 	}
+ 
+ 	if (enable_support_for_dual_tor) {

--- a/src/isc-dhcp/patch/series
+++ b/src/isc-dhcp/patch/series
@@ -15,3 +15,4 @@
 0015-option-to-set-primary-address-in-interface.patch
 0016-Don-t-look-up-the-ifindex-for-fallback.patch
 0017-Register-IO-obj-before-create-fd-watch.patch
+0018-Allow-BOOTP-reply-on-rfc-5549-interfaces.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

If DHCP Servers are reachable only over RFC 5549 enabled links (that is V4 destinations over V6 neighbors) BOOTP responses are dropped by the relay switch and thus client DHCP requests are never complete.

#### How I did it

- Added Flag "-ih" for interfaces configured with only ipv6 address.
- Added check to allow packets received (with no ipv4 address) on above interfaces.

#### How to verify it

- Have a DHCP Server reachable over RFC 5549 enabled links.
- Capture BOOTP resposes via tcpdump.
- Check the DHCP relay address learnt via "show dhcp_relay ipv4 helper".

#### Description for the changelog

- Adding the "-ih" flag to distinguish UPSTREAM interface with ipv6 address only.
- For above case added a check to process the DHCP replies.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
