### PR TITLE
[ptf] Consider only expected packets for timeout

### DIFF
--- a/src/ptf-py3.patch/0004-Consider-only-expected-packets-for-timeout.patch
+++ b/src/ptf-py3.patch/0004-Consider-only-expected-packets-for-timeout.patch
@@ -1,0 +1,40 @@
+From f961a46cd8b3736a7ac8534fad774433b2a8ce6b Mon Sep 17 00:00:00 2001
+From: Vinod Kumar <vkjammala@arista.com>
+Date: Thu, 12 Dec 2024 11:04:21 +0000
+Subject: [PATCH] Consider only expected packets for timeout
+
+"count_matched_packets" method is getting stuck in a while loop as long
+as ptf server port receives any packet (Ex: in dualtor case, we do see
+continuous ICMP packets on ptf port). Fix is to consider only expected
+packets w.r.t timeout (similar to "count_matched_packets_all_ports" logic).
+---
+ src/ptf/testutils.py | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/ptf/testutils.py b/src/ptf/testutils.py
+index 46b926c..2402e8f 100755
+--- a/src/ptf/testutils.py
++++ b/src/ptf/testutils.py
+@@ -3636,14 +3636,19 @@ def count_matched_packets(test, exp_packet, port, device_number=0, timeout=None)
+             "%s() requires positive timeout value." % sys._getframe().f_code.co_name
+         )
+ 
++    last_matched_packet_time = time.time()
+     total_rcv_pkt_cnt = 0
+     while True:
++        if (time.time() - last_matched_packet_time) > timeout:
++            break
++
+         result = dp_poll(
+             test, device_number=device_number, port_number=port, timeout=timeout
+         )
+         if isinstance(result, test.dataplane.PollSuccess):
+             if ptf.dataplane.match_exp_pkt(exp_packet, result.packet):
+                 total_rcv_pkt_cnt += 1
++                last_matched_packet_time = time.time()
+         else:
+             break
+ 
+-- 
+2.43.5
+

--- a/src/ptf-py3.patch/series
+++ b/src/ptf-py3.patch/series
@@ -1,3 +1,4 @@
 0001-Remove-ord-in-get_mac-to-avoid-TypeError.patch
 0002-Fill-byte-formatted-client-mac-address-in-DHCP-Disco.patch
 0003-Avoid-local-version-scheme-by-setuptools-scm.patch
+0004-Consider-only-expected-packets-for-timeout.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[offer|ack]` tests are failing on dualtor topologies with signature `Failed: /tmp/dhcp_stress_test_offer.json is missing`, see issue https://github.com/aristanetworks/sonic-qual.msft/issues/325 for more details.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
`count_matched_packets` method is getting stuck in a while loop as long as ptf server port receives any packet (Ex: in dualtor case, we do see continuous ICMP packets on ptf port). Fix is to consider only expected packets w.r.t timeout (similar to `count_matched_packets_all_ports` logic).

#### How to verify it
With this PR changes we should not see dhcp_relay/test_dhcp_relay_stress.py failures on dualtor topologies with symptom `Failed: /tmp/dhcp_stress_test_offer.json is missing`.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
- [x] 202405
- [x] 202411

Reason: Issue is seen in 202405 branch.
#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202405
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

