### PR TITLE
[supervisord.conf] enable neighsyncd to autorestart when exit code is 0

### DIFF
--- a/dockers/docker-orchagent/supervisord.conf.j2
+++ b/dockers/docker-orchagent/supervisord.conf.j2
@@ -135,7 +135,8 @@ environment=ASAN_OPTIONS="log_path=/var/log/asan/coppmgrd-asan.log{{ asan_extra_
 command=/usr/bin/neighsyncd
 priority=7
 autostart=false
-autorestart=false
+autorestart=unexpected
+exitcodes=0
 stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true

--- a/platform/p4/docker-sonic-p4/supervisord.conf
+++ b/platform/p4/docker-sonic-p4/supervisord.conf
@@ -72,7 +72,8 @@ stderr_logfile=syslog
 command=/usr/bin/neighsyncd
 priority=8
 autostart=false
-autorestart=false
+autorestart=unexpected
+exitcodes=0
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/platform/vs/docker-sonic-vs/supervisord.conf.j2
+++ b/platform/vs/docker-sonic-vs/supervisord.conf.j2
@@ -101,7 +101,8 @@ environment=ASAN_OPTIONS="log_path=/var/log/asan/coppmgrd-asan.log{{ asan_extra_
 command=/usr/bin/neighsyncd
 priority=8
 autostart=false
-autorestart=false
+autorestart=unexpected
+exitcodes=0
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}


### PR DESCRIPTION
handle exception where neighsyncd exited normally but did not autorestart. enables autorestart for neighsyncd if exit code is 0.

#### Why I did it
auto-restart was not enabled for syncd

##### Work item tracking
- Microsoft ADO **(number only)**: 29962787

#### How I did it
edited supervisord.conf to set neighsyncd autorestart=unexpected and exitcodes=0. this will auto-restart neighsyncd if the exit code is 0 but not otherwise.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 20231110.11

#### Description for the changelog
enable neighsyncd to autorestart when exit code is 0

