### PR TITLE
[macsec/config]: Handle deleting macsec if not configured on port

### DIFF
--- a/dockers/docker-macsec/cli-plugin-tests/test_config_macsec.py
+++ b/dockers/docker-macsec/cli-plugin-tests/test_config_macsec.py
@@ -128,6 +128,10 @@ class TestConfigMACsec(object):
         assert "macsec" not in port_table or not port_table["macsec"]
         assert port_table["admin_status"] == "up"
 
+        # Test deleting on port without it enabled
+        result = runner.invoke(macsec.macsec, ["port", "del", "Ethernet0"], obj=cfgdb)
+        assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+
 
     def test_macsec_invalid_operation(self, mock_cfgdb):
         cfgdb = mock_cfgdb

--- a/dockers/docker-macsec/cli/config/plugins/macsec.py
+++ b/dockers/docker-macsec/cli/config/plugins/macsec.py
@@ -84,10 +84,11 @@ def del_port(port):
     if len(port_entry) == 0:
         ctx.fail("port {} doesn't exist".format(port))
 
-    del port_entry['macsec']
-
-    config_db.set_entry("PORT", port, port_entry)
-
+    if 'macsec' in port_entry:
+        del port_entry['macsec']
+        config_db.set_entry("PORT", port, port_entry)
+    else:
+        click.echo("port {} has no configured macsec profile".format(port))
 
 #
 # 'profile' group ('config macsec profile ...')


### PR DESCRIPTION
#### Why I did it
Trying to remove macsec from a port without it configured would lead to a crash/backtrace of the config command

##### Work item tracking
- issue #20631

#### How I did it
Check if macsec exists on the port before trying to delete it.

#### How to verify it
Run config macsec del <port> on a port without macsec, and ensure it returns gracefully

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ x] 202205

#### Description for the changelog
Handle the case where macsec is deleted on a port which does not have it configured.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
