### PR TITLE
[dell] S5248F-ON support broadcom common config

### DIFF
--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-25G/td3-s5248f-25g.config.bcm
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-25G/td3-s5248f-25g.config.bcm
@@ -1,3 +1,7 @@
+# Common config will automatically be imported from
+# broadcom/x86_64-broadcom_common/x86_64-broadcom_b87/broadcom-sonic-td3.config.bcm
+# as per https://github.com/sonic-net/SONiC/blob/master/doc/platform/common_config.md
+# due to existence of /usr/share/sonic/platform/common_config_support
 os=unix
 dpp_clock_ratio=2:3
 oversubscribe_mode=1
@@ -20,23 +24,9 @@ l3_alpm_ipv6_128b_bkt_rsvd=1
 l2_mem_entries=40960
 l3_mem_entries=40960
 
-#Tunnels
-bcm_tunnel_term_compatible_mode=1
-use_all_splithorizon_groups=1
-sai_tunnel_support=1
-
 sai_interface_type_auto_detect=0
 
-#RIOT Enable
-riot_enable=1
-riot_overlay_l3_intf_mem_size=8192
-riot_overlay_l3_egress_mem_size=32768
-l3_ecmp_levels=2
-riot_overlay_ecmp_resilient_hash_size=16384
-
-
 stable_size=0x6400000
-
 
 #New Additions
 pfc_deadlock_seq_control=1
@@ -48,7 +38,6 @@ pfc_deadlock_seq_control=1
 pbmp_oversubscribe=0x7f878787f878787f9fe1e1e1fe1e1e1fe
 pbmp_xport_xe=0x7f878787f878787f9fe1e1e1fe1e1e1fe
 oversubscribe_mixed_sister_25_50_enable=1
