### PR TITLE
[SmartSwitch] Added inbound traffic capability for DPU management traffic script

### DIFF
--- a/files/scripts/sonic-dpu-mgmt-traffic.sh
+++ b/files/scripts/sonic-dpu-mgmt-traffic.sh
@@ -166,7 +166,7 @@ ctrl_dpu_ib_forwarding(){
     local dest_port=22
     control_forwarding $op
     add_rem_valid_iptable $op filter FORWARD -i ${midplane_iface} -o ${mgmt_iface} -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    add_rem_valid_iptable $op filter FORWARD -i ${mgmt_iface} -o ${midplane_iface} -p tcp --dport $dest_port -m conntrack --ctstate NEW,RELATED,ESTABLISHED -j ACCEPT
+    add_rem_valid_iptable $op filter FORWARD -i ${mgmt_iface} -o ${midplane_iface} -p tcp --dport $dest_port -j ACCEPT
     for index in ${!sel_dpu_names[@]}; do
         dpu_name="${sel_dpu_names[$index]}"
         dpu_midplane_ip="${midplane_ip_dict[$dpu_name]}"

--- a/files/scripts/sonic-dpu-mgmt-traffic.sh
+++ b/files/scripts/sonic-dpu-mgmt-traffic.sh
@@ -225,10 +225,6 @@ case $1 in
                     shift;
                     arg_port_list=$1
                 ;;
-                --ports)
-                    shift;
-                    arg_port_list=$1
-                ;;
                 --nofwctrl)
                     fw_change="disable"
                 ;;

--- a/files/scripts/sonic-dpu-mgmt-traffic.sh
+++ b/files/scripts/sonic-dpu-mgmt-traffic.sh
@@ -4,11 +4,21 @@
 command_name=$0
 
 usage(){
-    echo "Syntax: $command_name -e|--enable -d|--disable"
+    echo "Syntax: $command_name inbound/outbound -e|--enable -d|--disable [--dpus,--ports,--nofwctrl]"
     echo "Arguments:"
-    echo "-e			Enable dpu management traffic forwarding"
-    echo "-d			Disable dpu management traffic forwarding"
+    echo "inbound		Control DPU Inbound traffic forwarding"
+    echo "outbound		Control DPU Outbound traffic forwarding"
+    echo "-e			Enable dpu management traffic forwarding in a specific direction"
+    echo "-d			Disable dpu management traffic forwarding in a specific direction"
+    echo "--dpus		Selection of dpus for which the inbound traffic has to be controlled (all can be specified)"
+    echo "--ports		Selection of ports for which the inbound traffic has to be controlled"
+    echo "--nofwctrl	Disable changing the general ipv4 forwarding (Could be useful if inbound is enabled and outbound is disabled)"
 }
