### PR TITLE
[database]: Fix "program:redisprogram:redis_bmp" ERR from supervisor

### DIFF
--- a/dockers/docker-database/critical_processes.j2
+++ b/dockers/docker-database/critical_processes.j2
@@ -1,5 +1,5 @@
-{% if INSTANCES %}
-{%     for redis_inst, redis_items in INSTANCES.items() %}
+{% if INSTANCES -%}
+{%     for redis_inst, redis_items in INSTANCES.items() -%}
 program:{{ redis_inst }}
-{%-     endfor %}
-{%- endif %}
+{%     endfor -%}
+{% endif -%}


### PR DESCRIPTION
#### Why I did it

Commit 06c469e added an extra redis instance. This resulted in a two item string without linefeeds in /etc/supervisor/critical_processes:
  ```
  program:redisprogram:redis_bmp
  ```
That resulted in an error in syslog and docker-database failing.

#### Work item tracking

ERR database#supervisor-proc-exit-listener: Syntax of the line
  program:redisprogram:redis_bmp#012 in processes file is incorrect.
  Exiting... (#20636)

ossobv/sonic-buildimage#17

#### How I did it

Replace the jinja2 whitespace eating hyphens from BOL to EOL.

Note that j2 and the jinja2 parser in sonig-cfggen do not behave the same. The sonig-cfggen is the relevant one.

Before:
  ```
  $ j2 ./dockers/docker-database/critical_processes.j2.old -f json \
      <<< '{"INSTANCES":{"foo":"bar","baz":"..."}}'
  |
  |
  program:foo
  program:baz
  ```
  ```
  # docker exec database sonic-cfggen \
      -j /var/run/redis/sonic-db/database_config.json \
      -t /usr/share/sonic/templates/critical_processes.j2.old
  program:redisprogram:redis_bmp
  ```
After:
  ```
  $ j2 ./dockers/docker-database/critical_processes.j2 -f json \
      <<< '{"INSTANCES":{"foo":"bar","baz":"..."}}'
  program:foo
  program:baz
  ```
  ```
  # docker exec database sonic-cfggen \
      -j /var/run/redis/sonic-db/database_config.json \
      -t /usr/share/sonic/templates/critical_processes.j2
  program:redis
  program:redis_bmp
  |
  ```

After this fix, the output in /etc/supervisor/critical_processes is correct and the error from docker-database is gone.