### PR TITLE
[system-health] delay system-health service start

### DIFF
--- a/src/system-health/scripts/healthd
+++ b/src/system-health/scripts/healthd
@@ -5,6 +5,9 @@
     System health monitor daemon for SONiC
 """
 
+from swsscommon.swsscommon import RestartWaiter
+RestartWaiter.waitAdvancedBootDone()
+
 import signal
 import threading
 import time

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -22,6 +22,7 @@ from sonic_py_common import device_info
 from .mock_connector import MockConnector
 
 swsscommon.SonicV2Connector = MockConnector
+swsscommon.RestartWaiter = MagicMock()
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 telemetry_path = os.path.join(test_path, 'telemetry')
@@ -48,7 +49,7 @@ snmpd                       RUNNING   pid 67, uptime 1:03:56
 snmp-subagent               EXITED    Oct 19 01:53 AM
 """
 device_info.get_platform = MagicMock(return_value='unittest')
- 
+
 device_runtime_metadata = {"DEVICE_RUNTIME_METADATA": {"ETHERNET_PORTS_PRESENT":True}}
 
 def no_op(*args, **kwargs):
@@ -843,7 +844,7 @@ def test_publish_system_status_allowed_status():
     sysmon = Sysmonitor()
     sysmon.publish_system_status('UP')
     sysmon.publish_system_status('DOWN')
-    
+
     expected_calls = [
         (("UP",), {}),
         (("DOWN",), {})
@@ -856,7 +857,7 @@ def test_publish_system_status():
     sysmon = Sysmonitor()
     sysmon.publish_system_status('UP')
     result = swsscommon.SonicV2Connector.get(MockConnector, 0, "SYSTEM_READY|SYSTEM_STATE", 'Status')
-    assert result == "UP" 
+    assert result == "UP"
 
 @patch('health_checker.sysmonitor.Sysmonitor.get_all_system_status', test_get_all_system_status_ok())
 @patch('health_checker.sysmonitor.Sysmonitor.publish_system_status', test_publish_system_status())


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To improve boot time and stabilize boot time as well as fast-reboot downtime consistency.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Delay system-health daemon till boot is finished, same as other daemons.

#### How to verify it

Boot the system, verify system-health service starts with a delay, execute command:

```
admin@sonic:~$ sudo show system-health summary
System status summary

  System status LED  green
  Services:
    Status: OK
  Hardware:
    Status: OK
``` 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

