### PR TITLE
[Mellanox]: Clean up syncd Python development packages

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -1,5 +1,6 @@
 ##
-## Copyright (c) 2016-2024 NVIDIA CORPORATION & AFFILIATES.
+## SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+## Copyright (c) 2016-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 ## Apache-2.0
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +15,7 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ##
+
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
@@ -26,15 +28,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y \
-        libxml2     \
-        python3-pip  \
-        python3-dev \
-        python-is-python3 \
-        python3-jsonschema \
 {%- if ENABLE_ASAN == "y" %}
         libasan6 \
 {%- endif %}
-        python3-setuptools
+        libxml2 \
+        python3-pip \
+        python3-dev \
+        python3-jsonschema \
+        python-is-python3
 
 RUN pip3 install --upgrade pip
 RUN apt-get purge -y python-pip
@@ -56,8 +57,11 @@ RUN apt-get purge -y python-pip
 {% endif %}
 
 ## Clean up
-RUN apt-get clean -y && \
-    apt-get autoclean -y && \
+RUN apt-get purge -y         \
+        python3-dev          \
+        python3-pip       && \
+    apt-get clean -y      && \
+    apt-get autoclean -y  && \
     apt-get autoremove -y && \
     rm -rf /debs
 


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Resolves: https://github.com/sonic-net/sonic-buildimage/issues/20419

#### Why I did it
* To clean up `syncd` environment

#### Work item tracking
* N/A

#### How I did it
* Removed python development packages from a `Dockerfile` template

#### How to verify it
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
1. make configure PLATFORM=mellanox
2. make target/sonic-mellanox.bin

#### Which release branch to backport (provide reason below if selected)
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master <!-- image version 1 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
* N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```