### PR TITLE
[BUILD TEST]Revert "[QoS] Add tunnel pipe mode support for IPIP Decap mode to use…

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -83,12 +83,10 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-{% if "mlnx" in DEVICE_METADATA.localhost.platform %}
             "dscp_mode":"uniform",
+{% if "mlnx" in DEVICE_METADATA.localhost.platform %}
             "ecn_mode":"standard",
 {% else %}
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
             "ecn_mode":"copy_from_outer",
 {% endif %}
             "ttl_mode":"pipe"
@@ -138,12 +136,10 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-{% if "mlnx" in DEVICE_METADATA.localhost.platform %}
             "dscp_mode":"uniform",
+{% if "mlnx" in DEVICE_METADATA.localhost.platform %}
             "ecn_mode":"standard",
 {% else %}
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
             "ecn_mode":"copy_from_outer",
 {% endif %}
             "ttl_mode":"pipe"

--- a/src/sonic-config-engine/tests/multi_npu_data/py2/ipinip.json
+++ b/src/sonic-config-engine/tests/multi_npu_data/py2/ipinip.json
@@ -2,8 +2,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -42,8 +41,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },

--- a/src/sonic-config-engine/tests/multi_npu_data/py3/ipinip.json
+++ b/src/sonic-config-engine/tests/multi_npu_data/py3/ipinip.json
@@ -2,8 +2,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -42,8 +41,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },

--- a/src/sonic-config-engine/tests/sample_output/py2/ipinip.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/ipinip.json
@@ -2,8 +2,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -66,8 +65,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },

--- a/src/sonic-config-engine/tests/sample_output/py2/ipinip_subnet_decap_enable.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/ipinip_subnet_decap_enable.json
@@ -25,8 +25,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -98,8 +97,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },

--- a/src/sonic-config-engine/tests/sample_output/py3/ipinip.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/ipinip.json
@@ -2,8 +2,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -66,8 +65,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },

--- a/src/sonic-config-engine/tests/sample_output/py3/ipinip_subnet_decap_enable.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/ipinip_subnet_decap_enable.json
@@ -25,8 +25,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -98,8 +97,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },


### PR DESCRIPTION
… SAI_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP (#20650)"

This reverts commit da30d12cadfa8f8e28554c64f6823612fe4d2b09.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

