### PR TITLE
[yang] frr-mgmt-framework: admin_status should be up/down but wants true/false

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1843,7 +1843,7 @@ class BGPConfigDaemon:
     cmn_key_map = [('asn&peer_type',                        '{no:no-prefix}neighbor {} remote-as {}'),
                    (['local_asn', '+local_as_no_prepend',
                      '+local_as_replace_as'],               '{no:no-prefix}neighbor {} local-as {} {:no-prepend} {:replace-as}'),
-                   (['admin_status', '+shutdown_message'],  '{no:no-prefix}neighbor {} shutdown {:shutdown-msg}', ['false', 'true']),
+                   (['admin_status', '+shutdown_message'],  '{no:no-prefix}neighbor {} shutdown {:shutdown-msg}', ['down', 'up']),
                    ('local_addr',                           '{no:no-prefix}neighbor {} update-source {}'),
                    ('name',                                 '{no:no-prefix}neighbor {} description {}'),
                    (['ebgp_multihop', '+ebgp_multihop_ttl'],'{no:no-prefix}neighbor {} ebgp-multihop {}', ['true', 'false']),
@@ -1870,9 +1870,9 @@ class BGPConfigDaemon:
     nbr_key_map = [('peer_group_name',  '{no:no-prefix}neighbor {} peer-group {}')]
 
     nbr_af_key_map = [(['allow_as_in', '+allow_as_count&allow_as_origin'],  '{no:no-prefix}neighbor {} allowas-in {:allow-as-in}', ['true', 'false']),
-                      ('admin_status|ipv4',                                 '{no:no-prefix}neighbor {} activate', ['true', 'false', False]),
-                      ('admin_status|ipv6',                                 '{no:no-prefix}neighbor {} activate', ['true', 'false', False]),
-                      ('admin_status|l2vpn',                                '{no:no-prefix}neighbor {} activate', ['true', 'false', False]),
+                      ('admin_status|ipv4',                                 '{no:no-prefix}neighbor {} activate', ['up', 'down', False]),
+                      ('admin_status|ipv6',                                 '{no:no-prefix}neighbor {} activate', ['up', 'down', False]),
+                      ('admin_status|l2vpn',                                '{no:no-prefix}neighbor {} activate', ['up', 'down', False]),
                       (['send_default_route', '+default_rmap'],             '{no:no-prefix}neighbor {} default-originate {:default-rmap}', ['true', 'false']),
                       ('default_rmap',                                      '{no:no-prefix}neighbor {} default-originate route-map {}'),
                       (['max_prefix_limit', '++max_prefix_warning_threshold',

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_af.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_af.j2
@@ -2,7 +2,7 @@
 {# this is called with the "vrf" and "address-family matched    #}
 {# ------------------------------------------------------------ #}
 {% if 'admin_status' in n_af_val %}
-{% if n_af_val['admin_status'] == 'true' %}
+{% if n_af_val['admin_status'] == 'up' or n_af_val['admin_status'] == 'true' %}
   neighbor {{nbr_name}} activate
 {% else %}
   no neighbor {{nbr_name}} activate

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_or_peer.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_or_peer.j2
@@ -30,7 +30,7 @@
 {% if 'name' in nbr_or_peer %}
  neighbor {{name_or_ip}} description {{nbr_or_peer['name']}}
 {% endif %}
-{% if 'admin_status' in nbr_or_peer and nbr_or_peer['admin_status'] == 'false' %}
+{% if 'admin_status' in nbr_or_peer and (nbr_or_peer['admin_status'] == 'down' or nbr_or_peer['admin_status'] == 'false') %}
 {% if 'shutdown_message' in nbr_or_peer %}
  neighbor {{name_or_ip}} shutdown message {{nbr_or_peer['shutdown_message']}}
 {% else %}


### PR DESCRIPTION
#### Why I did it

YANG uses `stypes:admin_status;` instead of `boolean` here:
https://github.com/sonic-net/sonic-buildimage/blob/f7014a3cbab56d1c7e1d0f078565378b2684085a/src/sonic-yang-models/yang-models/sonic-bgp-common.yang#L320-L323
https://github.com/sonic-net/sonic-buildimage/blob/f7014a3cbab56d1c7e1d0f078565378b2684085a/src/sonic-yang-models/yang-models/sonic-bgp-common.yang#L344-L347
https://github.com/sonic-net/sonic-buildimage/blob/f7014a3cbab56d1c7e1d0f078565378b2684085a/src/sonic-yang-models/yang-models/sonic-bgp-common.yang#L576-L579

But the code expects `true/false` as seen in:
https://github.com/sonic-net/sonic-buildimage/blob/8e0f1c66b1d49463b984b18dd417ec37fb5af24a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_af.j2#L5-L9
and
https://github.com/sonic-net/sonic-buildimage/blob/8e0f1c66b1d49463b984b18dd417ec37fb5af24a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_or_peer.j2#L33-L38
and also relied upon in
https://github.com/sonic-net/sonic-buildimage/blob/b25a06fbb5acfc2a6b8c27d10d24d2aba6745495/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py#L1873-L1875

Test cases not only in sonic-frr-mgmt-framework, but also externally such as minigraph conversions all expect up/down.  Also for consistency admin_state in other areas of sonic  such as INTERFACES all use up/down for admin_status.

true/false compatibility was left in jinja2 in case someone is using that functionality without yang validation.

##### Work item tracking

#### How I did it

Modified the jinja2 templates and python code.

#### How to verify it


#### Which release branch to backport (provide reason below if selected)

- [x] 202411

#### Tested branch (Please provide the tested image version)

master as of 20241205

#### Description for the changelog
[yang] frr-mgmt-framework: admin_status should be up/down but wants true/false

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)
Signed-off-by: Brad House (@bradh352)

