### PR TITLE
[smart_switch][dhcp_server] Fix query dhcp lease get unknown in smart switch by Cli

### DIFF
--- a/dockers/docker-dhcp-server/cli-plugin-tests/mock_state_db.json
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/mock_state_db.json
@@ -14,6 +14,11 @@
         "lease_end": "1677641481",
         "ip": "192.168.0.3"
     },
+    "DHCP_SERVER_IPV4_LEASE|bridge-midplane|10:70:fd:b6:13:03": {
+        "lease_start": "1677640581",
+        "lease_end": "1677641481",
+        "ip": "192.168.0.4"
+    },
     "DHCP_SERVER_IPV4_SERVER_IP|eth0": {
         "ip": "240.127.1.2"
     },

--- a/dockers/docker-dhcp-server/cli-plugin-tests/pytest.ini
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
-addopts = --cov-config=.coveragerc --cov --cov-report html --cov-report term --cov-report xml --junitxml=test-results.xml -vv
-
+addopts = --cov=/sonic/dockers/docker-dhcp-server/cli --cov-config=.coveragerc --cov-report html --cov-report term --cov-report xml --junitxml=test-results.xml -vv

--- a/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
@@ -1,4 +1,5 @@
 import click
+import re
 from tabulate import tabulate
 import utilities_common.cli as clicommon
 
@@ -43,6 +44,12 @@ def lease(db, dhcp_interface):
         entry = dbconn.get_all("STATE_DB", key)
         interface, mac = key.split("|")[1:]
         port = dbconn.get("STATE_DB", "FDB_TABLE|" + interface + ":" + mac, "port")
+        if not port:
+            # Smart switch sample: aa:bb:cc:dd:ee:ff dev dpu0 master bridge-midplane
+            (out, _) = clicommon.run_command("sudo bridge fdb show | grep {}".format(mac), return_cmd=True, shell=True)
+            match = re.match(r'([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2} dev (.*) master (.*)', out)
+            if match and match.group(3) == interface:
+                port = match.group(2)
         if not port:
             port = "<Unknown>"
         table.append([interface + "|" + port, mac, entry["ip"], ts_to_str(entry["lease_start"]), ts_to_str(entry["lease_end"])])

--- a/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
@@ -43,15 +43,12 @@ def lease(db, dhcp_interface):
     for key in dbconn.keys("STATE_DB", "DHCP_SERVER_IPV4_LEASE|" + dhcp_interface + "|*"):
         entry = dbconn.get_all("STATE_DB", key)
         interface, mac = key.split("|")[1:]
-        port = ""
-        # Smart switch sample: aa:bb:cc:dd:ee:ff dev dpu0 master bridge-midplane
-        (out, _) = clicommon.run_command("sudo bridge fdb show | grep {}".format(mac), return_cmd=True, shell=True)
-        match = re.match(r'([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2} dev (.*) master (.*)', out)
-        if match:
-            splits = match.group(2).split(" ")
-            if len(splits) == 3 and "Vlan{}".format(splits[2]) == interface:
-                port = splits[0]
-            elif match.group(3) == interface:
+        port = dbconn.get("STATE_DB", "FDB_TABLE|" + interface + ":" + mac, "port")
+        if not port:
+            # Smart switch sample: aa:bb:cc:dd:ee:ff dev dpu0 master bridge-midplane
+            (out, _) = clicommon.run_command("sudo bridge fdb show | grep {}".format(mac), return_cmd=True, shell=True)
+            match = re.match(r'([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2} dev (.*) master (.*)', out)
+            if match and match.group(3) == interface:
                 port = match.group(2)
         if not port:
             port = "<Unknown>"

--- a/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
@@ -48,8 +48,8 @@ def lease(db, dhcp_interface):
             # Smart switch sample: aa:bb:cc:dd:ee:ff dev dpu0 master bridge-midplane
             (out, _) = clicommon.run_command("sudo bridge fdb show | grep {}".format(mac), return_cmd=True, shell=True)
             match = re.match(r'([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2} dev (.*) master (.*)', out)
-            if match and match.group(3) == interface:
-                port = match.group(2)
+            if match and match.group(3).strip() == interface:
+                port = match.group(2).strip()
         if not port:
             port = "<Unknown>"
         table.append([interface + "|" + port, mac, entry["ip"], ts_to_str(entry["lease_start"]), ts_to_str(entry["lease_end"])])


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In smart switch, there is an issue that Cli query dhcp lease got unknow interface due to dpu fdb hasn't present in STATE_DB FDB_TABLE. Issue: https://github.com/sonic-net/sonic-buildimage/issues/20155

##### Work item tracking
- Microsoft ADO **(number only)**: 30001797

#### How I did it
Query bridge fdb if there is no fdb record in STATE_DB

#### How to verify it
UT passed

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

