### PR TITLE
Fixed build issues caused due to inaccessible mirror URLs

### DIFF
--- a/scripts/build_mirror_config.sh
+++ b/scripts/build_mirror_config.sh
@@ -7,18 +7,21 @@ export DISTRIBUTION=$3
 
 DEFAULT_MIRROR_URL_PREFIX=http://packages.trafficmanager.net
 MIRROR_VERSION_FILE=
-[[ "$SONIC_VERSION_CONTROL_COMPONENTS" == *deb* || $SONIC_VERSION_CONTROL_COMPONENTS == *all* ]] && MIRROR_VERSION_FILE=files/build/versions/default/versions-mirror
+[[ "$SONIC_VERSION_CONTROL_COMPONENTS" == *deb* || $SONIC_VERSION_CONTROL_COMPONENTS == *all* ]] && MIRROR_VERSION_FILE=files/build/versions/default/versions-mirror && MIRROR_SNAPSHOT=y
 [ -f target/versions/default/versions-mirror ] && MIRROR_VERSION_FILE=target/versions/default/versions-mirror
 
 # The default mirror urls
-DEFAULT_MIRROR_URLS=http://debian-archive.trafficmanager.net/debian/,http://packages.trafficmanager.net/debian/debian/
-DEFAULT_MIRROR_SECURITY_URLS=http://debian-archive.trafficmanager.net/debian-security/,http://packages.trafficmanager.net/debian/debian-security/
+DEFAULT_MIRROR_URLS=http://debian-archive.trafficmanager.net/debian/
+DEFAULT_MIRROR_SECURITY_URLS=http://debian-archive.trafficmanager.net/debian-security/
 
+if [ "$DISTRIBUTION" == "buster" ]; then
+   DEFAULT_MIRROR_URLS=http://archive.debian.org/debian/
+fi
 
 # The debian-archive.trafficmanager.net does not support armhf, use debian.org instead
 if [ "$ARCHITECTURE" == "armhf" ]; then
-    DEFAULT_MIRROR_URLS=http://deb.debian.org/debian/,http://packages.trafficmanager.net/debian/debian/
-    DEFAULT_MIRROR_SECURITY_URLS=http://deb.debian.org/debian-security/,http://packages.trafficmanager.net/debian/debian-security/
+    DEFAULT_MIRROR_URLS=http://deb.debian.org/debian/
+    DEFAULT_MIRROR_SECURITY_URLS=http://deb.debian.org/debian-security/
 fi
 
 if [ "$MIRROR_SNAPSHOT" == y ]; then


### PR DESCRIPTION
#### Why I did it
Fixed build issues caused due to inaccessible mirror URLs

Failure logs:
```
0.323 Err:1 http://packages.trafficmanager.net/debian/debian buster InRelease                                                                                                                         
0.323   400  The account being accessed does not support http. [IP: 13.107.246.69 80]                                                                                                                 
0.341 Get:2 http://debian-archive.trafficmanager.net/debian buster InRelease [122 kB]                                                                                                                 
0.357 Err:3 http://packages.trafficmanager.net/debian/debian buster-updates InRelease                                                                                                                 
0.357   400  The account being accessed does not support http. [IP: 13.107.246.69 80]                                                                                                                 
0.390 Err:4 http://packages.trafficmanager.net/debian/debian buster-backports InRelease                                                                                                               
0.390   400  The account being accessed does not support http. [IP: 13.107.246.69 80]                                                                                                                 
0.423 Err:5 http://packages.trafficmanager.net/debian/debian-security buster_updates InRelease                                                                                                        
0.423   400  The account being accessed does not support http. [IP: 13.107.246.69 80]                                                                                                                 
0.435 Get:6 http://debian-archive.trafficmanager.net/debian buster-updates InRelease [56.6 kB]                                                                                                        
0.460 Ign:7 http://debian-archive.trafficmanager.net/debian buster-backports InRelease                                                                                                                
0.484 Get:8 http://debian-archive.trafficmanager.net/debian-security buster/updates InRelease [34.8 kB]                                                                                               
0.509 Err:9 http://debian-archive.trafficmanager.net/debian buster-backports Release                                                                                                                  
0.509   404  Not Found [IP: 172.179.119.208 80]                                                     
```

#### How I did it
Updated build_mirror_config.sh script with the public debians storage links

#### How to verify it
Run "make configure" and try to build the buster and bullseye debian packages

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
UT logs:
```
sonic: docker images | grep "sonic-slave-buster"
sonic-slave-buster-nikhil                       76ee36d5772           90de8c3acf01   6 minutes ago    5.11GB
sonic-slave-buster                              72c2aad2758           8f7ee816c3a6   7 minutes ago    5.11GB
```

#### Description for the changelog
Fixed build issues caused due to inaccessible mirror URLs
