### PR TITLE
Add the option to not add CABLE_LENGTH to Config DB if SKU is lossy-only

### DIFF
--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -189,6 +189,7 @@ def
 {%- endfor %}
 {%- set port_names_inactive  = port_names_list_inactive  | join(',') %}
 {
+{%- if DEVICE_METADATA is defined and ((DEVICE_METADATA['localhost']['not_lossless'] is not defined) or (DEVICE_METADATA['localhost']['not_lossless'] == 'false')) %}
     "CABLE_LENGTH": {
         "AZURE": {
     {% for port in PORT_ALL %}
@@ -198,6 +199,7 @@ def
     {% endfor %}
     }
     },
+{%- endif %}
 
 {% if defs.generate_buffer_pool_and_profiles is defined %}
 {{ defs.generate_buffer_pool_and_profiles() }}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Added an option to not add CABLE_LENGTH table to Config DB, if SKU has lossy-only buffer pool
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
If METADATA|localhost table in config DB contains "not_lossless":"true" FVP, we will not add the table to CONFIG DB, and won't get into lossless pool calculation logic. 
#### How to verify it
add "not_lossless":"true" to Config DB, change SKU to be lossy-only. 
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

