### PR TITLE
[FRR] Enable pathd in frr

### DIFF
--- a/dockers/docker-fpm-frr/frr/supervisord/critical_processes.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/critical_processes.j2
@@ -6,6 +6,7 @@ program:fpmsyncd
 program:bfdd
 program:ospfd
 program:pimd
+program:pathd
 program:frrcfgd
 {%- else %}
 program:bgpcfgd

--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -193,3 +193,17 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=bgpd:running
 {% endif %}
+
+{% if DEVICE_METADATA.localhost.frr_mgmt_framework_config is defined and DEVICE_METADATA.localhost.frr_mgmt_framework_config == "true" %}
+[program:pathd]
+command=/usr/lib/frr/pathd -A 127.0.0.1
+priority=5
+stopsignal=KILL
+autostart=false
+autorestart=false
+startsecs=0
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=zebra:running
+{% endif %}

--- a/platform/vs/docker-sonic-vs/supervisord.conf.j2
+++ b/platform/vs/docker-sonic-vs/supervisord.conf.j2
@@ -198,6 +198,14 @@ stderr_logfile=syslog
 environment=ASAN_OPTIONS="log_path=/var/log/asan/fpmsyncd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
+[program:pathd]
+command=/usr/lib/frr/pathd -A 127.0.0.1
+priority=14
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+
 [program:arp_update]
 command=/usr/bin/arp_update
 priority=16


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To support srte policy, frr must enable pathd first. 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Enable pathd in frr docker.
#### How to verify it
Enter frr docker, check the pathd process.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [x] 202405
#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

