### PR TITLE
[202311]  Add GNMI client cert cname check support. 

### DIFF
--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -33,6 +33,8 @@ if [ -n "$CERTS" ]; then
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
+
+    TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
 elif [ -n "$X509" ]; then
     SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
     SERVER_KEY=$(echo $X509 | jq -r '.server_key')

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -34,6 +34,9 @@ if [ -n "$CERTS" ]; then
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
+
+    # Reuse GNMI_CLIENT_CERT for telemetry service
+    TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
 elif [ -n "$X509" ]; then
     SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
     SERVER_KEY=$(echo $X509 | jq -r '.server_key')

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1263,6 +1263,14 @@
                 "port": "50052"
             }
         },
+        "GNMI_CLIENT_CERT": {
+            "testcert1": {
+                "role": "RW"
+            },
+            "testcert2": {
+                "role": "RO"
+            }
+        },
         "TUNNEL": {
             "MuxTunnel0": {
                 "dscp_mode": "uniform",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/gnmi.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/gnmi.json
@@ -13,5 +13,12 @@
     },
     "GNMI_TABLE_WITH_VALID_CONFIG": {
         "desc": "TABLE WITH VALID CONFIG."
+    },
+    "GNMI_CLIENT_CERT_LIST_TABLE_WITH_MISSING_ROLE": {
+        "desc": "CLIENT_CERT_LIST_TABLE_WITH_MISSING_ROLE failure.",
+        "eStrKey": "Mandatory"
+    },
+    "GNMI_CLIENT_CERT_LIST_TABLE_WITH_VALID_CONFIG": {
+        "desc": "TABLE WITH VALID CONFIG."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/gnmi.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/gnmi.json
@@ -62,5 +62,32 @@
                 }
             }
         }
+    },
+    "GNMI_CLIENT_CERT_LIST_TABLE_WITH_MISSING_ROLE": {
+        "sonic-gnmi:sonic-gnmi": {
+            "sonic-gnmi:GNMI_CLIENT_CERT": {
+                "GNMI_CLIENT_CERT_LIST": [
+                {
+                    "cert_cname": "testcert1"
+                }
+                ]
+            }
+        }
+    },
+    "GNMI_CLIENT_CERT_LIST_TABLE_WITH_VALID_CONFIG": {
+        "sonic-gnmi:sonic-gnmi": {
+            "sonic-gnmi:GNMI_CLIENT_CERT": {
+                "GNMI_CLIENT_CERT_LIST": [
+                {
+                    "cert_cname": "testcert1",
+                    "role": "RW"
+                },
+                {
+                    "cert_cname": "testcert2",
+                    "role": "RO"
+                }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-gnmi.yang
+++ b/src/sonic-yang-models/yang-models/sonic-gnmi.yang
@@ -72,7 +72,28 @@ module sonic-gnmi {
                 }
 
             }
+        }
 
+        container GNMI_CLIENT_CERT {
+            description "GNMI client cert list";
+
+            list GNMI_CLIENT_CERT_LIST {
+                max-elements 8;
+                key "cert_cname";
+
+                leaf cert_cname {
+                    type string;
+                    description
+                        "client cert common name";
+                }
+
+                leaf role {
+                    type string;
+                    mandatory true;
+                    description
+                        "role of client cert common name";
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Add GNMI client cert cname list to yang model.
This is cherry-pick PR for https://github.com/sonic-net/sonic-buildimage/pull/18709

#### Why I did it
Allow gnmi service authentication client cert by cname.

##### Work item tracking
- Microsoft ADO: 25226269

#### How I did it
Add GNMI client cert cname list to yang model.

#### How to verify it
Pass all UT.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!-- 
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

will updated with this PR image later.
- [] SONiC.master-16482.360728-2c8b4066f
- [] SONiC.202405-20731.690016-d47b3771d
- [] SONiC.202311-20734.692072-6612467e4

#### Description for the changelog
Add GNMI client cert cname list to yang model.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

