### PR TITLE
Fix ssh too open permission issue in sonic-mgmt image.

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -38,6 +38,11 @@ stages:
     - template: cleanup.yml
     - checkout: self
       clean: true
+    - script: |
+        set -x
+        sudo setfacl -R -b $(Agent.BuildDirectory)
+      displayName: 'setfacl'
+
     - bash: |
         set -xe
         git submodule update --init --recursive -- src/sonic-platform-daemons src/sonic-genl-packet src/sonic-sairedis src/ptf src/sonic-device-data


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Previously, the sonic-mgmt image encountered an issue where the SSH configuration was overly permissive, preventing the Docker container from starting successfully. The error message is provided below. This PR addresses and resolves the issue.
```
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions 0644 for '/etc/ssh/ssh_host_rsa_key' are too open.
It is required that your private key files are NOT accessible by others.
This private key will be ignored.
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions 0644 for '/etc/ssh/ssh_host_ecdsa_key' are too open.
It is required that your private key files are NOT accessible by others.
This private key will be ignored.
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions 0644 for '/etc/ssh/ssh_host_ed25519_key' are too open.
It is required that your private key files are NOT accessible by others.
This private key will be ignored.
sshd: no hostkeys available -- exiting.

ERROR: failed to start SSH service
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add a step to reset permissions under the specific folder as #20346, which faced the same issue. 

#### How to verify it
I tested in my local environment, and it could successfully start the docker. 
```
 => [22/22] RUN if ! pip3 list | grep -c pytest >/dev/null && [ 'yutongzhang' != 'AzDevOps' ] && [ -d /var/AzDevOps/env-python3 ]; then /bin/bash -c   1.3s
 => exporting to image                                                                                                                                12.1s
 => => exporting layers                                                                                                                               12.0s
 => => writing image sha256:e3ed99ef8778d8e3aa50b1123b57747043d18982b7c34149f8ff304a996fedc9                                                           0.0s
 => => naming to docker.io/library/docker-sonic-mgmt-yutongzhang:master                                                                                0.0s
INFO: cleanup a temporary dir: /tmp/tmp.SUbOp2b2x2
INFO: creating a container: yutong_test ...
8e909a891449ac957c099d09fba146dc84128248aa242757edaa8a5098e272dd
 * Restarting OpenBSD Secure Shell server sshd
   ...done.
INFO: verifying UID and GID in container matches host
******************************************************************************
EXEC: docker exec --user yutongzhang -ti yutong_test bash
SSH:  ssh -i ~/.ssh/id_rsa_docker_sonic_mgmt yutongzhang@172.17.0.2
******************************************************************************

INFO: sonic-mgmt configuration is done!
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

