### PR TITLE
[Bug Fix] docker_image_ctl.j2: remove the logic that recreates database containers on VS platform

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -451,7 +451,7 @@ start() {
 
     DOCKERCHECK=`docker inspect --type container ${DOCKERNAME} 2>/dev/null`
     if [ "$?" -eq "0" ]; then
-        {%- if docker_container_name == "database" and sonic_asic_platform == "vs" %}
+        {%- if sonic_asic_platform == "vs" %}
         echo "Removing existing ${DOCKERNAME} container"
         docker rm -f ${DOCKERNAME}
         {%- else %}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -451,37 +451,28 @@ start() {
 
     DOCKERCHECK=`docker inspect --type container ${DOCKERNAME} 2>/dev/null`
     if [ "$?" -eq "0" ]; then
-        {%- if sonic_asic_platform == "vs" %}
-        # Get the uptime in minutes
-        uptime_minutes=$(uptime -p | grep -oP '\d+(?= minutes?)')
-        if [ "$uptime_minutes" -le 5 ]; then
-            echo "Removing existing ${DOCKERNAME} container"
-            docker rm -f ${DOCKERNAME}
-        fi
+        {%- if docker_container_name == "database" %}
+        DOCKERMOUNT=""
         {%- else %}
-            {%- if docker_container_name == "database" %}
-            DOCKERMOUNT=""
-            {%- else %}
-            DOCKERMOUNT=`getMountPoint "$DOCKERCHECK"`
-            {%- endif %}
-            if [ x"$DOCKERMOUNT" == x"$MOUNTPATH" ]; then
-                CONTAINER_EXISTS="yes"
-                preStartAction
-                {%- if docker_container_name == "database" %}
-                echo "Starting existing ${DOCKERNAME} container"
-                docker start ${DOCKERNAME}
-                {%- else %}
-                echo "Starting existing ${DOCKERNAME} container with HWSKU $HWSKU"
-                /usr/local/bin/container start ${DOCKERNAME}
-                {%- endif %}
-                postStartAction
-                exit $?
-            fi
-
-            # docker created with a different HWSKU, remove and recreate
-            echo "Removing obsolete ${DOCKERNAME} container with HWSKU $DOCKERMOUNT"
-            docker rm -f ${DOCKERNAME}
+        DOCKERMOUNT=`getMountPoint "$DOCKERCHECK"`
         {%- endif %}
+        if [ x"$DOCKERMOUNT" == x"$MOUNTPATH" ]; then
+            CONTAINER_EXISTS="yes"
+            preStartAction
+            {%- if docker_container_name == "database" %}
+            echo "Starting existing ${DOCKERNAME} container"
+            docker start ${DOCKERNAME}
+            {%- else %}
+            echo "Starting existing ${DOCKERNAME} container with HWSKU $HWSKU"
+            /usr/local/bin/container start ${DOCKERNAME}
+            {%- endif %}
+            postStartAction
+            exit $?
+        fi
+
+        # docker created with a different HWSKU, remove and recreate
+        echo "Removing obsolete ${DOCKERNAME} container with HWSKU $DOCKERMOUNT"
+        docker rm -f ${DOCKERNAME}
     fi
 
     {%- if docker_container_name == "database" %}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -452,8 +452,12 @@ start() {
     DOCKERCHECK=`docker inspect --type container ${DOCKERNAME} 2>/dev/null`
     if [ "$?" -eq "0" ]; then
         {%- if sonic_asic_platform == "vs" %}
-        echo "Removing existing ${DOCKERNAME} container"
-        docker rm -f ${DOCKERNAME}
+        # Get the uptime in minutes
+        uptime_minutes=$(uptime -p | grep -oP '\d+(?= minutes?)')
+        if [ "$uptime_minutes" -le 5 ]; then
+            echo "Removing existing ${DOCKERNAME} container"
+            docker rm -f ${DOCKERNAME}
+        fi
         {%- else %}
             {%- if docker_container_name == "database" %}
             DOCKERMOUNT=""


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To support the emulation of VS chassis, we need to remove the existing critical service containers before transforming the HwSKU of the VS device. A previous PR [#18512](https://github.com/sonic-net/sonic-buildimage/pull/18512) introduced a change to the docker_image_ctl.j2 that forces VS images to recreate database containers every time the OS is cold started while the behaviors of other containers(swss/bgp/teamd/syncd) remained unchanged. As a consequence, when the VS device is rebooted without proper human intervention, the database containers will be recreated while the other services will reuse existing containers. That can cause the swss/bgp/syncd containers to become invalid if the database containers get recreated with a different container ID, because swss/bgp/syncd containers are configured to use the database containers as the underlying networking stack.

By further investigation, we have found that it is not necessary to recreate the database containers in /usr/bin/database.sh to perform HwSKU transformation. So, we should remove this logic.

##### Work item tracking
- Microsoft ADO **(number only)**: 30454307

#### How I did it
Remove the code that removes existing database containers in /usr/bin/database.sh

#### How to verify it

* Build VS image and install it on a KVM sonic-vs
* Reboot the sonic-vs multiple times and check if all the containers are started successfully every time.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

The original change was introduced into 202205 branch so we need to backport this fix.

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [X] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)


<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [X] 20220532.72

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

docker_image_ctl.j2: change to not remove existing database containers on VS platform

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->


