### PR TITLE
Rename enable_sff_mgr flag to enable_sff_mgr_controlled_tx

### DIFF
--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -112,8 +112,8 @@ dependent_startup_wait_for=rsyslogd:running
     {%- set options = options + " --skip_cmis_mgr" %}
 {% endif -%}
 
-{% if enable_xcvrd_sff_mgr %}
-    {%- set options = options + " --enable_sff_mgr" %}
+{% if enable_xcvrd_sff_mgr_controlled_tx %}
+    {%- set options = options + " --enable_sff_mgr_controlled_tx" %}
 {% endif -%}
 
 {% if delay_xcvrd %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

All platforms/vendors by default should be able to get the benefit of high power class enabling/lpmode toggle/etc from sff_mgr, which is common standard logic.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Change enable_sff_mgr flag to enable_sff_mgr_controlled_tx, so that sff_mgr will always get spawned by default, and all platforms/vendors by default can get the benefit of high power class enabling/etc. Only sff_mgr's controlling on module Tx is platform based (enable_sff_mgr_controlled_tx)


#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
```
# sonic-cfggen -a '{"skip_xcvrd_cmis_mgr": false, "enable_xcvrd_sff_mgr_controlled_tx": true, "delay_xcvrd": false}' -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 | grep "program:xcvrd" -A 1
[program:xcvrd]
command=python3 /usr/local/bin/xcvrd --enable_sff_mgr_controlled_tx

# sonic-cfggen -a '{"skip_xcvrd_cmis_mgr": false, "enable_xcvrd_sff_mgr_controlled_tx": false, "delay_xcvrd": false}' -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 | grep "program:xcvrd" -A 1
[program:xcvrd]
command=python3 /usr/local/bin/xcvrd

# sonic-cfggen -a '{"skip_xcvrd_cmis_mgr": false, "delay_xcvrd": false}' -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 | grep "program:xcvrd" -A 1
[program:xcvrd]
command=python3 /usr/local/bin/xcvrd
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

