### PR TITLE
Delay eventd service start

### DIFF
--- a/files/build_templates/eventd.service.j2
+++ b/files/build_templates/eventd.service.j2
@@ -1,7 +1,8 @@
 [Unit]
 Description=EVENTD container
-Requires=config-setup.service
-After=config-setup.service
+Requires=database.service config-setup.service
+After=database.service config-setup.service swss.service syncd.service rsyslog-config.service
+Before=telemetry.service
 BindsTo=sonic.target
 After=sonic.target
 StartLimitIntervalSec=1200


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fixes issue #20544 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Required that eventd service requires database.service, config-setup.service.
Delay eventd service start after required services, rsyslog-config.service, and dataplane impacting services like syncd and swss.

rsyslog-config.service overrides rsyslog.conf and restarts so we need to make sure that eventd is not restarting rsyslog. To avoid this, we stagger eventd.service after rsyslog-config.service.

To avoid impacting any dataplane services like syncd, swss we will delay eventd till after crucial services are brought up.

We will prioritize eventd over telemetry service because telemetry service uses paths EVENTS which is populated by eventd service.

#### How to verify it


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

