### PR TITLE
[kernel] flushing neighbor entries on interface operational change

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -485,6 +485,8 @@ echo "logrotate-config.service" | sudo tee -a $GENERATED_SERVICE_FILE
 sudo cp -f $IMAGE_CONFIGS/systemd/journald.conf $FILESYSTEM_ROOT/etc/systemd/
 
 # Copy interfaces configuration files and templates
+sudo cp $IMAGE_CONFIGS/interfaces/flush-ndisc $FILESYSTEM_ROOT/etc/network/if-up.d/flush-ndisc
+sudo cp $IMAGE_CONFIGS/interfaces/flush-ndisc $FILESYSTEM_ROOT/etc/network/if-down.d/flush-ndisc
 sudo cp $IMAGE_CONFIGS/interfaces/interfaces-config.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
 sudo cp $IMAGE_CONFIGS/interfaces/interfaces-config.sh $FILESYSTEM_ROOT/usr/bin/
 sudo cp $IMAGE_CONFIGS/interfaces/*.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/

--- a/files/image_config/interfaces/flush-ndisc
+++ b/files/image_config/interfaces/flush-ndisc
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Flush IPv6 neighbor table on interface operational change
+logger "interface $IFACE operational change. flushing ipv6 neighbor table for interface..."
+
+ip -6 neigh flush dev $IFACE


### PR DESCRIPTION
Runs flush-ndisc script on if up and down. adds flush-ndisc script to /etc/network/if-up.d/flush-ndisc and /etc/network/if-down.d/flush-ndisc. Script is run when operation state of interface changes. Script will flush ipv6 neighbor entries for interface.

#### Why I did it
The Linux kernel on SONiC T1s (all of them, globally) do not remove ICMPv6 neighbor discovery MAC entries upon operational status change of interfaces. This is different from behavior on Arista, Cisco, and Juniper platforms.

##### Work item tracking
- Microsoft ADO **(number only)**: 29822840

#### How I did it
Created script flush-ndisc which will flush ipv6 neighbor entries for interface. It is placed in /etc/network/if-up.d/flush-ndisc and /etc/network/if-down.d/flush-ndisc, so the script will run when operational state of interface is changed

#### How to verify it
1. Add ipv6 neighbor to PortChannel interface
2. Add script to /etc/network/if-up.d/flush-ndisc and /etc/network/if-down.d/flush-ndisc
3. Simulate operation state change on lab testbed by shutting down and bringing up fanout interface.
4. Check neighbor entry to confirm neighbor is flushed. 


#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

- [x] 20231110.26

#### Description for the changelog
Kernel change to flush neighbor table for interface when operational state changes.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

