### PR TITLE
[Yang] Fix Yang model of BGP Allowed Prefix

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
@@ -158,43 +158,32 @@
     "BGP_PEERRANGE_ALL_VALID": {
         "desc": "Configure BGP peer range table."
     },
-    "BGP_ALLOWED_PREFIXES_COM_LIST_ALL_VALID": {
+    "BGP_ALLOWED_PREFIXES_ALL_VALID": {
         "desc": "Configue BGP allowed prefix list."
     },
-    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_DEPLOYMENT": {
-        "desc": "Invalid default action.",
+    "BGP_ALLOWED_PREFIXES_INVALID_DEPLOYMENT": {
+        "desc": "Invalid deployment.",
         "eStrKey" : "Pattern"
     },
-    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_DEFAULT_ACTION": {
+    "BGP_ALLOWED_PREFIXES_INVALID_ID": {
+        "desc": "Invalid id.",
+        "eStrKey" : "InvalidValue",
+        "eStr" : ["id"]
+    },
+    "BGP_ALLOWED_PREFIXES_INVALID_NEIGHBOR": {
+        "desc": "Invalid neighbor.",
+        "eStrKey" : "Pattern"
+    },
+    "BGP_ALLOWED_PREFIXES_INVALID_DEFAULT_ACTION": {
         "desc": "Invalid default action.",
         "eStrKey" : "InvalidValue",
         "eStr" : ["default_action"]
     },
-    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_PREFIXES_IPV4": {
+    "BGP_ALLOWED_PREFIXES_INVALID_PREFIXES_IPV4": {
         "desc": "Invalid IPv4 prefix.",
         "eStrKey" : "Pattern"
     },
-    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_PREFIXES_IPV6": {
-        "desc": "Invalid IPv6 prefix.",
-        "eStrKey" : "Pattern"
-    },
-    "BGP_ALLOWED_PREFIXES_LIST_ALL_VALID": {
-        "desc": "Configue BGP allowed prefix list."
-    },
-    "BGP_ALLOWED_PREFIXES_LIST_INVALID_DEPLOYMENT": {
-        "desc": "Invalid default action.",
-        "eStrKey" : "Pattern"
-    },
-    "BGP_ALLOWED_PREFIXES_LIST_INVALID_DEFAULT_ACTION": {
-        "desc": "Invalid default action.",
-        "eStrKey" : "InvalidValue",
-        "eStr" : ["default_action"]
-    },
-    "BGP_ALLOWED_PREFIXES_LIST_INVALID_PREFIXES_IPV4": {
-        "desc": "Invalid IPv4 prefix.",
-        "eStrKey" : "Pattern"
-    },
-    "BGP_ALLOWED_PREFIXES_LIST_INVALID_PREFIXES_IPV6": {
+    "BGP_ALLOWED_PREFIXES_INVALID_PREFIXES_IPV6": {
         "desc": "Invalid IPv6 prefix.",
         "eStrKey" : "Pattern"
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
@@ -1422,95 +1422,7 @@
         }
     },
 
