### PR TITLE
Update SmartSwitch config to align YANG standard

### DIFF
--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -50,8 +50,7 @@ def generate_t1_sample_config(data):
     data['DEVICE_METADATA']['localhost']['hostname'] = 'sonic'
     data['DEVICE_METADATA']['localhost']['type'] = 'LeafRouter'
     data['DEVICE_METADATA']['localhost']['bgp_asn'] = '65100'
-    data['LOOPBACK_INTERFACE'] = {"Loopback0": {},
-                                  "Loopback0|10.1.0.1/32": {}}
+    data['LOOPBACK_INTERFACE'] = {"Loopback0|10.1.0.1/32": {}}
     data['BGP_NEIGHBOR'] = {}
     data['DEVICE_NEIGHBOR'] = {}
     data['INTERFACE'] = {}
@@ -60,13 +59,10 @@ def generate_t1_sample_config(data):
     for port in natsorted(data['PORT']):
         data['PORT'][port]['admin_status'] = 'up'
         data['PORT'][port]['mtu'] = '9100'
-        if 'speed' not in data['PORT'][port]:
-            data['PORT'][port]['speed'] = '100000' 
         local_addr = '10.0.{}.{}'.format(2 * port_count // 256, 2 * port_count % 256)
         peer_addr = '10.0.{}.{}'.format(2 * port_count // 256, 2 * port_count % 256 + 1)
         peer_name='ARISTA{0:02d}{1}'.format(1+port_count%(total_port_amount // 2), 'T2' if port_count < (total_port_amount // 2) else 'T0')
         peer_asn = 65200 if port_count < (total_port_amount // 2) else 64001 + port_count - (total_port_amount // 2)
-        data['INTERFACE']['{}'.format(port)] = {}
         data['INTERFACE']['{}|{}/31'.format(port, local_addr)] = {}
         data['BGP_NEIGHBOR'][peer_addr] = {
                 'rrclient': 0,

--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -50,7 +50,8 @@ def generate_t1_sample_config(data):
     data['DEVICE_METADATA']['localhost']['hostname'] = 'sonic'
     data['DEVICE_METADATA']['localhost']['type'] = 'LeafRouter'
     data['DEVICE_METADATA']['localhost']['bgp_asn'] = '65100'
-    data['LOOPBACK_INTERFACE'] = {"Loopback0|10.1.0.1/32": {}}
+    data['LOOPBACK_INTERFACE'] = {"Loopback0": {},
+                                  "Loopback0|10.1.0.1/32": {}}
     data['BGP_NEIGHBOR'] = {}
     data['DEVICE_NEIGHBOR'] = {}
     data['INTERFACE'] = {}
@@ -59,10 +60,13 @@ def generate_t1_sample_config(data):
     for port in natsorted(data['PORT']):
         data['PORT'][port]['admin_status'] = 'up'
         data['PORT'][port]['mtu'] = '9100'
+        if 'speed' not in data['PORT'][port]:
+            data['PORT'][port]['speed'] = '100000' 
         local_addr = '10.0.{}.{}'.format(2 * port_count // 256, 2 * port_count % 256)
         peer_addr = '10.0.{}.{}'.format(2 * port_count // 256, 2 * port_count % 256 + 1)
         peer_name='ARISTA{0:02d}{1}'.format(1+port_count%(total_port_amount // 2), 'T2' if port_count < (total_port_amount // 2) else 'T0')
         peer_asn = 65200 if port_count < (total_port_amount // 2) else 64001 + port_count - (total_port_amount // 2)
+        data['INTERFACE']['{}'.format(port)] = {}
         data['INTERFACE']['{}|{}/31'.format(port, local_addr)] = {}
         data['BGP_NEIGHBOR'][peer_addr] = {
                 'rrclient': 0,
@@ -85,6 +89,12 @@ def generate_t1_smartswitch_switch_sample_config(data, ss_config):
 
     bridge_name = 'bridge-midplane'
 
+    data['MID_PLANE_BRIDGE'] = {
+        "GLOBAL": {
+            "bridge": bridge_name,
+            "ip_prefix": "169.254.200.254/24"
+            }
+    }
     dhcp_server_ports = {}
 
     for dpu_name in natsorted(ss_config.get('DPUS', {})):
@@ -122,10 +132,6 @@ def generate_t1_smartswitch_switch_sample_config(data, ss_config):
 
         data['DHCP_SERVER_IPV4'] = {
             bridge_name: {
-                'customized_options': [
-                    'option60',
-                    'option223'
-                ],
                 'gateway': mpbr_address,
                 'lease_time': '3600',
                 'mode': 'PORT',

--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -89,7 +89,7 @@ def generate_t1_smartswitch_switch_sample_config(data, ss_config):
         "GLOBAL": {
             "bridge": bridge_name,
             "ip_prefix": "169.254.200.254/24"
-            }
+        }
     }
     dhcp_server_ports = {}
 

--- a/src/sonic-config-engine/tests/sample_output/t1-smartswitch.json
+++ b/src/sonic-config-engine/tests/sample_output/t1-smartswitch.json
@@ -375,38 +375,6 @@
 		}
 	},
 	"INTERFACE": {
-		"Ethernet0":{},
-		"Ethernet104": {},
-		"Ethernet112": {},
-		"Ethernet120": {},
-		"Ethernet128": {},
-		"Ethernet136": {},
-		"Ethernet144": {},
-		"Ethernet152": {},
-		"Ethernet160": {},
-		"Ethernet168": {},
-		"Ethernet16": {},
-		"Ethernet176": {},
-		"Ethernet184": {},
-		"Ethernet192": {},
-		"Ethernet200": {},
-		"Ethernet208": {},
-		"Ethernet216": {},
-		"Ethernet224": {},
-		"Ethernet232": {},
-		"Ethernet240": {},
-		"Ethernet248": {},
-		"Ethernet24": {},
-		"Ethernet32": {},
-		"Ethernet40": {},
-		"Ethernet48": {},
-		"Ethernet56": {},
-		"Ethernet64": {},
-		"Ethernet72": {},
-		"Ethernet80": {},
-		"Ethernet88": {},
-		"Ethernet8": {},
-		"Ethernet96": {},
 		"Ethernet0|10.0.0.0/31": {},
 		"Ethernet104|10.0.0.26/31": {},
 		"Ethernet112|10.0.0.28/31": {},
@@ -441,7 +409,6 @@
 		"Ethernet96|10.0.0.24/31": {}
 	},
 	"LOOPBACK_INTERFACE": {
-		"Loopback0": {},
 		"Loopback0|10.1.0.1/32": {}
 	},
 	"MID_PLANE_BRIDGE": {
@@ -455,225 +422,193 @@
 			"admin_status": "up",
 			"alias": "etp1",
 			"lanes": "0,1,2,3,4,5,6,7",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet104": {
 			"admin_status": "up",
 			"alias": "etp14",
 			"lanes": "104,105,106,107,108,109,110,111",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet112": {
 			"admin_status": "up",
 			"alias": "etp15",
 			"lanes": "112,113,114,115,116,117,118,119",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet120": {
 			"admin_status": "up",
 			"alias": "etp16",
 			"lanes": "120,121,122,123,124,125,126,127",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet128": {
 			"admin_status": "up",
 			"alias": "etp17",
 			"lanes": "128,129,130,131,132,133,134,135",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet136": {
 			"admin_status": "up",
 			"alias": "etp18",
 			"lanes": "136,137,138,139,140,141,142,143",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet144": {
 			"admin_status": "up",
 			"alias": "etp19",
 			"lanes": "144,145,146,147,148,149,150,151",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet152": {
 			"admin_status": "up",
 			"alias": "etp20",
 			"lanes": "152,153,154,155,156,157,158,159",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet16": {
 			"admin_status": "up",
 			"alias": "etp3",
 			"lanes": "16,17,18,19,20,21,22,23",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet160": {
 			"admin_status": "up",
 			"alias": "etp21",
 			"lanes": "160,161,162,163,164,165,166,167",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet168": {
 			"admin_status": "up",
 			"alias": "etp22",
 			"lanes": "168,169,170,171,172,173,174,175",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet176": {
 			"admin_status": "up",
 			"alias": "etp23",
 			"lanes": "176,177,178,179,180,181,182,183",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet184": {
 			"admin_status": "up",
 			"alias": "etp24",
 			"lanes": "184,185,186,187,188,189,190,191",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet192": {
 			"admin_status": "up",
 			"alias": "etp25",
 			"lanes": "192,193,194,195,196,197,198,199",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet200": {
 			"admin_status": "up",
 			"alias": "etp26",
 			"lanes": "200,201,202,203,204,205,206,207",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet208": {
 			"admin_status": "up",
 			"alias": "etp27",
 			"lanes": "208,209,210,211,212,213,214,215",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet216": {
 			"admin_status": "up",
 			"alias": "etp28",
 			"lanes": "216,217,218,219,220,221,222,223",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet224": {
 			"admin_status": "up",
 			"alias": "etp29",
 			"lanes": "224,225,226,227,228,229,230,231",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet232": {
 			"admin_status": "up",
 			"alias": "etp30",
 			"lanes": "232,233,234,235,236,237,238,239",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet24": {
 			"admin_status": "up",
 			"alias": "etp4",
 			"lanes": "24,25,26,27,28,29,30,31",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet240": {
 			"admin_status": "up",
 			"alias": "etp31",
 			"lanes": "240,241,242,243,244,245,246,247",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet248": {
 			"admin_status": "up",
 			"alias": "etp32",
 			"lanes": "248,249,250,251,252,253,254,255",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet32": {
 			"admin_status": "up",
 			"alias": "etp5",
 			"lanes": "32,33,34,35,36,37,38,39",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet40": {
 			"admin_status": "up",
 			"alias": "etp6",
 			"lanes": "40,41,42,43,44,45,46,47",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet48": {
 			"admin_status": "up",
 			"alias": "etp7",
 			"lanes": "48,49,50,51,52,53,54,55",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet56": {
 			"admin_status": "up",
 			"alias": "etp8",
 			"lanes": "56,57,58,59,60,61,62,63",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet64": {
 			"admin_status": "up",
 			"alias": "etp9",
 			"lanes": "64,65,66,67,68,69,70,71",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet72": {
 			"admin_status": "up",
 			"alias": "etp10",
 			"lanes": "72,73,74,75,76,77,78,79",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet8": {
 			"admin_status": "up",
 			"alias": "etp2",
 			"lanes": "8,9,10,11,12,13,14,15",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet80": {
 			"admin_status": "up",
 			"alias": "etp11",
 			"lanes": "80,81,82,83,84,85,86,87",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet88": {
 			"admin_status": "up",
 			"alias": "etp12",
 			"lanes": "88,89,90,91,92,93,94,95",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		},
 		"Ethernet96": {
 			"admin_status": "up",
 			"alias": "etp13",
 			"lanes": "96,97,98,99,100,101,102,103",
-			"mtu": "9100", 
-			"speed": "100000"
+			"mtu": "9100"
 		}
 	}
 }

--- a/src/sonic-config-engine/tests/sample_output/t1-smartswitch.json
+++ b/src/sonic-config-engine/tests/sample_output/t1-smartswitch.json
@@ -301,10 +301,6 @@
 	"DEVICE_NEIGHBOR": {},
 	"DHCP_SERVER_IPV4": {
 		"bridge-midplane": {
-			"customized_options": [
-				"option60",
-				"option223"
-			],
 			"gateway": "169.254.200.254",
 			"lease_time": "3600",
 			"mode": "PORT",
@@ -379,6 +375,38 @@
 		}
 	},
 	"INTERFACE": {
+		"Ethernet0":{},
+		"Ethernet104": {},
+		"Ethernet112": {},
+		"Ethernet120": {},
+		"Ethernet128": {},
+		"Ethernet136": {},
+		"Ethernet144": {},
+		"Ethernet152": {},
+		"Ethernet160": {},
+		"Ethernet168": {},
+		"Ethernet16": {},
+		"Ethernet176": {},
+		"Ethernet184": {},
+		"Ethernet192": {},
+		"Ethernet200": {},
+		"Ethernet208": {},
+		"Ethernet216": {},
+		"Ethernet224": {},
+		"Ethernet232": {},
+		"Ethernet240": {},
+		"Ethernet248": {},
+		"Ethernet24": {},
+		"Ethernet32": {},
+		"Ethernet40": {},
+		"Ethernet48": {},
+		"Ethernet56": {},
+		"Ethernet64": {},
+		"Ethernet72": {},
+		"Ethernet80": {},
+		"Ethernet88": {},
+		"Ethernet8": {},
+		"Ethernet96": {},
 		"Ethernet0|10.0.0.0/31": {},
 		"Ethernet104|10.0.0.26/31": {},
 		"Ethernet112|10.0.0.28/31": {},
@@ -413,200 +441,239 @@
 		"Ethernet96|10.0.0.24/31": {}
 	},
 	"LOOPBACK_INTERFACE": {
+		"Loopback0": {},
 		"Loopback0|10.1.0.1/32": {}
+	},
+	"MID_PLANE_BRIDGE": {
+		"GLOBAL": {
+			"bridge": "bridge-midplane",
+			"ip_prefix": "169.254.200.254/24"
+		}
 	},
 	"PORT": {
 		"Ethernet0": {
 			"admin_status": "up",
 			"alias": "etp1",
 			"lanes": "0,1,2,3,4,5,6,7",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet104": {
 			"admin_status": "up",
 			"alias": "etp14",
 			"lanes": "104,105,106,107,108,109,110,111",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet112": {
 			"admin_status": "up",
 			"alias": "etp15",
 			"lanes": "112,113,114,115,116,117,118,119",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet120": {
 			"admin_status": "up",
 			"alias": "etp16",
 			"lanes": "120,121,122,123,124,125,126,127",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet128": {
 			"admin_status": "up",
 			"alias": "etp17",
 			"lanes": "128,129,130,131,132,133,134,135",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet136": {
 			"admin_status": "up",
 			"alias": "etp18",
 			"lanes": "136,137,138,139,140,141,142,143",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet144": {
 			"admin_status": "up",
 			"alias": "etp19",
 			"lanes": "144,145,146,147,148,149,150,151",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet152": {
 			"admin_status": "up",
 			"alias": "etp20",
 			"lanes": "152,153,154,155,156,157,158,159",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet16": {
 			"admin_status": "up",
 			"alias": "etp3",
 			"lanes": "16,17,18,19,20,21,22,23",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet160": {
 			"admin_status": "up",
 			"alias": "etp21",
 			"lanes": "160,161,162,163,164,165,166,167",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet168": {
 			"admin_status": "up",
 			"alias": "etp22",
 			"lanes": "168,169,170,171,172,173,174,175",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet176": {
 			"admin_status": "up",
 			"alias": "etp23",
 			"lanes": "176,177,178,179,180,181,182,183",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet184": {
 			"admin_status": "up",
 			"alias": "etp24",
 			"lanes": "184,185,186,187,188,189,190,191",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet192": {
 			"admin_status": "up",
 			"alias": "etp25",
 			"lanes": "192,193,194,195,196,197,198,199",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet200": {
 			"admin_status": "up",
 			"alias": "etp26",
 			"lanes": "200,201,202,203,204,205,206,207",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet208": {
 			"admin_status": "up",
 			"alias": "etp27",
 			"lanes": "208,209,210,211,212,213,214,215",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet216": {
 			"admin_status": "up",
 			"alias": "etp28",
 			"lanes": "216,217,218,219,220,221,222,223",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet224": {
 			"admin_status": "up",
 			"alias": "etp29",
 			"lanes": "224,225,226,227,228,229,230,231",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet232": {
 			"admin_status": "up",
 			"alias": "etp30",
 			"lanes": "232,233,234,235,236,237,238,239",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet24": {
 			"admin_status": "up",
 			"alias": "etp4",
 			"lanes": "24,25,26,27,28,29,30,31",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet240": {
 			"admin_status": "up",
 			"alias": "etp31",
 			"lanes": "240,241,242,243,244,245,246,247",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet248": {
 			"admin_status": "up",
 			"alias": "etp32",
 			"lanes": "248,249,250,251,252,253,254,255",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet32": {
 			"admin_status": "up",
 			"alias": "etp5",
 			"lanes": "32,33,34,35,36,37,38,39",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet40": {
 			"admin_status": "up",
 			"alias": "etp6",
 			"lanes": "40,41,42,43,44,45,46,47",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet48": {
 			"admin_status": "up",
 			"alias": "etp7",
 			"lanes": "48,49,50,51,52,53,54,55",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet56": {
 			"admin_status": "up",
 			"alias": "etp8",
 			"lanes": "56,57,58,59,60,61,62,63",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet64": {
 			"admin_status": "up",
 			"alias": "etp9",
 			"lanes": "64,65,66,67,68,69,70,71",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet72": {
 			"admin_status": "up",
 			"alias": "etp10",
 			"lanes": "72,73,74,75,76,77,78,79",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet8": {
 			"admin_status": "up",
 			"alias": "etp2",
 			"lanes": "8,9,10,11,12,13,14,15",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet80": {
 			"admin_status": "up",
 			"alias": "etp11",
 			"lanes": "80,81,82,83,84,85,86,87",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet88": {
 			"admin_status": "up",
 			"alias": "etp12",
 			"lanes": "88,89,90,91,92,93,94,95",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		},
 		"Ethernet96": {
 			"admin_status": "up",
 			"alias": "etp13",
 			"lanes": "96,97,98,99,100,101,102,103",
-			"mtu": "9100"
+			"mtu": "9100", 
+			"speed": "100000"
 		}
 	}
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/20730
#### Why I did it
The generated t1 config fails YANG validation, which leads to config setup failure since we enforce YANG validation in config reload. 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update config to align with YANG 
#### How to verify it
Run YANG validate on generated config.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

