### PR TITLE
[Nvidia-bluefield] Update SAI to SAIBuild0.0.36.0, SDK/FW to v24.10-RC2/v32.42.1000, BFSoC to 4.9.0

### DIFF
--- a/platform/nvidia-bluefield/recipes/bluefield-soc.mk
+++ b/platform/nvidia-bluefield/recipes/bluefield-soc.mk
@@ -16,8 +16,8 @@
 #
 
 # Bluefied Software Distribution Version
-BFSOC_VERSION = 4.7.0
-BFSOC_REVISION = 13127
+BFSOC_VERSION = 4.9.0
+BFSOC_REVISION = 13347
 BFB_IMG_TYPE = prod
 BFSOC_BUILD_DATE =
 

--- a/platform/nvidia-bluefield/recipes/dpu-sai.mk
+++ b/platform/nvidia-bluefield/recipes/dpu-sai.mk
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-DPU_SAI_VERSION = SAIBuild0.0.32.0
+DPU_SAI_VERSION = SAIBuild0.0.36.0
 
 # Place here URL where SAI sources exist
 DPU_SAI_SOURCE_BASE_URL=

--- a/platform/nvidia-bluefield/recipes/fw.mk
+++ b/platform/nvidia-bluefield/recipes/fw.mk
@@ -17,7 +17,7 @@
 
 BF3_FW_BASE_URL =
 
-BF3_FW_VERSION = 32.41.1000
+BF3_FW_VERSION = 32.42.1000
 
 BF3_FW_FILE = fw-BlueField-3-rel-$(subst .,_,$(BF3_FW_VERSION)).mfa
 

--- a/platform/nvidia-bluefield/recipes/sdk.mk
+++ b/platform/nvidia-bluefield/recipes/sdk.mk
@@ -19,7 +19,7 @@ SDK_BASE_PATH = $(PLATFORM_PATH)/sdk-src/sonic-bluefield-packages/bin
 
 # Place here URL where SDK sources exist
 SDK_SOURCE_BASE_URL =
-SDK_VERSION = 24.7-RC4
+SDK_VERSION = 24.10-RC2
 
 SDK_COLLECTX_URL = https://linux.mellanox.com/public/repo/doca/1.5.2/debian12/aarch64/
 


### PR DESCRIPTION
#### Why I did it

To include latest fixes and new functionality

#### How I did it

* SDK_VERSION 24.7-RC4 -> 24.10-RC2
* FW_VERSION 32.41.1000 -> 32.42.1000
* SAI_VERSION SAIBuild0.0.32.0 -> SAIBuild0.0.36.0
* BFSOC_VERSION: 4.7.0 -> 4.9.0

#### How to verify it
Build an image and run tests from "sonic-mgmt".

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog

#### A picture of a cute animal (not mandatory but encouraged)