### PR TITLE
[Mellanox][Smartswitch] Add no_wait option for dpu reboot and add platform information parsing  

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -1,6 +1,7 @@
 #
-# Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES.
-# Apache-2.0
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -19,11 +19,21 @@ import glob
 import os
 import time
 import re
+from enum import Enum
 
 from . import utils
 from sonic_py_common.general import check_output_pipe
 
 DEFAULT_WD_PERIOD = 65535
+
+
+class DpuInterfaceEnum(Enum):
+    MIDPLANE_INT = "midplane_interface"
+    RSHIM_INT = "rshim_info"
+    PCIE_INT = "bus_info"
+
+
+dpu_interface_values = [item.value for item in DpuInterfaceEnum]
 
 DEVICE_DATA = {
     'x86_64-mlnx_msn2700-r0': {
@@ -271,16 +281,26 @@ class DeviceDataManager:
     @classmethod
     @utils.read_only_cache()
     def get_platform_dpus_data(cls):
-        json_data = cls.get_platform_json_data()
-        return json_data.get('DPUS', None)
-
-    @classmethod
-    @utils.read_only_cache()
-    def get_platform_json_data(cls):
         from sonic_py_common import device_info
         platform_path = device_info.get_path_to_platform_dir()
         platform_json_path = os.path.join(platform_path, 'platform.json')
-        return utils.load_json_file(platform_json_path)
+        json_data = utils.load_json_file(platform_json_path)
+        return json_data.get('DPUS', None)
+
+    @classmethod
+    def get_dpu_interface(cls, dpu, interface):
+        dpu_data = cls.get_platform_dpus_data()
+        if (not dpu_data) or (interface not in dpu_interface_values):
+            return None
+        return dpu_data.get(dpu, {}).get(interface)
+
+    @classmethod
+    @utils.read_only_cache()
+    def get_dpu_count(cls):
+        dpu_data = cls.get_platform_dpus_data()
+        if not dpu_data:
+            return 0
+        return len(dpu_data)
 
     @classmethod
     def get_bios_component(cls):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpu_vpd_parser.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpu_vpd_parser.py
@@ -1,0 +1,46 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from .vpd_parser import VpdParser
+
+
+class DpuVpdParser(VpdParser):
+    """DPU Specific VPD parser"""
+    def __init__(self, file_path, dpu_name):
+        super(DpuVpdParser, self).__init__(file_path=file_path)
+        self.dpu_name = dpu_name
+
+    def get_dpu_data(self, key=None):
+        """Retrieves VPD Entry for DPU Specific Key"""
+        return self.get_entry_value(f"{self.dpu_name}_{key}")
+
+    def get_dpu_base_mac(self):
+        """Retrieves VPD Entry for DPU Specific Mac Address"""
+        return self.get_dpu_data("BASE_MAC")
+
+    def get_dpu_serial(self):
+        """Retrieves VPD Entry for DPU Specific Serial Number"""
+        return self.get_dpu_data("SN")
+
+    def get_dpu_revision(self):
+        """Retrieves VPD Entry for DPU Specific Revision"""
+        return self.get_dpu_data("REV")
+
+    def get_dpu_model(self):
+        """Retrieves VPD Entry for DPU Specific Model Number"""
+        return self.get_dpu_data("PN")

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -143,9 +143,7 @@ class DpuCtlPlat():
         """Method to execute shutdown activities for the DPU"""
         rshim_op = self.dpu_rshim_service_control("stop")
         pci_rem_op = self.dpu_pci_remove()
-        if rshim_op and pci_rem_op:
-            return True
-        return False
+        return rshim_op and pci_rem_op
 
     def dpu_post_startup(self):
         """Method to execute all post startup activities for the DPU"""

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -104,6 +104,8 @@ class DpuCtlPlat():
         self.shtdn_state = None
         self.dpu_ready_state = None
         self.setup_logger()
+        self.pci_dev_path = None
+        self.rshim_interface = None
         # Use systemd dbus to execute start and stop rshim service
         os.environ['DBUS_SESSION_BUS_ADDRESS'] = 'unix:path=/run/dbus/system_bus_socket'
         self.verbosity = False

--- a/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +28,7 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
-from sonic_platform.device_data import DeviceDataManager
+from sonic_platform.device_data import DeviceDataManager, DpuInterfaceEnum, dpu_interface_values
 
 
 class TestDeviceData:
@@ -83,3 +83,77 @@ class TestDeviceData:
         assert DeviceDataManager.wait_platform_ready()
         mock_exists.return_value = False
         assert not DeviceDataManager.wait_platform_ready()
+
+    @mock.patch('sonic_py_common.device_info.get_path_to_platform_dir', mock.MagicMock(return_value='/tmp'))
+    @mock.patch('sonic_platform.device_data.utils.load_json_file')
+    def test_dpu_count(self, mock_load_json):
+        mock_value = {
+            "DPUS": {
+                "dpu1": {
+                    "interface": {"Ethernet224": "Ethernet0"}
+                },
+                "dpu2": {
+                    "interface": {"Ethernet232": "Ethernet0"}
+                },
+                "dpu3": {
+                    "interface": {"EthernetX": "EthernetY"}
+                }
+            },
+        }
+        mock_load_json.return_value = mock_value
+        return_dict = DeviceDataManager.get_platform_dpus_data()
+        dpu_data = mock_value["DPUS"]
+        assert dpu_data == return_dict
+        mock_load_json.return_value = {}
+        # Data is Cached
+        assert DeviceDataManager.get_platform_dpus_data() == mock_value["DPUS"]
+        assert DeviceDataManager.get_dpu_count() == 3
+
+    @mock.patch('sonic_py_common.device_info.get_path_to_platform_dir', mock.MagicMock(return_value='/tmp'))
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_platform_dpus_data')
+    def test_dpu_interface_data(self, mock_load_json):
+        mock_value = {
+            "dpu0": {
+                "midplane_interface": "dpu0",
+                "interface": {
+                    "Ethernet224": "Ethernet0"
+                },
+                "rshim_info": "rshim0",
+                "bus_info": "0000:08:00.0"
+            },
+            "dpu1": {
+                "midplane_interface": "dpu1",
+                "interface": {
+                    "Ethernet232": "Ethernet0"
+                },
+                "rshim_info": "rshim1",
+                "bus_info": "0000:07:00.0"
+            },
+            "dpu2": {
+                "midplane_interface": "dpu2",
+                "interface": {
+                    "Ethernet240": "Ethernet0"
+                },
+                "rshim_info": "rshim2",
+                "bus_info": "0000:01:00.0"
+            },
+            "dpu3": {
+                "midplane_interface": "dpu3",
+                "interface": {
+                    "Ethernet248": "Ethernet0"
+                },
+                "rshim_info": "rshim3",
+                "bus_info": "0000:02:00.0"
+            }
+        }
+        mock_load_json.return_value = mock_value
+        for dpu_name in mock_value:
+            for dpu_interface in dpu_interface_values:
+                assert DeviceDataManager.get_dpu_interface(dpu_name, dpu_interface) == mock_value[dpu_name][dpu_interface]
+        invalid_dpu_names = ["dpu4", "", "dpu"]
+        invalid_interface_names = ["midplane", "rshim", "bus"]
+        for interface_name in invalid_interface_names:
+            assert not DeviceDataManager.get_dpu_interface("dpu0", interface_name)
+        for dpu_name in invalid_dpu_names:
+            assert not DeviceDataManager.get_dpu_interface(dpu_name, DpuInterfaceEnum.MIDPLANE_INT.value)
+        assert not DeviceDataManager.get_dpu_interface("", "")

--- a/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
@@ -1,6 +1,7 @@
 #
-# Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES.
-# Apache-2.0
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
@@ -48,6 +48,8 @@ obj = create_dpu_list()
 
 rshim_interface = "rshim@0"
 pci_dev_path = os.path.join(PCI_DEV_BASE, "0000:08:00.0", 'remove')
+
+
 class TestDpuClass:
     """Tests for dpuctl Platform API Wrapper"""
     @classmethod
@@ -113,7 +115,7 @@ class TestDpuClass:
             assert "0" == written_data[2]["data"]
             assert written_data[3]["file"].endswith(f"{dpuctl_obj.get_hwmgmt_name()}_pwr_force")
             assert "0" == written_data[3]["data"]
-        # Test whether value of boot_progress skips power off 
+        # Test whether value of boot_progress skips power off
         with patch.object(dpuctl_obj, 'read_boot_prog') as mock_boot_prog, \
              patch.object(dpuctl_obj, 'write_file', wraps=mock_write_file), \
              patch.object(dpuctl_obj, '_power_off_force') as mock_power_off_force, \
@@ -141,7 +143,7 @@ class TestDpuClass:
             assert dpuctl_obj.dpu_power_off(False)
             mock_power_off_force.assert_not_called()
             mock_power_off.assert_called_once()
-            
+
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('multiprocessing.Process.start', MagicMock(return_value=True))
     @patch('multiprocessing.Process.is_alive', MagicMock(return_value=False))
@@ -162,7 +164,7 @@ class TestDpuClass:
         with patch.object(dpuctl_obj, 'write_file', wraps=mock_write_file), \
              patch.object(dpuctl_obj, 'wait_for_pci', wraps=MagicMock(return_value=None)), \
              patch.object(dpuctl_obj, 'dpu_rshim_service_control', wraps=MagicMock(return_value=None)), \
-             patch.object(dpuctl_obj, 'read_boot_prog',  wraps=MagicMock(return_value=BootProgEnum.RST.value)):
+             patch.object(dpuctl_obj, 'read_boot_prog', wraps=MagicMock(return_value=BootProgEnum.RST.value)):
             assert dpuctl_obj.dpu_power_on(True)
             assert mock_inotify.call_args.args[0].endswith(
                 f"{dpuctl_obj.get_hwmgmt_name()}_ready")
@@ -261,7 +263,7 @@ class TestDpuClass:
         mock_inotify.reset_mock()
         mock_add_watch.return_value = True
         mock_inotify.return_value = None
-        written_data=[]
+        written_data = []
         with patch.object(dpuctl_obj, 'write_file', wraps=mock_write_file), \
              patch.object(dpuctl_obj, 'read_boot_prog', MagicMock(return_value=BootProgEnum.OS_RUN.value)), \
              patch.object(dpuctl_obj, 'dpu_rshim_service_control', wraps=MagicMock(return_value=None)):
@@ -370,6 +372,17 @@ class TestDpuClass:
             assert "1" == written_data[4]["data"]
             mock_inotify.called_once()
             mock_add_watch.called_once()
+        # Skip pre startup and post shutdown
+        written_data = []
+        with patch.object(dpuctl_obj, 'write_file', wraps=mock_write_file), \
+             patch.object(dpuctl_obj, 'read_boot_prog', MagicMock(return_value=BootProgEnum.OS_START.value)), \
+             patch.object(dpuctl_obj, 'dpu_rshim_service_control') as mock_rshim:
+            assert dpuctl_obj.dpu_reboot(skip_pre_post=True)
+            mock_rshim.assert_not_called()
+            # We skip writing PCI data
+            assert written_data[0]["file"].endswith(f"{dpuctl_obj.get_hwmgmt_name()}_rst")
+            assert "0" == written_data[0]["data"]
+            assert not written_data[-1]["file"].endswith("rescan")
 
     def test_prog_update(self):
         dpuctl_obj = obj["dpuctl_list"][0]
@@ -480,22 +493,21 @@ class TestDpuClass:
             mock_obj.register.assert_called_once()
             mock_obj.poll.assert_not_called()
         with patch.object(dpuctl_obj, 'pci_dev_path', None), \
-            patch('sonic_platform.device_data.DeviceDataManager.get_dpu_interface') as mock_int,\
-            patch.object(dpuctl_obj, 'log_error') as mock_obj:
-                mock_int.return_value = None
-                dpuctl_obj.wait_for_pci()
-                mock_obj.assert_called_once_with("Unable to wait for PCI device:Unable to obtain pci device id for dpu0 from platform.json")
-                new_pci_dev_id = "0000:05:00.0"
-                mock_int.return_value = new_pci_dev_id
-                dpuctl_obj.wait_for_pci()
-                assert dpuctl_obj.pci_dev_path.endswith(f"{new_pci_dev_id}/remove")
-                # pci dev_path is cached 
-                mock_int.reset_mock()
-                mock_int.return_value = "None"
-                dpuctl_obj.wait_for_pci()
-                mock_int.assert_not_called()
-                assert dpuctl_obj.pci_dev_path.endswith(f"{new_pci_dev_id}/remove")
-
+             patch('sonic_platform.device_data.DeviceDataManager.get_dpu_interface') as mock_int,\
+             patch.object(dpuctl_obj, 'log_error') as mock_obj:
+            mock_int.return_value = None
+            dpuctl_obj.wait_for_pci()
+            mock_obj.assert_called_once_with("Unable to wait for PCI device:Unable to obtain pci device id for dpu0 from platform.json")
+            new_pci_dev_id = "0000:05:00.0"
+            mock_int.return_value = new_pci_dev_id
+            dpuctl_obj.wait_for_pci()
+            assert dpuctl_obj.pci_dev_path.endswith(f"{new_pci_dev_id}/remove")
+            # pci dev_path is cached
+            mock_int.reset_mock()
+            mock_int.return_value = "None"
+            dpuctl_obj.wait_for_pci()
+            mock_int.assert_not_called()
+            assert dpuctl_obj.pci_dev_path.endswith(f"{new_pci_dev_id}/remove")
 
     def test_rshim_service(self):
         dpuctl_obj = obj["dpuctl_list"][0]
@@ -505,18 +517,18 @@ class TestDpuClass:
             cmd_string = ' '.join(mock_method.call_args.args[0])
             service_name = rshim_interface
             operation = "Start"
-            assert (operation in cmd_string) and  (service_name in cmd_string)
+            assert (operation in cmd_string) and (service_name in cmd_string)
             mock_method.reset_mock()
             operation = "Stop"
             dpuctl_obj.dpu_rshim_service_control('stop')
             cmd_string = ' '.join(mock_method.call_args.args[0])
-            assert (operation in cmd_string) and  (service_name in cmd_string)
+            assert (operation in cmd_string) and (service_name in cmd_string)
             mock_method.assert_called_once()
             with pytest.raises(TypeError):
                 dpuctl_obj.dpu_rshim_service_control()
             with patch.object(dpuctl_obj, 'rshim_interface', None), \
-                patch('sonic_platform.device_data.DeviceDataManager.get_dpu_interface') as mock_int,\
-                patch.object(dpuctl_obj, 'log_error') as mock_obj:
+                 patch('sonic_platform.device_data.DeviceDataManager.get_dpu_interface') as mock_int,\
+                 patch.object(dpuctl_obj, 'log_error') as mock_obj:
                 mock_int.return_value = None
                 dpuctl_obj.dpu_rshim_service_control('start')
                 mock_obj.assert_called_once_with("Failed to start rshim!: Unable to Parse rshim information for dpu0 from Platform.json")
@@ -526,7 +538,7 @@ class TestDpuClass:
                 mock_int.reset_mock()
                 mock_int.return_value = "rshim20"
                 dpuctl_obj.dpu_rshim_service_control('start')
-                # Rshim name is cached 
+                # Rshim name is cached
                 mock_int.assert_not_called()
                 assert dpuctl_obj.rshim_interface == "rshim@1"
 
@@ -536,12 +548,17 @@ class TestDpuClass:
             manager_mock = Mock()
             manager_mock.attach_mock(mock_rshim, 'rshim')
             manager_mock.attach_mock(mock_write, 'write')
-            dpuctl_obj.dpu_pre_shutdown()
+            mock_rshim.return_value = True
+            mock_write.return_value = True
+            assert dpuctl_obj.dpu_pre_shutdown()
             mock_rshim.assert_called_once()
             mock_write.assert_called_once()
             # Confirm the order of calls and the parameters
             manager_mock.mock_calls[0] == call.rshim('stop')
             manager_mock.mock_calls[1] == call.rshim(dpuctl_obj.pci_dev_path, '1')
+            mock_rshim.return_value = False
+            assert not dpuctl_obj.dpu_pre_shutdown()
+            mock_rshim.return_value = True
             # Test post startup
             mock_rshim.reset_mock()
             mock_write.reset_mock()
@@ -558,6 +575,22 @@ class TestDpuClass:
                 manager_mock.mock_calls[0] == call.rshim('/sys/bus/pci/rescan', '1')
                 manager_mock.mock_calls[1] == call.pci()
                 manager_mock.mock_calls[2] == call.rshim('start')
+                mock_rshim.return_value = False
+                assert not dpuctl_obj.dpu_post_startup()
+        with patch.object(dpuctl_obj, 'write_file', side_effect=Exception("Mock")), \
+             patch.object(dpuctl_obj, 'run_cmd_output', MagicMock(return_value=True)):
+            assert not dpuctl_obj.dpu_pre_shutdown()
+        with patch.object(dpuctl_obj, 'run_cmd_output', side_effect=Exception("Mock")), \
+             patch.object(dpuctl_obj, 'dpu_pci_remove', MagicMock(return_value=True)):
+            assert not dpuctl_obj.dpu_pre_shutdown()
+        with patch.object(dpuctl_obj, 'write_file', side_effect=Exception("Mock")), \
+             patch.object(dpuctl_obj, 'wait_for_pci', MagicMock(return_value=True)), \
+             patch.object(dpuctl_obj, 'run_cmd_output', MagicMock(return_value=True)):
+            assert not dpuctl_obj.dpu_post_startup()
+        with patch.object(dpuctl_obj, 'run_cmd_output', side_effect=Exception("Mock")), \
+             patch.object(dpuctl_obj, 'wait_for_pci', MagicMock(return_value=True)), \
+             patch.object(dpuctl_obj, 'dpu_pci_scan', MagicMock(return_value=True)):
+            assert not dpuctl_obj.dpu_post_startup()
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Changes for `dpuctlplat.py`:
- Added option to invoke systemctl rshim start/stop from the pmon container (Using dbus)
- Added no_wait option for reboot (Since we do not need to wait for the dpu to be ready if NPU+DPU reboot is ongoing)
- Added platform JSON parsing for rshim and pcie information

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Changed `dpuctlplat.py` to support systemctl commands from pmon container using the dbus-send command 
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

