### PR TITLE
[yang] add Yang model for GRPCCLIENT

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -42,6 +42,7 @@ Table of Contents
          * [FABRIC_MONITOR](#fabric-monitor)
          * [FABRIC_PORT](#fabric-port)
          * [FLEX_COUNTER_TABLE](#flex_counter_table)
+         * [GRPCCLIENT](#grpcclient)
          * [Hash](#hash)
          * [IPv6 Link-local] (#ipv6-link-local)
          * [KDUMP](#kdump)

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -204,6 +204,7 @@ setup(
                          './yang-models/sonic-bgp-sentinel.yang',
                          './yang-models/sonic-bmp.yang',
                          './yang-models/sonic-xcvrd-log.yang',
+                         './yang-models/sonic-grpcclient.yang',
                          './yang-models/sonic-serial-console.yang',
                          './yang-models/sonic-smart-switch.yang',]),
         ('cvlyang-models', ['./cvlyang-models/sonic-acl.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2752,6 +2752,19 @@
 		"log_verbosity": "notice"
 	    }
 	},
+	"GRPCCLIENT": {
+            "config": {
+                "type": "secure",
+                "auth_level": "server",
+                "log_level": "info"
+            },
+            "certs": {
+                "client_crt": "grpcclient.crt",
+                "client_key": "grpcclient.key",
+                "ca_crt": "root.pem",
+                "grpc_ssl_credential": "azureclient.ms"
+            } 
+	},
         "BANNER_MESSAGE": {
             "global": {
                 "state": "enabled",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/grpcclient.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/grpcclient.json
@@ -1,0 +1,5 @@
+{
+    "GRPCCLIENT_CONFIG_CHANGE_VERBOSITY_LEVEL": {
+        "desc": "Consume verbosity level config changes. "
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/grpcclient.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/grpcclient.json
@@ -2,7 +2,7 @@
     "GRPCCLIENT_CONFIG_CHANGE_VERBOSITY_LEVEL": {
         "sonic-grpcclient:sonic-grpcclient": {
             "sonic-grpcclient:GRPCCLIENT": {
-                "sonic-grpcclient:CONFIG": 
+                "sonic-grpcclient:config": 
                     {
                         "log_level": "info"
                     }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/grpcclient.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/grpcclient.json
@@ -1,0 +1,12 @@
+{
+    "GRPCCLIENT_CONFIG_CHANGE_VERBOSITY_LEVEL": {
+        "sonic-grpcclient:sonic-grpcclient": {
+            "sonic-grpcclient:GRPCCLIENT": {
+                "sonic-grpccleint:CONFIG": 
+                    {
+                        "log_level": "info"
+                    }
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/grpcclient.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/grpcclient.json
@@ -2,7 +2,7 @@
     "GRPCCLIENT_CONFIG_CHANGE_VERBOSITY_LEVEL": {
         "sonic-grpcclient:sonic-grpcclient": {
             "sonic-grpcclient:GRPCCLIENT": {
-                "sonic-grpccleint:CONFIG": 
+                "sonic-grpcclient:CONFIG": 
                     {
                         "log_level": "info"
                     }

--- a/src/sonic-yang-models/yang-models/sonic-grpcclient.yang
+++ b/src/sonic-yang-models/yang-models/sonic-grpcclient.yang
@@ -21,16 +21,14 @@ module sonic-grpcclient {
 
         container GRPCCLIENT {
 
-            container CONFIG {
+            container config {
 
                 leaf type {
                     type enumeration {
                         enum secure;
                         enum insecure;
                     }
-
                     description "grpc client security level. ";
-
                 }
 
                 leaf auth_level {
@@ -38,9 +36,7 @@ module sonic-grpcclient {
                         enum server;
                         enum client;
                     }
-
                     description "grpc client auth level. ";
-
                 }
 
                 leaf log_level {
@@ -51,18 +47,14 @@ module sonic-grpcclient {
                         enum warning;
                         enum critical;
                     }
-
                     description "grpc client log level. ";
-
-
                 }
             }
 
-            container CERTS {
+            container certs {
 
                 leaf client_crt {
                     type string;
-
                     description "grpc client certificate file name ";
 
                 }
@@ -70,27 +62,18 @@ module sonic-grpcclient {
                 leaf client_key {
                     type string;
                     description "grpc client key file name ";
-
                 }
 
                 leaf ca_crt {
-
                     type string;
                     description "grpc client root cert";
-
-
                 }
 
                 leaf grpc_ssl_credential {
                     type string;
                     description "grpc client ssl credential";
-
-
                 }
             }
-
-
-
         }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-grpcclient.yang
+++ b/src/sonic-yang-models/yang-models/sonic-grpcclient.yang
@@ -1,0 +1,96 @@
+module sonic-grpcclient {
+    namespace "http://github.com/sonic-net/sonic-grpcclient";
+    prefix grpcclient;
+    yang-version 1.1;
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "SONiC DualToR grpc client configuration data";
+
+    revision 2024-10-14 {
+        description
+            "Initial revision";
+    }
+
+    container sonic-grpcclient {
+
+        container GRPCCLIENT {
+
+            container CONFIG {
+
+                leaf type {
+                    type enumeration {
+                        enum secure;
+                        enum insecure;
+                    }
+
+                    description "grpc client security level. ";
+
+                }
+
+                leaf auth_level {
+                    type enumeration {
+                        enum server;
+                        enum client;
+                    }
+
+                    description "grpc client auth level. ";
+
+                }
+
+                leaf log_level {
+                    type enumeration {
+                        enum info;
+                        enum notice;
+                        enum debug;
+                        enum warning;
+                        enum critical;
+                    }
+
+                    description "grpc client log level. ";
+
+
+                }
+            }
+
+            container CERTS {
+
+                leaf client_crt {
+                    type string;
+
+                    description "grpc client certificate file name ";
+
+                }
+
+                leaf client_key {
+                    type string;
+                    description "grpc client key file name ";
+
+                }
+
+                leaf ca_crt {
+
+                    type string;
+                    description "grpc client root cert";
+
+
+                }
+
+                leaf grpc_ssl_credential {
+                    type string;
+                    description "grpc client ssl credential";
+
+
+                }
+            }
+
+
+
+        }
+    }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Adding yang model for CONFIG_DB table  GRPCCLIENT
Introduced by
https://github.com/sonic-net/sonic-platform-daemons/blob/b276e415d85f3e8a7c64532d95821c9000c9418d/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py#L407

sign-off: Vaibhav Dahiya [[vdahiya@microsoft.com](mailto:vdahiya@microsoft.com)]

##### Work item tracking
- Microsoft ADO **(number only)**:
30350460

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

