### PR TITLE
remove marvell from pfc_to_pg_map supported asic list

### DIFF
--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -77,7 +77,7 @@
 {% endif %}
 {%- endfor %}
 
-{%- set pfc_to_pg_map_supported_asics = ['mellanox', 'barefoot', 'marvell'] -%}
+{%- set pfc_to_pg_map_supported_asics = ['mellanox', 'barefoot'] -%}
 {%- set backend_device_types = ['BackEndToRRouter', 'BackEndLeafRouter'] -%}
 {%- set apollo_resource_types = ['DL-NPU-Apollo'] -%}
 


### PR DESCRIPTION

#### Why I did it
SONIC warm-reboot command is not working due to unsupported qos configs.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Build and verify that sonic warm-reboot is working fine.

#### How to verify it
execute the warm-reboot command, and verify it is going though fine.

#### Which release branch to backport (provide reason below if selected)


- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)
202405


#### Description for the changelog


#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

