### PR TITLE
Mounting /host/reboot-cause on pmon so that the modules can persist their reboot cause history

### DIFF
--- a/rules/docker-platform-monitor.mk
+++ b/rules/docker-platform-monitor.mk
@@ -54,6 +54,7 @@ $(DOCKER_PLATFORM_MONITOR)_CONTAINER_NAME = pmon
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += --privileged -t
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /etc/timezone:/etc/timezone:ro 
+$(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /host/reboot-cause:/host/reboot-cause:rw
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /host/pmon/stormond:/usr/share/stormond:rw
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /var/run/platform_cache:/var/run/platform_cache:ro
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /usr/share/sonic/device/pddf:/usr/share/sonic/device/pddf:ro


### PR DESCRIPTION
Mounting /host/reboot-cause on pmon so that the modules can persist their reboot cause history

#### Why I did it
In SmartSwitch each DPU module's reboot-cause history needs to be persisted on the host

#### How I did it
By mounting  "/host/reboot-cause" volume  on pmon

#### How to verify it
Once the host boot up check the path on the pmon container
