### PR TITLE
Update Arista SKU lag_id_end to 1023

### DIFF
--- a/device/arista/x86_64-arista_7800_sup/chassisdb.conf
+++ b/device/arista/x86_64-arista_7800_sup/chassisdb.conf
@@ -3,4 +3,4 @@ chassis_db_address=127.100.1.1
 midplane_subnet=127.100.0.0/16
 
 lag_id_start=1
-lag_id_end=1024
+lag_id_end=1023


### PR DESCRIPTION
The following PRs made `1024` incorrect:
https://github.com/sonic-net/sonic-buildimage/pull/20369
https://github.com/sonic-net/sonic-swss/pull/3303

This fixes:
https://github.com/sonic-net/sonic-buildimage/issues/21096


#### Which release branch to backport (provide reason below if selected)

- [x] 202405


