### PR TITLE
Fix docker-sonic-vs following upgrade to Bookworm

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -74,9 +74,8 @@ RUN pip3 uninstall -y enum34
 
 # Dependencies of restore_neighbors.py
 RUN pip3 install \
-         scapy==2.4.4 \
-         pyroute2==0.5.14 \
-         netifaces==0.10.9
+         pyroute2==0.7.2 \
+         netifaces==0.11.0
 
 {% if docker_sonic_vs_debs.strip() -%}
 # Copy built Debian packages

--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -160,6 +160,8 @@ supervisorctl start vlanmgrd
 
 supervisorctl start zebra
 
+supervisorctl start mgmtd
+
 supervisorctl start staticd
 
 supervisorctl start buffermgrd


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

FRR 10.0.1 upgrade (sonic-net/sonic-buildimage#20269) brought in a mgmtd daemon for FRR. This needs to be started up in docker-sonic-vs as part of the other daemons in this container.

Additionally, Debian Bookworm provides version 2.5.0 of scapy, but the pip3 command later in the file downgraded it to 2.4.5, which does not work in Bookworm. Fix this by removing the pip3 installation for scapy, and updating the other packages installed via pip3.

##### Work item tracking
- Microsoft ADO **(number only)**: 30480849

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

