### PR TITLE
[sonic-frr-mgmt-framework]: refactor the way of load srv6 locator opcode …

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -2078,7 +2078,7 @@ class BGPConfigDaemon:
                              ('icmo_ttl', 'ttl {}', handle_ip_sla_common),
                              ('icmp_tos', 'tos {}', handle_ip_sla_common),
                            ]
-    srv6_locator_key_map = [(['opcode_prefix', 'opcode_act', 'opcode_vrf'], '{no:no-prefix}opcode {} {} vrf {}', hdl_srv6_locator)]
+    srv6_locator_key_map = [(['opcode_prefix', 'opcode_act', 'opcode_data'], '{no:no-prefix}opcode {} {} {}', hdl_srv6_locator)]
 
 
     tbl_to_key_map = {'BGP_GLOBALS':                    global_key_map,


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
this pr refactor the way of load srv6 locator opcode in frrcfgd to support other opcode action 
#### Why I did it
Previous way of load srv6 locator config do not support end/endx opcode action.
The current configuration example of config_db json file is as follows：
- fd00:201:201:fff1:1:0:0:0,  action end, no configuration parameters required.
- fd00:201:201:fff2:2:0:0:0, action end-dt4, the target vrf needs to be configured.
- fd00:201:201:fff3:3:0:0:0,  action end-dt46, the target vrf needs to be configured.
- fd00:201:201:fff4:4:0:0:0, action end-dt6, the target vrf needs to be configured.
- fd00:201:201:fff5:5:0:0:0,  action end-x, the interface and nexthop need to be configured.

```
    "SRV6_LOCATOR": {
        "lsid1": {
            "block_len": "32",
            "func_len": "32",
            "node_len": "16",
            "opcode_prefix": [
                "::fff1:1:0:0:0",
                "::fff2:2:0:0:0",
                "::fff3:3:0:0:0",
                "::fff4:4:0:0:0",
                "::fff5:5:0:0:0"
            ],
            "opcode_act": [
                "end",
                "end-dt4",
                "end-dt46",
                "end-dt6",
                "end-x"
            ],
            "opcode_data": [
                "",
                "vrf Vrf1",
                "vrf Vrf2",
                "vrf Vrf3",
                "interface Ethernet24 nexthop 1::1"
            ],
            "prefix": "fd00:201:201::/48"
        }
    },
``` 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
it may impact config reload of srv6 locator
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202411
#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

