### PR TITLE
Fix bmp instance on DPU database issue

### DIFF
--- a/dockers/docker-database/database_config.json.j2
+++ b/dockers/docker-database/database_config.json.j2
@@ -23,13 +23,17 @@
             "unix_socket_path": "",
             "persistence_for_warm_boot" : "yes"
         }
-{% endif %},
+{% endif %}
+{% if DATABASE_TYPE is defined and DATABASE_TYPE == "dpudb" %}
+{% else %}
+        ,
         "redis_bmp":{
             "hostname" : "{{HOST_IP}}",
             "port" : {{BMP_DB_PORT}},
             "unix_socket_path" : "/var/run/redis{{DEV}}/redis_bmp.sock",
             "persistence_for_warm_boot" : "yes"
         }
+{% endif %}
     },
     "DATABASES" : {
         "APPL_DB" : {
@@ -135,12 +139,14 @@
             "separator": ":",
             "instance" : {% if include_remote_db %} "remote_redis" {% else %} "redis" {% endif %}
         }
-{% endif %},
-         "BMP_STATE_DB" : {
+{% else %}
+        ,
+        "BMP_STATE_DB" : {
             "id" : 20,
             "separator": "|",
             "instance" : "redis_bmp"
         }
+{% endif %}
     },
     "VERSION" : "1.0"
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
BMP instance should not be launched on DPU database.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added some condition check to avoid bmp instance from being instantiated on DPU database instances.

#### How to verify it
local verified on KVM NPU platform.

<img width="1010" alt="image" src="https://github.com/user-attachments/assets/aa44d546-5385-4706-91d3-7454564b3fbb">


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