-    "BGP_ALLOWED_PREFIXES_COM_LIST_ALL_VALID": {
-        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
-            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
-                "BGP_ALLOWED_PREFIXES_COM_LIST": [
-                    {
-                        "deployment": "DEPLOYMENT_ID",
-                        "id": "4",
-                        "community": "123:123",
-                        "default_action": "permit",
-                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24"],
-                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
-                    },
-                    {
-                        "deployment": "DEPLOYMENT_ID",
-                        "id": "5",
-                        "community": "456:456",
-                        "default_action": "permit",
-                        "prefixes_v4": ["10.10.0.0/24", "10.11.0.0/24"],
-                        "prefixes_v6": ["fc00:f1::/64", "fc00:a1::/64"]
-                    }
-                ]
-            }
-        }
-    },
-    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_DEPLOYMENT": {
-        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
-            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
-                "BGP_ALLOWED_PREFIXES_COM_LIST": [
-                    {
-                        "deployment": "DEPLOYMENTID",
-                        "id": "4",
-                        "community": "123:123",
-                        "default_action": "permitall",
-                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24"],
-                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
-                    }
-                ]
-            }
-        }
-    },
-    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_DEFAULT_ACTION": {
-        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
-            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
-                "BGP_ALLOWED_PREFIXES_COM_LIST": [
-                    {
-                        "deployment": "DEPLOYMENT_ID",
-                        "id": "4",
-                        "community": "123:123",
-                        "default_action": "permitall",
-                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24"],
-                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
-                    }
-                ]
-            }
-        }
-    },
-    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_PREFIXES_IPV4": {
-        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
-            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
-                "BGP_ALLOWED_PREFIXES_COM_LIST": [
-                    {
-                        "deployment": "DEPLOYMENT_ID",
-                        "id": "4",
-                        "community": "123:123",
-                        "default_action": "permit",
-                        "prefixes_v4": ["10.0.0.0/48", "10.1.0.0/24"],
-                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
-                    }
-                ]
-            }
-        }
-    },
-    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_PREFIXES_IPV6": {
-        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
-            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
-                "BGP_ALLOWED_PREFIXES_COM_LIST": [
-                    {
-                        "deployment": "DEPLOYMENT_ID",
-                        "id": "4",
-                        "community": "123:123",
-                        "default_action": "permit",
-                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0./24"],
-                        "prefixes_v6": ["fc00:f0::/129", "fc00:a0::/64"]
-                    }
-                ]
-            }
-        }
-    },
-    "BGP_ALLOWED_PREFIXES_LIST_ALL_VALID": {
+    "BGP_ALLOWED_PREFIXES_ALL_VALID": {
         "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
             "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
                 "BGP_ALLOWED_PREFIXES_LIST": [
@@ -1518,66 +1430,220 @@
                         "deployment": "DEPLOYMENT_ID",
                         "id": "4",
                         "default_action": "permit",
-                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24"],
-                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
-                    },
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_NEIGH_LIST": [
                     {
                         "deployment": "DEPLOYMENT_ID",
-                        "id": "5",
+                        "id": "4",
+                        "neighbor": "NEIGHBOR_TYPE",
+                        "neighbor_type": "DUMMY_NEIGHBOR_TYPE",
                         "default_action": "permit",
-                        "prefixes_v4": ["10.10.0.0/24", "10.11.0.0/24"],
-                        "prefixes_v6": ["fc00:f1::/64", "fc00:a1::/64"]
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
                     }
-                ]
-            }
-        }
-    },
-    "BGP_ALLOWED_PREFIXES_LIST_INVALID_DEPLOYMENT": {
-        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
-            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
-                "BGP_ALLOWED_PREFIXES_LIST": [
-                    {
-                        "deployment": "DEPLOYMENTID",
-                        "id": "4",
-                        "default_action": "permitall",
-                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24"],
-                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
-                    }
-                ]
-            }
-        }
-    },
-    "BGP_ALLOWED_PREFIXES_LIST_INVALID_DEFAULT_ACTION": {
-        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
-            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
-                "BGP_ALLOWED_PREFIXES_LIST": [
+                ],
+                "BGP_ALLOWED_PREFIXES_COM_LIST": [
                     {
                         "deployment": "DEPLOYMENT_ID",
                         "id": "4",
-                        "default_action": "permitall",
-                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24"],
-                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
+                        "community": "123:123",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_NEIGH_COM_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "neighbor": "NEIGHBOR_TYPE",
+                        "neighbor_type": "DUMMY_NEIGHBOR_TYPE",
+                        "community": "123:123",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
                     }
                 ]
             }
         }
     },
