### PR TITLE
Support yang model for bulk size per counter

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
@@ -163,6 +163,7 @@
                 "PORT": {
                     "FLEX_COUNTER_STATUS": "enable",
                     "BULK_CHUNK_SIZE": 100,
+                    "BULK_CHUNK_SIZE_PER_PREFIX": "SAI_PORT_STAT_IF_OUT_QLEN:0;SAI_PORT_STAT_IF_IN_FEC:32",
                     "POLL_INTERVAL": 1000
                 },
                 "PORT_BUFFER_DROP": {

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -47,6 +47,11 @@ module sonic-flex_counter {
                 }
             }
 
+            typedef bulk_chunk_size_per_prefix {
+                type string;
+                description "Bulk chunk size per counter name prefix";
+            }
+
             description "FLEX_COUNTER_TABLE part of config_db.json";
 
             /* below are in alphabetical order */
@@ -111,6 +116,9 @@ module sonic-flex_counter {
                 leaf BULK_CHUNK_SIZE {
                     type bulk_chunk_size;
                 }
+                leaf BULK_CHUNK_SIZE_PER_PREFIX {
+                    type bulk_chunk_size_per_prefix;
+                }
             }
 
             container PG_WATERMARK {
@@ -127,6 +135,9 @@ module sonic-flex_counter {
                 leaf BULK_CHUNK_SIZE {
                     type bulk_chunk_size;
                 }
+                leaf BULK_CHUNK_SIZE_PER_PREFIX {
+                    type bulk_chunk_size_per_prefix;
+                }
             }
 
             container PORT {
@@ -142,6 +153,9 @@ module sonic-flex_counter {
                 }
                 leaf BULK_CHUNK_SIZE {
                     type bulk_chunk_size;
+                }
+                leaf BULK_CHUNK_SIZE_PER_PREFIX {
+                    type bulk_chunk_size_per_prefix;
                 }
             }
 
@@ -169,6 +183,9 @@ module sonic-flex_counter {
                 leaf BULK_CHUNK_SIZE {
                     type bulk_chunk_size;
                 }
+                leaf BULK_CHUNK_SIZE_PER_PREFIX {
+                    type bulk_chunk_size_per_prefix;
+                }
             }
 
             container QUEUE {
@@ -185,6 +202,9 @@ module sonic-flex_counter {
                 leaf BULK_CHUNK_SIZE {
                     type bulk_chunk_size;
                 }
+                leaf BULK_CHUNK_SIZE_PER_PREFIX {
+                    type bulk_chunk_size_per_prefix;
+                }
             }
 
             container QUEUE_WATERMARK {
@@ -200,6 +220,9 @@ module sonic-flex_counter {
                 }
                 leaf BULK_CHUNK_SIZE {
                     type bulk_chunk_size;
+                }
+                leaf BULK_CHUNK_SIZE_PER_PREFIX {
+                    type bulk_chunk_size_per_prefix;
                 }
             }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Support yang model for bulk size per counter

HLD: https://github.com/sonic-net/SONiC/pull/1864

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

