### PR TITLE
To Fix the issue: redis-cli build broken on Debian/Bookworm (librdb use-after-free)

### DIFF
--- a/src/rdb-cli/Makefile
+++ b/src/rdb-cli/Makefile
@@ -8,7 +8,8 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf ./librdb
 	git clone https://github.com/redis/librdb.git
 	pushd ./librdb/
-	git checkout 2fdfc0c2bc914d643fe3f86e6715aeb843d8966e
+	git checkout tags/v1.0.0
 	git submodule update --init --recursive	
-	make -j$(SONIC_CONFIG_MAKE_JOBS)
+	# Set WARNS=... to work around https://github.com/redis/librdb/issues/55
+	make -j$(SONIC_CONFIG_MAKE_JOBS) WARNS='-Wall -Wextra -pedantic -flto=auto'
 	mv bin/rdb-cli $(DEST)/


### PR DESCRIPTION
#### Why I did it
To Fix the issue: redis-cli build broken on Debian/Bookworm (librdb use-after-free) 
https://github.com/sonic-net/sonic-buildimage/issues/20757

#### How I did it
This issue is a known open issue below:
https://github.com/redis/librdb/issues/55

According to Walter Doekes's solution, currently to work around it by adding -floto=auto compiler option.
```
	make -j$(SONIC_CONFIG_MAKE_JOBS) WARNS='-Wall -Wextra -pedantic -flto=auto'
```

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)
 

#### Description for the changelog

