### PR TITLE
[frr/bgpd] fix frr VXLAN EVPN configuration for unified config

### DIFF
--- a/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
+++ b/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
@@ -10,9 +10,18 @@
 !
 agentx
 !
-！Add fpm address for zebra
+{% if ( ('localhost' in DEVICE_METADATA) and ('nexthop_group' in  DEVICE_METADATA['localhost']) and
+        (DEVICE_METADATA['localhost']['nexthop_group'] == 'enabled') ) %}
+! enable next hop group support
+fpm use-next-hop-groups
+{% else %}
+! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
+no fpm use-next-hop-groups
+{% endif %}
+!
+! Add fpm address for zebra
 fpm address 127.0.0.1
-！
+!
 {% include "zebra/zebra.interfaces.conf.j2" %}
 !
 {% if MGMT_VRF_CONFIG %}


### PR DESCRIPTION
#### Why I did it
During debugging of VXLAN EVPN using unified vs split configuration, the same BGP configuration is made with one exception, the setting of `no fpm use-next-hop-groups` which is forcibly set for all FRR instances.

This change was introduced in PR #12852 when switching to the new fpm dataplane plugin.

When running `vtysh -c "config" -c "no fpm use-next-hop-groups"` it can be seen the VTEP immediately comes online and traffic flows as expected.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

This adds the option as is present in dockers/docker-fpm-frr/frr/zebra/zebra.conf.j2 controlled by the DEVICE_METADATA nexthop_group option.

#### How to verify it

See #21034 for details

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [X] 202305
- [X] 202311
- [X] 202405
- [X] 202411

#### Tested branch (Please provide the tested image version)

master as of 20241205

#### Description for the changelog
[frr/bgpd] fix frr VXLAN EVPN configuration for unified config

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)

Fixes #21034 
Signed-off-by: Brad House (@bradh352)
