### PR TITLE
Apply pfc_asym cfg from port config file

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2476,7 +2476,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     for port in ports.values():
         if 'pfc_asym' not in port:
             port['pfc_asym'] = 'off'
-        elif port['pfc_asym'] == 'N/A':
+        elif port['pfc_asym'] == '-':
             del port['pfc_asym']
 
     # set physical port default admin status up

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2474,7 +2474,10 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
 
     # asymmetric PFC is disabled by default
     for port in ports.values():
-        port['pfc_asym'] = 'off'
+        if 'pfc_asym' not in port:
+            port['pfc_asym'] = 'off'
+        elif port['pfc_asym'] == 'N/A':
+            del port['pfc_asym']
 
     # set physical port default admin status up
     for port in phyport_intfs:

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -231,8 +231,7 @@ def parse_port_config_file(port_config_file):
             for i, item in enumerate(tokens):
                 if i == name_index:
                     continue
-                if item != '-':
-                    data[titles[i]] = item
+                data[titles[i]] = item
             data.setdefault('alias', name)
             ports[name] = data
             port_alias_map[data['alias']] = name

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -231,7 +231,8 @@ def parse_port_config_file(port_config_file):
             for i, item in enumerate(tokens):
                 if i == name_index:
                     continue
-                data[titles[i]] = item
+                if item != '-':
+                    data[titles[i]] = item
             data.setdefault('alias', name)
             ports[name] = data
             port_alias_map[data['alias']] = name

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -364,6 +364,15 @@ def main():
         if ports is None:
             print('Failed to get port config', file=sys.stderr)
             sys.exit(1)
+        for port in ports.values():
+            null_value_attrs = []
+            for attr in port:
+                if port[attr] == '-':
+                    null_value_attrs.append(attr)
+            if not null_value_attrs:
+                continue
+            for null_value_attr in null_value_attrs:
+                del port[null_value_attr]
         deep_update(data, {'PORT': ports})
 
         brkout_table = get_breakout_mode(hwsku, platform, args.port_config)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Some ports of new platforms don't support pfc_asym cfg.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Apply pfc_asym cfg from port config file(port_info.ini), if the value is "-", remove pfc_asym cfg.

