### PR TITLE
[macsec/show_macsec]: Only cache macsec stats

### DIFF
--- a/dockers/docker-macsec/cli/show/plugins/show_macsec.py
+++ b/dockers/docker-macsec/cli/show/plugins/show_macsec.py
@@ -63,7 +63,7 @@ class MACsecSA(MACsecAppMeta, MACsecCounters):
         counters = copy.deepcopy(self.counters)
         if cache:
             for k, v in counters.items():
-                if k in cache.counters:
+                if k in cache.counters and k.startswith("SAI_MACSEC_SA_STAT"):
                     counters[k] = int(counters[k]) - int(cache.counters[k])
         counters = sorted(counters.items(), key=lambda x: x[0])
         buffer += tabulate(meta + counters)


### PR DESCRIPTION

#### Why I did it
XPN is not a stat, it is a reflection of the SA state, so it should not be cleared on sonic-clear macsec.

##### Work item tracking
- issue #20653

#### How I did it
Only apply the stats cache for macsec on values that are explicitly stats (ie. start with "SAI_MACSEC_SA_STAT")

#### How to verify it

Run some traffic on a macsec session, clear the counters, and then show them and make sure XPN is not reset

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x ] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

Existing implementation would also cache XPN / SAI_MACSEC_ATTR values, which should not be reset on a sonic-clear macsec command. Change the show command to only look at SAI_MACSEC_SA_STAT values when accounting for the cache

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

