### PR TITLE
[yang] Add yang model for POE_PORT

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -67,6 +67,7 @@
   * [Port Channel](#port-channel)
   * [Portchannel member](#portchannel-member)
   * [SAG](#sag)
+  * [PoE Port](#poe-port)
   * [Scheduler](#scheduler)
   * [Port QoS Map](#port-qos-map)
   * [Queue](#queue)
@@ -2341,6 +2342,23 @@ The SAG table defines the global MAC address configuration for static-anycast-ga
 "SAG": {
     "GLOBAL": {
         "gateway_mac": "00:11:22:33:44:55"
+    }
+  }
+}
+```
+
+### PoE Port
+
+This table stores PoE port configuration. The interface name
+is used as the key.
+
+```
+{
+  "POE_PORT": {
+    "Ethernet0": {
+      "enabled": "enable",
+      "pwr_limit": "50.0",
+      "priority": "high"
     }
   }
 }

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -174,6 +174,7 @@ yang_files = [
     'sonic-policer.yang',
     'sonic-port-qos-map.yang',
     'sonic-port.yang',
+    'sonic-poe.yang',
     'sonic-portchannel.yang',
     'sonic-queue.yang',
     'sonic-restapi.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1104,6 +1104,48 @@
                 "LOGOUTPUT": "SYSLOG"
             }
         },
+        "POE_PORT": {
+            "Ethernet0": {
+                "enabled": "enable",
+                "pwr_limit": "50.0",
+                "priority": "high"
+            },
+            "Ethernet1": {
+                "enabled": "enable",
+                "pwr_limit": "50.0",
+                "priority": "high"
+            },
+            "Ethernet2": {
+                "enabled": "enable",
+                "pwr_limit": "50.0",
+                "priority": "high"
+            },
+            "Ethernet3": {
+                "enabled": "enable",
+                "pwr_limit": "50.0",
+                "priority": "high"
+            },
+            "Ethernet4": {
+                "enabled": "enable",
+                "pwr_limit": "50.0",
+                "priority": "high"
+            },
+            "Ethernet5": {
+                "enabled": "enable",
+                "pwr_limit": "50.0",
+                "priority": "high"
+            },
+            "Ethernet6": {
+                "enabled": "enable",
+                "pwr_limit": "50.0",
+                "priority": "high"
+            },
+            "Ethernet7": {
+                "enabled": "enable",
+                "pwr_limit": "50.0",
+                "priority": "crit"
+            }
+        },
         "ACL_TABLE": {
             "V4-ACL-TABLE": {
                 "type": "L3",

--- a/src/sonic-yang-models/tests/yang_model_pytests/test_poe_port.py
+++ b/src/sonic-yang-models/tests/yang_model_pytests/test_poe_port.py
@@ -1,0 +1,116 @@
+import pytest
+
+
+class TestPoePort:
+
+    def test_valid_data(self, yang_model):
+        data = {
+            "sonic-port:sonic-port": {
+                "sonic-port:PORT": {
+                    "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                    ]
+                }
+            },
+            "sonic-poe:sonic-poe": {
+                "sonic-poe:POE_PORT": {
+                    "POE_PORT_LIST": [
+                        {
+                            "ifname": "Ethernet0",
+                            "enabled": "enable",
+                            "pwr_limit": "50",
+                            "priority": "high"
+                        }
+                    ]
+                }
+            }
+        }
+
+        yang_model.load_data(data)
+
+    @pytest.mark.parametrize(
+        "enabled, error_message", [
+            ("enable", None),
+            ("disable", None),
+            ("xyz", "xyz")]
+        )
+    def test_enabled_field(self, yang_model, enabled, error_message):
+        data = {
+            "sonic-port:sonic-port": {
+                "sonic-port:PORT": {
+                    "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                    ]
+                }
+            },
+            "sonic-poe:sonic-poe": {
+                "sonic-poe:POE_PORT": {
+                    "POE_PORT_LIST": [
+                        {
+                            "ifname": "Ethernet0",
+                            "enabled": enabled,
+                            "pwr_limit": "50",
+                            "priority": "high"
+                        }
+                    ]
+                }
+            }
+        }
+
+        yang_model.load_data(data, error_message)
+
+    @pytest.mark.parametrize(
+        "priority, error_message", [
+            ("low", None),
+            ("high", None),
+            ("crit", None),
+            ("xyz", "xyz")]
+        )
+    def test_priority_field(self, yang_model, priority, error_message):
+        data = {
+            "sonic-port:sonic-port": {
+                "sonic-port:PORT": {
+                    "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                    ]
+                }
+            },
+            "sonic-poe:sonic-poe": {
+                "sonic-poe:POE_PORT": {
+                    "POE_PORT_LIST": [
+                        {
+                            "ifname": "Ethernet0",
+                            "enabled": "enable",
+                            "pwr_limit": "50",
+                            "priority": priority
+                        }
+                    ]
+                }
+            }
+        }
+
+        yang_model.load_data(data, error_message)

--- a/src/sonic-yang-models/yang-models/sonic-poe.yang
+++ b/src/sonic-yang-models/yang-models/sonic-poe.yang
@@ -1,0 +1,77 @@
+module sonic-poe {
+    yang-version 1.1;
+
+    namespace "http://github.com/sonic-net/sonic-poe";
+
+    prefix poe;
+
+    import sonic-types {
+        prefix stypes;
+    }
+
+    import sonic-port {
+        prefix port;
+    }
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "PoE YANG Module for SONiC OS";
+
+    revision 2024-06-13 {
+        description
+            "First Revision";
+    }
+
+    container sonic-poe {
+
+        container POE_PORT {
+
+            description "Power over Ethernet configuration (POE_PORT table in config_db.json)";
+
+            typedef poe-priority {
+
+                type enumeration {
+                    enum crit;
+                    enum high;
+                    enum low;
+                }
+            }
+
+            list POE_PORT_LIST {
+                key "ifname";
+                leaf ifname {
+                    type leafref {
+                        path /port:sonic-port/port:PORT/port:PORT_LIST/port:name;
+                    }
+                    description "Interface name from the PORT table in config_db.json";
+                }
+                leaf enabled {
+                    type stypes:mode-status;
+                    default disable;
+                    description "PoE status on port. [enable/disable]";
+                }
+                leaf pwr_limit {
+                    mandatory true;
+                    type string {
+                        length 1..255;
+                    }
+                    description "Power limit on PoE port. [0..999]";
+                }
+                leaf priority {
+                    type poe-priority;
+                    default high;
+                    description "Port priority level. [crit/high/low]";
+                }
+            }
+            /* end of POE_PORT_LIST */
+        }
+        /* end of container POE_PORT */
+    }
+    /* end of top-level container sonic-poe */
+}
+/* end of module sonic-poe */


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

POE_PORT yang model is required for PoE CLI validation

HLD: https://github.com/sonic-net/SONiC/pull/1631

Related PRs:
- https://github.com/sonic-net/sonic-buildimage/pull/19636
- https://github.com/sonic-net/sonic-utilities/pull/3436

##### Work item tracking

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

