### PR TITLE
gNOI Cold Reboot - Adding the framework docker in the sonic-buildimage

### DIFF
--- a/dockers/docker-framework/Dockerfile.j2
+++ b/dockers/docker-framework/Dockerfile.j2
@@ -1,0 +1,36 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
+
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%syslogtag%/;" /etc/rsyslog.conf
+
+## Make apt-get non-interactive
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update        && \
+    apt-get install -f -y    \
+        libdbus-1-3          \
+        libdbus-c++-1-0v5
+
+{% if docker_framework_debs.strip() -%}
+# Copy locally-built Debian package dependencies
+{{ copy_files("debs/", docker_framework_debs.split(' '), "/debs/") }}
+
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_framework_debs.split(' ')) }}
+{%- endif %}
+
+RUN apt-get clean -y      && \
+    apt-get autoclean -   && \
+    apt-get autoremove -y && \
+    rm -rf /debs /var/lib/apt/lists/* /tmp/* ~/.cache/
+
+# creating sonic conig_status file.
+RUN mkdir -p /var/sonic
+RUN echo "# Config files managed by sonic-config-engine" > /var/sonic/config_status
+
+COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
+COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
+COPY ["critical_processes", "/etc/supervisor"]
+
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-framework/critical_processes
+++ b/dockers/docker-framework/critical_processes
@@ -1,0 +1,1 @@
+program:rebootbackend

--- a/dockers/docker-framework/framework.sh
+++ b/dockers/docker-framework/framework.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+
+exec /usr/local/bin/framework --logtostderr

--- a/dockers/docker-framework/supervisord.conf
+++ b/dockers/docker-framework/supervisord.conf
@@ -1,0 +1,43 @@
+[supervisord]
+logfile_maxbytes=1MB
+logfile_backups=2
+loglevel=warn
+nodaemon=true
+
+[eventlistener:dependent-startup]
+command=python3 -m supervisord_dependent_startup --log-level warn
+autostart=true
+autorestart=unexpected
+stdout_logfile=syslog
+stderr_logfile=syslog
+startretries=0
+exitcodes=0,3
+events=PROCESS_STATE
+buffer_size=50
+
+[eventlistener:supervisor-proc-exit-listener]
+command=/usr/bin/supervisor-proc-exit-listener --container-name framework
+events=PROCESS_STATE_EXITED
+autostart=true
+autorestart=unexpected
+stdout_logfile=syslog
+stderr_logfile=syslog
+
+[program:rsyslogd]
+command=/usr/sbin/rsyslogd -n -iNONE
+priority=1
+autostart=false
+autorestart=unexpected
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+
+[program:rebootbackend]
+command=/usr/bin/rebootbackend
+priority=2
+autostart=false
+autorestart=true
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=start:exited


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
This PR creates framework docker, which will be managing the Cold/Warm reboot requests from gNOI.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

