### PR TITLE
Exclude PIE ports from buffer and qos config

### DIFF
--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -115,6 +115,7 @@ def
 {%- set PORT_BP  = [] %}
 {%- set PORT_DPC  = [] %}
 {%- set SYSTEM_PORT_ALL = [] %}
+{%- set PORT_PIE = [] %}
 
 {%- if voq_chassis %}
     {%- for system_port in SYSTEM_PORT %}
@@ -144,6 +145,9 @@ def
     {%- if defs.generate_bp_port_list is defined %}
         {%- if defs.generate_bp_port_list(PORT,PORT_BP) %} {% endif %}
     {%- endif %}
+    {%- if defs.generate_pie_port_list is defined %}
+        {%- if defs.generate_pie_port_list(PORT_PIE) %} {% endif %}
+    {%- endif %}
 {%- endif %}
 
 {%- set PORT_ACTIVE  = [] %}
@@ -166,6 +170,7 @@ def
         {%- endif %}
     {%- endfor %}
 {%- endif %}
+{%- set PORT_ACTIVE = PORT_ACTIVE | reject('in', PORT_PIE) | list %}
 
 {%- set port_names_list_active  = [] %}
 {%- for port in PORT_ACTIVE %}

--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -115,7 +115,7 @@ def
 {%- set PORT_BP  = [] %}
 {%- set PORT_DPC  = [] %}
 {%- set SYSTEM_PORT_ALL = [] %}
-{%- set PORT_PIE = [] %}
+{%- set PORT_QOS_BYPASS = [] %}
 
 {%- if voq_chassis %}
     {%- for system_port in SYSTEM_PORT %}
@@ -145,8 +145,8 @@ def
     {%- if defs.generate_bp_port_list is defined %}
         {%- if defs.generate_bp_port_list(PORT,PORT_BP) %} {% endif %}
     {%- endif %}
-    {%- if defs.generate_pie_port_list is defined %}
-        {%- if defs.generate_pie_port_list(PORT_PIE) %} {% endif %}
+    {%- if defs.generate_qos_bypass_port_list is defined %}
+        {%- if defs.generate_qos_bypass_port_list(PORT_QOS_BYPASS) %} {% endif %}
     {%- endif %}
 {%- endif %}
 
@@ -170,7 +170,7 @@ def
         {%- endif %}
     {%- endfor %}
 {%- endif %}
-{%- set PORT_ACTIVE = PORT_ACTIVE | reject('in', PORT_PIE) | list %}
+{%- set PORT_ACTIVE = PORT_ACTIVE | reject('in', PORT_QOS_BYPASS) | list %}
 
 {%- set port_names_list_active  = [] %}
 {%- for port in PORT_ACTIVE %}

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -2,6 +2,7 @@
 {%- set PORT_BP = [] %}
 {%- set PORT_DPC  = [] %}
 {%- set SYSTEM_PORT_ALL = [] %}
+{%- set PORT_PIE = [] %}
 
 {%- set voq_chassis = false %}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost']['switch_type'] is defined and  DEVICE_METADATA['localhost']['switch_type']  == 'voq' %}
@@ -31,6 +32,9 @@
 {%- if generate_bp_port_list is defined %}
     {%- if generate_bp_port_list(PORT,PORT_BP) %} {% endif %}
 {%- endif %}
+{%- if generate_pie_port_list is defined %}
+    {%- if generate_pie_port_list(PORT_PIE) %} {% endif %}
+{%- endif %}
 
 {%- if PORT_ALL | sort_by_port_index %}{% endif %}
 
@@ -55,6 +59,7 @@
         {%- if PORT_ACTIVE.append(port) %}{%- endif %}
     {%- endfor %}
 {%- endif %}
+{%- set PORT_ACTIVE = PORT_ACTIVE | reject('in', PORT_PIE) | list %}
 {%- if PORT_ACTIVE | sort_by_port_index %}{% endif %}
 
 {%- set port_names_list_active = [] %}

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -2,7 +2,7 @@
 {%- set PORT_BP = [] %}
 {%- set PORT_DPC  = [] %}
 {%- set SYSTEM_PORT_ALL = [] %}
-{%- set PORT_PIE = [] %}
+{%- set PORT_QOS_BYPASS = [] %}
 
 {%- set voq_chassis = false %}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost']['switch_type'] is defined and  DEVICE_METADATA['localhost']['switch_type']  == 'voq' %}
