### PR TITLE
[Mellanox] Update buffer calculations for Mellanox-SN5600-C224O8 SKU

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/buffers_defaults_t0.j2
@@ -17,7 +17,7 @@
 #}
 {% set default_cable = '40m' %}
 {% set ingress_lossless_pool_size =  '113722268' %}
-{% set ingress_lossless_pool_xoff =  '19062784' %}
+{% set ingress_lossless_pool_xoff =  '1024' %}
 {% set egress_lossless_pool_size =  '158229504' %}
 {% set egress_lossy_pool_size =  '113722268' %}
 

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/buffers_defaults_t0.j2
@@ -16,10 +16,10 @@
     limitations under the License.
 #}
 {% set default_cable = '40m' %}
-{% set ingress_lossless_pool_size =  '113722268' %}
+{% set ingress_lossless_pool_size =  '144188416' %}
 {% set ingress_lossless_pool_xoff =  '1024' %}
 {% set egress_lossless_pool_size =  '158229504' %}
-{% set egress_lossy_pool_size =  '113722268' %}
+{% set egress_lossy_pool_size =  '144188416' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/buffers_defaults_t1.j2
@@ -16,10 +16,10 @@
     limitations under the License.
 #}
 {% set default_cable = '250m' %}
-{% set ingress_lossless_pool_size =  '113722368' %}
-{% set ingress_lossless_pool_xoff =  '19062784' %}
+{% set ingress_lossless_pool_size =  '144188416' %}
+{% set ingress_lossless_pool_xoff =  '1024' %}
 {% set egress_lossless_pool_size =  '158229504' %}
-{% set egress_lossy_pool_size =  '113722368' %}
+{% set egress_lossy_pool_size =  '144188416' %}
 
 {%-set ports2cable = {
             'torrouter_server'       : '40m',


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Update buffer calculations for Mellanox-SN5600-C224O8 HwSKU.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update the lossless pull size

#### How to verify it
Run sonic-mgmt QoS test

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

