### PR TITLE
[nvidia-bluefield] Remove the virtual smart switch leftovers.

### DIFF
--- a/platform/nvidia-bluefield/bluefield-platform-modules/bin/bfnet.sh
+++ b/platform/nvidia-bluefield/bluefield-platform-modules/bin/bfnet.sh
@@ -17,25 +17,6 @@
 #
 
 pci_iface=eth0-midplane
-cp_iface=Ethernet0
-pidfile=/run/dhcl-internal.$cp_iface.pid
-leasefile=/var/lib/dhcp/dhcl-internal.$cp_iface.leases
-
-stop_cp_dhclient()
-{
-    if [[ -f $pidfile ]]; then
-        kill $(cat $pidfile)
-	rm -f $pidfile
-    fi
-    rm -f $leasefile
-}
-
-start_cp_dhclient()
-{
-    stop_cp_dhclient
-
-    /sbin/dhclient -pf $pidfile -lf $leasefile $cp_iface -nw
-}
 
 start()
 {
@@ -46,17 +27,10 @@ start()
     if [[ $? != "0" ]]; then
         exit 1
     fi
-
-    hwsku=$(sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]')
-    if [[ $hwsku == *"-C1" ]]; then
-        start_cp_dhclient
-    fi
 }
 
 stop()
 {
-    stop_cp_dhclient
-
     /usr/bin/mst stop
     rmmod mlx5_ib mlx5_core
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Remove the virtual smart switch leftovers from the Nvidia DPU initialization flow. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Remove unused code from the bash script.

#### How to verify it
Run sonic-mgmt tests.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

