### PR TITLE
[Nokia][asic-sensors] Modify the platform.json to enable the asic_sensors polling on Nokia platforms

### DIFF
--- a/device/nokia/arm64-nokia_ixs7215_52xb-r0/platform.json
+++ b/device/nokia/arm64-nokia_ixs7215_52xb-r0/platform.json
@@ -275,5 +275,9 @@
             }
        	]
     },
-    "interfaces": {}
+    "interfaces": {},
+    "asic_sensors": {
+        "poll_interval": "10",
+        "poll_admin_status": "enable"
+    }
 }

--- a/device/nokia/x86_64-nokia_ixr7220_h4-r0/platform.json
+++ b/device/nokia/x86_64-nokia_ixr7220_h4-r0/platform.json
@@ -495,5 +495,9 @@
             }
        	]
     },
-    "interfaces": {}
+    "interfaces": {},
+    "asic_sensors": {
+        "poll_interval": "10",
+        "poll_admin_status": "enable"
+    }
 }

--- a/device/nokia/x86_64-nokia_ixr7220_h4_32d-r0/platform.json
+++ b/device/nokia/x86_64-nokia_ixr7220_h4_32d-r0/platform.json
@@ -447,5 +447,10 @@
             }
        	]
     },
-    "interfaces": {}
+    "interfaces": {},
+
+    "asic_sensors": {
+        "poll_interval": "10",
+        "poll_admin_status": "enable"
+    }
 }

--- a/device/nokia/x86_64-nokia_ixr7220_h5_64d-r0/platform.json
+++ b/device/nokia/x86_64-nokia_ixr7220_h5_64d-r0/platform.json
@@ -460,5 +460,9 @@
             }
        	]
     },
-    "interfaces": {}
+    "interfaces": {},
+    "asic_sensors": {
+        "poll_interval": "10",
+        "poll_admin_status": "enable"
+    }
 }

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform.json
@@ -275,5 +275,9 @@
             }
         ]
     },
-    "interfaces": {}
+    "interfaces": {},
+    "asic_sensors": {
+        "poll_interval": "10",
+        "poll_admin_status": "enable"
+    }
 }


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Enable and use the asic_sensors polling on the Nokia platforms:
  arm64-nokia_ixs7215_52xb-r0
  x86_64-nokia_ixr7220_h4-r0
  x86_64-nokia_ixr7220_h4_32d-r0
  x86_64-nokia_ixr7220_h5_64d-r0
Fixes https://github.com/Nokia-ION/ndk/issues/36

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modify the platform.json files with the below definition no Nokia platforms to enable the asic_sensors polling.
  "asic_sensors": {
      "polling_interval": "10",
      "poll_admin_status": "enable"
   }
This PR works with PR https://github.com/sonic-net/sonic-buildimage/pull/20826

#### How to verify it
execute CLI "show platform temperature". The output will display the asic_sensors temperature.
```
admin@ixre-egl-board25:~$ show platform temperature 
         Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
---------------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
  ASIC0_0--FAB0             47        100        10           100                1      False  20241201 04:06:38
  ASIC0_1--FAB1             46        100        10           100                1      False  20241201 04:06:38
  ASIC0_2--FAB2             47        100        10           100                1      False  20241201 04:06:38
  ASIC0_3--FAB3             48        100        10           100                1      False  20241201 04:06:39
  ASIC0_4--NIF0             47        100        10           100                1      False  20241201 04:06:39
  ASIC0_5--NIF1             47        100        10           100                1      False  20241201 04:06:39
   ASIC0_6--PRM             46        100        10           100                1      False  20241201 04:06:39
  ASIC0_7--EMI0             44        100        10           100                1      False  20241201 04:06:39
  ASIC0_8--EMI1             44        100        10           100                1      False  20241201 04:06:40
 ASIC0_9--DRAM0             39        100        10           100                1      False  20241201 04:06:40
ASIC0_10--DRAM1             40        100        10           100                1      False  20241201 04:06:38
  ASIC1_0--FAB0             49        100        10           100                1      False  20241201 04:06:40
  ASIC1_1--FAB1             49        100        10           100                1      False  20241201 04:06:40
  ASIC1_2--FAB2             49        100        10           100                1      False  20241201 04:06:41
  ASIC1_3--FAB3             48        100        10           100                1      False  20241201 04:06:41
  ASIC1_4--NIF0             51        100        10           100                1      False  20241201 04:06:41
  ASIC1_5--NIF1             51        100        10           100                1      False  20241201 04:06:41
   ASIC1_6--PRM             50        100        10           100                1      False  20241201 04:06:42
  ASIC1_7--EMI0             47        100        10           100                1      False  20241201 04:06:42
  ASIC1_8--EMI1             47        100        10           100                1      False  20241201 04:06:42
 ASIC1_9--DRAM0             45        100        10           100                1      False  20241201 04:06:42
ASIC1_10--DRAM1             43        100        10           100                1      False  20241201 04:06:41
    temp_1(fan)             50        100        10           100                1      False  20241201 04:06:36
    temp_2(fan)             43         78        10            85.8              1      False  20241201 04:06:36
    temp_3(fan)             52         85        10            93.5              1      False  20241201 04:06:36
    temp_4(fan)             51         99        10           100                1      False  20241201 04:06:36
         temp_5             44         85        10            93.5              1      False  20241201 04:06:36
         temp_6             45         85        10            93.5              1      False  20241201 04:06:37
    temp_7(fan)             48        100        10           100                1      False  20241201 04:06:37
    temp_8(fan)             32         68        10            74.8              1      False  20241201 04:06:37
    temp_9(fan)             30         68        10            74.8              1      False  20241201 04:06:37
   temp_10(fan)             38         68        10            74.8              1      False  20241201 04:06:37
   temp_11(fan)             46         99        10           100                1      False  20241201 04:06:38

```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