-ifp_inports_support_enable=1
 port_flex_enable=1
 phy_an_c73=3
 

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/pcie.yaml
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/pcie.yaml
@@ -1,0 +1,141 @@
+- bus: '00'
+  dev: '00'
+  fn: '0'
+  id: '1980'
+  name: 'Host bridge: Intel Corporation Atom Processor C3000 Series System Agent (rev
+    11)'
+- bus: '00'
+  dev: '04'
+  fn: '0'
+  id: 19a1
+  name: 'Host bridge: Intel Corporation Atom Processor C3000 Series Error Registers
+    (rev 11)'
+- bus: '00'
+  dev: '05'
+  fn: '0'
+  id: 19a2
+  name: 'Generic system peripheral [0807]: Intel Corporation Atom Processor C3000
+    Series Root Complex Event Collector (rev 11)'
+- bus: '00'
+  dev: '06'
+  fn: '0'
+  id: 19a3
+  name: 'PCI bridge: Intel Corporation Atom Processor C3000 Series Integrated QAT
+    Root Port (rev 11)'
+- bus: '00'
+  dev: 09
+  fn: '0'
+  id: 19a4
+  name: 'PCI bridge: Intel Corporation Atom Processor C3000 Series PCI Express Root
+    Port #0 (rev 11)'
+- bus: '00'
+  dev: 0b
+  fn: '0'
+  id: 19a6
+  name: 'PCI bridge: Intel Corporation Atom Processor C3000 Series PCI Express Root
+    Port #2 (rev 11)'
+- bus: '00'
+  dev: 0c
+  fn: '0'
+  id: 19a7
+  name: 'PCI bridge: Intel Corporation Atom Processor C3000 Series PCI Express Root
+    Port #3 (rev 11)'
+- bus: '00'
+  dev: 0e
+  fn: '0'
+  id: 19a8
+  name: 'PCI bridge: Intel Corporation Atom Processor C3000 Series PCI Express Root
+    Port #4 (rev 11)'
+- bus: '00'
+  dev: '12'
+  fn: '0'
+  id: 19ac
+  name: 'System peripheral: Intel Corporation Atom Processor C3000 Series SMBus Contoller
+    - Host (rev 11)'
+- bus: '00'
+  dev: '14'
+  fn: '0'
+  id: 19c2
+  name: 'SATA controller: Intel Corporation Atom Processor C3000 Series SATA Controller
+    1 (rev 11)'
+- bus: '00'
+  dev: '15'
+  fn: '0'
+  id: 19d0
+  name: 'USB controller: Intel Corporation Atom Processor C3000 Series USB 3.0 xHCI
+    Controller (rev 11)'
+- bus: '00'
+  dev: '18'
+  fn: '0'
+  id: 19d3
+  name: 'Communication controller: Intel Corporation Atom Processor C3000 Series ME
+    HECI 1 (rev 11)'
+- bus: '00'
+  dev: 1a
+  fn: '0'
+  id: 19d8
+  name: 'Serial controller: Intel Corporation Atom Processor C3000 Series HSUART Controller
+    (rev 11)'
+- bus: '00'
+  dev: 1a
+  fn: '1'
+  id: 19d8
+  name: 'Serial controller: Intel Corporation Atom Processor C3000 Series HSUART Controller
+    (rev 11)'
+- bus: '00'
+  dev: 1a
+  fn: '2'
+  id: 19d8
+  name: 'Serial controller: Intel Corporation Atom Processor C3000 Series HSUART Controller
+    (rev 11)'
+- bus: '00'
+  dev: 1c
+  fn: '0'
+  id: 19db
+  name: 'SD Host controller: Intel Corporation Device 19db (rev 11)'
+- bus: '00'
+  dev: 1f
+  fn: '0'
+  id: 19dc
+  name: 'ISA bridge: Intel Corporation Atom Processor C3000 Series LPC or eSPI (rev
+    11)'
+- bus: '00'
+  dev: 1f
+  fn: '2'
+  id: 19de
+  name: 'Memory controller: Intel Corporation Atom Processor C3000 Series Power Management
+    Controller (rev 11)'
+- bus: '00'
+  dev: 1f
+  fn: '4'
+  id: 19df
+  name: 'SMBus: Intel Corporation Atom Processor C3000 Series SMBus controller (rev
+    11)'
+- bus: '00'
+  dev: 1f
+  fn: '5'
+  id: 19e0
+  name: 'Serial bus controller: Intel Corporation Atom Processor C3000 Series SPI
+    Controller (rev 11)'
+- bus: '01'
+  dev: '00'
+  fn: '0'
+  id: 19e2
+  name: 'Co-processor: Intel Corporation Atom Processor C3000 Series QuickAssist Technology
+    (rev 11)'
+- bus: '02'
+  dev: '00'
+  fn: '0'
+  id: b873
+  name: 'Ethernet controller: Broadcom Inc. and subsidiaries Device b873 (rev 01)'
+- bus: '03'
+  dev: '00'
+  fn: '0'
+  id: '1533'
+  name: 'Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev
+    03)'
+- bus: '04'
+  dev: '00'
+  fn: '0'
+  id: '7021'
+  name: 'Non-VGA unclassified device: Xilinx Corporation Device 7021'


### PR DESCRIPTION
#### Why I did it

As per #20802 broadcom provides a common configuration for silicon- wide application configuration settings.  More details can be found here: https://github.com/sonic-net/SONiC/blob/master/doc/platform/common_config.md

Broadcom also updated the common configuration files in #20802 which contains a lot of settings that are otherwise not included in the Dell S5248F platform config.

There is also an error message on the platform at boot:
```
2024 Dec  1 20:16:42.639522 sw2 NOTICE root: /usr/bin/pcie-check.sh : pcie.yaml does not exist! Can't check PCIe status!
```

##### Work item tracking

#### How I did it

This commit creates the "dummy" `common_config_support` as required to load the common configuration, as well as removes any duplicate entries.

This also adds the missing `pcie.yaml` file generated via `pcieutil generate` which corrects the error in the log.

#### How to verify it

Boot on switch and verify everything still works and error message is gone in logs.

#### Which release branch to backport (provide reason below if selected)

None, master only.

#### Tested branch (Please provide the tested image version)

master as of 20241201

#### Description for the changelog

[dell] S5248F-ON support broadcom common config

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)

Signed-off-by: Brad House (@bradh352)
