### PR TITLE
[Mellanox] Enable get_rx_los API support in CMIS cable host mgmt mode

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -927,8 +927,6 @@ class SFP(NvidiaSFPCommon):
         """
         if self._xcvr_api is None:
             self.refresh_xcvr_api()
-            if self._xcvr_api is not None:
-                self._xcvr_api.get_rx_los = self.get_rx_los
         return self._xcvr_api
 
     def is_sw_control(self):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -815,6 +815,11 @@ class SFP(NvidiaSFPCommon):
             list: [False] * channels
         """
         api = self.get_xcvr_api()
+        try:
+            if self.is_sw_control():
+                return api.get_rx_los() if api else None
+        except Exception as e:
+            print(e)
         return [False] * api.NUM_CHANNELS if api else None
 
     def get_tx_fault(self):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The `show int transceiver status PORT` CLI always displays Rx LOS as False for all the lanes.

```
root@sonic:/home/admin# show int transceiver status Ethernet0 | grep "Rx loss"
        Rx loss of signal flag on media lane 1: False
        Rx loss of signal flag on media lane 2: False
        Rx loss of signal flag on media lane 3: False
        Rx loss of signal flag on media lane 4: False
        Rx loss of signal flag on media lane 5: False
        Rx loss of signal flag on media lane 6: False
        Rx loss of signal flag on media lane 7: False
        Rx loss of signal flag on media lane 8: False
root@sonic:/home/admin# 
```
##### Work item tracking
- Microsoft ADO **(number only)**: 30180403

#### How I did it
On Mellanox platforms, the `get_rx_los` API is overridden through the platform implementation (https://github.com/sonic-net/sonic-buildimage/blob/679997639ede79a7beef53654be101b14d04b006/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py#L1069) rather than using the implementation defined through cmis.py (https://github.com/sonic-net/sonic-platform-common/blob/59babf59f9aa611b84082896391b01a39ffcb866/sonic_platform_base/sonic_xcvr/api/public/cmis.py#L404).

The Mellanox platform is overriding the `get_rx_los` due to the below code
https://github.com/sonic-net/sonic-buildimage/blob/679997639ede79a7beef53654be101b14d04b006/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py#L1188-L1189

The current platform implementation assigns Rx LOS as False for all the lanes (irrespective of the actual status on the module) which in turn causes the `show int transceiver status PORT` CLI to display the Rx LOS as False for all the lanes.

Hence, removing the overriding part to ensure that the API is not overridden by the platform.

#### How to verify it
Verified the CLI on first 2 lanes which are in admin disabled state from the peer side.

```
root@sonic:/home/admin# show int transceiver status Ethernet0 | grep "Rx loss"
        Rx loss of signal flag on media lane 1: False
        Rx loss of signal flag on media lane 2: False
        Rx loss of signal flag on media lane 3: True
        Rx loss of signal flag on media lane 4: True
        Rx loss of signal flag on media lane 5: True
        Rx loss of signal flag on media lane 6: True
        Rx loss of signal flag on media lane 7: True
        Rx loss of signal flag on media lane 8: True
root@sonic:/home/admin# 
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

