### PR TITLE
[libyang bug] workaround leaf-list via uses bug in BGP route-map

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
@@ -382,22 +382,6 @@ module sonic-bgp-common {
             description "Interval after which connection will get re-established";
         }
 
-        leaf-list route_map_in {
-            type leafref {
-                path "/rmap:sonic-route-map/rmap:ROUTE_MAP_SET/rmap:ROUTE_MAP_SET_LIST/rmap:name";
-            }
-            description "Route-map filter for incoming routes";
-            max-elements 1;
-        }
-
-        leaf-list route_map_out {
-            type leafref {
-                path "/rmap:sonic-route-map/rmap:ROUTE_MAP_SET/rmap:ROUTE_MAP_SET_LIST/rmap:name";
-            }
-            description "Route-map filter for outgoing routes";
-            max-elements 1;
-        }
-
         leaf soft_reconfiguration_in {
             type boolean;
             description "Inbound soft reconfiguration";

--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -28,6 +28,10 @@ module sonic-bgp-neighbor {
     //    prefix vlan;
     //}
 
+    import sonic-route-map {
+        prefix rmap;
+    }
+
     import sonic-bgp-global {
         prefix bgpg;
     }
@@ -130,7 +134,26 @@ module sonic-bgp-neighbor {
                     }
                     description "BGP Neighbor, it will be neighbor address or interface name";
                 }
+
                 uses bgpcmn:sonic-bgp-cmn-af;
+
+                // These should logically be in sonic-bgp-cmn-af, however due to a libyang2 bug when including
+                // a leaf-list entry, there are validation failures.
+                leaf-list route_map_in {
+                    type leafref {
+                        path "/rmap:sonic-route-map/rmap:ROUTE_MAP_SET/rmap:ROUTE_MAP_SET_LIST/rmap:name";
+                    }
+                    description "Route-map filter for incoming routes";
+                    max-elements 1;
+                }
+
+                leaf-list route_map_out {
+                    type leafref {
+                        path "/rmap:sonic-route-map/rmap:ROUTE_MAP_SET/rmap:ROUTE_MAP_SET_LIST/rmap:name";
+                    }
+                    description "Route-map filter for outgoing routes";
+                    max-elements 1;
+                }
             }
         }
     }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-peergroup.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-peergroup.yang
@@ -15,6 +15,10 @@ module sonic-bgp-peergroup {
         prefix bgpg;
     }
 
+    import sonic-route-map {
+        prefix rmap;
+    }
+
     organization
         "SONiC";
 
@@ -68,6 +72,24 @@ module sonic-bgp-peergroup {
                 }
 
                 uses bgpcmn:sonic-bgp-cmn-af;
+
+                // These should logically be in sonic-bgp-cmn-af, however due to a libyang2 bug when including
+                // a leaf-list entry, there are validation failures.
+                leaf-list route_map_in {
+                    type leafref {
+                        path "/rmap:sonic-route-map/rmap:ROUTE_MAP_SET/rmap:ROUTE_MAP_SET_LIST/rmap:name";
+                    }
+                    description "Route-map filter for incoming routes";
+                    max-elements 1;
+                }
+
+                leaf-list route_map_out {
+                    type leafref {
+                        path "/rmap:sonic-route-map/rmap:ROUTE_MAP_SET/rmap:ROUTE_MAP_SET_LIST/rmap:name";
+                    }
+                    description "Route-map filter for outgoing routes";
+                    max-elements 1;
+                }
             }
         }
 


### PR DESCRIPTION
#### Why I did it

There is a bug in libyang when attempting to validate table `BGP_PEER_GROUP_AF` and likely `BGP_NEIGHBOR_AF` in respect to `route_map_in` and `route_map_out`.

The issue is with the use of `leaf-list` specifically when it is pulled in via a `uses` clause of `bgpcmn:sonic-bgp-cmn-af`.

The error message resembles that of if a child is specified that isn't recognized at all:
```
All Keys are not parsed in BGP_PEER_GROUP_AF
dict_keys(['default|PEERS|ipv4_unicast'])
exceptionList:["'route_map_in'"]
```

##### Work item tracking

#### How I did it

Moving the leaf-list to the parent rather than being imported through the `uses` clause works around this issue.

Again, this is a bug in libyang itself, and the same block in `sonic-bgp-cmn-af` was simply moved to the parents and it magically fixes the issue.

#### How to verify it

Relevant config section to cause the issue (probably included too much here, but none-the-less effective):
```json
{
    "DEVICE_METADATA": {
        "localhost": {
           {# ... #}
            "docker_routing_config_mode": "unified",
            "frr_mgmt_framework_config": "true"
           {# ... #}
        }
    },
    "BGP_GLOBALS": {
        "default": {
            "load_balance_mp_relax": "true",
            "local_asn": "4210000001",
            "log_nbr_state_changes": "true",
            "router_id": "172.16.0.1"
        }
    },
    "BGP_GLOBALS_AF": {
        "default|ipv4_unicast": {
            "max_ebgp_paths": "2"
        },
        "default|ipv6_unicast": {
            "max_ebgp_paths": "2"
        },
        "default|l2vpn_evpn": {
            "advertise-all-vni": "true"
        }
    },
    "BGP_NEIGHBOR": {
        "default|Ethernet72": {
            "peer_group_name": "PEERS"
        }
    },
    "BGP_PEER_GROUP": {
        "default|PEERS": {
            "bfd": "true",
            "capability_ext_nexthop": "true",
            "ebgp_multihop": "true",
            "holdtime": "9",
            "keepalive": "3",
            "min_adv_interval": "5",
            "peer_type": "external"
        }
    },
    "BGP_PEER_GROUP_AF": {
        "default|PEERS|ipv4_unicast": {
            "admin_status": "up",
            "route_map_in": [
                "ALLOW"
            ],
            "route_map_out": [
                "ALLOW"
            ]
        },
        "default|PEERS|ipv6_unicast": {
            "admin_status": "up",
            "route_map_in": [
                "ALLOW"
            ],
            "route_map_out": [
                "ALLOW"
            ]
        },
        "default|PEERS|l2vpn_evpn": {
            "admin_status": "up",
            "route_map_in": [
                "ALLOW"
            ],
            "route_map_out": [
                "ALLOW"
            ],
            "unchanged_nexthop": "true"
        }
    },
    "ROUTE_MAP": {
        "ALLOW|1": {
            "route_operation": "permit"
        }
    },
    "ROUTE_MAP_SET": {
        "ALLOW": {}
    }
}
```
#### Which release branch to backport (provide reason below if selected)

- [X] 202411

#### Tested branch (Please provide the tested image version)
master as of 20241206

#### Description for the changelog

[libyang bug] workaround leaf-list via uses bug in BGP route-map

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)
Signed-off-by: Brad House (@bradh352)



