### PR TITLE
[Dynamic buffer] Reduce small packet percentage to 50%

### DIFF
--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -302,7 +302,7 @@ def
     "LOSSLESS_TRAFFIC_PATTERN": {
         "AZURE": {
             "mtu": "1024",
-            "small_packet_percentage": "100"
+            "small_packet_percentage": "50"
         }
     }
 {% endif %}

--- a/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2410-dynamic.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2410-dynamic.json
@@ -1302,7 +1302,7 @@
     "LOSSLESS_TRAFFIC_PATTERN": {
         "AZURE": {
             "mtu": "1024",
-            "small_packet_percentage": "100"
+            "small_packet_percentage": "50"
         }
     }
 }

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2410-dynamic.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2410-dynamic.json
@@ -1302,7 +1302,7 @@
     "LOSSLESS_TRAFFIC_PATTERN": {
         "AZURE": {
             "mtu": "1024",
-            "small_packet_percentage": "100"
+            "small_packet_percentage": "50"
         }
     }
 }

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox4600c-t0-dynamic-remap-disabled.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox4600c-t0-dynamic-remap-disabled.json
@@ -2002,7 +2002,7 @@
     "LOSSLESS_TRAFFIC_PATTERN": {
         "AZURE": {
             "mtu": "1024",
-            "small_packet_percentage": "100"
+            "small_packet_percentage": "50"
         }
     }
 }

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox4600c-t0-dynamic.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox4600c-t0-dynamic.json
@@ -2038,7 +2038,7 @@
     "LOSSLESS_TRAFFIC_PATTERN": {
         "AZURE": {
             "mtu": "1024",
-            "small_packet_percentage": "100"
+            "small_packet_percentage": "50"
         }
     }
 }

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox4600c-t1-dynamic-remap-disabled.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox4600c-t1-dynamic-remap-disabled.json
@@ -1475,7 +1475,7 @@
     "LOSSLESS_TRAFFIC_PATTERN": {
         "AZURE": {
             "mtu": "1024",
-            "small_packet_percentage": "100"
+            "small_packet_percentage": "50"
         }
     }
 }

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox4600c-t1-dynamic.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox4600c-t1-dynamic.json
@@ -1654,7 +1654,7 @@
     "LOSSLESS_TRAFFIC_PATTERN": {
         "AZURE": {
             "mtu": "1024",
-            "small_packet_percentage": "100"
+            "small_packet_percentage": "50"
         }
     }
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Reduce the small packet percentage to 50% as it is more reasonable than 100%.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

Run regression

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