+
+dpu_l=()
+declare -A midplane_dict
+declare -A midplane_ip_dict
+fw_change="enable"
 
 add_rem_valid_iptable(){
     local op=$1
@@ -39,20 +49,135 @@ control_forwarding(){
     if [ "$op" = "enable" ]; then
         value=1
     fi
-    echo $value > /proc/sys/net/ipv4/ip_forward
-    echo $value > /proc/sys/net/ipv4/conf/eth0/forwarding
+    if [ "$fw_change" = "enable" ]; then
+        echo $value > /proc/sys/net/ipv4/ip_forward
+        echo $value > /proc/sys/net/ipv4/conf/eth0/forwarding
+    fi
 }
 
-ctrl_dpu_forwarding(){
+validate_dpus(){
+    local provided_list=("$@")
+    for item1 in "${provided_list[@]}"; do
+        local found=0
+        for item2 in "${dpu_l[@]}"; do
+            if [[ "$item1" = "$item2" ]]; then
+                found=1
+                break
+            fi
+        done
+        if [[ $found -eq 0 ]]; then
+            echo "$item1 is not detected! Please provide proper dpu names list!"
+            exit 1
+        fi
+    done
+}
+
+general_validation(){
+    if [ -z "$direction" ]; then
+        echo "Please provide the direction argument (inbound or outboud)"
+        usage
+        exit 1
+    fi
+
+    if [ -z "$operation" ]; then
+        echo "Please provide the operation option (-e or -d)"
+        usage
+        exit 1
+    fi
+}
+
+
+inbound_validation(){
+    #DPU Validation
+    while IFS= read -r line; do
+        dpu_name=$( echo "$line" | sed 's/.*|//;s/"//g')
+        dpu_l+=("$dpu_name")
+    done < <(redis-cli -n 4 keys DPUS*)
+    len1=${#dpu_name[@]}
+    if [ "$len1" -eq 0 ]; then
+        echo "No dpus detected on device!"
+        exit 1
+    fi
+    sorted_dpu_l=($(for item in "${dpu_l[@]}"; do
+        echo "$item"
+    done | sort))
+    if [ -z "$arg_dpu_names" ]; then
+            echo "No DPUs provided!"
+            usage
+            exit 1
+        else
+            if [ "$arg_dpu_names" = "all" ]; then
+                sel_dpu_names=("${sorted_dpu_l[@]}")
+                echo "${#sorted_dpu_l[@]} DPUs detected:"
+                echo "${sorted_dpu_l[@]}"
+            else
+                IFS=',' read -ra sel_dpu_names <<< "$arg_dpu_names"
+                validate_dpus ${sel_dpu_names[@]}
+            fi
+    fi
+    #Port validation
+    IFS=',' read -ra provided_ports <<< "$arg_port_list"
+    len1=${#sel_dpu_names[@]}
+    len2=${#provided_ports[@]}
+    if [ "$len1" -ne "$len2" ]; then
+        echo "Length of ${sel_dpu_names[@]} does not match provided port length ${provided_ports[@]}"
+        usage
+        exit 1
+    fi
+    for dpu in "${sel_dpu_names[@]}"; do
+        midplane_int_name=$(redis-cli -n 4 hget "DPUS|$dpu" "midplane_interface")
+        if [ -z "$midplane_int_name" ]; then
+            echo "Cannot obtain midplane interface for $dpu"
+            exit 1
+        fi
+        midplane_dict["$dpu"]="$midplane_int_name"
+    done
+
+    for key in "${!midplane_dict[@]}"; do
+        echo "\"$key\":\"${midplane_dict[$key]}\""
+    done
+
+    for dpu in "${!midplane_dict[@]}"; do
+        midplane_ip=$(redis-cli -n 4 hget "DHCP_SERVER_IPV4_PORT|$midplane_iface|${midplane_dict[$dpu]}" "ips@")
+        if [ -z "$midplane_ip" ]; then
+            echo "Cannot obtain midplane ip for $dpu"
+            exit 1
+        fi
+        midplane_ip_dict["$dpu"]="$midplane_ip"
+    done
+}
+
+# Outbound Traffice forwarding control function
+ctrl_dpu_ob_forwarding(){
     local op=$1
     control_forwarding $op
     add_rem_valid_iptable $op nat POSTROUTING -o ${mgmt_iface}  -j MASQUERADE
     add_rem_valid_iptable $op filter FORWARD -i ${mgmt_iface} -o ${midplane_iface} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
     add_rem_valid_iptable $op filter FORWARD -i ${midplane_iface} -o ${mgmt_iface} -j ACCEPT
     if [ "$op" = "enable" ]; then
-        echo "Enabled DPU management traffic Forwarding"
+        echo "Enabled DPU management outbound traffic Forwarding"
     else
-        echo "Disabled DPU management traffic Forwarding"
+        echo "Disabled DPU management outbound traffic Forwarding"
+    fi
+}
+
+ctrl_dpu_ib_forwarding(){
+    local op=$1
+    local dest_port=22
+    control_forwarding $op
+    add_rem_valid_iptable $op filter FORWARD -i ${midplane_iface} -o ${mgmt_iface} -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    add_rem_valid_iptable $op filter FORWARD -i ${mgmt_iface} -o ${midplane_iface} -p tcp --dport $dest_port -m conntrack --ctstate NEW,RELATED,ESTABLISHED -j ACCEPT
+    for index in ${!sel_dpu_names[@]}; do
+        dpu_name="${sel_dpu_names[$index]}"
+        dpu_midplane_ip="${midplane_ip_dict[$dpu_name]}"
+        switch_port="${provided_ports[$index]}"
+        add_rem_valid_iptable $op nat POSTROUTING -p tcp -d $dpu_midplane_ip --dport $dest_port -j MASQUERADE
+        add_rem_valid_iptable $op nat PREROUTING -i ${mgmt_iface}  -p tcp --dport $switch_port -j DNAT --to-destination $dpu_midplane_ip:$dest_port
+    done
+    if [ "$op" = "enable" ]; then
+        echo "Enabled DPU management inbound traffic Forwarding"
+    else
+        echo "Disabled DPU management inbound traffic Forwarding"
     fi
 }
 
@@ -70,16 +195,85 @@ if ! ifconfig "$midplane_iface" > /dev/null 2>&1; then
     exit 1
 fi
 
+operation=""
+direction=""
+
+invalid_arg(){
+    echo "Invalid arguments $1"
+    usage
+    exit 1
+}
+
+
 case $1 in
-    -e|--enable)
-        ctrl_dpu_forwarding enable
-        ;;
-    -d|--disable)
-        ctrl_dpu_forwarding disable
-        ;;
+    inbound)
+        direction="inbound"
+        shift
+        while [ "$1" != "--" ]  && [ -n "$1" ]; do
+            case $1 in
+                -e|--enable)
+                    operation="enable"
+                ;;
+                -d|--disable)
+                    operation="disable"
+                ;;
+                --dpus)
+                    shift;
+                    arg_dpu_names=$1
+                ;;
+                --ports)
+                    shift;
+                    arg_port_list=$1
+                ;;
+                --ports)
+                    shift;
+                    arg_port_list=$1
+                ;;
+                --nofwctrl)
+                    fw_change="disable"
+                ;;
+                *)
+                    invalid_arg $1
+                ;;
+            esac
+        shift
+        done
+    ;;
+    outbound)
+        direction="outbound"
+        shift
+        while [ "$1" != "--" ]  && [ -n "$1" ]; do
+            case $1 in
+                -e|--enable)
+                    operation="enable"
+                ;;
+                -d|--disable)
+                    operation="disable"
+                ;;
+                --nofwctrl)
+                    fw_change="disable"
+                ;;
+                *)
+                    invalid_arg $1
+                ;;
+            esac
+        shift
+        done
+    ;;
     *)
