### PR TITLE
[BGP]Tuning zebra nexthop-group keep parameter

### DIFF
--- a/dockers/docker-fpm-frr/frr/zebra/zebra.conf.j2
+++ b/dockers/docker-fpm-frr/frr/zebra/zebra.conf.j2
@@ -18,6 +18,7 @@ no fpm use-next-hop-groups
 !
 fpm address 127.0.0.1
 {% endblock fpm %}
+zebra nexthop-group keep 1
 !
 {% include "common/daemons.common.conf.j2" %}
 !

--- a/platform/vs/docker-sonic-vs/frr/zebra.conf
+++ b/platform/vs/docker-sonic-vs/frr/zebra.conf
@@ -1,4 +1,5 @@
 no fpm use-next-hop-groups
 
 fpm address 127.0.0.1
+zebra nexthop-group keep 1
 

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/zebra.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/zebra.conf
@@ -8,6 +8,7 @@
 no fpm use-next-hop-groups
 !
 fpm address 127.0.0.1
+zebra nexthop-group keep 1
 !
 ! template: common/daemons.common.conf.j2
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-vni-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-vni-zebra.conf
@@ -8,6 +8,7 @@
 no fpm use-next-hop-groups
 !
 fpm address 127.0.0.1
+zebra nexthop-group keep 1
 !
 ! template: common/daemons.common.conf.j2
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-zebra.conf
@@ -8,6 +8,7 @@
 no fpm use-next-hop-groups
 !
 fpm address 127.0.0.1
+zebra nexthop-group keep 1
 !
 ! template: common/daemons.common.conf.j2
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/zebra_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/zebra_frr.conf
@@ -8,6 +8,7 @@
 no fpm use-next-hop-groups
 !
 fpm address 127.0.0.1
+zebra nexthop-group keep 1
 !
 ! template: common/daemons.common.conf.j2
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/zebra_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/zebra_frr_dualtor.conf
@@ -8,6 +8,7 @@
 no fpm use-next-hop-groups
 !
 fpm address 127.0.0.1
+zebra nexthop-group keep 1
 !
 ! template: common/daemons.common.conf.j2
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-vni-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-vni-zebra.conf
@@ -8,6 +8,7 @@
 no fpm use-next-hop-groups
 !
 fpm address 127.0.0.1
+zebra nexthop-group keep 1
 !
 ! template: common/daemons.common.conf.j2
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-zebra.conf
@@ -8,6 +8,7 @@
 no fpm use-next-hop-groups
 !
 fpm address 127.0.0.1
+zebra nexthop-group keep 1
 !
 ! template: common/daemons.common.conf.j2
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/zebra_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/zebra_frr.conf
@@ -8,6 +8,7 @@
 no fpm use-next-hop-groups
 !
 fpm address 127.0.0.1
+zebra nexthop-group keep 1
 !
 ! template: common/daemons.common.conf.j2
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/zebra_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/zebra_frr_dualtor.conf
@@ -8,6 +8,7 @@
 no fpm use-next-hop-groups
 !
 fpm address 127.0.0.1
+zebra nexthop-group keep 1
 !
 ! template: common/daemons.common.conf.j2
 !


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Setting the nexthop-group keep parameter to 1. This will instruct zebra not to save nexthop group for more than 1 second after removal.  Without this zebra will keep nexthop group in the system for 180 seconds.
In scaled scenarios when this parameter is not set it resulted in the queue growing so big and crashing zebra due to OOM when there is test on link flapping.



##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update the zebra template and initialize nexthop-group keep as 1.

#### How to verify it
Running the scale test with link flapping and ensure no memory increase in zebra.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

