### PR TITLE
[dhcp_relay] Only check parent dhcrelay process in dhcprelayd

### DIFF
--- a/src/sonic-dhcp-utilities/dhcp_utilities/common/utils.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/common/utils.py
@@ -150,24 +150,6 @@ def _parse_table_to_dict(table):
     return ret
 
 
-def get_target_process_cmds(process_name):
-    """
-    Get running process cmds
-    Args:
-        process_name: name of process
-    Returns:
-        List of cmds list
-    """
-    res = []
-    for proc in psutil.process_iter():
-        try:
-            if proc.name() == process_name:
-                res.append(proc.cmdline())
-        except psutil.NoSuchProcess:
-            continue
-    return res
-
-
 def is_smart_switch(device_metadata):
     """
     Check in device metadata whether subtype is smartswitch

--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
@@ -8,7 +8,7 @@ import sys
 import syslog
 import time
 from swsscommon import swsscommon
-from dhcp_utilities.common.utils import DhcpDbConnector, terminate_proc, get_target_process_cmds, is_smart_switch
+from dhcp_utilities.common.utils import DhcpDbConnector, terminate_proc, is_smart_switch
 from dhcp_utilities.common.dhcp_db_monitor import DhcpRelaydDbMonitor, DhcpServerTableIntfEnablementEventChecker, \
      VlanTableEventChecker, VlanIntfTableEventChecker, DhcpServerFeatureStateChecker, MidPlaneTableEventChecker
 
@@ -226,7 +226,23 @@ class DhcpRelayd(object):
         """
         Check whether dhcrelay running as expected, if not, dhcprelayd will exit with code 1
         """
-        running_cmds = get_target_process_cmds("dhcrelay")
+        procs = {}
+        for proc in psutil.process_iter():
+            try:
+                if proc.name() != "dhcrelay":
+                    continue
+                procs[proc.pid] = [proc.ppid(), proc.cmdline()]
+            except psutil.NoSuchProcess:
+                continue
+
+        # When there is network io, dhcrelay would create child process to proceed them, psutil has chance to get
+        # duplicated cmdline. Hence ignore chlid process in here
+        running_cmds = []
+        for _, (parent_pid, cmdline) in procs.items():
+            if parent_pid in procs:
+                continue
+            running_cmds.append(cmdline)
+
         running_cmds.sort()
         expected_cmds = [value for key, value in self.dhcp_relay_supervisor_config.items() if "isc-dhcpv4-relay" in key]
         expected_cmds.sort()

--- a/src/sonic-dhcp-utilities/tests/common_utils.py
+++ b/src/sonic-dhcp-utilities/tests/common_utils.py
@@ -65,10 +65,11 @@ def mock_get_config_db_table(table_name):
 
 
 class MockProc(object):
-    def __init__(self, name, pid=1, exited=False):
+    def __init__(self, name, pid=1, exited=False, ppid=1):
         self.proc_name = name
         self.pid = pid
         self.exited = exited
+        self.parent_id = ppid
 
     def name(self):
         if self.exited:
@@ -95,6 +96,9 @@ class MockProc(object):
 
     def status(self):
         return self.status
+
+    def ppid(self):
+        return self.parent_id
 
 
 class MockPopen(object):

--- a/src/sonic-dhcp-utilities/tests/test_utils.py
+++ b/src/sonic-dhcp-utilities/tests/test_utils.py
@@ -141,21 +141,6 @@ def test_validate_ttr_type(test_data):
     assert res == test_data[2]
 
 
-def test_get_target_process_cmds():
-    with patch.object(psutil, "process_iter", return_value=[MockProc("dhcrelay", 1),
-                                                            MockProc("dhcrelay", 1, exited=True),
-                                                            MockProc("dhcpmon", 2)],
-                      new_callable=PropertyMock):
-        res = utils.get_target_process_cmds("dhcrelay")
-        expected_res = [
-            [
-                "/usr/sbin/dhcrelay", "-d", "-m", "discard", "-a", "%h:%p", "%P", "--name-alias-map-file",
-                "/tmp/port-name-alias-map.txt", "-id", "Vlan1000", "-iu", "docker0", "240.127.1.2"
-            ]
-        ]
-        assert res == expected_res
-
-
 @pytest.mark.parametrize("is_smart_switch", [True, False])
 def test_is_smart_switch(is_smart_switch):
     device_metadata = {"localhost": {"subtype": "SmartSwitch"}} if is_smart_switch else {"localhost": {}}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In master and 202405 branch, dhcp_relay container was updated to Bookworm, hence isc-dhcp-relay was updated from 4.4.1 to 4.4.3. In this version, isc-dhcp-relay would create child process to proceed when there is network io, hence dhcprelayd would get duplicated dhcrelay process when checking
```
2024 Oct  2 03:28:58.972742 sonic ERR dhcp_relay#dhcprelayd: Running processes is not as expected! Runnning: [['/usr/sbin/dhcrelay', '-d', '-m', 'discard', '-a', '%h:%p', '%P', '--name-alias-map-file', '/tmp/port-name-alias-map.txt', '-id', 'Vlan1000', '-iu', 'PortChannel101', '-iu', 'PortChannel102', '-iu', 'PortChannel103', '-iu', 'PortChannel104', '192.0.0.1', '192.0.0.2', '192.0.0.3', '192.0.0.4', '192.0.0.5', '192.0.0.6', '192.0.0.7', '192.0.0.8', '192.0.0.9', '192.0.0.10', '192.0.0.11', '192.0.0.12', '192.0.0.13', '192.0.0.14', '192.0.0.15', '192.0.0.16', '192.0.0.17', '192.0.0.18', '192.0.0.19', '192.0.0.20', '192.0.0.21', '192.0.0.22', '192.0.0.23', '192.0.0.24', '192.0.0.25', '192.0.0.26', '192.0.0.27', '192.0.0.28', '192.0.0.29', '192.0.0.30', '192.0.0.31', '192.0.0.32', '192.0.0.33', '192.0.0.34', '192.0.0.35', '192.0.0.36', '192.0.0.37', '192.0.0.38', '192.0.0.39', '192.0.0.40', '192.0.0.41', '192.0.0.42', '192.0.0.43', '192.0.0.44', '192.0.0.45', '192.0.0.46', '192.0.0.47', '192.0.0.48'], ['/usr/sbin/dhcrelay', '-d', '-m', 'discard', '-a', '%h:%p', '%P', '--name-alias-map-file', '/tmp/port-name-alias-map.txt', '-id', 'Vlan1000', '-iu', 'PortChannel101', '-iu', 'PortChannel102', '-iu', 'PortChannel103', '-iu', 'PortChannel104', '192.0.0.1', '192.0.0.2', '192.0.0.3', '192.0.0.4', '192.0.0.5', '192.0.0.6', '192.0.0.7', '192.0.0.8', '192.0.0.9', '192.0.0.10', '192.0.0.11', '192.0.0.12', '192.0.0.13', '192.0.0.14', '192.0.0.15', '192.0.0.16', '192.0.0.17', '192.0.0.18', '192.0.0.19', '192.0.0.20', '192.0.0.21', '192.0.0.22', '192.0.0.23', '192.0.0.24', '192.0.0.25', '192.0.0.26', '192.0.0.27', '192.0.0.28', '192.0.0.29', '192.0.0.30', '192.0.0.31', '192.0.0.32', '192.0.0.33', '192.0.0.34', '192.0.0.35', '192.0.0.36', '192.0.0.37', '192.0.0.38', '192.0.0.39', '192.0.0.40', '192.0.0.41', '192.0.0.42', '192.0.0.43', '192.0.0.44', '192.0.0.45', '192.0.0.46', '192.0.0.47', '192.0.0.48']]. Expected: [['/usr/sbin/dhcrelay', '-d', '-m', 'discard', '-a', '%h:%p', '%P', '--name-alias-map-file', '/tmp/port-name-alias-map.txt', '-id', 'Vlan1000', '-iu', 'PortChannel101', '-iu', 'PortChannel102', '-iu', 'PortChannel103', '-iu', 'PortChannel104', '192.0.0.1', '192.0.0.2', '192.0.0.3', '192.0.0.4', '192.0.0.5', '192.0.0.6', '192.0.0.7', '192.0.0.8', '192.0.0.9', '192.0.0.10', '192.0.0.11', '192.0.0.12', '192.0.0.13', '192.0.0.14', '192.0.0.15', '192.0.0.16', '192.0.0.17', '192.0.0.18', '192.0.0.19', '192.0.0.20', '192.0.0.21', '192.0.0.22', '192.0.0.23', '192.0.0.24', '192.0.0.25', '192.0.0.26', '192.0.0.27', '192.0.0.28', '192.0.0.29', '192.0.0.30', '192.0.0.31', '192.0.0.32', '192.0.0.33', '192.0.0.34', '192.0.0.35', '192.0.0.36', '192.0.0.37', '192.0.0.38', '192.0.0.39', '192.0.0.40', '192.0.0.41', '192.0.0.42', '192.0.0.43', '192.0.0.44', '192.0.0.45', '192.0.0.46', '192.0.0.47', '192.0.0.48']]
```

##### Work item tracking
- Microsoft ADO **(number only)**: 29969786

#### How I did it
Only check parent dhcp_relay process

#### How to verify it
1) UT
2) Run https://github.com/sonic-net/sonic-mgmt/blob/master/tests/dhcp_relay/test_dhcp_relay_stress.py with latest dhcprelayd

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

