### PR TITLE
[DASH] enable offload manager on Nvidia SmartSwitch

### DIFF
--- a/dockers/docker-orchagent/critical_processes.j2
+++ b/dockers/docker-orchagent/critical_processes.j2
@@ -4,6 +4,14 @@
 {% set is_fabric_asic = 1 %}
 {% endif %}
 {% endif %}
+{% set dash_offload_enabled = 0 %}
+{% if DEVICE_METADATA.localhost.subtype %}
+{% if DEVICE_METADATA.localhost.subtype == "SmartSwitch" %}
+{% if "nvidia" in DEVICE_METADATA.localhost.platform %}
+{% set dash_offload_enabled = 1 %}
+{%- endif %}
+{%- endif %}
+{%- endif %}
 program:orchagent
 {% if is_fabric_asic == 0 %}
 program:portsyncd
@@ -19,4 +27,7 @@ program:nbrmgrd
 program:vxlanmgrd
 program:coppmgrd
 program:tunnelmgrd
+{% if dash_offload_enabled == 1 %}
+program:dashoffloadmanager
+{%- endif %}
 {%- endif %}

--- a/dockers/docker-orchagent/supervisord.conf.j2
+++ b/dockers/docker-orchagent/supervisord.conf.j2
@@ -38,6 +38,15 @@ dependent_startup=true
 {%- endif %}
 {% set asan_extra_options = ':print_suppressions=0' %}
 
+{% set dash_offload_enabled = 0 %}
+{% if DEVICE_METADATA.localhost.subtype %}
+{% if DEVICE_METADATA.localhost.subtype == "SmartSwitch" %}
+{% if "nvidia" in DEVICE_METADATA.localhost.platform %}
+{% set dash_offload_enabled = 1 %}
+{%- endif %}
+{%- endif %}
+{%- endif %}
+
 {% if is_fabric_asic == 0 %}
 [program:gearsyncd]
 command=/usr/bin/gearsyncd -p /usr/share/sonic/hwsku/gearbox_config.json
@@ -301,4 +310,21 @@ dependent_startup_wait_for=swssconfig:exited
 {% if ENABLE_ASAN == "y" %}
 environment=ASAN_OPTIONS="log_path=/var/log/asan/fdbsyncd-asan.log{{ asan_extra_options }}"
 {% endif %}
+{%- endif %}
+
+{% if is_fabric_asic == 0 %}
+{% if dash_offload_enabled == 1 %}
+[program:dashoffloadmanager]
+command=/usr/bin/dashoffloadmanager --zmq_server_base_addr 127.0.10.10
+priority=17
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=swssconfig:exited
+{% if ENABLE_ASAN == "y" %}
+environment=ASAN_OPTIONS="log_path=/var/log/asan/dashoffloadmanager-asan.log{{ asan_extra_options }}"
+{% endif %}
+{%- endif %}
 {%- endif %}

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -74,8 +74,13 @@ fi
 
 # Enable ZMQ for SmartSwitch
 LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "subtype"`
+PLATFORM=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "platform"`
 if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
     TELEMETRY_ARGS+=" -zmq_port=8100"
+
+    if [[ $PLATFORM =~ .*nvidia.* ]]; then
+        TELEMETRY_ARGS+=" -zmq_dpu_proxy_address_base=127.0.10.10"
+    fi
 fi
 
 # Add VRF parameter when mgmt-vrf enabled


### PR DESCRIPTION
#### Why I did it
To enable DASH offload manager for Nvidia SmartSwitch

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
* added the dashoffloadmanager app start to orchagent
* added an extra parameter to the gnmi app

#### How to verify it
Manual test

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

