### PR TITLE
[nvidia-bluefield] Extend platform dump.

### DIFF
--- a/platform/nvidia-bluefield/bluefield-platform-modules/bin/platform-dump.sh
+++ b/platform/nvidia-bluefield/bluefield-platform-modules/bin/platform-dump.sh
@@ -49,5 +49,13 @@ dump_cmd "lspci -vvv" "lspci" "5"
 dump_cmd "top -SHb -n 1 | tail -n +8 | sort -nrk 11" "top" "5"
 dump_cmd "tail /sys/kernel/debug/mlxbf-ptm/monitors/status/*" "mlxbf-ptm-dump" "3"
 
+pushd /dev/mst/
+mstdevs=$(ls mt*)
+popd
+
+for mstdev in $mstdevs; do
+	dump_cmd "mstdump -full /dev/mst/$mstdev" "mstdump_$mstdev" "20"
+done
+
 tar czf /tmp/platform-dump.tar.gz -C $DUMP_FOLDER .
 rm -rf $DUMP_FOLDER


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Extend platform dump to include MST devices information.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Extend platform-dump.sh scrip.

#### How to verify it
Run `show techsupport` command

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

