### PR TITLE
Include DPU module to sonic-chassis-module.yang  - replaces #20445

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1903,6 +1903,9 @@
             "LINE-CARD0": {
                 "admin_status": "down"
             },
+            "DPU0": {
+                "admin_status": "down"
+            },
             "FABRIC-CARD1": {
                 "admin_status": "down"
             },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/chassis_module.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/chassis_module.json
@@ -9,5 +9,13 @@
         "desc": "Load chassis module table with admin_status set to invalid value",
         "eStrKey": "InvalidValue",
         "eStr": ["admin_status"]
+    },
+    "CHASSIS_MODULE_WITH_DPU_ADMIN_DOWN": {
+        "desc": "Load chassis module table with dpu admin_status set to down"
+    },
+    "CHASSIS_MODULE_WITH_DPU_ADMIN_INVALID_VALUE": {
+        "desc": "Load chassis module table with dpu admin_status set to down",
+        "eStrKey": "InvalidValue",
+        "eStr": ["admin_status"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/chassis_module.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/chassis_module.json
@@ -12,6 +12,14 @@
                         "admin_status": "up"
                     },
                     {
+                        "name": "DPU0",
+                        "admin_status": "down"
+                    },
+                    {
+                        "name": "DPU1",
+                        "admin_status": "down"
+                    },
+                    {
                         "name": "FABRIC-CARD0",
                         "admin_status": "up"
                     },
@@ -58,6 +66,30 @@
                 "CHASSIS_MODULE_LIST": [
                     {
                         "name": "LINE-CARD0",
+                        "admin_status": "false"
+                    }
+                ]
+            }
+        }
+    },
+    "CHASSIS_MODULE_WITH_DPU_ADMIN_DOWN": {
+        "sonic-chassis-module:sonic-chassis-module": {
+            "sonic-chassis-module:CHASSIS_MODULE": {
+                "CHASSIS_MODULE_LIST": [
+                    {
+                        "name": "DPU0",
+                        "admin_status": "down"
+                    }
+                ]
+            }
+        }
+    },
+    "CHASSIS_MODULE_WITH_DPU_ADMIN_INVALID_VALUE": {
+        "sonic-chassis-module:sonic-chassis-module": {
+            "sonic-chassis-module:CHASSIS_MODULE": {
+                "CHASSIS_MODULE_LIST": [
+                    {
+                        "name": "DPU0",
                         "admin_status": "false"
                     }
                 ]


### PR DESCRIPTION
Why I did it
The modules have been extended to DPUx to support SmartSwitch. As part of the SmartSwitch development module "DPUx" needs to be supported in every section of the code that referring to modules.

Work item tracking
Microsoft ADO (number only):
How I did it
Updated "src/sonic-yang-models/yang-models/sonic-chassis-module.yang" file with "|DPU[0-9]" dpu module name.

How to verify it
Update "src/sonic-yang-models/tests/yang_model_tests/tests_config/chassis_module.json" to include DPUx modules and update /src/sonic-yang-models/tests/yang_model_tests/tests/chassis_module.json to verify DPU modules
Update "src/sonic-yang-models/tests/files/sample_config_db.json" to include DPUx modules and verify using src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
Which release branch to backport (provide reason below if selected)
No need to brackport

Tested branch (Please provide the tested image version)
master

Description for the changelog
Added DPU modules to sonic-chassis-module.yang

Link to config_db schema for YANG module changes
Updated https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md

A picture of a cute animal (not mandatory but encouraged)