### PR TITLE
[smart-switch][dpu] Do not run dhclient on the eth0 interface.

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -131,6 +131,7 @@ iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
 {# TODO: COPP policy type rules #}
 {% endfor %}
 {% else %}
+{% if not (DEVICE_METADATA['localhost']['subtype'] == 'SmartSwitch' and DEVICE_METADATA['localhost']['switch_type'] == 'dpu') %}
 auto eth0
 iface eth0 inet dhcp
     metric 202
@@ -140,6 +141,7 @@ iface eth0 inet dhcp
 iface eth0 inet6 dhcp
     up sysctl net.ipv6.conf.eth0.accept_ra=1
     down sysctl net.ipv6.conf.eth0.accept_ra=0
+{% endif %}
 {% endif %}
 {% endif %}
 #


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The Smart Switch DPU uses `midplane-eth0` interface instead of `eth0` for the control plane access. The tails are described in [IP address asignment HLD](https://github.com/sonic-net/SONiC/blob/master/doc/smart-switch/ip-address-assigment/smart-switch-ip-address-assignment.md).
When the `dhclient` is running on top of `eth0` interface that is down on the Smart Switch DPU it generates errors in the logs:

```
ERR dhclient[2083]: send_packet: Network is down
2024 Nov 19 15:27:42.157924 sonic ERR dhclient[2083]: send_packet: Network is down
2024 Nov 19 15:27:42.158000 sonic ERR dhclient[2083]: dhclient.c:2600: Failed to send 300 byte long packet over eth0 interface.
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Do not run dhclient on the eth0 interface.

#### How to verify it
Run the image on the Smart Switch DPU. Generated `/etc/network/interfaces` should not contain dhcp configuration for the `eth0` interface.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

