### PR TITLE
Revert "Move eventd enabled check from build time to runtime"

### DIFF
--- a/dockers/docker-dhcp-relay/Dockerfile.j2
+++ b/dockers/docker-dhcp-relay/Dockerfile.j2
@@ -50,11 +50,14 @@ COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 COPY ["cli", "/cli/"]
 
-RUN mkdir -p /usr/share/sonic/templates/rsyslog_plugin
-
-# Copy rsyslog plugin configuration file and regexes to docker
-COPY ["dhcp_relay_regex.json", "/etc/rsyslog.d/"]
-COPY ["events_info.json", "/usr/share/sonic/templates/rsyslog_plugin/"]
-COPY ["files/rsyslog_plugin.conf.j2", "/usr/share/sonic/templates/rsyslog_plugin/"]
+{% if include_system_eventd == "y" and build_reduce_image_size != "y" %}
+# Copy regex json and rsyslog_plugin.conf file into rsyslog.d
+COPY ["*.json", "/etc/rsyslog.d/"]
+COPY ["files/rsyslog_plugin.conf.j2", "/etc/rsyslog.d/"]
+# Create dhcp_relay_regex.conf
+RUN j2 -f json /etc/rsyslog.d/rsyslog_plugin.conf.j2 /etc/rsyslog.d/events_info.json  > /etc/rsyslog.d/dhcp_relay_events.conf
+RUN rm -f /etc/rsyslog.d/rsyslog_plugin.conf.j2
+RUN rm -f /etc/rsyslog.d/events_info.json
+{% endif %}
 
 ENTRYPOINT ["/usr/bin/docker_init.sh"]

--- a/dockers/docker-dhcp-relay/docker_init.sh
+++ b/dockers/docker-dhcp-relay/docker_init.sh
@@ -21,7 +21,4 @@ chmod +x /usr/bin/wait_for_intf.sh
 # The docker container should start this script as PID 1, so now that supervisord is
 # properly configured, we exec /usr/local/bin/supervisord so that it runs as PID 1 for the
 # duration of the container's lifetime
-export EVENTD_STATE=$(sonic-db-cli -s CONFIG_DB HGET 'FEATURE|eventd' 'state')
-j2 -f json --import-env=ENVIRONMENT /usr/share/sonic/templates/rsyslog_plugin/rsyslog_plugin.conf.j2 /usr/share/sonic/templates/rsyslog_plugin/events_info.json  > /etc/rsyslog.d/dhcp_relay_events.conf
-
 exec /usr/local/bin/supervisord

--- a/dockers/docker-fpm-frr/Dockerfile.j2
+++ b/dockers/docker-fpm-frr/Dockerfile.j2
@@ -59,11 +59,12 @@ RUN chmod a+x /usr/bin/TSA && \
     chmod a+x /usr/bin/TSC && \
     chmod a+x /usr/bin/zsocket.sh
 
-RUN mkdir -p /usr/share/sonic/templates/rsyslog_plugin
-
-# Copy rsyslog plugin configuration file and regexes to docker
-COPY ["bgp_regex.json", "/etc/rsyslog.d/"]
-COPY ["events_info.json", "/usr/share/sonic/templates/rsyslog_plugin/"]
-COPY ["files/rsyslog_plugin.conf.j2", "/usr/share/sonic/templates/rsyslog_plugin/"]
+{% if include_system_eventd == "y" and build_reduce_image_size != "y" %}
+COPY ["*.json", "/etc/rsyslog.d/"]
+COPY ["files/rsyslog_plugin.conf.j2", "/etc/rsyslog.d/"]
+RUN j2 -f json /etc/rsyslog.d/rsyslog_plugin.conf.j2 /etc/rsyslog.d/events_info.json  > /etc/rsyslog.d/bgp_events.conf
+RUN rm -f /etc/rsyslog.d/rsyslog_plugin.conf.j2
+RUN rm -f /etc/rsyslog.d/events_info.json
+{% endif %}
 
 ENTRYPOINT ["/usr/bin/docker_init.sh"]

--- a/dockers/docker-fpm-frr/docker_init.sh
+++ b/dockers/docker-fpm-frr/docker_init.sh
@@ -112,7 +112,4 @@ TZ=$(cat /etc/timezone)
 rm -rf /etc/localtime
 ln -sf /usr/share/zoneinfo/$TZ /etc/localtime
 
-export EVENTD_STATE=$(sonic-db-cli -s CONFIG_DB HGET 'FEATURE|eventd' 'state')
-j2 -f json --import-env=ENVIRONMENT /usr/share/sonic/templates/rsyslog_plugin/rsyslog_plugin.conf.j2 /usr/share/sonic/templates/rsyslog_plugin/events_info.json  > /etc/rsyslog.d/bgp_events.conf
-
 exec /usr/local/bin/supervisord

--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -80,11 +80,14 @@ RUN sonic-cfggen -a "{\"ENABLE_ASAN\":\"{{ENABLE_ASAN}}\"}" -t /usr/share/sonic/
 RUN rm -f /usr/share/sonic/templates/docker-init.j2
 RUN chmod 755 /usr/bin/docker-init.sh
 
