### PR TITLE
[docker-ptf]: CI change to publish docker-ptf image to the docker registry

### DIFF
--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -61,20 +61,20 @@ jobs:
           BUILD_REASON=$(Build.Reason)
           echo "Build.Reason = $BUILD_REASON"
           echo "Build.DefinitionName = $BUILD_DEFINITIONNAME"
-          # if [[ "$BUILD_REASON" != "PullRequest" && "$BUILD_DEFINITIONNAME" == "saikiran.test.pipeline.vs" ]]
-          # then
-          PORT=443
-          DOCKERS=$(ls target/docker-ptf.gz)
-          BRANCH=$(Build.SourceBranchName)
-          echo "Branch = $BRANCH"
-          LABELS="$BRANCH"
-          [[ "$BRANCH" == "master" ]] && LABELS="$LABELS latest"
-          for f in $DOCKERS; do
-            echo $f
-            echo "Labels = $LABELS"
-            ./push_docker.sh $f $(REGISTRY_SERVER_PUBLIC) $PORT $(REGISTRY_USERNAME) "$REGISTRY_PASSWD" "$LABELS"
-          done
-          # fi
+          if [[ "$BUILD_REASON" != "PullRequest" && "$BUILD_DEFINITIONNAME" == "Azure.sonic-buildimage.official.vs" ]]
+          then
+            PORT=443
+            DOCKERS=$(ls target/docker-ptf.gz)
+            BRANCH=$(Build.SourceBranchName)
+            echo "Branch = $BRANCH"
+            LABELS="$BRANCH"
+            [[ "$BRANCH" == "master" ]] && LABELS="$LABELS latest"
+            for f in $DOCKERS; do
+              echo $f
+              echo "Labels = $LABELS"
+              ./push_docker.sh $f $(REGISTRY_SERVER_PUBLIC) $PORT $(REGISTRY_USERNAME) "$REGISTRY_PASSWD" "$LABELS"
+            done
+          fi
           mkdir -p $(Build.ArtifactStagingDirectory)/target
           mv target/* $(Build.ArtifactStagingDirectory)/target/
         env:

--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -59,9 +59,8 @@ jobs:
     postSteps:
       - script: |
           BUILD_REASON=$(Build.Reason)
-          if [[ "$BUILD_REASON" != "PullRequest" && "$GROUP_NAME" == "vs" ]]
+          if [[ "$BUILD_REASON" != "PullRequest" && "$BUILD_DEFINITIONNAME" == "Azure.sonic-buildimage.official.vs" ]]
           then
-            SONIC_VERSION=$(cat target/sonic.version)
             PORT=443
             DOCKERS=$(ls target/docker-ptf.gz)
             BRANCH=$(Build.SourceBranchName)

--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -73,6 +73,8 @@ jobs:
           fi
           mkdir -p $(Build.ArtifactStagingDirectory)/target
           mv target/* $(Build.ArtifactStagingDirectory)/target/
+        env:
+          REGISTRY_PASSWD: $(REGISTRY_PASSWD)
         displayName: Publish to Docker Registry and Copy Artifacts
         condition: always()
       - publish:  $(Build.ArtifactStagingDirectory)

--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -58,16 +58,20 @@ jobs:
         displayName: 'Make configure'
     postSteps:
       - script: |
-          # BUILD_REASON=$(Build.Reason)
-          # if [[ "$BUILD_REASON" != "PullRequest" && "$BUILD_DEFINITIONNAME" == "Azure.sonic-buildimage.official.vs" ]]
+          BUILD_REASON=$(Build.Reason)
+          echo "Build.Reason = $BUILD_REASON"
+          echo "Build.DefinitionName = $BUILD_DEFINITIONNAME"
+          # if [[ "$BUILD_REASON" != "PullRequest" && "$BUILD_DEFINITIONNAME" == "saikiran.test.pipeline.vs" ]]
           # then
           PORT=443
           DOCKERS=$(ls target/docker-ptf.gz)
           BRANCH=$(Build.SourceBranchName)
+          echo "Branch = $BRANCH"
           LABELS="$BRANCH"
           [[ "$BRANCH" == "master" ]] && LABELS="$LABELS latest"
           for f in $DOCKERS; do
             echo $f
+            echo "Labels = $LABELS"
             ./push_docker.sh $f $(REGISTRY_SERVER_PUBLIC) $PORT $(REGISTRY_USERNAME) "$REGISTRY_PASSWD" "$LABELS"
           done
           # fi

--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -59,7 +59,6 @@ jobs:
     postSteps:
       - script: |
           BUILD_REASON=$(Build.Reason)
-          GROUP_NAME=$(GROUP_NAME)
           if [[ "$BUILD_REASON" != "PullRequest" && "$GROUP_NAME" == "vs" ]]
           then
             SONIC_VERSION=$(cat target/sonic.version)

--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -58,19 +58,19 @@ jobs:
         displayName: 'Make configure'
     postSteps:
       - script: |
-          BUILD_REASON=$(Build.Reason)
-          if [[ "$BUILD_REASON" != "PullRequest" && "$BUILD_DEFINITIONNAME" == "Azure.sonic-buildimage.official.vs" ]]
-          then
-            PORT=443
-            DOCKERS=$(ls target/docker-ptf.gz)
-            BRANCH=$(Build.SourceBranchName)
-            LABELS="$BRANCH"
-            [[ "$BRANCH" == "master" ]] && LABELS="$LABELS latest"
-            for f in $DOCKERS; do
-              echo $f
-              ./push_docker.sh $f $(REGISTRY_SERVER_PUBLIC) $PORT $(REGISTRY_USERNAME) "$REGISTRY_PASSWD" "$LABELS"
-            done
-          fi
+          # BUILD_REASON=$(Build.Reason)
+          # if [[ "$BUILD_REASON" != "PullRequest" && "$BUILD_DEFINITIONNAME" == "Azure.sonic-buildimage.official.vs" ]]
+          # then
+          PORT=443
+          DOCKERS=$(ls target/docker-ptf.gz)
+          BRANCH=$(Build.SourceBranchName)
+          LABELS="$BRANCH"
+          [[ "$BRANCH" == "master" ]] && LABELS="$LABELS latest"
+          for f in $DOCKERS; do
+            echo $f
+            ./push_docker.sh $f $(REGISTRY_SERVER_PUBLIC) $PORT $(REGISTRY_USERNAME) "$REGISTRY_PASSWD" "$LABELS"
+          done
+          # fi
           mkdir -p $(Build.ArtifactStagingDirectory)/target
           mv target/* $(Build.ArtifactStagingDirectory)/target/
         env:

--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -58,9 +58,24 @@ jobs:
         displayName: 'Make configure'
     postSteps:
       - script: |
+          BUILD_REASON=$(Build.Reason)
+          GROUP_NAME=$(GROUP_NAME)
+          if [[ "$BUILD_REASON" != "PullRequest" && "$GROUP_NAME" == "vs" ]]
+          then
+            SONIC_VERSION=$(cat target/sonic.version)
+            PORT=443
+            DOCKERS=$(ls target/docker-ptf.gz)
+            BRANCH=$(Build.SourceBranchName)
+            LABELS="$BRANCH"
+            [[ "$BRANCH" == "master" ]] && LABELS="$LABELS latest"
+            for f in $DOCKERS; do
+              echo $f
+              ./push_docker.sh $f $(REGISTRY_SERVER_PUBLIC) $PORT $(REGISTRY_USERNAME) "$REGISTRY_PASSWD" "$LABELS"
+            done
+          fi
           mkdir -p $(Build.ArtifactStagingDirectory)/target
           mv target/* $(Build.ArtifactStagingDirectory)/target/
-        displayName: Copy Artifacts
+        displayName: Publish to Docker Registry and Copy Artifacts
         condition: always()
       - publish:  $(Build.ArtifactStagingDirectory)
         artifact: 'sonic-buildimage.$(GROUP_NAME)$(GROUP_EXTNAME)'

--- a/.azure-pipelines/official-build.yml
+++ b/.azure-pipelines/official-build.yml
@@ -36,6 +36,7 @@ stages:
 - stage: Build
   pool: sonicbld-1es
   variables:
+  - group: Container-Registry
   - name: CACHE_MODE
     value: wcache
   - template: .azure-pipelines/azure-pipelines-repd-build-variables.yml@buildimage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,8 @@ variables:
 stages:
 - stage: BuildVS
   pool: sonicbld-1es
+  variables:
+    - group: Container-Registry
   jobs:
   - template: .azure-pipelines/azure-pipelines-build.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,8 +52,6 @@ variables:
 stages:
 - stage: BuildVS
   pool: sonicbld-1es
-  variables:
-    - group: Container-Registry
   jobs:
   - template: .azure-pipelines/azure-pipelines-build.yml
     parameters:


### PR DESCRIPTION
#### Why I did it

Changes to `docker-ptf` Dockerfile don't get automatically published to the docker registry accessed by the community. This PR addresses the issue.

##### Work item tracking
- Microsoft ADO **(number only)**: 29869315

#### How I did it

Modified the `postSteps` phase in `azure-pipelines-image-template.yml` to invoke the script to push `docker-ptf` image to the docker registry. The push is applicable to build branches (`master`, `202305`, `202311` etc.) and not feature branches.

#### How to verify it

TBD

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

Not applicable.

#### Description for the changelog

[docker-ptf]: CI change to publish docker-ptf image to the public/community docker registry

* Change pipeline YAML to publish docker-ptf image to docker registry
* Publish only docker-ptf image for main or release branches only and not feature branch

#### Link to config_db schema for YANG module changes

Not applicable

#### A picture of a cute animal (not mandatory but encouraged)