### PR TITLE
sonic-buildimage: ignore missing hwsku dict intfs

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -417,7 +417,7 @@ def parse_platform_json_file(hwsku_json_file, platform_json_file):
 
     for intf in port_dict[INTF_KEY]:
         if intf not in hwsku_dict[INTF_KEY]:
-            raise Exception("{} is not available in hwsku_dict".format(intf))
+            continue
 
         # take default_brkout_mode from hwsku.json
         brkout_mode = hwsku_dict[INTF_KEY][intf][BRKOUT_MODE]


### PR DESCRIPTION
#### Why I did it
For new hwskus that leave some front panel ports unpopulated, sonic-config-engine will raise an exception when checking the hwsku dict for interfaces corresponding to those front panel ports. This change removes that exception, allowing duts for those hwskus to be configured.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Replaced the raised exception with a continue statement.

#### How to verify it
This can be verfied by configuring an appropriate dut against the Arista-7060X6-64PE-C256S2 hwsku.

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)
202405

#### Description for the changelog
With the introduction of new hwskus that do not utilize every front panel port available, i.e. the ports are not fully populated, the
sonic-config-engine will raise an exception when checking the hwsku dict for such interfaces. This change removes that exception, allowing duts for those hwskus to be configured.