### PR TITLE
[Mellanox] Extend Nvidia Bluefield DPU chassis implementation

### DIFF
--- a/device/nvidia-bluefield/arm64-nvda_bf-bf3comdpu/pmon_daemon_control.json
+++ b/device/nvidia-bluefield/arm64-nvda_bf-bf3comdpu/pmon_daemon_control.json
@@ -2,6 +2,6 @@
     "skip_ledd": true,
     "skip_psud": true,
     "skip_fancontrol": true,
-    "skip_chassisd": true,
+    "skip_chassisd": false,
     "skip_ycabled": true
 }

--- a/platform/nvidia-bluefield/platform-api/tests/test_chassis.py
+++ b/platform/nvidia-bluefield/platform-api/tests/test_chassis.py
@@ -17,6 +17,8 @@
 
 import os
 import sys
+import socket
+from collections import namedtuple
 
 from unittest.mock import patch
 from unittest.mock import mock_open
@@ -83,3 +85,11 @@ class TestChassis:
         assert len(sfp_list) == 2
         assert id(sfp1) == id(sfp_list[0])
         assert id(sfp2) == id(sfp_list[1])
+
+
+    @patch('psutil.net_if_addrs', return_value={
+        'eth0-midplane': [namedtuple('snicaddr', ['family', 'address'])(family=socket.AF_INET, address='169.254.200.1')]})
+    def test_get_dpu_id(self, *args):
+        chassis = Chassis()
+
+        assert chassis.get_dpu_id() == 0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Implement the interface required to run DPU chassisd on the Nvidia Smart Switch.
Implement `get_dpu_id` API that deducts the DPU ID based on the midplane interface IP address.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Implement platform API

#### How to verify it
The implementation is covered by the UT.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

