### PR TITLE
[database]: Fix "program:redisprogram:redis_bmp" ERR from supervisor …

### DIFF
--- a/dockers/docker-database/critical_processes.j2
+++ b/dockers/docker-database/critical_processes.j2
@@ -1,5 +1,5 @@
-{% if INSTANCES %}
-{%     for redis_inst, redis_items in INSTANCES.items() %}
+{% if INSTANCES -%}
+{%     for redis_inst, redis_items in INSTANCES.items() -%}
 program:{{ redis_inst }}
-{%-     endfor %}
-{%- endif %}
+{%     endfor -%}
+{% endif -%}


### PR DESCRIPTION
## Why I did it

Backport of 4807ac5109c2f5f20d92b33041ac45b9b9b11c89 for 202405.

The problem isn't there yet, but this fix is correct. And the problem might crop up once someone starts using two DBs.

## Original issue

Issue: https://github.com/sonic-net/sonic-buildimage/issues/20636
PR-for-master: https://github.com/sonic-net/sonic-buildimage/pull/20726

@FengPan-Frank can you merge this one as well?