### PR TITLE
Update internal template peer-group.conf.j2 for ttl-security hops command.

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/internal/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/internal/peer-group.conf.j2
@@ -5,6 +5,7 @@
   neighbor INTERNAL_PEER_V6 peer-group
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
   neighbor INTERNAL_PEER_V4 update-source Loopback4096
+  neighbor INTERNAL_PEER_V4 ttl-security hops 1
 {% endif %}
   address-family ipv4
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
@@ -15,10 +16,10 @@
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
     neighbor INTERNAL_PEER_V4 send-community
-    neighbor INTERNAL_PEER_V4 ttl-security hops 1
   exit-address-family
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
   neighbor INTERNAL_PEER_V6 update-source Loopback4096
+  neighbor INTERNAL_PEER_V6 ttl-security hops 1
 {% endif %}
   address-family ipv6
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
@@ -29,7 +30,6 @@
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
     neighbor INTERNAL_PEER_V6 send-community
-    neighbor INTERNAL_PEER_V6 ttl-security hops 1
   exit-address-family
 !
 ! end of template: bgpd/templates/internal/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_back.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_back.conf
@@ -10,7 +10,6 @@
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
     neighbor INTERNAL_PEER_V4 send-community
-    neighbor INTERNAL_PEER_V4 ttl-security hops 1
   exit-address-family
   address-family ipv6
     neighbor INTERNAL_PEER_V6 route-reflector-client
@@ -19,7 +18,6 @@
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
     neighbor INTERNAL_PEER_V6 send-community
-    neighbor INTERNAL_PEER_V6 ttl-security hops 1
   exit-address-family
 !
 ! end of template: bgpd/templates/internal/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chasiss_packet.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chasiss_packet.conf
@@ -3,23 +3,23 @@
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
-  neighbor INTERNAL_PEER_V4 update-source Loopback4096 
+  neighbor INTERNAL_PEER_V4 update-source Loopback4096
+  neighbor INTERNAL_PEER_V4 ttl-security hops 1
   address-family ipv4
     neighbor INTERNAL_PEER_V4 soft-reconfiguration inbound
     neighbor INTERNAL_PEER_V4 allowas-in 1
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
     neighbor INTERNAL_PEER_V4 send-community
-    neighbor INTERNAL_PEER_V4 ttl-security hops 1
   exit-address-family
-  neighbor INTERNAL_PEER_V6 update-source Loopback4096 
+  neighbor INTERNAL_PEER_V6 update-source Loopback4096
+  neighbor INTERNAL_PEER_V6 ttl-security hops 1
   address-family ipv6
     neighbor INTERNAL_PEER_V6 soft-reconfiguration inbound
     neighbor INTERNAL_PEER_V6 allowas-in 1
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
     neighbor INTERNAL_PEER_V6 send-community
-    neighbor INTERNAL_PEER_V6 ttl-security hops 1
   exit-address-family
 !
 ! end of template: bgpd/templates/internal/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chassis_packet_isolate.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chassis_packet_isolate.conf
@@ -3,23 +3,23 @@
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
-  neighbor INTERNAL_PEER_V4 update-source Loopback4096 
+  neighbor INTERNAL_PEER_V4 update-source Loopback4096
+  neighbor INTERNAL_PEER_V4 ttl-security hops 1
   address-family ipv4
     neighbor INTERNAL_PEER_V4 soft-reconfiguration inbound
     neighbor INTERNAL_PEER_V4 allowas-in 1
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
     neighbor INTERNAL_PEER_V4 send-community
-    neighbor INTERNAL_PEER_V4 ttl-security hops 1
   exit-address-family
-  neighbor INTERNAL_PEER_V6 update-source Loopback4096 
+  neighbor INTERNAL_PEER_V6 update-source Loopback4096
+  neighbor INTERNAL_PEER_V6 ttl-security hops 1
   address-family ipv6
     neighbor INTERNAL_PEER_V6 soft-reconfiguration inbound
     neighbor INTERNAL_PEER_V6 allowas-in 1
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
     neighbor INTERNAL_PEER_V6 send-community
-    neighbor INTERNAL_PEER_V6 ttl-security hops 1
   exit-address-family
 !
 ! end of template: bgpd/templates/internal/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chassis_packet_unisolate.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_chassis_packet_unisolate.conf
@@ -3,23 +3,23 @@
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
-  neighbor INTERNAL_PEER_V4 update-source Loopback4096 
+  neighbor INTERNAL_PEER_V4 update-source Loopback4096
+  neighbor INTERNAL_PEER_V4 ttl-security hops 1
   address-family ipv4
     neighbor INTERNAL_PEER_V4 soft-reconfiguration inbound
     neighbor INTERNAL_PEER_V4 allowas-in 1
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
     neighbor INTERNAL_PEER_V4 send-community
-    neighbor INTERNAL_PEER_V4 ttl-security hops 1
   exit-address-family
-  neighbor INTERNAL_PEER_V6 update-source Loopback4096 
+  neighbor INTERNAL_PEER_V6 update-source Loopback4096
+  neighbor INTERNAL_PEER_V6 ttl-security hops 1
   address-family ipv6
     neighbor INTERNAL_PEER_V6 soft-reconfiguration inbound
     neighbor INTERNAL_PEER_V6 allowas-in 1
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
     neighbor INTERNAL_PEER_V6 send-community
-    neighbor INTERNAL_PEER_V6 ttl-security hops 1
   exit-address-family
 !
 ! end of template: bgpd/templates/internal/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_front.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_front.conf
@@ -9,7 +9,6 @@
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
     neighbor INTERNAL_PEER_V4 send-community
-    neighbor INTERNAL_PEER_V4 ttl-security hops 1
   exit-address-family
   address-family ipv6
     neighbor INTERNAL_PEER_V6 soft-reconfiguration inbound
@@ -17,7 +16,6 @@
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
     neighbor INTERNAL_PEER_V6 send-community
-    neighbor INTERNAL_PEER_V6 ttl-security hops 1
   exit-address-family
 !
 ! end of template: bgpd/templates/internal/peer-group.conf.j2


### PR DESCRIPTION
What I did:
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/21116

Why I did:
FRR behavior change w.r.t to command `ttl-security hops <>` from being removed from address-family .