#### How to verify it
Verified on 8122 with pie ports:
```
root@ixia-light-dut:/opt/cisco/bin# platform_cisco_cfg.py
INFO:PlatformCfg:No need to update /usr/share/sonic/device/x86_64-8122_64eh_o-r0/platform.json for interfaces section
INFO:PlatformCfg:Generating cfg for /usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-64EH-O/
INFO:PlatformCfg:Generating cfg for /usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-64x800G/
INFO:PlatformCfg:Generating cfg for /usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-C512/
INFO:PlatformCfg:Generating cfg for /usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-O128/
INFO:PlatformCfg:Generating cfg for /usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-O64/
root@ixia-light-dut:/opt/cisco/bin# cd Cisco-8122-O64
bash: cd: Cisco-8122-O64: No such file or directory
root@ixia-light-dut:/opt/cisco/bin# cd /usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-O64/
root@ixia-light-dut:/usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-O64# ls
asic_cfg.json		buffers_defaults_t1.j2	buffers_extra_queues.j2  pg_profile_lookup.ini	  platform_cisco_cfg.yaml.backup  port_config.ini  sai.profile
buffers_defaults_t0.j2	buffers_extra_pgs.j2	buffers.json.j2		 platform_cisco_cfg.yaml  platform_npu_cfg.yaml		  qos.json.j2	   sai_sdk_log_config.json
root@ixia-light-dut:/usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-O64# cat port_config.ini 
# name                                              lanes             alias    index      speed    subport    pfc_asym
Ethernet0         1536,1537,1538,1539,1540,1541,1542,1543              etp0        0     400000          0        off
Ethernet8         1544,1545,1546,1547,1548,1549,1550,1551              etp1        1     400000          0        off
Ethernet16        1560,1561,1562,1563,1564,1565,1566,1567              etp2        2     400000          0        off
Ethernet24        1552,1553,1554,1555,1556,1557,1558,1559              etp3        3     400000          0        off
Ethernet32        1792,1793,1794,1795,1796,1797,1798,1799              etp4        4     400000          0        off
Ethernet40        1800,1801,1802,1803,1804,1805,1806,1807              etp5        5     400000          0        off
Ethernet48        1816,1817,1818,1819,1820,1821,1822,1823              etp6        6     400000          0        off
Ethernet56        1808,1809,1810,1811,1812,1813,1814,1815              etp7        7     400000          0        off
Ethernet64        1288,1289,1290,1291,1292,1293,1294,1295              etp8        8     400000          0        off
Ethernet72        1280,1281,1282,1283,1284,1285,1286,1287              etp9        9     400000          0        off
Ethernet80        1296,1297,1298,1299,1300,1301,1302,1303             etp10       10     400000          0        off
Ethernet88        1304,1305,1306,1307,1308,1309,1310,1311             etp11       11     400000          0        off
Ethernet96        1024,1025,1026,1027,1028,1029,1030,1031             etp12       12     400000          0        off
Ethernet104       1032,1033,1034,1035,1036,1037,1038,1039             etp13       13     400000          0        off
Ethernet112       1040,1041,1042,1043,1044,1045,1046,1047             etp14       14     400000          0        off
Ethernet120       1048,1049,1050,1051,1052,1053,1054,1055             etp15       15     400000          0        off
Ethernet128               536,537,538,539,540,541,542,543             etp16       16     400000          0        off
Ethernet136               528,529,530,531,532,533,534,535             etp17       17     400000          0        off
Ethernet144               520,521,522,523,524,525,526,527             etp18       18     400000          0        off
Ethernet152               512,513,514,515,516,517,518,519             etp19       19     400000          0        off
Ethernet160               792,793,794,795,796,797,798,799             etp20       20     400000          0        off
Ethernet168               784,785,786,787,788,789,790,791             etp21       21     400000          0        off
Ethernet176               776,777,778,779,780,781,782,783             etp22       22     400000          0        off
Ethernet184               768,769,770,771,772,773,774,775             etp23       23     400000          0        off
Ethernet192               256,257,258,259,260,261,262,263             etp24       24     400000          0        off
Ethernet200               264,265,266,267,268,269,270,271             etp25       25     400000          0        off
Ethernet208               272,273,274,275,276,277,278,279             etp26       26     400000          0        off
Ethernet216               280,281,282,283,284,285,286,287             etp27       27     400000          0        off
Ethernet224                               0,1,2,3,4,5,6,7             etp28       28     400000          0        off
Ethernet232                         8,9,10,11,12,13,14,15             etp29       29     400000          0        off
Ethernet240                       16,17,18,19,20,21,22,23             etp30       30     400000          0        off
Ethernet248                       24,25,26,27,28,29,30,31             etp31       31     400000          0        off
Ethernet256       3600,3601,3602,3603,3604,3605,3606,3607             etp32       32     400000          0        off
Ethernet264       3608,3609,3610,3611,3612,3613,3614,3615             etp33       33     400000          0        off
Ethernet272       3584,3585,3586,3587,3588,3589,3590,3591             etp34       34     400000          0        off
Ethernet280       3592,3593,3594,3595,3596,3597,3598,3599             etp35       35     400000          0        off
Ethernet288       3856,3857,3858,3859,3860,3861,3862,3863             etp36       36     400000          0        off
Ethernet296       3864,3865,3866,3867,3868,3869,3870,3871             etp37       37     400000          0        off
Ethernet304       3840,3841,3842,3843,3844,3845,3846,3847             etp38       38     400000          0        off
Ethernet312       3848,3849,3850,3851,3852,3853,3854,3855             etp39       39     400000          0        off
Ethernet320       3352,3353,3354,3355,3356,3357,3358,3359             etp40       40     400000          0        off
Ethernet328       3344,3345,3346,3347,3348,3349,3350,3351             etp41       41     400000          0        off
Ethernet336       3328,3329,3330,3331,3332,3333,3334,3335             etp42       42     400000          0        off
Ethernet344       3336,3337,3338,3339,3340,3341,3342,3343             etp43       43     400000          0        off
Ethernet352       3096,3097,3098,3099,3100,3101,3102,3103             etp44       44     400000          0        off
Ethernet360       3088,3089,3090,3091,3092,3093,3094,3095             etp45       45     400000          0        off
Ethernet368       3080,3081,3082,3083,3084,3085,3086,3087             etp46       46     400000          0        off
Ethernet376       3072,3073,3074,3075,3076,3077,3078,3079             etp47       47     400000          0        off
Ethernet384       2560,2561,2562,2563,2564,2565,2566,2567             etp48       48     400000          0        off
Ethernet392       2568,2569,2570,2571,2572,2573,2574,2575             etp49       49     400000          0        off
Ethernet400       2576,2577,2578,2579,2580,2581,2582,2583             etp50       50     400000          0        off
Ethernet408       2584,2585,2586,2587,2588,2589,2590,2591             etp51       51     400000          0        off
Ethernet416       2816,2817,2818,2819,2820,2821,2822,2823             etp52       52     400000          0        off
Ethernet424       2824,2825,2826,2827,2828,2829,2830,2831             etp53       53     400000          0        off
Ethernet432       2832,2833,2834,2835,2836,2837,2838,2839             etp54       54     400000          0        off
Ethernet440       2840,2841,2842,2843,2844,2845,2846,2847             etp55       55     400000          0        off
Ethernet448       2304,2305,2306,2307,2308,2309,2310,2311             etp56       56     400000          0        off
Ethernet456       2312,2313,2314,2315,2316,2317,2318,2319             etp57       57     400000          0        off
Ethernet464       2328,2329,2330,2331,2332,2333,2334,2335             etp58       58     400000          0        off
Ethernet472       2320,2321,2322,2323,2324,2325,2326,2327             etp59       59     400000          0        off
Ethernet480       2048,2049,2050,2051,2052,2053,2054,2055             etp60       60     400000          0        off
Ethernet488       2056,2057,2058,2059,2060,2061,2062,2063             etp61       61     400000          0        off
Ethernet496       2072,2073,2074,2075,2076,2077,2078,2079             etp62       62     400000          0        off
Ethernet504       2064,2065,2066,2067,2068,2069,2070,2071             etp63       63     400000          0        off
Ethernet512                                         65520             etp64       64      10000          0          -
Ethernet513                                         65521             etp65       65      10000          0          -
root@ixia-light-dut:/usr/local/lib/python3.11/dist-packages# config load_minigraph
Reload config from minigraph? [y/N]: y
Acquired lock on /etc/sonic/reload.lock
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
Warning: mirror table EVERFLOW in ACL_TABLE does not have any ports bound to it
Warning: mirror table EVERFLOWV6 in ACL_TABLE does not have any ports bound to it
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Running command: config qos reload --no-dynamic-buffer --no-delay
Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-O64/buffers.json.j2,/tmp/cfg_buffer.json -t /usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-O64/qos.json.j2,/tmp/cfg_qos.json -y /etc/sonic/sonic_version.yml
Running command: /usr/local/bin/sonic-cfggen -j /tmp/cfg_buffer.json -j /tmp/cfg_qos.json --write-to-db
Warning: mirror table EVERFLOW in ACL_TABLE does not have any ports bound to it
Warning: mirror table EVERFLOWV6 in ACL_TABLE does not have any ports bound to it
Running command: pfcwd start_default
Warning: mirror table EVERFLOW in ACL_TABLE does not have any ports bound to it
Warning: mirror table EVERFLOWV6 in ACL_TABLE does not have any ports bound to it
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon
Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
Released lock on /etc/sonic/reload.lock
root@ixia-light-dut:/usr/local/lib/python3.11/dist-packages# show interface status
  Interface                                    Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                                             Type    Asym PFC
-----------  ---------------------------------------  -------  -----  -----  -------  ------  ------  -------  -----------------------------------------------  ----------
  Ethernet0  1536,1537,1538,1539,1540,1541,1542,1543     400G   9100    N/A     etp0  routed    down     down  QSFP-DD Double Density 8X Pluggable Transceiver         off
  Ethernet8  1544,1545,1546,1547,1548,1549,1550,1551     400G   9100    N/A     etp1  routed    down     down                                              N/A         off
 Ethernet16  1560,1561,1562,1563,1564,1565,1566,1567     400G   9100    N/A     etp2  routed    down     down  QSFP-DD Double Density 8X Pluggable Transceiver         off
 Ethernet24  1552,1553,1554,1555,1556,1557,1558,1559     400G   9100    N/A     etp3  routed    down     down                                              N/A         off
 Ethernet32  1792,1793,1794,1795,1796,1797,1798,1799     400G   9100    N/A     etp4  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
 Ethernet40  1800,1801,1802,1803,1804,1805,1806,1807     400G   9100    N/A     etp5  routed    down     down                                              N/A         off
 Ethernet48  1816,1817,1818,1819,1820,1821,1822,1823     400G   9100    N/A     etp6  routed    down     down                                              N/A         off
 Ethernet56  1808,1809,1810,1811,1812,1813,1814,1815     400G   9100    N/A     etp7  routed    down     down                                              N/A         off
 Ethernet64  1288,1289,1290,1291,1292,1293,1294,1295     400G   9100    N/A     etp8  routed    down     down                                              N/A         off
 Ethernet72  1280,1281,1282,1283,1284,1285,1286,1287     400G   9100    N/A     etp9  routed    down     down                                              N/A         off
 Ethernet80  1296,1297,1298,1299,1300,1301,1302,1303     400G   9100    N/A    etp10  routed    down     down                                              N/A         off
 Ethernet88  1304,1305,1306,1307,1308,1309,1310,1311     400G   9100    N/A    etp11  routed    down     down                                              N/A         off
 Ethernet96  1024,1025,1026,1027,1028,1029,1030,1031     400G   9100    N/A    etp12  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
Ethernet104  1032,1033,1034,1035,1036,1037,1038,1039     400G   9100    N/A    etp13  routed    down     down                                              N/A         off
Ethernet112  1040,1041,1042,1043,1044,1045,1046,1047     400G   9100    N/A    etp14  routed    down     down                                              N/A         off
Ethernet120  1048,1049,1050,1051,1052,1053,1054,1055     400G   9100    N/A    etp15  routed    down     down                                              N/A         off
Ethernet128          536,537,538,539,540,541,542,543     400G   9100    N/A    etp16  routed    down     down                                              N/A         off
Ethernet136          528,529,530,531,532,533,534,535     400G   9100    N/A    etp17  routed    down     down                                              N/A         off
Ethernet144          520,521,522,523,524,525,526,527     400G   9100    N/A    etp18  routed    down     down                                              N/A         off
Ethernet152          512,513,514,515,516,517,518,519     400G   9100    N/A    etp19  routed    down     down                                              N/A         off
Ethernet160          792,793,794,795,796,797,798,799     400G   9100    N/A    etp20  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
Ethernet168          784,785,786,787,788,789,790,791     400G   9100    N/A    etp21  routed    down     down                                              N/A         off
Ethernet176          776,777,778,779,780,781,782,783     400G   9100    N/A    etp22  routed    down     down                                              N/A         off
Ethernet184          768,769,770,771,772,773,774,775     400G   9100    N/A    etp23  routed    down     down                                              N/A         off
Ethernet192          256,257,258,259,260,261,262,263     400G   9100    N/A    etp24  routed    down     down                                              N/A         off
Ethernet200          264,265,266,267,268,269,270,271     400G   9100    N/A    etp25  routed    down     down                                              N/A         off
Ethernet208          272,273,274,275,276,277,278,279     400G   9100    N/A    etp26  routed    down     down                                              N/A         off
Ethernet216          280,281,282,283,284,285,286,287     400G   9100    N/A    etp27  routed    down     down                                              N/A         off
Ethernet224                          0,1,2,3,4,5,6,7     400G   9100    N/A    etp28  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
Ethernet232                    8,9,10,11,12,13,14,15     400G   9100    N/A    etp29  routed    down     down                                              N/A         off
Ethernet240                  16,17,18,19,20,21,22,23     400G   9100    N/A    etp30  routed    down     down                                              N/A         off
Ethernet248                  24,25,26,27,28,29,30,31     400G   9100    N/A    etp31  routed    down     down                                              N/A         off
Ethernet256  3600,3601,3602,3603,3604,3605,3606,3607     400G   9100    N/A    etp32  routed    down     down                                              N/A         off
Ethernet264  3608,3609,3610,3611,3612,3613,3614,3615     400G   9100    N/A    etp33  routed    down     down                                              N/A         off
Ethernet272  3584,3585,3586,3587,3588,3589,3590,3591     400G   9100    N/A    etp34  routed    down     down                                              N/A         off
Ethernet280  3592,3593,3594,3595,3596,3597,3598,3599     400G   9100    N/A    etp35  routed    down     down                                              N/A         off
Ethernet288  3856,3857,3858,3859,3860,3861,3862,3863     400G   9100    N/A    etp36  routed    down     down                                              N/A         off
Ethernet296  3864,3865,3866,3867,3868,3869,3870,3871     400G   9100    N/A    etp37  routed    down     down                                              N/A         off
Ethernet304  3840,3841,3842,3843,3844,3845,3846,3847     400G   9100    N/A    etp38  routed    down     down                                              N/A         off
Ethernet312  3848,3849,3850,3851,3852,3853,3854,3855     400G   9100    N/A    etp39  routed    down     down                                              N/A         off
Ethernet320  3352,3353,3354,3355,3356,3357,3358,3359     400G   9100    N/A    etp40  routed    down     down                                              N/A         off
Ethernet328  3344,3345,3346,3347,3348,3349,3350,3351     400G   9100    N/A    etp41  routed    down     down                                              N/A         off
Ethernet336  3328,3329,3330,3331,3332,3333,3334,3335     400G   9100    N/A    etp42  routed    down     down                                              N/A         off
Ethernet344  3336,3337,3338,3339,3340,3341,3342,3343     400G   9100    N/A    etp43  routed    down     down                                              N/A         off
Ethernet352  3096,3097,3098,3099,3100,3101,3102,3103     400G   9100    N/A    etp44  routed    down     down                                              N/A         off
Ethernet360  3088,3089,3090,3091,3092,3093,3094,3095     400G   9100    N/A    etp45  routed    down     down                                              N/A         off
Ethernet368  3080,3081,3082,3083,3084,3085,3086,3087     400G   9100    N/A    etp46  routed    down     down                                              N/A         off
Ethernet376  3072,3073,3074,3075,3076,3077,3078,3079     400G   9100    N/A    etp47  routed    down     down                                              N/A         off
Ethernet384  2560,2561,2562,2563,2564,2565,2566,2567     400G   9100    N/A    etp48  routed    down     down                                              N/A         off
Ethernet392  2568,2569,2570,2571,2572,2573,2574,2575     400G   9100    N/A    etp49  routed    down     down                                              N/A         off
Ethernet400  2576,2577,2578,2579,2580,2581,2582,2583     400G   9100    N/A    etp50  routed    down     down                                              N/A         off
Ethernet408  2584,2585,2586,2587,2588,2589,2590,2591     400G   9100    N/A    etp51  routed    down     down                                              N/A         off
Ethernet416  2816,2817,2818,2819,2820,2821,2822,2823     400G   9100    N/A    etp52  routed    down     down                                              N/A         off
Ethernet424  2824,2825,2826,2827,2828,2829,2830,2831     400G   9100    N/A    etp53  routed    down     down                                              N/A         off
Ethernet432  2832,2833,2834,2835,2836,2837,2838,2839     400G   9100    N/A    etp54  routed    down     down                                              N/A         off
Ethernet440  2840,2841,2842,2843,2844,2845,2846,2847     400G   9100    N/A    etp55  routed    down     down                                              N/A         off
Ethernet448  2304,2305,2306,2307,2308,2309,2310,2311     400G   9100    N/A    etp56  routed    down     down                                              N/A         off
Ethernet456  2312,2313,2314,2315,2316,2317,2318,2319     400G   9100    N/A    etp57  routed    down     down                                              N/A         off
Ethernet464  2328,2329,2330,2331,2332,2333,2334,2335     400G   9100    N/A    etp58  routed    down     down                                              N/A         off
Ethernet472  2320,2321,2322,2323,2324,2325,2326,2327     400G   9100    N/A    etp59  routed    down     down                                              N/A         off
Ethernet480  2048,2049,2050,2051,2052,2053,2054,2055     400G   9100    N/A    etp60  routed    down     down                                              N/A         off
Ethernet488  2056,2057,2058,2059,2060,2061,2062,2063     400G   9100    N/A    etp61  routed    down     down                                              N/A         off
Ethernet496  2072,2073,2074,2075,2076,2077,2078,2079     400G   9100    N/A    etp62  routed    down     down                                              N/A         off
Ethernet504  2064,2065,2066,2067,2068,2069,2070,2071     400G   9100    N/A    etp63  routed    down     down                                              N/A         off
Ethernet512                                    65520      10G   9100    N/A    etp64  routed    down     down                                              N/A         N/A
Ethernet513                                    65521      10G   9100    N/A    etp65  routed    down     down                                              N/A         N/A
root@ixia-light-dut:/usr/local/lib/python3.11/dist-packages# 
root@ixia-light-dut:/usr/local/lib/python3.11/dist-packages# docker ps
CONTAINER ID   IMAGE                                COMMAND                  CREATED       STATUS          PORTS     NAMES
5020c2ca0483   docker-snmp:latest                   "/usr/local/bin/supe…"   2 weeks ago   Up 11 minutes             snmp
32445dd8f16d   docker-platform-monitor:latest       "/usr/bin/docker_ini…"   2 weeks ago   Up 11 minutes             pmon
e67d96368018   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe…"   2 weeks ago   Up 11 minutes             mgmt-framework
69ffe66c7cec   docker-lldp:latest                   "/usr/bin/docker-lld…"   2 weeks ago   Up 11 minutes             lldp
18ca54995539   docker-sonic-gnmi:latest             "/usr/local/bin/supe…"   2 weeks ago   Up 11 minutes             gnmi
8e950b4d6b77   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   2 weeks ago   Up 12 minutes             bgp
a5be32538cdf   docker-router-advertiser:latest      "/usr/bin/docker-ini…"   2 weeks ago   Up 12 minutes             radv
d44b28014456   docker-syncd-cisco:latest            "/usr/local/bin/supe…"   2 weeks ago   Up 12 minutes             syncd
f4875e2c4b93   docker-teamd:latest                  "/usr/local/bin/supe…"   2 weeks ago   Up 12 minutes             teamd
7ada4e4a39c7   docker-orchagent:latest              "/usr/bin/docker-ini…"   2 weeks ago   Up 12 minutes             swss
300c07241ba9   docker-eventd:latest                 "/usr/local/bin/supe…"   2 weeks ago   Up 12 minutes             eventd
b43a74d7865f   docker-database:latest               "/usr/local/bin/dock…"   2 weeks ago   Up 25 hours               database
```
```
cisco@sonic:/etc/sonic$ sudo rm config_db.json
cisco@sonic:/etc/sonic$ ls
asic_config_checksum   copp_cfg.json          dhcp_relay_reconcile  generated_services.conf  mgmt_test_mark  reload.lock                 sonic-environment  warm-reboot_order
config_db_backup.json  core_analyzer.rc.json  fast-reboot_order     init_cfg.json            minigraph.xml   running_golden_config.json  sonic_version.yml
constants.yml          default_users.json     frr                   macsec_reconcile         old_config      snmp.yml                    swss_dependent
cisco@sonic:/etc/sonic$ 
cisco@sonic:/etc/sonic$ 
cisco@sonic:/etc/sonic$ 
cisco@sonic:/etc/sonic$ 
cisco@sonic:/etc/sonic$ sudo reboot
Watchdog armed for 360 seconds
requested COLD shutdown
fstrim: /mnt/obfl_mnt_dir: the discard operation is not supported
/var/log: 191.5 MiB (200822784 bytes) trimmed on /dev/loop1
/host: 329.2 MiB (345223168 bytes) trimmed on /dev/sda3
Watchdog armed for 300 seconds
Fri Dec 6 08:06:06 PM UTC 2024 Rebooting with platform x86_64-8122_64eh_o-r0 specific tool ...
Connection to 1.3.103.48 closed by remote host.
Connection to 1.3.103.48 closed.
sonic@sonic-ucs-m5-14:~$ ssh cisco@1.3.103.48
ssh: connect to host 1.3.103.48 port 22: No route to host
sonic@sonic-ucs-m5-14:~$ ssh cisco@1.3.103.48
ssh: connect to host 1.3.103.48 port 22: No route to host
sonic@sonic-ucs-m5-14:~$ ssh cisco@1.3.103.48
Debian GNU/Linux 12 \n \l

cisco@1.3.103.48's password: 
Linux sonic 6.1.0-22-2-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.94-1 (2024-06-21) x86_64
You are on
  ____   ___  _   _ _  ____
 / ___| / _ \| \ | (_)/ ___|
 \___ \| | | |  \| | | |
  ___) | |_| | |\  | | |___
 |____/ \___/|_| \_|_|\____|

-- Software for Open Networking in the Cloud --

Unauthorized access and/or use are prohibited.
All access and/or use are subject to monitoring.

Help:    https://sonic-net.github.io/SONiC/

Last login: Fri Dec  6 20:10:59 2024 from 1.3.103.20
cisco@sonic:~$ show interface status
  Interface                                    Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                                             Type    Asym PFC
-----------  ---------------------------------------  -------  -----  -----  -------  ------  ------  -------  -----------------------------------------------  ----------
  Ethernet0  1536,1537,1538,1539,1540,1541,1542,1543     400G   9100    N/A     etp0  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
  Ethernet8  1544,1545,1546,1547,1548,1549,1550,1551     400G   9100    N/A     etp1  routed    down       up                                              N/A         off
 Ethernet16  1560,1561,1562,1563,1564,1565,1566,1567     400G   9100    N/A     etp2  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
 Ethernet24  1552,1553,1554,1555,1556,1557,1558,1559     400G   9100    N/A     etp3  routed    down       up                                              N/A         off
 Ethernet32  1792,1793,1794,1795,1796,1797,1798,1799     400G   9100    N/A     etp4  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
 Ethernet40  1800,1801,1802,1803,1804,1805,1806,1807     400G   9100    N/A     etp5  routed    down       up                                              N/A         off
 Ethernet48  1816,1817,1818,1819,1820,1821,1822,1823     400G   9100    N/A     etp6  routed    down       up                                              N/A         off
 Ethernet56  1808,1809,1810,1811,1812,1813,1814,1815     400G   9100    N/A     etp7  routed    down       up                                              N/A         off
 Ethernet64  1288,1289,1290,1291,1292,1293,1294,1295     400G   9100    N/A     etp8  routed    down       up                                              N/A         off
 Ethernet72  1280,1281,1282,1283,1284,1285,1286,1287     400G   9100    N/A     etp9  routed    down       up                                              N/A         off
 Ethernet80  1296,1297,1298,1299,1300,1301,1302,1303     400G   9100    N/A    etp10  routed    down       up                                              N/A         off
 Ethernet88  1304,1305,1306,1307,1308,1309,1310,1311     400G   9100    N/A    etp11  routed    down       up                                              N/A         off
 Ethernet96  1024,1025,1026,1027,1028,1029,1030,1031     400G   9100    N/A    etp12  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
Ethernet104  1032,1033,1034,1035,1036,1037,1038,1039     400G   9100    N/A    etp13  routed    down       up                                              N/A         off
Ethernet112  1040,1041,1042,1043,1044,1045,1046,1047     400G   9100    N/A    etp14  routed    down       up                                              N/A         off
Ethernet120  1048,1049,1050,1051,1052,1053,1054,1055     400G   9100    N/A    etp15  routed    down       up                                              N/A         off
Ethernet128          536,537,538,539,540,541,542,543     400G   9100    N/A    etp16  routed    down       up                                              N/A         off
Ethernet136          528,529,530,531,532,533,534,535     400G   9100    N/A    etp17  routed    down       up                                              N/A         off
Ethernet144          520,521,522,523,524,525,526,527     400G   9100    N/A    etp18  routed    down       up                                              N/A         off
Ethernet152          512,513,514,515,516,517,518,519     400G   9100    N/A    etp19  routed    down       up                                              N/A         off
Ethernet160          792,793,794,795,796,797,798,799     400G   9100    N/A    etp20  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
Ethernet168          784,785,786,787,788,789,790,791     400G   9100    N/A    etp21  routed    down       up                                              N/A         off
Ethernet176          776,777,778,779,780,781,782,783     400G   9100    N/A    etp22  routed    down       up                                              N/A         off
Ethernet184          768,769,770,771,772,773,774,775     400G   9100    N/A    etp23  routed    down       up                                              N/A         off
Ethernet192          256,257,258,259,260,261,262,263     400G   9100    N/A    etp24  routed    down       up                                              N/A         off
Ethernet200          264,265,266,267,268,269,270,271     400G   9100    N/A    etp25  routed    down       up                                              N/A         off
Ethernet208          272,273,274,275,276,277,278,279     400G   9100    N/A    etp26  routed    down       up                                              N/A         off
Ethernet216          280,281,282,283,284,285,286,287     400G   9100    N/A    etp27  routed    down       up                                              N/A         off
Ethernet224                          0,1,2,3,4,5,6,7     400G   9100    N/A    etp28  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
Ethernet232                    8,9,10,11,12,13,14,15     400G   9100    N/A    etp29  routed    down       up                                              N/A         off
Ethernet240                  16,17,18,19,20,21,22,23     400G   9100    N/A    etp30  routed    down       up                                              N/A         off
Ethernet248                  24,25,26,27,28,29,30,31     400G   9100    N/A    etp31  routed    down       up                                              N/A         off
Ethernet256  3600,3601,3602,3603,3604,3605,3606,3607     400G   9100    N/A    etp32  routed    down       up                                              N/A         off
Ethernet264  3608,3609,3610,3611,3612,3613,3614,3615     400G   9100    N/A    etp33  routed    down       up                                              N/A         off
Ethernet272  3584,3585,3586,3587,3588,3589,3590,3591     400G   9100    N/A    etp34  routed    down       up                                              N/A         off
Ethernet280  3592,3593,3594,3595,3596,3597,3598,3599     400G   9100    N/A    etp35  routed    down       up                                              N/A         off
Ethernet288  3856,3857,3858,3859,3860,3861,3862,3863     400G   9100    N/A    etp36  routed    down       up                                              N/A         off
Ethernet296  3864,3865,3866,3867,3868,3869,3870,3871     400G   9100    N/A    etp37  routed    down       up                                              N/A         off
Ethernet304  3840,3841,3842,3843,3844,3845,3846,3847     400G   9100    N/A    etp38  routed    down       up                                              N/A         off
Ethernet312  3848,3849,3850,3851,3852,3853,3854,3855     400G   9100    N/A    etp39  routed    down       up                                              N/A         off
Ethernet320  3352,3353,3354,3355,3356,3357,3358,3359     400G   9100    N/A    etp40  routed    down       up                                              N/A         off
Ethernet328  3344,3345,3346,3347,3348,3349,3350,3351     400G   9100    N/A    etp41  routed    down       up                                              N/A         off
Ethernet336  3328,3329,3330,3331,3332,3333,3334,3335     400G   9100    N/A    etp42  routed    down       up                                              N/A         off
Ethernet344  3336,3337,3338,3339,3340,3341,3342,3343     400G   9100    N/A    etp43  routed    down       up                                              N/A         off
Ethernet352  3096,3097,3098,3099,3100,3101,3102,3103     400G   9100    N/A    etp44  routed    down       up                                              N/A         off
Ethernet360  3088,3089,3090,3091,3092,3093,3094,3095     400G   9100    N/A    etp45  routed    down       up                                              N/A         off
Ethernet368  3080,3081,3082,3083,3084,3085,3086,3087     400G   9100    N/A    etp46  routed    down       up                                              N/A         off
Ethernet376  3072,3073,3074,3075,3076,3077,3078,3079     400G   9100    N/A    etp47  routed    down       up                                              N/A         off
Ethernet384  2560,2561,2562,2563,2564,2565,2566,2567     400G   9100    N/A    etp48  routed    down       up                                              N/A         off
Ethernet392  2568,2569,2570,2571,2572,2573,2574,2575     400G   9100    N/A    etp49  routed    down       up                                              N/A         off
Ethernet400  2576,2577,2578,2579,2580,2581,2582,2583     400G   9100    N/A    etp50  routed    down       up                                              N/A         off
Ethernet408  2584,2585,2586,2587,2588,2589,2590,2591     400G   9100    N/A    etp51  routed    down       up                                              N/A         off
Ethernet416  2816,2817,2818,2819,2820,2821,2822,2823     400G   9100    N/A    etp52  routed    down       up                                              N/A         off
Ethernet424  2824,2825,2826,2827,2828,2829,2830,2831     400G   9100    N/A    etp53  routed    down       up                                              N/A         off
Ethernet432  2832,2833,2834,2835,2836,2837,2838,2839     400G   9100    N/A    etp54  routed    down       up                                              N/A         off
Ethernet440  2840,2841,2842,2843,2844,2845,2846,2847     400G   9100    N/A    etp55  routed    down       up                                              N/A         off
Ethernet448  2304,2305,2306,2307,2308,2309,2310,2311     400G   9100    N/A    etp56  routed    down       up                                              N/A         off
Ethernet456  2312,2313,2314,2315,2316,2317,2318,2319     400G   9100    N/A    etp57  routed    down       up                                              N/A         off
Ethernet464  2328,2329,2330,2331,2332,2333,2334,2335     400G   9100    N/A    etp58  routed    down       up                                              N/A         off
Ethernet472  2320,2321,2322,2323,2324,2325,2326,2327     400G   9100    N/A    etp59  routed    down       up                                              N/A         off
Ethernet480  2048,2049,2050,2051,2052,2053,2054,2055     400G   9100    N/A    etp60  routed    down       up                                              N/A         off
Ethernet488  2056,2057,2058,2059,2060,2061,2062,2063     400G   9100    N/A    etp61  routed    down       up                                              N/A         off
Ethernet496  2072,2073,2074,2075,2076,2077,2078,2079     400G   9100    N/A    etp62  routed    down       up                                              N/A         off
Ethernet504  2064,2065,2066,2067,2068,2069,2070,2071     400G   9100    N/A    etp63  routed    down       up                                              N/A         off
Ethernet512                                    65520      10G   9100    N/A    etp64  routed    down       up                                              N/A         N/A
Ethernet513                                    65521      10G   9100    N/A    etp65  routed    down       up                                              N/A         N/A
cisco@sonic:~$
```