-    "BGP_ALLOWED_PREFIXES_LIST_INVALID_PREFIXES_IPV4": {
+    "BGP_ALLOWED_PREFIXES_INVALID_DEPLOYMENT": {
         "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
             "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
                 "BGP_ALLOWED_PREFIXES_LIST": [
                     {
-                        "deployment": "DEPLOYMENT_ID",
+                        "deployment": "INVALID_DEPLOYMENT",
                         "id": "4",
                         "default_action": "permit",
-                        "prefixes_v4": ["10.0.0.0/48", "10.1.0.0/24"],
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_NEIGH_LIST": [
+                    {
+                        "deployment": "INVALID_DEPLOYMENT",
+                        "id": "4",
+                        "neighbor": "NEIGHBOR_TYPE",
+                        "neighbor_type": "DUMMY_NEIGHBOR_TYPE",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_COM_LIST": [
+                    {
+                        "deployment": "INVALID_DEPLOYMENT",
+                        "id": "4",
+                        "community": "123:123",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24"],
                         "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_NEIGH_COM_LIST": [
+                    {
+                        "deployment": "INVALID_DEPLOYMENT",
+                        "id": "4",
+                        "neighbor": "NEIGHBOR_TYPE",
+                        "neighbor_type": "DUMMY_NEIGHBOR_TYPE",
+                        "community": "123:123",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
                     }
                 ]
             }
         }
     },
-    "BGP_ALLOWED_PREFIXES_LIST_INVALID_PREFIXES_IPV6": {
+    "BGP_ALLOWED_PREFIXES_INVALID_ID": {
+        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
+            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
+                "BGP_ALLOWED_PREFIXES_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "INVALID_ID",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_NEIGH_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "INVALID_ID",
+                        "neighbor": "NEIGHBOR_TYPE",
+                        "neighbor_type": "DUMMY_NEIGHBOR_TYPE",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_COM_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "INVALID_ID",
+                        "community": "123:123",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_NEIGH_COM_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "INVALID_ID",
+                        "neighbor": "NEIGHBOR_TYPE",
+                        "neighbor_type": "DUMMY_NEIGHBOR_TYPE",
+                        "community": "123:123",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_ALLOWED_PREFIXES_INVALID_NEIGHBOR": {
+        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
+            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
+                "BGP_ALLOWED_PREFIXES_NEIGH_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "neighbor": "INVALID_NEIGHBOR_TYPE",
+                        "neighbor_type": "DUMMY_NEIGHBOR_TYPE",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_NEIGH_COM_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "neighbor": "INVALID_NEIGHBOR_TYPE",
+                        "neighbor_type": "DUMMY_NEIGHBOR_TYPE",
+                        "community": "123:123",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_ALLOWED_PREFIXES_INVALID_DEFAULT_ACTION": {
+        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
+            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
+                "BGP_ALLOWED_PREFIXES_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "default_action": "INVALID_DEFAULT_ACTION",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_NEIGH_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "neighbor": "NEIGHBOR_TYPE",
+                        "neighbor_type": "DUMMY_NEIGHBOR_TYPE",
+                        "default_action": "INVALID_DEFAULT_ACTION",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_COM_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "community": "123:123",
+                        "default_action": "INVALID_DEFAULT_ACTION",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_NEIGH_COM_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "neighbor": "NEIGHBOR_TYPE",
+                        "neighbor_type": "DUMMY_NEIGHBOR_TYPE",
+                        "community": "123:123",
+                        "default_action": "INVALID_DEFAULT_ACTION",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_ALLOWED_PREFIXES_INVALID_PREFIXES_IPV4": {
         "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
             "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
                 "BGP_ALLOWED_PREFIXES_LIST": [
@@ -1585,8 +1651,89 @@
                         "deployment": "DEPLOYMENT_ID",
                         "id": "4",
                         "default_action": "permit",
-                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0./24"],
-                        "prefixes_v6": ["fc00:f0::/129", "fc00:a0::/64"]
+                        "prefixes_v4": ["10.0.0.0/100"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_NEIGH_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "neighbor": "NEIGHBOR_TYPE",
+                        "neighbor_type": "DUMMY_NEIGHBOR_TYPE",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.1.0.0/24 ge 100"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_COM_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "community": "123:123",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.2.0.0/24 le 100"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_NEIGH_COM_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "neighbor": "NEIGHBOR_TYPE",
+                        "neighbor_type": "DUMMY_NEIGHBOR_TYPE",
+                        "community": "123:123",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.2.0.0/24 eq 28"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64 ge 96", "fc00:b0::/64 le 96"]
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_ALLOWED_PREFIXES_INVALID_PREFIXES_IPV6": {
+        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
+            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
+                "BGP_ALLOWED_PREFIXES_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:f0::/200"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_NEIGH_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "neighbor": "NEIGHBOR_TYPE",
+                        "neighbor_type": "DUMMY_NEIGHBOR_TYPE",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:a0::/64 ge 200", "fc00:b0::/64 le 96"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_COM_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "community": "123:123",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:b0::/64 le 200"]
+                    }
+                ],
+                "BGP_ALLOWED_PREFIXES_NEIGH_COM_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "neighbor": "NEIGHBOR_TYPE",
+                        "neighbor_type": "DUMMY_NEIGHBOR_TYPE",
+                        "community": "123:123",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24 ge 28", "10.2.0.0/24 le 28"],
+                        "prefixes_v6": ["fc00:b0::/64 eq 96"]
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-allowed-prefix.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-allowed-prefix.yang
@@ -43,7 +43,7 @@ module sonic-bgp-allowed-prefix {
 
          The string format is an inet:ipv4-prefix (defined in RFC 6991) value
          appended with an optional suffix.
-         
+
          The optional suffix consists of a string 'le' or 'ge' followed by a
          number which is less than or equal to 32.";
     }
@@ -67,7 +67,7 @@ module sonic-bgp-allowed-prefix {
 
          The string format is an inet:ipv6-prefix (defined in RFC 6991) value
          appended with an optional suffix.
-         
+
          The optional suffix consists of a string 'le' or 'ge' followed by a
          number which is less than or equal to 128.";
     }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-allowed-prefix.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-allowed-prefix.yang
@@ -62,14 +62,14 @@ module sonic-bgp-allowed-prefix {
                + '( (le|ge) (([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))?';
        }
        description
-        "The bgp-allowed-ipv4-prefix type represents an IPv4 address prefix
+        "The bgp-allowed-ipv6-prefix type represents an IPv6 address prefix
          in BGP allowed prefix format.
 
-         The string format is an inet:ipv4-prefix (defined in RFC 6991) value
+         The string format is an inet:ipv6-prefix (defined in RFC 6991) value
          appended with an optional suffix.
          
          The optional suffix consists of a string 'le' or 'ge' followed by a
-         number which is less than or equal to 32.";
+         number which is less than or equal to 128.";
     }
 
     container sonic-bgp-allowed-prefix {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-allowed-prefix.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-allowed-prefix.yang
@@ -29,8 +29,125 @@ module sonic-bgp-allowed-prefix {
             "Initial revision.";
     }
 
+    typedef bgp-allowed-ipv4-prefix {
+       type string {
+         pattern
+            '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+          +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+          + '/(([0-9])|([1-2][0-9])|(3[0-2]))'
+          + '( (le|ge) (([0-9])|([1-2][0-9])|(3[0-2])))?';
+       }
+       description
+        "The bgp-allowed-ipv4-prefix type represents an IPv4 address prefix
+         in BGP allowed prefix format.
+
+         The string format is an inet:ipv4-prefix (defined in RFC 6991) value
+         appended with an optional suffix.
+         
+         The optional suffix consists of a string 'le' or 'ge' followed by a
+         number which is less than or equal to 32.";
+    }
+
+    typedef bgp-allowed-ipv6-prefix {
+       type string {
+         pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+               + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+               + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+               + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+               + '(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))'
+               + '( (le|ge) (([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))?';
+         pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+               + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'
+               + '(/.+)'
+               + '( (le|ge) (([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))?';
+       }
+       description
+        "The bgp-allowed-ipv4-prefix type represents an IPv4 address prefix
+         in BGP allowed prefix format.
+
+         The string format is an inet:ipv4-prefix (defined in RFC 6991) value
+         appended with an optional suffix.
+         
+         The optional suffix consists of a string 'le' or 'ge' followed by a
+         number which is less than or equal to 32.";
+    }
+
     container sonic-bgp-allowed-prefix {
         container BGP_ALLOWED_PREFIXES {
+            list BGP_ALLOWED_PREFIXES_LIST {
+                key "deployment id";
+
+                leaf deployment {
+                    type string {
+                        pattern "DEPLOYMENT_ID";
+                    }
+                    description "BGP allowed prefix list key type";
+                }
+
+                leaf id {
+                    type uint32;
+                    description "BGP allowed prefix list deployment id";
+                }
+
+                leaf default_action {
+                    type rpolsets:routing-policy-action-type;
+                    description "Permit/Deny action for BGP allow prefix list";
+                }
+
+                leaf-list prefixes_v4 {
+                    type bgp-allowed-ipv4-prefix;
+                    description "BGP V4 allowed prefix list";
+                }
+
+                leaf-list prefixes_v6 {
+                    type bgp-allowed-ipv6-prefix;
+                    description "BGP V6 allowed prefix list";
+                }
+            }
+
+            list BGP_ALLOWED_PREFIXES_NEIGH_LIST {
+                key "deployment id neighbor neighbor_type";
+
+                leaf deployment {
+                    type string {
+                        pattern "DEPLOYMENT_ID";
+                    }
+                    description "BGP allowed prefix list key type";
+                }
+
+                leaf id {
+                    type uint32;
+                    description "BGP allowed prefix list deployment id";
+                }
+
+                leaf neighbor {
+                    type string {
+                        pattern "NEIGHBOR_TYPE";
+                    }
+                    description "BGP allowed prefix list neighbor";
+                }
+
+                leaf neighbor_type {
+                    type string;
+                    description "BGP allowed prefix list neighbor type";
+                }
+
+                leaf default_action {
+                    type rpolsets:routing-policy-action-type;
+                    description "Permit/Deny action for BGP allow prefix list";
+                }
+
+                leaf-list prefixes_v4 {
+                    type bgp-allowed-ipv4-prefix;
+                    description "BGP V4 allowed prefix list";
+                }
+
+                leaf-list prefixes_v6 {
+                    type bgp-allowed-ipv6-prefix;
+                    description "BGP V6 allowed prefix list";
+                }
+            }
+
             list BGP_ALLOWED_PREFIXES_COM_LIST {
                 key "deployment id community";
 
@@ -57,18 +174,18 @@ module sonic-bgp-allowed-prefix {
                 }
 
                 leaf-list prefixes_v4 {
-                    type inet:ipv4-prefix;
+                    type bgp-allowed-ipv4-prefix;
                     description "BGP V4 allowed prefix list";
                 }
 
                 leaf-list prefixes_v6 {
-                    type inet:ipv6-prefix;
+                    type bgp-allowed-ipv6-prefix;
                     description "BGP V6 allowed prefix list";
                 }
             }
 
-            list BGP_ALLOWED_PREFIXES_LIST {
-                key "deployment id";
+            list BGP_ALLOWED_PREFIXES_NEIGH_COM_LIST {
+                key "deployment id neighbor neighbor_type community";
 
                 leaf deployment {
                     type string {
@@ -82,18 +199,35 @@ module sonic-bgp-allowed-prefix {
                     description "BGP allowed prefix list deployment id";
                 }
 
+                leaf neighbor {
+                    type string {
+                        pattern "NEIGHBOR_TYPE";
+                    }
+                    description "BGP allowed prefix list neighbor";
+                }
+
+                leaf neighbor_type {
+                    type string;
+                    description "BGP allowed prefix list neighbor type";
+                }
+
+                leaf community {
+                    type string;
+                    description "BGP allowed prefix list deployment community";
+                }
+
                 leaf default_action {
                     type rpolsets:routing-policy-action-type;
                     description "Permit/Deny action for BGP allow prefix list";
                 }
 
                 leaf-list prefixes_v4 {
-                    type inet:ipv4-prefix;
+                    type bgp-allowed-ipv4-prefix;
                     description "BGP V4 allowed prefix list";
                 }
 
                 leaf-list prefixes_v6 {
-                    type inet:ipv6-prefix;
+                    type bgp-allowed-ipv6-prefix;
                     description "BGP V6 allowed prefix list";
                 }
             }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Bugfix for Yang model of BGP Allowed Prefix.
1. Support optional `NEIGHBOR_TYPE` in key.
2. Support optional `le` and `ge` in prefixes_v4/prefixes_v6 list (e.g., `10.20.30.0/24 le 30`).

##### Work item tracking
- Microsoft ADO **(number only)**: 30001113

#### How I did it

Updated `sonic-bgp-allowed-prefix.yang`.
1. Define optional value `NEIGHBOR_TYPE` in key.
2. Define type `bgp-allowed-ipv4-prefix` and `bgp-allowed-ipv6-prefix` to support the optional suffix in prefixes_v4/prefixes_v6 list.

#### How to verify it

Verified by UT:

```
collected 870 items

tests/test_sonic_yang_models.py ..                                                        [  0%]
tests/yang_model_pytests/test_crm.py .................................................... [  6%]
......................................................................................... [ 16%]
......................................................................................... [ 26%]
......................................................................................... [ 36%]
......................................................................................... [ 47%]
......................................................................................... [ 57%]
.......................                                                                   [ 60%]
tests/yang_model_pytests/test_dash_crm.py ............................................... [ 65%]
......................................................................................... [ 75%]
......................................................................................... [ 85%]
......................................................................................... [ 96%]
........................                                                                  [ 98%]
tests/yang_model_pytests/test_smart_switch.py .........                                   [ 99%]
tests/yang_model_tests/test_yang_model.py .                                               [100%]

===================================== 870 passed in 33.19s ======================================
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

