### PR TITLE
[Mellanox][Smartswitch] Mapping script for pci rshim and dpu data

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -1115,6 +1115,8 @@ sudo install -m 755 platform/mellanox/smartswitch/dpuctl/dpu.conf $FILESYSTEM_RO
 # Install dpuctl services
 sudo cp platform/mellanox/smartswitch/dpuctl/dpuctl.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/
 
+# Install dpumap script
+sudo install -m 755 platform/mellanox/smartswitch/dpumap.sh $FILESYSTEM_ROOT/usr/bin/dpumap.sh
 {% endif %}
 
 {% if sonic_asic_platform == "nvidia-bluefield" %}

--- a/platform/mellanox/rshim/files/rshim.sh
+++ b/platform/mellanox/rshim/files/rshim.sh
@@ -21,24 +21,18 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-dpu_id=$1
+rshim_name="rshim$1"
+pcie=$(dpumap.sh rshim2pcie $rshim_name)
 
-declare -A dpu2pcie
-dpu2pcie[0]="08:00.0"
-dpu2pcie[1]="07:00.0"
-dpu2pcie[2]="01:00.0"
-dpu2pcie[3]="02:00.0"
-
-if [ -z "${dpu2pcie[$dpu_id]}" ]; then
-    echo "Error: Invalid dpu index $dpu_id"
+if [ -z "$pcie" ]; then
+    echo "Error: Invalid rshim index $1"
     exit 1
 fi
 
-pcie=${dpu2pcie[$dpu_id]}
 
-if ! lspci | grep $pcie > /dev/null; then
+if ! lspci -D | grep $pcie > /dev/null; then
     echo "PCIE device $pcie is not available"
     exit 1
 fi
 
-/usr/sbin/rshim -i $dpu_id -d pcie-0000:$pcie
+/usr/sbin/rshim -i $1 -d pcie-$pcie

--- a/platform/mellanox/rshim/files/rshim.sh
+++ b/platform/mellanox/rshim/files/rshim.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/rshim/files/rshim.sh
+++ b/platform/mellanox/rshim/files/rshim.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/rshim/files/rshim.sh
+++ b/platform/mellanox/rshim/files/rshim.sh
@@ -24,7 +24,7 @@ fi
 rshim_name="rshim$1"
 pcie=$(dpumap.sh rshim2pcie $rshim_name)
 
-if [ -z "$pcie" ]; then
+if [ $? -ne 0 ]; then
     echo "Error: Invalid rshim index $1"
     exit 1
 fi

--- a/platform/mellanox/smartswitch/dpumap.sh
+++ b/platform/mellanox/smartswitch/dpumap.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 
 PLAT_FILE=/etc/mlnx/platform.json

--- a/platform/mellanox/smartswitch/dpumap.sh
+++ b/platform/mellanox/smartswitch/dpumap.sh
@@ -18,13 +18,8 @@
 #
 
 
