### PR TITLE
Revert "[QoS] Add tunnel pipe mode support for IPIP Decap mode to use SAI_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP"

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -83,12 +83,10 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-{% if "mlnx" in DEVICE_METADATA.localhost.platform %}
             "dscp_mode":"uniform",
+{% if "mlnx" in DEVICE_METADATA.localhost.platform %}
             "ecn_mode":"standard",
 {% else %}
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
             "ecn_mode":"copy_from_outer",
 {% endif %}
             "ttl_mode":"pipe"
@@ -138,12 +136,10 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-{% if "mlnx" in DEVICE_METADATA.localhost.platform %}
             "dscp_mode":"uniform",
+{% if "mlnx" in DEVICE_METADATA.localhost.platform %}
             "ecn_mode":"standard",
 {% else %}
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
             "ecn_mode":"copy_from_outer",
 {% endif %}
             "ttl_mode":"pipe"

--- a/src/sonic-config-engine/tests/multi_npu_data/py2/ipinip.json
+++ b/src/sonic-config-engine/tests/multi_npu_data/py2/ipinip.json
@@ -2,8 +2,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -42,8 +41,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },

--- a/src/sonic-config-engine/tests/multi_npu_data/py3/ipinip.json
+++ b/src/sonic-config-engine/tests/multi_npu_data/py3/ipinip.json
@@ -2,8 +2,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -42,8 +41,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },

--- a/src/sonic-config-engine/tests/sample_output/py2/ipinip.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/ipinip.json
@@ -2,8 +2,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -66,8 +65,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },

--- a/src/sonic-config-engine/tests/sample_output/py2/ipinip_subnet_decap_enable.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/ipinip_subnet_decap_enable.json
@@ -25,8 +25,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -98,8 +97,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },

--- a/src/sonic-config-engine/tests/sample_output/py3/ipinip.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/ipinip.json
@@ -2,8 +2,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -66,8 +65,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },

--- a/src/sonic-config-engine/tests/sample_output/py3/ipinip_subnet_decap_enable.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/ipinip_subnet_decap_enable.json
@@ -25,8 +25,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -98,8 +97,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"pipe",
-            "decap_dscp_to_tc_map":"AZURE",
+            "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#20650, which caused Orchanget crash #21246 

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>