-RUN mkdir -p /usr/share/sonic/templates/rsyslog_plugin
-
-# Copy rsyslog plugin configuration file and regexes to docker
-COPY ["swss_regex.json", "/etc/rsyslog.d/"]
-COPY ["events_info.json", "/usr/share/sonic/templates/rsyslog_plugin/"]
-COPY ["files/rsyslog_plugin.conf.j2", "/usr/share/sonic/templates/rsyslog_plugin/"]
+{% if include_system_eventd == "y" and build_reduce_image_size != "y" %}
+# Copy all regex json files and rsyslog_plugin.conf to rsyslog.d
+COPY ["*.json", "/etc/rsyslog.d/"]
+COPY ["files/rsyslog_plugin.conf.j2", "/etc/rsyslog.d/"]
+# Create swss rsyslog_plugin conf file
+RUN j2 -f json /etc/rsyslog.d/rsyslog_plugin.conf.j2 /etc/rsyslog.d/events_info.json  > /etc/rsyslog.d/swss_events.conf
+RUN rm -f /etc/rsyslog.d/rsyslog_plugin.conf.j2
+RUN rm -f /etc/rsyslog.d/events_info.json
+{% endif %}
 
 ENTRYPOINT ["/usr/bin/docker-init.sh"]

--- a/dockers/docker-orchagent/docker-init.j2
+++ b/dockers/docker-orchagent/docker-init.j2
@@ -74,7 +74,4 @@ TZ=$(cat /etc/timezone)
 rm -rf /etc/localtime
 ln -sf /usr/share/zoneinfo/$TZ /etc/localtime
 
-export EVENTD_STATE=$(sonic-db-cli -s CONFIG_DB HGET 'FEATURE|eventd' 'state')
-j2 -f json --import-env=ENVIRONMENT /usr/share/sonic/templates/rsyslog_plugin/rsyslog_plugin.conf.j2 /usr/share/sonic/templates/rsyslog_plugin/events_info.json  > /etc/rsyslog.d/swss_events.conf
-
 exec /usr/local/bin/supervisord

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -336,11 +336,6 @@ function postStartAction()
             docker cp $PSENSOR pmon:/usr/bin/
         fi
     fi
-{%- elif docker_container_name == "eventd" %}
-    export EVENTD_STATE=$(sonic-db-cli -s CONFIG_DB HGET 'FEATURE|eventd' 'state')
-    j2 -f json --import-env=ENVIRONMENT /usr/share/sonic/templates/rsyslog_plugin/rsyslog_plugin.conf.j2 /usr/share/sonic/templates/rsyslog_plugin/events_info.json  > /etc/rsyslog.d/host_events.conf
-    j2 -f json --import-env=ENVIRONMENT /usr/share/sonic/templates/rsyslog_plugin/rsyslog_plugin.conf.j2 /usr/share/sonic/templates/rsyslog_plugin/syncd_events_info.json  > /etc/rsyslog.d/syncd_events.conf
-    systemctl restart rsyslog
 {%- else %}
     : # nothing
 {%- endif %}

--- a/files/build_templates/rsyslog_plugin.conf.j2
+++ b/files/build_templates/rsyslog_plugin.conf.j2
@@ -1,6 +1,7 @@
 ## rsyslog-plugin for streaming telemetry via gnmi
 
-{% if ENVIRONMENT['EVENTD_STATE'] == "enabled" %}
+
+
 template(name="prog_msg" type="list") {
     property(name="msg")
     constant(value="\n")
@@ -15,4 +16,3 @@ if re_match($programname, "{{ proc.name }}") then {
         template="prog_msg")
 }
 {% endfor %}
-{% endif %}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -358,16 +358,13 @@ sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/sonic-db-cli_*.deb || \
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
 
 
-{% if include_system_eventd == "y" %}
+{% if include_system_eventd == "y" and build_reduce_image_size != "y" %}
 # Install sonic-rsyslog-plugin
 sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/sonic-rsyslog-plugin_*.deb || \
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
 
 # Generate host conf for rsyslog_plugin
-sudo mkdir -p $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/rsyslog_plugin
-sudo cp $BUILD_TEMPLATES/rsyslog_plugin.conf.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/rsyslog_plugin/
-sudo cp $BUILD_TEMPLATES/events_info.json $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/rsyslog_plugin/
-sudo cp $BUILD_TEMPLATES/syncd_events_info.json $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/rsyslog_plugin/
+j2 -f json $BUILD_TEMPLATES/rsyslog_plugin.conf.j2 $BUILD_TEMPLATES/events_info.json | sudo tee $FILESYSTEM_ROOT_ETC/rsyslog.d/host_events.conf
 sudo cp $BUILD_TEMPLATES/monit_regex.json $FILESYSTEM_ROOT_ETC/rsyslog.d/
 sudo cp $BUILD_TEMPLATES/sshd_regex.json $FILESYSTEM_ROOT_ETC/rsyslog.d/
 sudo cp $BUILD_TEMPLATES/systemd_regex.json $FILESYSTEM_ROOT_ETC/rsyslog.d/
@@ -376,7 +373,11 @@ sudo cp $BUILD_TEMPLATES/dockerd_regex.json $FILESYSTEM_ROOT_ETC/rsyslog.d/
 sudo cp $BUILD_TEMPLATES/seu_regex.json $FILESYSTEM_ROOT_ETC/rsyslog.d/
 sudo cp $BUILD_TEMPLATES/zebra_regex.json $FILESYSTEM_ROOT_ETC/rsyslog.d/
 sudo cp $BUILD_TEMPLATES/bgpd_regex.json $FILESYSTEM_ROOT_ETC/rsyslog.d/
+
+
+j2 -f json $BUILD_TEMPLATES/rsyslog_plugin.conf.j2 $BUILD_TEMPLATES/syncd_events_info.json | sudo tee $FILESYSTEM_ROOT_ETC/rsyslog.d/syncd_events.conf
 sudo cp $BUILD_TEMPLATES/syncd_regex.json $FILESYSTEM_ROOT_ETC/rsyslog.d/
+
 {% endif %}
 
 # Install custom-built monit package and SONiC configuration files


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#20248 and fixes https://github.com/sonic-net/sonic-buildimage/issues/20544