-PLAT_FILE=/etc/mlnx/platform.json
-if [[ ! -f $PLAT_FILE ]]; then
-	PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
-	PLATFORM_JSON=/usr/share/sonic/device/$PLATFORM/platform.json
-	ln -s $PLATFORM_JSON $PLAT_FILE
-fi
-
+PLATFORM=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
+PLATFORM_JSON=/usr/share/sonic/device/$PLATFORM/platform.json
 
 usage(){
     echo "Usage: $0 {dpu2pcie|dpu2rshim|rshim2dpu|pcie2dpu} name"
@@ -32,7 +27,7 @@ usage(){
 declare -A dpu2pcie
 
 validate_platform(){
-    if [[ ! -f $PLAT_FILE ]]; then
+    if [[ ! -f $PLATFORM_JSON ]]; then
         echo "platform.json file not found. Exiting script"
         exit 1
     fi
@@ -73,7 +68,7 @@ esac
 
 IFS=',' read -r -a identifier_array <<< "$2"
 for identifier in "${identifier_array[@]}"; do
-	op=$(jq -r --arg "$var" "$identifier" "$jq_query" "$PLAT_FILE")
+	op=$(jq -r --arg "$var" "$identifier" "$jq_query" "$PLATFORM_JSON")
 	if [[ "$op" != "null" ]]; then
 		echo "$op"
 	else

--- a/platform/mellanox/smartswitch/dpumap.sh
+++ b/platform/mellanox/smartswitch/dpumap.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+
+PLAT_FILE=/etc/mlnx/platform.json
+if [[ ! -f $PLAT_FILE ]]; then
+PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
+PLATFORM_JSON=/usr/share/sonic/device/x86_64-nvidia_sn4280-r0/platform.json
+ln -s $PLATFORM_JSON $PLAT_FILE
+fi
+
+
+usage(){
+    echo "Usage: $0 {dpu2pcie|dpu2rshim|rshim2dpu|pcie2dpu} name"
+}
+declare -A dpu2pcie
+
+validate_platform(){
+    if [[ ! -f $PLAT_FILE ]]; then
+        echo "platform.json file not found. Exiting script"
+        exit 1
+    fi
+}
+
+
+validate_platform
+case $1 in
+    "dpu2rshim")
+	jq_query='.DPUS[$dpu].rshim_info'
+	var="dpu"
+	;;
+    "dpu2pcie")
+	jq_query='.DPUS[$dpu].bus_info'
+	var="dpu"
+	;;
+    "pcie2dpu")
+	jq_query='.DPUS | to_entries[] | select(.value.bus_info == $bus) | .key'
+	var="bus"
+	;;
+    "pcie2rshim")
+	jq_query='.DPUS | to_entries[] | select(.value.bus_info == $bus) | .value.rshim_info'
+	var="bus"
+	;;
+    "rshim2dpu")
+	jq_query='.DPUS | to_entries[] | select(.value.rshim_info == $rshim) | .key'
+	var="rshim"
+	;;
+    "rshim2pcie")
+	jq_query='.DPUS | to_entries[] | select(.value.rshim_info == $rshim) | .value.bus_info'
+	var="rshim"
+	;;
+    *)
+        echo "Invalid usage of script!"
+        usage
+        exit 1
+esac
+
+IFS=',' read -r -a identifier_array <<< "$2"
+for identifier in "${identifier_array[@]}"; do
+	op=$(jq -r --arg "$var" "$identifier" "$jq_query" "$PLAT_FILE")
+	if [[ "$op" != "null" ]]; then
+		echo "$op"
+	fi
+done
+

