### PR TITLE
[yang] LOGGER missing require_manual_refresh

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-logger.yang
+++ b/src/sonic-yang-models/yang-models/sonic-logger.yang
@@ -67,6 +67,11 @@ module sonic-logger{
                     }
                     default SYSLOG;
                 }
+
+                leaf require_manual_refresh {
+                    type stypes:boolean_type;
+                    description "When updating the log level, will refresh configuration via SIGHUP sent to the process.";
+                }
             }/* end of list LOGGER_LIST */
         }/* end of LOGGER container */
     }/* end of sonic-logger container */


### PR DESCRIPTION
#### Why I did it
YANG failures during `config replace` with default configuration.

As of https://github.com/sonic-net/sonic-buildimage/pull/19611 and https://github.com/sonic-net/sonic-utilities/pull/3428 a new database field of `require_manual_refresh` was added.

This leads to YANG failures in the factory-default configuration for the `xcvrd` log entry which by default is written as true.

##### Work item tracking

#### How I did it

Updated YANG file for new field.

#### How to verify it

Verify `config replace` works with factory default configuration.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

None, this only exists in master.

#### Tested branch (Please provide the tested image version)

master as of 20241129

#### Description for the changelog
[yang] LOGGER missing require_manual_refresh

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

Signed-off-by: Brad House (@bradh352)
