### PR TITLE
[build] Fix against stray tmp.XXXXXX files in ./dpkg dir

### DIFF
--- a/rules/functions
+++ b/rules/functions
@@ -168,12 +168,12 @@ endef
 ## Setup overlay fs for dpkg admin directory /var/lib/dpkg
 ###############################################################################
 define SETUP_OVERLAYFS_FOR_DPKG_ADMINDIR
-upperdir=$(shell mktemp -d -p $(DPKG_ADMINDIR_PATH))
-workdir=$(shell mktemp -d -p $(DPKG_ADMINDIR_PATH))
-mergedir=$(shell mktemp -d -p $(DPKG_ADMINDIR_PATH))
+upperdir=$$(mktemp -d -p $(DPKG_ADMINDIR_PATH))
+workdir=$$(mktemp -d -p $(DPKG_ADMINDIR_PATH))
+mergedir=$$(mktemp -d -p $(DPKG_ADMINDIR_PATH))
+trap "sudo umount $$mergedir && rm -rf $$mergedir $$upperdir $$workdir" EXIT
 sudo mount -t overlay overlay -olowerdir=/var/lib/dpkg,upperdir=$$upperdir,workdir=$$workdir $$mergedir
 export SONIC_DPKG_ADMINDIR=$$mergedir
-trap "sudo umount $$mergedir && rm -rf $$mergedir $$upperdir $$workdir" EXIT
 endef
 
 


### PR DESCRIPTION
#### Why I did it

I don't like a bunch of useless tempdirs laying around. Issue: #20772

#### How I did it

The make function SETUP_OVERLAYFS_FOR_DPKG_ADMINDIR is not always run, but if it's parsed, the $(shell) calls would be executed. They caused tempdirs to be created. But only if the function was run, were those dirs cleaned up.

This change moves the tempdir creation to the function run.

Additionally it moves the trap EXIT two lines earlier, so that a failing mount would not leave useless dirs either.

#### How to verify it

Run `make` and observe how at the end there aren't lots of stale temp dirs `./dpkg`.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

I think this change could be backported to at least the active 202405 branch, but it's not strictly necessary.

#### Tested branch (Please provide the tested image version)

master
