### PR TITLE
[Arista] Reserve memory for 7060CX-32S

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -479,6 +479,7 @@ write_platform_specific_cmdline() {
     local sid="$(cmdline_get sid | sed 's/Ssd$//')"
 
     local varlog_size=0
+    local pmem_enable=false
 
     # sonic_mode is set to fixed by default.
     sonic_mode="fixed"
@@ -502,6 +503,7 @@ write_platform_specific_cmdline() {
     if in_array "$sid" "Upperlake" "UpperlakeES" "UpperlakeElite"; then
         aboot_machine=arista_7060_cx32s
         flash_size=3700
+        pmem_enable=true
     fi
     if [ "$sid" = "UpperlakePlus" ]; then
         aboot_machine=arista_7060cx2_32s
@@ -694,6 +696,10 @@ write_platform_specific_cmdline() {
                varlog_size=128
            fi
        fi
+    fi
+
+    if $pmem_enable; then
+       cmdline_add "memmap=1G!4G"
     fi
 
     cmdline_add "varlog_size=$varlog_size"


### PR DESCRIPTION
Allocate 1G to PMEM upon the next reboot.
This pmem memory won't be formatted but it'll be ready once the next
upgrade is necessary.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
7060CX-32S has limited disk space, and starting with 202405 the platform cannot fit two SONiC images at once. This PMEM allocation is needed to support upgrades starting from 202405. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add memmap kernel boot param to configure 1G of PMEM starting at address 4G

#### How to verify it
Verify via `/proc/iomem`: 
```
...
100000000-13fffffff : Persistent Memory (legacy)
...
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