-        echo "Incorrect Usage!"
-        usage
-        exit 1
+        invalid_arg $1
+    ;;
+esac
+
+general_validation
+
+
+case $direction in
+    outbound)
+        ctrl_dpu_ob_forwarding $operation
+        ;;
+    inbound)
+        inbound_validation
+        ctrl_dpu_ib_forwarding $operation
         ;;
 esac

--- a/files/scripts/sonic-dpu-mgmt-traffic.sh
+++ b/files/scripts/sonic-dpu-mgmt-traffic.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 #Script to control the DPU management traffic forwarding through the SmartSwitch
 
 command_name=$0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To add capability to control the inbound traffic for DPUs, Using the script we can now enable:
- Outbound: Allow Traffic from DPU to reach the internet
- Inbound: Allow SSH connection to reach the DPU from a specific port on the switch


Command examples:
`sonic-dpu-mgmt-traffic.sh outbound -e` This enables traffic to reach the internet from the DPU

`sonic-dpu-mgmt-traffic.sh outbound -d` This disables traffic to reach the internet from the DPU

`sonic-dpu-mgmt-traffic.sh inbound -e --dpus dpu1 --ports 9090` This enables SSH traffic to the dpu1 from the internet
We can connect to the DPU using `ssh admin@<switch name/ip> -p 9090`

`sonic-dpu-mgmt-traffic.sh inbound -e --dpus dpu1,dpu2 --ports 9090,5005` This enables SSH traffic to the dpu1 and dpu2 from the internet
We can connect to dpu2 using `ssh admin@<switch name/ip> -p 5005`

`sonic-dpu-mgmt-traffic.sh inbound -e --dpus all --ports 9090,8090,8091,5032` This enables SSH traffic to all the dpus from the internet using the ports specified (in sorted order the DPUs will use the ports in the order the user specifies) 
We can connect to the DPU using `ssh admin@<switch name/ip> -p 5032` to connect to the 4th dpu (in sorted order)

`sonic-dpu-mgmt-traffic.sh inbound -d --dpus dpu1 --ports 9090` This disables SSH traffic to the dpu1 from the internet
The same rule which was used for enable has to be used (by replacing -e with -d)

`--nofwctrl` Option - If both inbound and outbound rules are enabled, if we try to disable only one of them the ipv4 enabled forwarding for `eth0` interface would be disabled so this option can be used in that specific case where we only need to disable either outbound or inbound traffic without affecting the other.

**This feature is enabled using the ip table rules, so if the rules are flushed the connection will be terminated**

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