Tested on 8111 without PIE.
```
root@croc-aaa12-dut:/opt/cisco/bin# platform_cisco_cfg.py
INFO:PlatformCfg:No need to update /usr/share/sonic/device/x86_64-8111_32eh_o-r0/platform.json for interfaces section
INFO:PlatformCfg:Generating cfg for /usr/share/sonic/device/x86_64-8111_32eh_o-r0/Cisco-8111-32EH-O/
INFO:PlatformCfg:Generating cfg for /usr/share/sonic/device/x86_64-8111_32eh_o-r0/Cisco-8111-C32/
INFO:PlatformCfg:Generating cfg for /usr/share/sonic/device/x86_64-8111_32eh_o-r0/Cisco-8111-O32/
INFO:PlatformCfg:Generating cfg for /usr/share/sonic/device/x86_64-8111_32eh_o-r0/Cisco-8111-O62C2/
INFO:PlatformCfg:Generating cfg for /usr/share/sonic/device/x86_64-8111_32eh_o-r0/Cisco-8111-O64/
root@croc-aaa12-dut:/opt/cisco/bin# cd /usr/share/sonic/device/x86_64-8111_32eh_o-r0/Cisco-8111-O64/
root@croc-aaa12-dut:/usr/share/sonic/device/x86_64-8111_32eh_o-r0/Cisco-8111-O64# ls
acl_key_profile.json  buffers_defaults_t0.j2  buffers_extra_pgs.j2     buffers.json.j2	      platform_cisco_cfg.yaml  port_config.ini	sai.profile
asic_cfg.json	      buffers_defaults_t1.j2  buffers_extra_queues.j2  pg_profile_lookup.ini  platform_npu_cfg.yaml    qos.json.j2	sai_sdk_log_config.json
root@croc-aaa12-dut:/usr/share/sonic/device/x86_64-8111_32eh_o-r0/Cisco-8111-O64# cat port_config.ini
# name                                              lanes             alias    index      speed    subport    pfc_asym
Ethernet0                             2048,2049,2050,2051             etp0a        0     400000          1        off
Ethernet4                             2052,2053,2054,2055             etp0b        0     400000          2        off
Ethernet8                             2056,2057,2058,2059             etp1a        1     400000          1        off
Ethernet12                            2060,2061,2062,2063             etp1b        1     400000          2        off
Ethernet16                            2304,2305,2306,2307             etp2a        2     400000          1        off
Ethernet20                            2308,2309,2310,2311             etp2b        2     400000          2        off
Ethernet24                            2312,2313,2314,2315             etp3a        3     400000          1        off
Ethernet28                            2316,2317,2318,2319             etp3b        3     400000          2        off
Ethernet32                            2824,2825,2826,2827             etp4a        4     400000          1        off
Ethernet36                            2828,2829,2830,2831             etp4b        4     400000          2        off
Ethernet40                            2816,2817,2818,2819             etp5a        5     400000          1        off
Ethernet44                            2820,2821,2822,2823             etp5b        5     400000          2        off
Ethernet48                            2568,2569,2570,2571             etp6a        6     400000          1        off
Ethernet52                            2572,2573,2574,2575             etp6b        6     400000          2        off
Ethernet56                            2560,2561,2562,2563             etp7a        7     400000          1        off
Ethernet60                            2564,2565,2566,2567             etp7b        7     400000          2        off
Ethernet64                            1800,1801,1802,1803             etp8a        8     400000          1        off
Ethernet68                            1804,1805,1806,1807             etp8b        8     400000          2        off
Ethernet72                            1792,1793,1794,1795             etp9a        9     400000          1        off
Ethernet76                            1796,1797,1798,1799             etp9b        9     400000          2        off
Ethernet80                            1544,1545,1546,1547            etp10a       10     400000          1        off
Ethernet84                            1548,1549,1550,1551            etp10b       10     400000          2        off
Ethernet88                            1536,1537,1538,1539            etp11a       11     400000          1        off
Ethernet92                            1540,1541,1542,1543            etp11b       11     400000          2        off
Ethernet96                            1024,1025,1026,1027            etp12a       12     400000          1        off
Ethernet100                           1028,1029,1030,1031            etp12b       12     400000          2        off
Ethernet104                           1032,1033,1034,1035            etp13a       13     400000          1        off
Ethernet108                           1036,1037,1038,1039            etp13b       13     400000          2        off
Ethernet112                           1280,1281,1282,1283            etp14a       14     400000          1        off
Ethernet116                           1284,1285,1286,1287            etp14b       14     400000          2        off
Ethernet120                           1288,1289,1290,1291            etp15a       15     400000          1        off
Ethernet124                           1292,1293,1294,1295            etp15b       15     400000          2        off
Ethernet128                               768,769,770,771            etp16a       16     400000          1        off
Ethernet132                               772,773,774,775            etp16b       16     400000          2        off
Ethernet136                               776,777,778,779            etp17a       17     400000          1        off
Ethernet140                               780,781,782,783            etp17b       17     400000          2        off
Ethernet144                               512,513,514,515            etp18a       18     400000          1        off
Ethernet148                               516,517,518,519            etp18b       18     400000          2        off
Ethernet152                               520,521,522,523            etp19a       19     400000          1        off
Ethernet156                               524,525,526,527            etp19b       19     400000          2        off
Ethernet160                                     8,9,10,11            etp20a       20     400000          1        off
Ethernet164                                   12,13,14,15            etp20b       20     400000          2        off
Ethernet168                                       0,1,2,3            etp21a       21     400000          1        off
Ethernet172                                       4,5,6,7            etp21b       21     400000          2        off
Ethernet176                               264,265,266,267            etp22a       22     400000          1        off
Ethernet180                               268,269,270,271            etp22b       22     400000          2        off
Ethernet184                               256,257,258,259            etp23a       23     400000          1        off
Ethernet188                               260,261,262,263            etp23b       23     400000          2        off
Ethernet192                           3080,3081,3082,3083            etp24a       24     400000          1        off
Ethernet196                           3084,3085,3086,3087            etp24b       24     400000          2        off
Ethernet200                           3072,3073,3074,3075            etp25a       25     400000          1        off
Ethernet204                           3076,3077,3078,3079            etp25b       25     400000          2        off
Ethernet208                           3336,3337,3338,3339            etp26a       26     400000          1        off
Ethernet212                           3340,3341,3342,3343            etp26b       26     400000          2        off
Ethernet216                           3328,3329,3330,3331            etp27a       27     400000          1        off
Ethernet220                           3332,3333,3334,3335            etp27b       27     400000          2        off
Ethernet224                           3840,3841,3842,3843            etp28a       28     400000          1        off
Ethernet228                           3844,3845,3846,3847            etp28b       28     400000          2        off
Ethernet232                           3848,3849,3850,3851            etp29a       29     400000          1        off
Ethernet236                           3852,3853,3854,3855            etp29b       29     400000          2        off
Ethernet240                           3584,3585,3586,3587            etp30a       30     400000          1        off
Ethernet244                           3588,3589,3590,3591            etp30b       30     400000          2        off
Ethernet248                           3592,3593,3594,3595            etp31a       31     400000          1        off
Ethernet252                           3596,3597,3598,3599            etp31b       31     400000          2        off
root@croc-aaa12-dut:/usr/share/sonic/device/x86_64-8111_32eh_o-r0/Cisco-8111-O64# 
root@croc-aaa12-dut:/usr/share/sonic/device/x86_64-8111_32eh_o-r0/Cisco-8111-O32# config load_minigraph 
Reload config from minigraph? [y/N]: y
Acquired lock on /etc/sonic/reload.lock
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Running command: config qos reload --no-dynamic-buffer --no-delay
Running command: /usr/local/bin/sonic-cfggen -d --write-to-db -t /usr/share/sonic/device/x86_64-8111_32eh_o-r0/Cisco-8111-O32/buffers.json.j2,config-db -t /usr/share/sonic/device/x86_64-8111_32eh_o-r0/Cisco-8111-O32/qos.json.j2,config-db -y /etc/sonic/sonic_version.yml
Running command: pfcwd start_default
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon
Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
Released lock on /etc/sonic/reload.lock
root@croc-aaa12-dut:/usr/share/sonic/device/x86_64-8111_32eh_o-r0/Cisco-8111-O32# show interface status
      Interface                                    Lanes    Speed    MTU    FEC    Alias             Vlan    Oper    Admin    Type    Asym PFC
---------------  ---------------------------------------  -------  -----  -----  -------  ---------------  ------  -------  ------  ----------
      Ethernet0  2048,2049,2050,2051,2052,2053,2054,2055     400G   9100    N/A     etp0   PortChannel102    down       up     N/A         off
      Ethernet8  2056,2057,2058,2059,2060,2061,2062,2063     400G   9100    N/A     etp1   PortChannel102    down       up     N/A         off
     Ethernet16  2304,2305,2306,2307,2308,2309,2310,2311     400G   9100    N/A     etp2   PortChannel105    down       up     N/A         off
     Ethernet24  2312,2313,2314,2315,2316,2317,2318,2319     400G   9100    N/A     etp3   PortChannel105    down       up     N/A         off
     Ethernet32  2824,2825,2826,2827,2828,2829,2830,2831     400G   9100    N/A     etp4   PortChannel108    down       up     N/A         off
     Ethernet40  2816,2817,2818,2819,2820,2821,2822,2823     400G   9100    N/A     etp5   PortChannel108    down       up     N/A         off
     Ethernet48  2568,2569,2570,2571,2572,2573,2574,2575     400G   9100    N/A     etp6  PortChannel1011    down       up     N/A         off
     Ethernet56  2560,2561,2562,2563,2564,2565,2566,2567     400G   9100    N/A     etp7  PortChannel1011    down       up     N/A         off
     Ethernet64  1800,1801,1802,1803,1804,1805,1806,1807     400G   9100    N/A     etp8  PortChannel1014    down       up     N/A         off
     Ethernet72  1792,1793,1794,1795,1796,1797,1798,1799     400G   9100    N/A     etp9  PortChannel1014    down       up     N/A         off
     Ethernet80  1544,1545,1546,1547,1548,1549,1550,1551     400G   9100    N/A    etp10  PortChannel1017    down       up     N/A         off
     Ethernet88  1536,1537,1538,1539,1540,1541,1542,1543     400G   9100    N/A    etp11  PortChannel1017    down       up     N/A         off
     Ethernet96  1024,1025,1026,1027,1028,1029,1030,1031     400G   9100    N/A    etp12  PortChannel1020    down       up     N/A         off
    Ethernet104  1032,1033,1034,1035,1036,1037,1038,1039     400G   9100    N/A    etp13  PortChannel1020    down       up     N/A         off
    Ethernet112  1280,1281,1282,1283,1284,1285,1286,1287     400G   9100    N/A    etp14  PortChannel1023    down       up     N/A         off
    Ethernet120  1288,1289,1290,1291,1292,1293,1294,1295     400G   9100    N/A    etp15  PortChannel1023    down       up     N/A         off
    Ethernet128          768,769,770,771,772,773,774,775     400G   9100    N/A    etp16           routed    down       up     N/A         off
    Ethernet136          776,777,778,779,780,781,782,783     400G   9100    N/A    etp17           routed    down       up     N/A         off
    Ethernet144          512,513,514,515,516,517,518,519     400G   9100    N/A    etp18           routed    down       up     N/A         off
    Ethernet152          520,521,522,523,524,525,526,527     400G   9100    N/A    etp19           routed    down       up     N/A         off
    Ethernet160                    8,9,10,11,12,13,14,15     400G   9100    N/A    etp20           routed    down       up     N/A         off
    Ethernet168                          0,1,2,3,4,5,6,7     400G   9100    N/A    etp21           routed    down       up     N/A         off
    Ethernet176          264,265,266,267,268,269,270,271     400G   9100    N/A    etp22           routed    down       up     N/A         off
    Ethernet184          256,257,258,259,260,261,262,263     400G   9100    N/A    etp23           routed    down       up     N/A         off
    Ethernet192  3080,3081,3082,3083,3084,3085,3086,3087     400G   9100    N/A    etp24           routed    down       up     N/A         off
    Ethernet200  3072,3073,3074,3075,3076,3077,3078,3079     400G   9100    N/A    etp25           routed    down       up     N/A         off
    Ethernet208  3336,3337,3338,3339,3340,3341,3342,3343     400G   9100    N/A    etp26           routed    down       up     N/A         off
    Ethernet216  3328,3329,3330,3331,3332,3333,3334,3335     400G   9100    N/A    etp27           routed    down       up     N/A         off
    Ethernet224  3840,3841,3842,3843,3844,3845,3846,3847     400G   9100    N/A    etp28           routed    down       up     N/A         off
    Ethernet232  3848,3849,3850,3851,3852,3853,3854,3855     400G   9100    N/A    etp29           routed    down       up     N/A         off
    Ethernet240  3584,3585,3586,3587,3588,3589,3590,3591     400G   9100    N/A    etp30           routed    down       up     N/A         off
    Ethernet248  3592,3593,3594,3595,3596,3597,3598,3599     400G   9100    N/A    etp31           routed    down       up     N/A         off
 PortChannel102                                      N/A     800G   9100    N/A      N/A           routed    down       up     N/A         N/A
 PortChannel105                                      N/A     800G   9100    N/A      N/A           routed    down       up     N/A         N/A
 PortChannel108                                      N/A     800G   9100    N/A      N/A           routed    down       up     N/A         N/A
PortChannel1011                                      N/A     800G   9100    N/A      N/A           routed    down       up     N/A         N/A
PortChannel1014                                      N/A     800G   9100    N/A      N/A           routed    down       up     N/A         N/A
PortChannel1017                                      N/A     800G   9100    N/A      N/A           routed    down       up     N/A         N/A
PortChannel1020                                      N/A     800G   9100    N/A      N/A           routed    down       up     N/A         N/A
PortChannel1023                                      N/A     800G   9100    N/A      N/A           routed    down       up     N/A         N/A
root@croc-aaa12-dut:/usr/share/sonic/device/x86_64-8111_32eh_o-r0/Cisco-8111-O32# show interface status
      Interface                                    Lanes    Speed    MTU    FEC    Alias             Vlan    Oper    Admin                                             Type    Asym PFC
---------------  ---------------------------------------  -------  -----  -----  -------  ---------------  ------  -------  -----------------------------------------------  ----------
      Ethernet0  2048,2049,2050,2051,2052,2053,2054,2055     400G   9100    N/A     etp0   PortChannel102      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
      Ethernet8  2056,2057,2058,2059,2060,2061,2062,2063     400G   9100    N/A     etp1   PortChannel102      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet16  2304,2305,2306,2307,2308,2309,2310,2311     400G   9100    N/A     etp2   PortChannel105      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet24  2312,2313,2314,2315,2316,2317,2318,2319     400G   9100    N/A     etp3   PortChannel105      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet32  2824,2825,2826,2827,2828,2829,2830,2831     400G   9100    N/A     etp4   PortChannel108      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet40  2816,2817,2818,2819,2820,2821,2822,2823     400G   9100    N/A     etp5   PortChannel108      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet48  2568,2569,2570,2571,2572,2573,2574,2575     400G   9100    N/A     etp6  PortChannel1011      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet56  2560,2561,2562,2563,2564,2565,2566,2567     400G   9100    N/A     etp7  PortChannel1011      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet64  1800,1801,1802,1803,1804,1805,1806,1807     400G   9100    N/A     etp8  PortChannel1014      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet72  1792,1793,1794,1795,1796,1797,1798,1799     400G   9100    N/A     etp9  PortChannel1014      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet80  1544,1545,1546,1547,1548,1549,1550,1551     400G   9100    N/A    etp10  PortChannel1017      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet88  1536,1537,1538,1539,1540,1541,1542,1543     400G   9100    N/A    etp11  PortChannel1017      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet96  1024,1025,1026,1027,1028,1029,1030,1031     400G   9100    N/A    etp12  PortChannel1020      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet104  1032,1033,1034,1035,1036,1037,1038,1039     400G   9100    N/A    etp13  PortChannel1020      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet112  1280,1281,1282,1283,1284,1285,1286,1287     400G   9100    N/A    etp14  PortChannel1023      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet120  1288,1289,1290,1291,1292,1293,1294,1295     400G   9100    N/A    etp15  PortChannel1023      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet128          768,769,770,771,772,773,774,775     400G   9100    N/A    etp16           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet136          776,777,778,779,780,781,782,783     400G   9100    N/A    etp17           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet144          512,513,514,515,516,517,518,519     400G   9100    N/A    etp18           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet152          520,521,522,523,524,525,526,527     400G   9100    N/A    etp19           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet160                    8,9,10,11,12,13,14,15     400G   9100    N/A    etp20           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet168                          0,1,2,3,4,5,6,7     400G   9100    N/A    etp21           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet176          264,265,266,267,268,269,270,271     400G   9100    N/A    etp22           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet184          256,257,258,259,260,261,262,263     400G   9100    N/A    etp23           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet192  3080,3081,3082,3083,3084,3085,3086,3087     400G   9100    N/A    etp24           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet200  3072,3073,3074,3075,3076,3077,3078,3079     400G   9100    N/A    etp25           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet208  3336,3337,3338,3339,3340,3341,3342,3343     400G   9100    N/A    etp26           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet216  3328,3329,3330,3331,3332,3333,3334,3335     400G   9100    N/A    etp27           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet224  3840,3841,3842,3843,3844,3845,3846,3847     400G   9100    N/A    etp28           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet232  3848,3849,3850,3851,3852,3853,3854,3855     400G   9100    N/A    etp29           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet240  3584,3585,3586,3587,3588,3589,3590,3591     400G   9100    N/A    etp30           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet248  3592,3593,3594,3595,3596,3597,3598,3599     400G   9100    N/A    etp31           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
 PortChannel102                                      N/A     800G   9100    N/A      N/A           routed      up       up                                              N/A         N/A
 PortChannel105                                      N/A     800G   9100    N/A      N/A           routed      up       up                                              N/A         N/A
 PortChannel108                                      N/A     800G   9100    N/A      N/A           routed      up       up                                              N/A         N/A
PortChannel1011                                      N/A     800G   9100    N/A      N/A           routed      up       up                                              N/A         N/A
PortChannel1014                                      N/A     800G   9100    N/A      N/A           routed      up       up                                              N/A         N/A
PortChannel1017                                      N/A     800G   9100    N/A      N/A           routed      up       up                                              N/A         N/A
PortChannel1020                                      N/A     800G   9100    N/A      N/A           routed      up       up                                              N/A         N/A
PortChannel1023                                      N/A     800G   9100    N/A      N/A           routed      up       up                                              N/A         N/A
root@croc-aaa12-dut:/usr/share/sonic/device/x86_64-8111_32eh_o-r0/Cisco-8111-O32# 
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

