### PR TITLE
fix typo: enviroment

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -54,7 +54,7 @@ DEFAULT_PASSWORD = YourPaSsWoRd
 # ENABLE_ZTP - installs Zero Touch Provisioning support.
 # ENABLE_ZTP = y
 
-# INCLUDE_PDE - Enable platform development enviroment
+# INCLUDE_PDE - Enable platform development environment
 # INCLUDE_PDE = y
 # SHUTDOWN_BGP_ON_START - if set to y all bgp sessions will be in admin down state when
 # bgp service starts.


### PR DESCRIPTION
#### Why I did it

Found typo (wrong spelling)

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

enviroment -> environment

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

typo of comment so no need for backporting.

#### Tested branch (Please provide the tested image version)

no test required.

#### Description for the changelog

n/a

#### Link to config_db schema for YANG module changes
none

#### A picture of a cute animal (not mandatory but encouraged)

```
 /\_/\  
( o.o ) 
 > ^ <
```