@@ -32,8 +32,8 @@
 {%- if generate_bp_port_list is defined %}
     {%- if generate_bp_port_list(PORT,PORT_BP) %} {% endif %}
 {%- endif %}
-{%- if generate_pie_port_list is defined %}
-    {%- if generate_pie_port_list(PORT_PIE) %} {% endif %}
+{%- if generate_qos_bypass_port_list is defined %}
+    {%- if generate_qos_bypass_port_list(PORT_QOS_BYPASS) %} {% endif %}
 {%- endif %}
 
 {%- if PORT_ALL | sort_by_port_index %}{% endif %}
@@ -59,7 +59,7 @@
         {%- if PORT_ACTIVE.append(port) %}{%- endif %}
     {%- endfor %}
 {%- endif %}
-{%- set PORT_ACTIVE = PORT_ACTIVE | reject('in', PORT_PIE) | list %}
+{%- set PORT_ACTIVE = PORT_ACTIVE | reject('in', PORT_QOS_BYPASS) | list %}
 {%- if PORT_ACTIVE | sort_by_port_index %}{% endif %}
 
 {%- set port_names_list_active = [] %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
PIE ports are used for internal traffic (telemetry), not for regular data traffic, doesn't support buffer or qos config.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Exclude PIE ports from PORTS_ACTIVE.

#### How to verify it
config load_minigraph.
```
cisco@ixia-light-dut:/usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-O64$ sudo config load_minigraph 
Reload config from minigraph? [y/N]: y
Acquired lock on /etc/sonic/reload.lock
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
Warning: mirror table EVERFLOW in ACL_TABLE does not have any ports bound to it
Warning: mirror table EVERFLOWV6 in ACL_TABLE does not have any ports bound to it
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Running command: config qos reload --no-dynamic-buffer --no-delay
Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-O64/buffers.json.j2,/tmp/cfg_buffer.json -t /usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-O64/qos.json.j2,/tmp/cfg_qos.json -y /etc/sonic/sonic_version.yml
Running command: /usr/local/bin/sonic-cfggen -j /tmp/cfg_buffer.json -j /tmp/cfg_qos.json --write-to-db
Warning: mirror table EVERFLOW in ACL_TABLE does not have any ports bound to it
Warning: mirror table EVERFLOWV6 in ACL_TABLE does not have any ports bound to it
Running command: pfcwd start_default
Warning: mirror table EVERFLOW in ACL_TABLE does not have any ports bound to it
Warning: mirror table EVERFLOWV6 in ACL_TABLE does not have any ports bound to it
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon
Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
Released lock on /etc/sonic/reload.lock
cisco@ixia-light-dut:/usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-O64$ show interface status
  Interface                                    Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                                             Type    Asym PFC
-----------  ---------------------------------------  -------  -----  -----  -------  ------  ------  -------  -----------------------------------------------  ----------
  Ethernet0  1536,1537,1538,1539,1540,1541,1542,1543     400G   9100    N/A     etp0  routed    down     down  QSFP-DD Double Density 8X Pluggable Transceiver         off
  Ethernet8  1544,1545,1546,1547,1548,1549,1550,1551     400G   9100    N/A     etp1  routed    down     down                                              N/A         off
 Ethernet16  1560,1561,1562,1563,1564,1565,1566,1567     400G   9100    N/A     etp2  routed    down     down  QSFP-DD Double Density 8X Pluggable Transceiver         off
 Ethernet24  1552,1553,1554,1555,1556,1557,1558,1559     400G   9100    N/A     etp3  routed    down     down                                              N/A         off
 Ethernet32  1792,1793,1794,1795,1796,1797,1798,1799     400G   9100    N/A     etp4  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
 Ethernet40  1800,1801,1802,1803,1804,1805,1806,1807     400G   9100    N/A     etp5  routed    down     down                                              N/A         off
 Ethernet48  1816,1817,1818,1819,1820,1821,1822,1823     400G   9100    N/A     etp6  routed    down     down                                              N/A         off
 Ethernet56  1808,1809,1810,1811,1812,1813,1814,1815     400G   9100    N/A     etp7  routed    down     down                                              N/A         off
 Ethernet64  1288,1289,1290,1291,1292,1293,1294,1295     400G   9100    N/A     etp8  routed    down     down                                              N/A         off
 Ethernet72  1280,1281,1282,1283,1284,1285,1286,1287     400G   9100    N/A     etp9  routed    down     down                                              N/A         off
 Ethernet80  1296,1297,1298,1299,1300,1301,1302,1303     400G   9100    N/A    etp10  routed    down     down                                              N/A         off
 Ethernet88  1304,1305,1306,1307,1308,1309,1310,1311     400G   9100    N/A    etp11  routed    down     down                                              N/A         off
 Ethernet96  1024,1025,1026,1027,1028,1029,1030,1031     400G   9100    N/A    etp12  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
Ethernet104  1032,1033,1034,1035,1036,1037,1038,1039     400G   9100    N/A    etp13  routed    down     down                                              N/A         off
Ethernet112  1040,1041,1042,1043,1044,1045,1046,1047     400G   9100    N/A    etp14  routed    down     down                                              N/A         off
Ethernet120  1048,1049,1050,1051,1052,1053,1054,1055     400G   9100    N/A    etp15  routed    down     down                                              N/A         off
Ethernet128          536,537,538,539,540,541,542,543     400G   9100    N/A    etp16  routed    down     down                                              N/A         off
Ethernet136          528,529,530,531,532,533,534,535     400G   9100    N/A    etp17  routed    down     down                                              N/A         off
Ethernet144          520,521,522,523,524,525,526,527     400G   9100    N/A    etp18  routed    down     down                                              N/A         off
Ethernet152          512,513,514,515,516,517,518,519     400G   9100    N/A    etp19  routed    down     down                                              N/A         off
Ethernet160          792,793,794,795,796,797,798,799     400G   9100    N/A    etp20  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
Ethernet168          784,785,786,787,788,789,790,791     400G   9100    N/A    etp21  routed    down     down                                              N/A         off
Ethernet176          776,777,778,779,780,781,782,783     400G   9100    N/A    etp22  routed    down     down                                              N/A         off
Ethernet184          768,769,770,771,772,773,774,775     400G   9100    N/A    etp23  routed    down     down                                              N/A         off
Ethernet192          256,257,258,259,260,261,262,263     400G   9100    N/A    etp24  routed    down     down                                              N/A         off
Ethernet200          264,265,266,267,268,269,270,271     400G   9100    N/A    etp25  routed    down     down                                              N/A         off
Ethernet208          272,273,274,275,276,277,278,279     400G   9100    N/A    etp26  routed    down     down                                              N/A         off
Ethernet216          280,281,282,283,284,285,286,287     400G   9100    N/A    etp27  routed    down     down                                              N/A         off
Ethernet224                          0,1,2,3,4,5,6,7     400G   9100    N/A    etp28  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
Ethernet232                    8,9,10,11,12,13,14,15     400G   9100    N/A    etp29  routed    down     down                                              N/A         off
Ethernet240                  16,17,18,19,20,21,22,23     400G   9100    N/A    etp30  routed    down     down                                              N/A         off
Ethernet248                  24,25,26,27,28,29,30,31     400G   9100    N/A    etp31  routed    down     down                                              N/A         off
Ethernet256  3600,3601,3602,3603,3604,3605,3606,3607     400G   9100    N/A    etp32  routed    down     down                                              N/A         off
Ethernet264  3608,3609,3610,3611,3612,3613,3614,3615     400G   9100    N/A    etp33  routed    down     down                                              N/A         off
Ethernet272  3584,3585,3586,3587,3588,3589,3590,3591     400G   9100    N/A    etp34  routed    down     down                                              N/A         off
Ethernet280  3592,3593,3594,3595,3596,3597,3598,3599     400G   9100    N/A    etp35  routed    down     down                                              N/A         off
Ethernet288  3856,3857,3858,3859,3860,3861,3862,3863     400G   9100    N/A    etp36  routed    down     down                                              N/A         off
Ethernet296  3864,3865,3866,3867,3868,3869,3870,3871     400G   9100    N/A    etp37  routed    down     down                                              N/A         off
Ethernet304  3840,3841,3842,3843,3844,3845,3846,3847     400G   9100    N/A    etp38  routed    down     down                                              N/A         off
Ethernet312  3848,3849,3850,3851,3852,3853,3854,3855     400G   9100    N/A    etp39  routed    down     down                                              N/A         off
Ethernet320  3352,3353,3354,3355,3356,3357,3358,3359     400G   9100    N/A    etp40  routed    down     down                                              N/A         off
Ethernet328  3344,3345,3346,3347,3348,3349,3350,3351     400G   9100    N/A    etp41  routed    down     down                                              N/A         off
Ethernet336  3328,3329,3330,3331,3332,3333,3334,3335     400G   9100    N/A    etp42  routed    down     down                                              N/A         off
Ethernet344  3336,3337,3338,3339,3340,3341,3342,3343     400G   9100    N/A    etp43  routed    down     down                                              N/A         off
Ethernet352  3096,3097,3098,3099,3100,3101,3102,3103     400G   9100    N/A    etp44  routed    down     down                                              N/A         off
Ethernet360  3088,3089,3090,3091,3092,3093,3094,3095     400G   9100    N/A    etp45  routed    down     down                                              N/A         off
Ethernet368  3080,3081,3082,3083,3084,3085,3086,3087     400G   9100    N/A    etp46  routed    down     down                                              N/A         off
Ethernet376  3072,3073,3074,3075,3076,3077,3078,3079     400G   9100    N/A    etp47  routed    down     down                                              N/A         off
Ethernet384  2560,2561,2562,2563,2564,2565,2566,2567     400G   9100    N/A    etp48  routed    down     down                                              N/A         off
Ethernet392  2568,2569,2570,2571,2572,2573,2574,2575     400G   9100    N/A    etp49  routed    down     down                                              N/A         off
Ethernet400  2576,2577,2578,2579,2580,2581,2582,2583     400G   9100    N/A    etp50  routed    down     down                                              N/A         off
Ethernet408  2584,2585,2586,2587,2588,2589,2590,2591     400G   9100    N/A    etp51  routed    down     down                                              N/A         off
Ethernet416  2816,2817,2818,2819,2820,2821,2822,2823     400G   9100    N/A    etp52  routed    down     down                                              N/A         off
Ethernet424  2824,2825,2826,2827,2828,2829,2830,2831     400G   9100    N/A    etp53  routed    down     down                                              N/A         off
Ethernet432  2832,2833,2834,2835,2836,2837,2838,2839     400G   9100    N/A    etp54  routed    down     down                                              N/A         off
Ethernet440  2840,2841,2842,2843,2844,2845,2846,2847     400G   9100    N/A    etp55  routed    down     down                                              N/A         off
Ethernet448  2304,2305,2306,2307,2308,2309,2310,2311     400G   9100    N/A    etp56  routed    down     down                                              N/A         off
Ethernet456  2312,2313,2314,2315,2316,2317,2318,2319     400G   9100    N/A    etp57  routed    down     down                                              N/A         off
Ethernet464  2328,2329,2330,2331,2332,2333,2334,2335     400G   9100    N/A    etp58  routed    down     down                                              N/A         off
Ethernet472  2320,2321,2322,2323,2324,2325,2326,2327     400G   9100    N/A    etp59  routed    down     down                                              N/A         off
Ethernet480  2048,2049,2050,2051,2052,2053,2054,2055     400G   9100    N/A    etp60  routed    down     down                                              N/A         off
Ethernet488  2056,2057,2058,2059,2060,2061,2062,2063     400G   9100    N/A    etp61  routed    down     down                                              N/A         off
Ethernet496  2072,2073,2074,2075,2076,2077,2078,2079     400G   9100    N/A    etp62  routed    down     down                                              N/A         off
Ethernet504  2064,2065,2066,2067,2068,2069,2070,2071     400G   9100    N/A    etp63  routed    down     down                                              N/A         off
Ethernet512                                    65520      10G   9100    N/A    etp64  routed    down     down                                              N/A         N/A
Ethernet513                                    65521      10G   9100    N/A    etp65  routed    down     down                                              N/A         N/A
cisco@ixia-light-dut:/usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-O64$ docker exec -it database redis-cli
127.0.0.1:6379> select 4
OK
127.0.0.1:6379[4]> keys *Ethernet512*
1) "PORT|Ethernet512"
127.0.0.1:6379[4]> hgetall PORT|Ethernet512
 1) "alias"
 2) "etp64"
 3) "description"
 4) "etp64"
 5) "index"
 6) "64"
 7) "lanes"
 8) "65520"
 9) "mtu"
10) "9100"
11) "speed"
12) "10000"
13) "subport"
14) "0"
15) "tpid"
16) "0x8100"
127.0.0.1:6379[4]> exit
cisco@ixia-light-dut:/usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-O64$ 
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