--- a/platform/mellanox/smartswitch/dpumap.sh
+++ b/platform/mellanox/smartswitch/dpumap.sh
@@ -23,9 +23,8 @@ PLATFORM=${PLATFORM:-`sonic-db-cli CONFIG_DB HGET 'DEVICE_METADATA|localhost' pl
 PLATFORM_JSON=/usr/share/sonic/device/$PLATFORM/platform.json
 
 usage(){
-    echo "Usage: $0 {dpu2pcie|dpu2rshim|rshim2dpu|pcie2dpu} name"
+    echo "Usage: $0 {dpu2pcie|dpu2rshim|rshim2dpu|pcie2dpu|rshim2pcie|pcie2rshim} name"
 }
-declare -A dpu2pcie
 
 validate_platform(){
     if [[ ! -f $PLATFORM_JSON ]]; then

--- a/platform/mellanox/smartswitch/dpumap.sh
+++ b/platform/mellanox/smartswitch/dpumap.sh
@@ -20,9 +20,9 @@
 
 PLAT_FILE=/etc/mlnx/platform.json
 if [[ ! -f $PLAT_FILE ]]; then
-PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
-PLATFORM_JSON=/usr/share/sonic/device/x86_64-nvidia_sn4280-r0/platform.json
-ln -s $PLATFORM_JSON $PLAT_FILE
+	PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
+	PLATFORM_JSON=/usr/share/sonic/device/$PLATFORM/platform.json
+	ln -s $PLATFORM_JSON $PLAT_FILE
 fi
 
 
@@ -76,6 +76,9 @@ for identifier in "${identifier_array[@]}"; do
 	op=$(jq -r --arg "$var" "$identifier" "$jq_query" "$PLAT_FILE")
 	if [[ "$op" != "null" ]]; then
 		echo "$op"
+	else
+		echo "Invald entry! $identifier"
+		exit 1
 	fi
 done
 

--- a/platform/mellanox/smartswitch/dpumap.sh
+++ b/platform/mellanox/smartswitch/dpumap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/smartswitch/dpumap.sh
+++ b/platform/mellanox/smartswitch/dpumap.sh
@@ -17,8 +17,9 @@
 # limitations under the License.
 #
 
-
-PLATFORM=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
+# read SONiC immutable variables
+[ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
+PLATFORM=${PLATFORM:-`sonic-db-cli CONFIG_DB HGET 'DEVICE_METADATA|localhost' platform`}
 PLATFORM_JSON=/usr/share/sonic/device/$PLATFORM/platform.json
 
 usage(){

--- a/platform/mellanox/sonic-bfb-installer.sh
+++ b/platform/mellanox/sonic-bfb-installer.sh
@@ -44,7 +44,6 @@ bfb_install_call(){
     fi
     echo "Installing bfb image on DPU connected to $rshim using $cmd"
     local indicator="$rshim:"
-	exit 0
     trap 'kill_ch_procs' SIGINT SIGTERM SIGHUP
     eval "$cmd"  > >(while IFS= read -r line; do echo "$indicator $line"; done >> "$result_file") 2>&1 &
     cmd_pid=$!

--- a/platform/mellanox/sonic-bfb-installer.sh
+++ b/platform/mellanox/sonic-bfb-installer.sh
@@ -120,7 +120,7 @@ get_mapping(){
 
     for item1 in "${provided_list[@]}"; do
         var=$(dpumap.sh rshim2dpu $item1)
-        if [[ -z "$var" ]]; then
+        if [ $? -ne 0 ]; then
             echo "$item1 does not have a valid dpu mapping!"
             exit 1
         fi
@@ -132,7 +132,7 @@ validate_dpus(){
     local provided_list=("$@")
     for item1 in "${provided_list[@]}"; do
         var=$(dpumap.sh dpu2rshim $item1)
-        if [[ -z "$var" ]]; then
+        if [ $? -ne 0 ]; then
             echo "$item1 does not have a valid rshim mapping!"
             exit 1
         fi

--- a/platform/mellanox/sonic-bfb-installer.sh
+++ b/platform/mellanox/sonic-bfb-installer.sh
@@ -16,12 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 declare -A rshim2dpu
-rshim2dpu["rshim0"]="dpu0"
-rshim2dpu["rshim1"]="dpu1"
-rshim2dpu["rshim2"]="dpu2"
-rshim2dpu["rshim3"]="dpu3"
 
 command_name="sonic-bfb-installer.sh"
 usage(){
@@ -37,16 +32,19 @@ WORK_DIR=`mktemp -d -p "$DIR"`
 
 bfb_install_call(){
     #Example:sudo bfb-install -b <full path to image> -r rshim<id>
-    local appendix=$3
+    local appendix=$4
     local -r rshim=$1
+    local dpu=$2
+    local bfb=$3
     local result_file=$(mktemp "${WORK_DIR}/result_file.XXXXX")
     if [ -z "$appendix" ]; then
-        local cmd="timeout 600s bfb-install -b $2 -r $1"
+        local cmd="timeout 600s bfb-install -b $bfb -r $1"
     else
-        local cmd="timeout 600s bfb-install -b $2 -r $1 -c $appendix"
+        local cmd="timeout 600s bfb-install -b $bfb -r $1 -c $appendix"
     fi
-    echo "Installing bfb image on DPU connected to $1 using $cmd"
+    echo "Installing bfb image on DPU connected to $rshim using $cmd"
     local indicator="$rshim:"
+	exit 0
     trap 'kill_ch_procs' SIGINT SIGTERM SIGHUP
     eval "$cmd"  > >(while IFS= read -r line; do echo "$indicator $line"; done >> "$result_file") 2>&1 &
     cmd_pid=$!
@@ -72,14 +70,11 @@ bfb_install_call(){
     if [ $exit_status -ne 0 ] ||[ $verbose = true ]; then
         cat "$result_file"
     fi
-
-    dpu=${rshim2dpu[$rshim]}
     echo "$rshim: Resetting DPU $dpu"
     cmd="dpuctl dpu-reset --force $dpu"
     if [[ $verbose == true ]]; then
         cmd="$cmd -v"
     fi
-
     eval $cmd
 }
 
@@ -120,6 +115,31 @@ validate_rshim(){
     done
 }
 
+get_mapping(){
+    local provided_list=("$@")
+
+    for item1 in "${provided_list[@]}"; do
+        var=$(dpumap.sh rshim2dpu $item1)
+        if [[ -z "$var" ]]; then
+            echo "$item1 does not have a valid dpu mapping!"
+            exit 1
+        fi
+        rshim2dpu["$item1"]="$var"
+    done
+}
+
+validate_dpus(){
+    local provided_list=("$@")
+    for item1 in "${provided_list[@]}"; do
+        var=$(dpumap.sh dpu2rshim $item1)
+        if [[ -z "$var" ]]; then
+            echo "$item1 does not have a valid rshim mapping!"
+            exit 1
+        fi
+        rshim2dpu["$var"]="$item1"
+        dev_names+=("$var")
+    done
+}
 check_for_root(){
     if [ "$EUID" -ne 0 ]
         then echo "Please run the script in sudo mode"
@@ -144,6 +164,10 @@ main(){
                 shift;
                 rshim_dev=$1
             ;;
+            --dpu|-d)
+                shift;
+                dpus=$1
+	    ;;
             --config|-c)
                 shift;
                 config=$1
@@ -170,18 +194,33 @@ main(){
         exit 1
     fi
     if [ -z "$rshim_dev" ]; then
-        echo "No rshim interfaces provided!"
-        usage
-        exit 1
-    else
-        if [ "$rshim_dev" = "all" ]; then
+        if [ -z "$dpus" ]; then
+        	echo "No rshim interfaces provided!"
+        	usage
+        	exit 1
+       fi
+       if [ "$dpus" = "all" ]; then
+            rshim_dev="$dpus" 
+       else
+            IFS=',' read -ra dpu_names <<< "$dpus"
+            validate_dpus ${dpu_names[@]}
+       fi
+    fi
+
+
+    if [ "$rshim_dev" = "all" ]; then
             dev_names=("${dev_names_det[@]}")
             echo "${#dev_names_det[@]} rshim interfaces detected:"
             echo "${dev_names_det[@]}"
         else
-            IFS=',' read -ra dev_names <<< "$rshim_dev"
+            if [ ${#dev_names[@]} -eq 0 ]; then
+                # If the list is not empty, the list is obtained from the DPUs
+                IFS=',' read -ra dev_names <<< "$rshim_dev"
+            fi
             validate_rshim ${dev_names[@]}
-        fi
+    fi
+    if [ ${#rshim2dpu[@]} -eq 0 ]; then
+        get_mapping ${dev_names[@]}
     fi
     # Sort list of rshim interfaces so that config is applied in a known order
     sorted_devs=($(for i in "${dev_names[@]}"; do echo $i; done | sort))
@@ -211,7 +250,9 @@ main(){
     for i in "${!sorted_devs[@]}"
     do
         :
-        bfb_install_call ${sorted_devs[$i]} $bfb ${arr[$i]} &
+        rshim_name=${sorted_devs[$i]}
+        dpu_name=${rshim2dpu[$rshim_name]}
+        bfb_install_call ${rshim_name} ${dpu_name} $bfb ${arr[$i]} &
     done
     wait
 }
@@ -238,3 +279,4 @@ kill_ch_procs(){
 appendix=
 verbose=false
 main "$@"
+

--- a/platform/mellanox/sonic-bfb-installer.sh
+++ b/platform/mellanox/sonic-bfb-installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Introduce `dpumap.sh` script, Which provides the following mappings:
`dpu2pcie` - This subcommand provides mapping from dpu to pcie, If dpu name is provided then pcie is returned
`dpu2rshim` - This subcommand provides mapping from dpu to rshim, If dpu name is provided then pcie is returned
`rshim2dpu` - This subcommand provides mapping from rshim to dpu, If rshim is provided then dpu name is returned
`rshim2pcie` - This subcommand provides mapping from rshim to pcie, If rshim is provided then pcie is returned
`pcie2dpu` - This subcommand provides mapping from pcie to dpu, If pcie is provided then dpu name is returned
`pcie2rshim` - This subcommand provides mapping from pcie to rshim, If pcie is provided then rshim is returned

The command also accept multiple inputs which returns the output 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Created `dpumap.sh` script and updated `rshim.sh` - which uses rshim to pcie mapping, updated `dpuctl.sh` which uses dpu to pcie mapping, updated sonic-bfb-installer.sh to acacept dpu inputs


#### How to verify it
The example outputs are provided below:
```
admin@r-bobcat-03:~$ dpumap.sh dpu2pcie dpu1,dpu2,dpu3
0000:07:00.0
0000:01:00.0
0000:02:00.0
```
```
admin@r-bobcat-03:~$ dpumap.sh dpu2rshim dpu1
rshim1
```
```
admin@r-bobcat-03:~$ dpumap.sh  pcie2rshim 0000:01:00.0
rshim2
```
```
admin@r-bobcat-03:~$ dpumap.sh  rshim2dpu rshim2,rshim3
dpu2
dpu3
admin@r-bobcat-03:~$ dpumap.sh  rshim2pcie rshim2
0000:01:00.0
```
```
admin@r-bobcat-03:~$ dpumap.sh dpu2rshim dpu2
rshim2
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

