### PR TITLE
Enable SFF Manger on Arista linecards by default

### DIFF
--- a/device/arista/x86_64-arista_common/pmon_daemon_control_linecard.json
+++ b/device/arista/x86_64-arista_common/pmon_daemon_control_linecard.json
@@ -1,5 +1,6 @@
 {
     "skip_fancontrol": true,
-    "skip_pcied": true
+    "skip_pcied": true,
+    "enable_xcvrd_sff_mgr": true
 }
 


### PR DESCRIPTION
SFF Manager in xcvrd needs to run to take non-cmis transceivers out of lpmode as part of the fix for these transceivers remaining in down state.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
We wanted to enable SFF Manager on Arista linecards. 

##### Work item tracking

#### How I did it

#### How to verify it
This is intended to work together with the change in https://github.com/sonic-net/sonic-platform-daemons/pull/565.

Can be tested by loading an image containing this change alongside the change from https://github.com/sonic-net/sonic-platform-daemons/pull/565 on an Arista chassis.

Verify that without this image some interfaces were in a down state but with the image all interfaces came up as expected.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)

- [x] 202405

#### Description for the changelog
Added enable sff mgr in xcvrd by default on Arista linecards.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

