### PR TITLE
Fixing SRv6 SID uninstall

### DIFF
--- a/src/sonic-frr/patch/bgpd-lib-Include-SID-structure-in-seg6local-nexthop.patch
+++ b/src/sonic-frr/patch/bgpd-lib-Include-SID-structure-in-seg6local-nexthop.patch
@@ -1,0 +1,207 @@
+From 8b9b9549e6d2785d4237ddb510d285aba022bb68 Mon Sep 17 00:00:00 2001
+From: Carmine Scarpitta <cscarpit@cisco.com>
+Date: Sun, 15 Sep 2024 17:23:34 +0200
+Subject: [PATCH 1/5] lib: Include SID structure in seg6local nexthop
+
+Include SID structure information in seg6local nexthop data structure.
+
+Signed-off-by: Carmine Scarpitta <cscarpit@cisco.com>
+---
+ lib/srv6.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/lib/srv6.h b/lib/srv6.h
+index acfb0631cc..3749b01563 100644
+--- a/lib/srv6.h
++++ b/lib/srv6.h
+@@ -72,6 +72,10 @@ struct seg6local_context {
+ 	struct in_addr nh4;
+ 	struct in6_addr nh6;
+ 	uint32_t table;
++	uint8_t block_len;
++	uint8_t node_len;
++	uint8_t function_len;
++	uint8_t argument_len;
+ };
+ 
+ struct srv6_locator {
+-- 
+2.45.2
+
+
+From ebea171cadaae63d89c41fdd5e4d507cf9084e42 Mon Sep 17 00:00:00 2001
+From: Carmine Scarpitta <cscarpit@cisco.com>
+Date: Sun, 15 Sep 2024 18:53:35 +0200
+Subject: [PATCH 2/5] bgpd: Include structure when installing End.DT4/6 SID
+
+Include SID structure information when installing an SRv6 End.DT6 or End.DT4 SID
+in the forwarding plane.
+
+Signed-off-by: Carmine Scarpitta <cscarpit@cisco.com>
+---
+ bgpd/bgp_mplsvpn.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/bgpd/bgp_mplsvpn.c b/bgpd/bgp_mplsvpn.c
+index 2af553d982..b9eef35812 100644
+--- a/bgpd/bgp_mplsvpn.c
++++ b/bgpd/bgp_mplsvpn.c
+@@ -393,6 +393,18 @@ void vpn_leak_zebra_vrf_sid_update_per_af(struct bgp *bgp, afi_t afi)
+ 	if (!vrf)
+ 		return;
+ 
++	if (bgp->vpn_policy[afi].tovpn_sid_locator) {
++		ctx.block_len =
++			bgp->vpn_policy[afi].tovpn_sid_locator->block_bits_length;
++		ctx.node_len =
++			bgp->vpn_policy[afi].tovpn_sid_locator->node_bits_length;
++		ctx.function_len =
++			bgp->vpn_policy[afi]
++				.tovpn_sid_locator->function_bits_length;
++		ctx.argument_len =
++			bgp->vpn_policy[afi]
++				.tovpn_sid_locator->argument_bits_length;
++	}
+ 	ctx.table = vrf->data.l.table_id;
+ 	act = afi == AFI_IP ? ZEBRA_SEG6_LOCAL_ACTION_END_DT4
+ 		: ZEBRA_SEG6_LOCAL_ACTION_END_DT6;
+-- 
+2.45.2
+
+
+From f5c7cf0edc25905d357effe54ece27ed5db0ae6b Mon Sep 17 00:00:00 2001
+From: Carmine Scarpitta <cscarpit@cisco.com>
+Date: Sun, 15 Sep 2024 18:54:55 +0200
+Subject: [PATCH 3/5] bgpd: Include structure when installing End.DT46 SID
+
+Include SID structure information when installing an SRv6 End.DT46 SID
+in the forwarding plane.
+
+Signed-off-by: Carmine Scarpitta <cscarpit@cisco.com>
+---
+ bgpd/bgp_mplsvpn.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/bgpd/bgp_mplsvpn.c b/bgpd/bgp_mplsvpn.c
+index b9eef35812..005a54ec1b 100644
+--- a/bgpd/bgp_mplsvpn.c
++++ b/bgpd/bgp_mplsvpn.c
+@@ -453,6 +453,12 @@ void vpn_leak_zebra_vrf_sid_update_per_vrf(struct bgp *bgp)
+ 	if (!vrf)
+ 		return;
+ 
++	if (bgp->tovpn_sid_locator) {
++		ctx.block_len = bgp->tovpn_sid_locator->block_bits_length;
++		ctx.node_len = bgp->tovpn_sid_locator->node_bits_length;
++		ctx.function_len = bgp->tovpn_sid_locator->function_bits_length;
++		ctx.argument_len = bgp->tovpn_sid_locator->argument_bits_length;
++	}
+ 	ctx.table = vrf->data.l.table_id;
+ 	act = ZEBRA_SEG6_LOCAL_ACTION_END_DT46;
+ 	zclient_send_localsid(zclient, tovpn_sid, bgp->vrf_id, act, &ctx);
+-- 
+2.45.2
+
+
+From e2428a573321cb5909a3858008df2968b655a086 Mon Sep 17 00:00:00 2001
+From: Carmine Scarpitta <cscarpit@cisco.com>
+Date: Sun, 15 Sep 2024 18:56:21 +0200
+Subject: [PATCH 4/5] bgpd: Include structure when removing End.DT4/6 SID
+
+Include SID structure information when removing an SRv6 End.DT4 or End.DT6 SID
+from the forwarding plane.
+
+Signed-off-by: Carmine Scarpitta <cscarpit@cisco.com>
+---
+ bgpd/bgp_mplsvpn.c | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/bgpd/bgp_mplsvpn.c b/bgpd/bgp_mplsvpn.c
+index 005a54ec1b..aba1b4febe 100644
+--- a/bgpd/bgp_mplsvpn.c
++++ b/bgpd/bgp_mplsvpn.c
+@@ -495,6 +495,7 @@ void vpn_leak_zebra_vrf_sid_update(struct bgp *bgp, afi_t afi)
+ void vpn_leak_zebra_vrf_sid_withdraw_per_af(struct bgp *bgp, afi_t afi)
+ {
+ 	int debug = BGP_DEBUG(vpn, VPN_LEAK_LABEL);
++	struct seg6local_context seg6localctx = {};
+ 
+ 	if (bgp->vrf_id == VRF_UNKNOWN) {
+ 		if (debug)
+@@ -507,9 +508,22 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_af(struct bgp *bgp, afi_t afi)
+ 		zlog_debug("%s: deleting sid for vrf %s afi (id=%d)", __func__,
+ 			   bgp->name_pretty, bgp->vrf_id);
+ 
++	if (bgp->vpn_policy[afi].tovpn_sid_locator) {
++		seg6localctx.block_len =
++			bgp->vpn_policy[afi].tovpn_sid_locator->block_bits_length;
++		seg6localctx.node_len =
++			bgp->vpn_policy[afi].tovpn_sid_locator->node_bits_length;
++		seg6localctx.function_len =
++			bgp->vpn_policy[afi]
++				.tovpn_sid_locator->function_bits_length;
++		seg6localctx.argument_len =
++			bgp->vpn_policy[afi]
++				.tovpn_sid_locator->argument_bits_length;
++	}
+ 	zclient_send_localsid(zclient,
+-		bgp->vpn_policy[afi].tovpn_zebra_vrf_sid_last_sent,
+-		bgp->vrf_id, ZEBRA_SEG6_LOCAL_ACTION_UNSPEC, NULL);
++			      bgp->vpn_policy[afi].tovpn_zebra_vrf_sid_last_sent,
++			      bgp->vrf_id, ZEBRA_SEG6_LOCAL_ACTION_UNSPEC,
++			      &seg6localctx);
+ 	XFREE(MTYPE_BGP_SRV6_SID,
+ 	      bgp->vpn_policy[afi].tovpn_zebra_vrf_sid_last_sent);
+ }
+-- 
+2.45.2
+
+
+From 8d148b738cdf8b987a67e13979331d91337494f3 Mon Sep 17 00:00:00 2001
+From: Carmine Scarpitta <cscarpit@cisco.com>
+Date: Sun, 15 Sep 2024 18:56:48 +0200
+Subject: [PATCH 5/5] bgpd: Include structure when removing End.DT46 SID
+
+Include SID structure information when removing an SRv6 End.DT46 SID
+from the forwarding plane.
+
+Signed-off-by: Carmine Scarpitta <cscarpit@cisco.com>
+---
+ bgpd/bgp_mplsvpn.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/bgpd/bgp_mplsvpn.c b/bgpd/bgp_mplsvpn.c
+index aba1b4febe..6589f3e388 100644
+--- a/bgpd/bgp_mplsvpn.c
++++ b/bgpd/bgp_mplsvpn.c
+@@ -535,6 +535,7 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_af(struct bgp *bgp, afi_t afi)
+ void vpn_leak_zebra_vrf_sid_withdraw_per_vrf(struct bgp *bgp)
+ {
+ 	int debug = BGP_DEBUG(vpn, VPN_LEAK_LABEL);
++	struct seg6local_context seg6localctx = {};
+ 
+ 	if (bgp->vrf_id == VRF_UNKNOWN) {
+ 		if (debug)
+@@ -548,9 +549,18 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_vrf(struct bgp *bgp)
+ 		zlog_debug("%s: deleting sid for vrf %s (id=%d)", __func__,
+ 			   bgp->name_pretty, bgp->vrf_id);
+ 
++	if (bgp->tovpn_sid_locator) {
++		seg6localctx.block_len =
++			bgp->tovpn_sid_locator->block_bits_length;
++		seg6localctx.node_len = bgp->tovpn_sid_locator->node_bits_length;
++		seg6localctx.function_len =
++			bgp->tovpn_sid_locator->function_bits_length;
++		seg6localctx.argument_len =
++			bgp->tovpn_sid_locator->argument_bits_length;
++	}
+ 	zclient_send_localsid(zclient, bgp->tovpn_zebra_vrf_sid_last_sent,
+ 			      bgp->vrf_id, ZEBRA_SEG6_LOCAL_ACTION_UNSPEC,
+-			      NULL);
++			      &seg6localctx);
+ 	XFREE(MTYPE_BGP_SRV6_SID, bgp->tovpn_zebra_vrf_sid_last_sent);
+ }
+ 
+-- 
+2.45.2
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -52,3 +52,4 @@
 0052-bgpd-backpressure-log-error-for-evpn-when-route-inst.patch
 0053-bgpd-Set-md5-TCP-socket-option-for-outgoing-connections-on-listener.patch
 build-dplane-fpm-sonic-module.patch
+bgpd-lib-Include-SID-structure-in-seg6local-nexthop.patch


### PR DESCRIPTION
This PR fixes the SRv6 SID uninstall introduced in this PR: https://github.com/sonic-net/sonic-buildimage/pull/18715
This fix has been already merged in the FRR mainline: https://github.com/FRRouting/frr/pull/16835
