### PR TITLE
[eventd] Ignore control character event if it comes in UT

### DIFF
--- a/src/sonic-eventd/tests/eventd_ut.cpp
+++ b/src/sonic-eventd/tests/eventd_ut.cpp
@@ -164,16 +164,12 @@ void run_cap(void *zctx, bool &term, string &read_source,
     EXPECT_EQ(0, zmq_setsockopt(mock_cap, ZMQ_SUBSCRIBE, "", 0));
     EXPECT_EQ(0, zmq_setsockopt(mock_cap, ZMQ_RCVTIMEO, &block_ms, sizeof (block_ms)));
 
-    zmq_msg_t msg;
-    zmq_msg_init(&msg);
-    int rc = zmq_msg_recv(&msg, mock_cap, 0);
-    EXPECT_EQ(1, rc); // read control character
 
     while(!term) {
         string source;
         internal_event_t ev_int;
-
-        if (0 == zmq_message_read(mock_cap, 0, source, ev_int)) {
+        int rc = zmq_message_read(mock_cap, 0, source, ev_int);
+        if (0 == rc && !ev_int.empty()) { // ignore control character empty event
             cnt = ++i;
         }
     }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fixes https://github.com/sonic-net/sonic-buildimage/issues/21140

In https://github.com/sonic-net/sonic-buildimage/pull/20024 and https://github.com/sonic-net/sonic-swss-common/pull/906, we made the change that when a control character is read, zmq_message_read will return with rc 0, which will create an empty internal event. 

As part of eventd design, empty structured events are dropped, which leads to control characters being a no-op which is the expected behavior.

In UT, we are still always expecting a control character to be the first message to be read by zmq which is not the case as described in https://github.com/sonic-net/sonic-buildimage/pull/20024. We are also not ignoring empty events that are read which is being done by eventd. 

With this change, control characters are properly ignored if it does after the first test event.

##### Work item tracking
- Microsoft ADO **(number only)**:28728116

#### How I did it

Ignore empty structured events and not expect first zmq_message_read to be control character.

#### How to verify it

Manual test/pipeline

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

