### PR TITLE
Set `xoff` of `x86_64-arista_7800r3_48cq2_lc` to the same as`x86_64-arista_7800r3_48cqm2_lc`

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/buffers_defaults_t2.j2
@@ -22,7 +22,7 @@
             "size": "6441610000",
             "type": "both",
             "mode": "dynamic",
-            "xoff": "20761804"
+            "xoff": "1056256819"
         }
     },
     "BUFFER_PROFILE": {

--- a/src/sonic-config-engine/tests/sample_output/py2/buffer-arista7800r3-48cq2-lc.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffer-arista7800r3-48cq2-lc.json
@@ -57,7 +57,7 @@
             "size": "6441610000",
             "type": "both",
             "mode": "dynamic",
-            "xoff": "20761804"
+            "xoff": "1056256819"
         }
     },
     "BUFFER_PROFILE": {

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7800r3-48cq2-lc.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7800r3-48cq2-lc.json
@@ -57,7 +57,7 @@
             "size": "6441610000",
             "type": "both",
             "mode": "dynamic",
-            "xoff": "20761804"
+            "xoff": "1056256819"
         }
     },
     "BUFFER_PROFILE": {


### PR DESCRIPTION
Set `xoff` of `x86_64-arista_7800r3_48cq2_lc` to the same as `x86_64-arista_7800r3_48cqm2_lc`

In https://github.com/sonic-net/sonic-buildimage/pull/14908 these SKUs diverged in `xoff` values.
This causes the PFC generation behavior to diverge between these SKUs.

#### Which release branch to backport (provide reason below if selected)

- [x] 202405

#### Tested branch (Please provide the tested image version)

Confirmed the pool resources match now on both SKUs.

Previously:
```
root@cmp206-6:~# bcmcmd "tm ing vsq resources"
tm ing vsq resources
========================================================================================
|                              Core 0 Resource Allocation                              |
========================================================================================
| Parameter        | Bytes                   | OCB Buffers    | OCB Packet Descriptors |
========================================================================================
| Nominal Headroom | 10380800                | 0              | 0                      |
| (Max Headroom)   | 10380800                | 0              | 0                      |
| Pool 0           | 3210423808              | 65504          | 131040                 |
| Pool 1           | 0                       | 0              | 0                      |
| Reserved         | 256000                  | 16             | 16                     |
| Maximal          | 4294967295 (0xffffffff) | 65535 (0xffff) | 131071 (0x1ffff)       |
| Unused           | 1073906688              | 0              | 0                      |
========================================================================================
```

Now:
```
root@cmp206-6:~# bcmcmd "tm ing vsq resources"
tm ing vsq resources
========================================================================================
|                              Core 0 Resource Allocation                              |
========================================================================================
| Parameter        | Bytes                   | OCB Buffers    | OCB Packet Descriptors |
========================================================================================
| Nominal Headroom | 528128256               | 0              | 0                      |
| (Max Headroom)   | 528128256               | 0              | 0                      |
| Pool 0           | 2692676352              | 65504          | 131040                 |
| Pool 1           | 0                       | 0              | 0                      |
| Reserved         | 256000                  | 16             | 16                     |
| Maximal          | 4294967295 (0xffffffff) | 65535 (0xffff) | 131071 (0x1ffff)       |
| Unused           | 1073906688              | 0              | 0                      |
========================================================================================
```