### PR TITLE
Ensure database container auto restart after redis crash

### DIFF
--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -162,7 +162,11 @@ def main(argv):
                 group_name = payload_headers['groupname']
 
                 if (process_name in critical_process_list or group_name in critical_group_list) and expected == 0:
-                    is_auto_restart = get_autorestart_state(container_name, use_unix_socket_path)
+                    # If redis crashes, get_autorestart_state() will hang
+                    if container_name == "database" and process_name == "redis":
+                        is_auto_restart = "always_enabled"
+                    else:
+                        is_auto_restart = get_autorestart_state(container_name, use_unix_socket_path)
                     if is_auto_restart != "disabled":
                         MSG_FORMAT_STR = "Process '{}' exited unexpectedly. Terminating supervisor '{}'"
                         msg = MSG_FORMAT_STR.format(payload_headers['processname'], container_name)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
If the redis service in the database container unexpectedly stops, the get_autorestart_state function becomes unresponsive, preventing a restart from being triggered, as it relies on querying Redis ConfigDB.

#### How I did it
Directly assign the value when the situation is `container_name == "database"` and `process_name == "redis"`, bypassing the get_autorestart_state function to allow the restart to proceed.

#### How to verify it
Kill the redis-server process inside the database container, then wait for a period of time to confirm that the database container has restarted.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

