### PR TITLE
Change the default number of Kernel dumps to 3

### DIFF
--- a/src/kdump-tools/patch/0004-kdump-num-dumps.patch
+++ b/src/kdump-tools/patch/0004-kdump-num-dumps.patch
@@ -1,0 +1,13 @@
+diff --git a/debian/kdump-tools.conf.in b/debian/kdump-tools.conf.in
+index fc51d67..c88d7c4 100644
+--- a/debian/kdump-tools.conf.in
++++ b/debian/kdump-tools.conf.in
+@@ -37,7 +37,7 @@ KDUMP_INITRD=/var/lib/kdump/initrd.img
+ KDUMP_COREDIR="/var/crash"
+ #KDUMP_FAIL_CMD="reboot -f"
+ #KDUMP_DUMP_DMESG=
+-#KDUMP_NUM_DUMPS=
++KDUMP_NUM_DUMPS=3
+ #KDUMP_COMPRESSION=
+ 
+ 

--- a/src/kdump-tools/patch/series
+++ b/src/kdump-tools/patch/series
@@ -1,2 +1,3 @@
 0002-core-file-prefixed-by-kdump.patch
 0003-Revert-the-MODULES-dep-optimization.patch
+0004-kdump-num-dumps.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Currently there is no limit on the number of kernel dumps that will be captured in the system. This leads to excessive disk space usage if the system encounters many kernel crashes (e.g. as part of sonic-mgmt test suite runs). 

According to the HLD, the default number of kdumps should be 3. However the fix is missing in code.

https://github.com/sonic-net/SONiC/blob/master/doc/kdump/SONiC-kdump.md#config-kdump-num_dumps-number

This PR is providing the fix.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Set the number of kernel dumps to 3 in /etc/default/kdump-tools

#### How to verify it
UT Log:
root@sonic:/home/cisco# show reboot h
Name                 Cause                                                                   Time                             User    Comment
-------------------  ----------------------------------------------------------------------  -------------------------------  ------  ---------
2024_08_26_19_35_54  Kernel Panic                                                            Mon Aug 26 07:32:18 PM UTC 2024  N/A     N/A
2024_08_26_19_29_47  Kernel Panic                                                            Mon Aug 26 07:26:16 PM UTC 2024  N/A     N/A
2024_08_26_19_04_03  Kernel Panic                                                            Mon Aug 26 07:00:36 PM UTC 2024  N/A     N/A
2024_08_26_18_54_39  Kernel Panic                                                            Mon Aug 26 06:51:35 PM UTC 2024  N/A     N/A
2024_08_26_18_43_13  reboot                                                                  Mon Aug 26 06:36:53 PM UTC 2024  cisco   N/A
...
root@sonic:/home/cisco# show kdump files
          Kernel core dump files                        Kernel dmesg files
------------------------------------------  ------------------------------------------
/var/crash/202408261932/kdump.202408261932  /var/crash/202408261932/dmesg.202408261932
/var/crash/202408261926/kdump.202408261926  /var/crash/202408261926/dmesg.202408261926
/var/crash/202408261900/kdump.202408261900  /var/crash/202408261900/dmesg.202408261900
root@sonic:/home/cisco# ls /var/crash/
202408261900  202408261926  202408261932  kdump_lock  kexec_cmd


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->
- [x] 202405

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Set the number of kernel dumps to 3 in /etc/default/kdump-tools
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
N/A
#### A picture of a cute animal (not mandatory but encouraged)

