### PR TITLE
Support bulk chunk size in bulk counter polling operation

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/flex_counter.json
@@ -7,6 +7,14 @@
         "eStrKey": "Range",
         "eStr": "100..4294967295"
     },
+    "FLEX_COUNTER_TABLE_WITH_VALID_BULK_CHUNK_SIZE": {
+        "desc": "FLEX_COUNTER_TABLE_WITH_VALID_BULK_CHUNK_SIZE no failure."
+    },
+    "FLEX_COUNTER_TABLE_WITH_INVALID_BULK_CHUNK_SIZE": {
+        "desc": "Out of range bulk chunk size.",
+        "eStrKey": "Range",
+        "eStr": "1..4294967295"
+    },
     "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_VRF": {
         "desc": "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_VRF no failure."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
@@ -137,6 +137,158 @@
             }
         }
     },
+    "FLEX_COUNTER_TABLE_WITH_VALID_BULK_CHUNK_SIZE": {
+        "sonic-flex_counter:sonic-flex_counter": {
+            "sonic-flex_counter:FLEX_COUNTER_TABLE": {
+                "BUFFER_POOL_WATERMARK": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "DEBUG_COUNTER": {
+                    "FLEX_COUNTER_STATUS": "enable"
+                },
+                "ENI": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "PFCWD": {
+                    "FLEX_COUNTER_STATUS": "enable"
+                },
+                "PG_DROP": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "BULK_CHUNK_SIZE": 100,
+                    "POLL_INTERVAL": 10000
+                },
+                "PG_WATERMARK": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "BULK_CHUNK_SIZE": 100,
+                    "POLL_INTERVAL": 10000
+                },
+                "PORT": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "BULK_CHUNK_SIZE": 100,
+                    "POLL_INTERVAL": 1000
+                },
+                "PORT_BUFFER_DROP": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 60000
+                },
+                "PORT_RATES": {
+                    "FLEX_COUNTER_STATUS": "enable"
+                },
+                "QUEUE": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "BULK_CHUNK_SIZE": 100,
+                    "POLL_INTERVAL": 10000
+                },
+                "QUEUE_WATERMARK": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "BULK_CHUNK_SIZE": 100,
+                    "POLL_INTERVAL": 10000
+                },
+                "ACL": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "TUNNEL": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "FLOW_CNT_TRAP": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "FLOW_CNT_ROUTE": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "WRED_ECN_QUEUE": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "WRED_ECN_PORT": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 1000
+                }
+            }
+        }
+    },
+    "FLEX_COUNTER_TABLE_WITH_INVALID_BULK_CHUNK_SIZE": {
+        "sonic-flex_counter:sonic-flex_counter": {
+            "sonic-flex_counter:FLEX_COUNTER_TABLE": {
+                "BUFFER_POOL_WATERMARK": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "DEBUG_COUNTER": {
+                    "FLEX_COUNTER_STATUS": "enable"
+                },
+                "ENI": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "PFCWD": {
+                    "FLEX_COUNTER_STATUS": "enable"
+                },
+                "PG_DROP": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "BULK_CHUNK_SIZE": 0,
+                    "POLL_INTERVAL": 10000
+                },
+                "PG_WATERMARK": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "BULK_CHUNK_SIZE": 0,
+                    "POLL_INTERVAL": 10000
+                },
+                "PORT": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "BULK_CHUNK_SIZE": 0,
+                    "POLL_INTERVAL": 1000
+                },
+                "PORT_BUFFER_DROP": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 60000
+                },
+                "PORT_RATES": {
+                    "FLEX_COUNTER_STATUS": "enable"
+                },
+                "QUEUE": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "BULK_CHUNK_SIZE": 0,
+                    "POLL_INTERVAL": 10000
+                },
+                "QUEUE_WATERMARK": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "BULK_CHUNK_SIZE": 0,
+                    "POLL_INTERVAL": 10000
+                },
+                "ACL": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "TUNNEL": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "FLOW_CNT_TRAP": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "FLOW_CNT_ROUTE": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "WRED_ECN_QUEUE": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
+                "WRED_ECN_PORT": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 1000
+                }
+            }
+        }
+    },
     "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_VRF": {
         "sonic-vrf:sonic-vrf":{
             "sonic-vrf:VRF": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
@@ -147,10 +147,6 @@
                 "DEBUG_COUNTER": {
                     "FLEX_COUNTER_STATUS": "enable"
                 },
-                "ENI": {
-                    "FLEX_COUNTER_STATUS": "enable",
-                    "POLL_INTERVAL": 10000
-                },
                 "PFCWD": {
                     "FLEX_COUNTER_STATUS": "enable"
                 },
@@ -222,10 +218,6 @@
                 },
                 "DEBUG_COUNTER": {
                     "FLEX_COUNTER_STATUS": "enable"
-                },
-                "ENI": {
-                    "FLEX_COUNTER_STATUS": "enable",
-                    "POLL_INTERVAL": 10000
                 },
                 "PFCWD": {
                     "FLEX_COUNTER_STATUS": "enable"

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -41,6 +41,12 @@ module sonic-flex_counter {
                 }
             }
 
+            typedef bulk_chunk_size {
+                type uint32 {
+                    range 1..4294967295;
+                }
+            }
+
             description "FLEX_COUNTER_TABLE part of config_db.json";
 
             /* below are in alphabetical order */
@@ -102,6 +108,9 @@ module sonic-flex_counter {
                 leaf POLL_INTERVAL {
                     type poll_interval;
                 }
+                leaf BULK_CHUNK_SIZE {
+                    type bulk_chunk_size;
+                }
             }
 
             container PG_WATERMARK {
@@ -115,6 +124,9 @@ module sonic-flex_counter {
                 leaf POLL_INTERVAL {
                     type poll_interval;
                 }
+                leaf BULK_CHUNK_SIZE {
+                    type bulk_chunk_size;
+                }
             }
 
             container PORT {
@@ -127,6 +139,9 @@ module sonic-flex_counter {
                 }
                 leaf POLL_INTERVAL {
                     type poll_interval;
+                }
+                leaf BULK_CHUNK_SIZE {
+                    type bulk_chunk_size;
                 }
             }
 
@@ -151,6 +166,9 @@ module sonic-flex_counter {
                 leaf POLL_INTERVAL {
                     type poll_interval;
                 }
+                leaf BULK_CHUNK_SIZE {
+                    type bulk_chunk_size;
+                }
             }
 
             container QUEUE {
@@ -164,6 +182,9 @@ module sonic-flex_counter {
                 leaf POLL_INTERVAL {
                     type poll_interval;
                 }
+                leaf BULK_CHUNK_SIZE {
+                    type bulk_chunk_size;
+                }
             }
 
             container QUEUE_WATERMARK {
@@ -176,6 +197,9 @@ module sonic-flex_counter {
                 }
                 leaf POLL_INTERVAL {
                     type poll_interval;
+                }
+                leaf BULK_CHUNK_SIZE {
+                    type bulk_chunk_size;
                 }
             }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Added a new field in FLEX_COUNTER_TABLE to represent the bulk chunk size for bulk counter polling.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

