### PR TITLE
[nvidia-bluefield] Apply FW configuration after the FW upgrade.

### DIFF
--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -389,6 +389,18 @@ function RunFwUpdateCmd() {
         failure_msg="${output#*Fail : }"
         ExitFailure "FW Update command: ${COMMAND} failed with error: ${failure_msg}"
     fi
+
+    local COMMAND="mlxconfig -d ${_MST_DEVICE} -y s INTERNAL_CPU_MODEL=1 LAG_RESOURCE_ALLOCATION=1 NUM_OF_PF=0 CQE_COMPRESSION=1 NUM_OF_VFS=0 HAIRPIN_DATA_BUFFER_LOCK=1 MEMIC_SIZE_LIMIT=0 PCI_WR_ORDERING=1"
+
+    output=$(eval "${COMMAND}")
+
+    ERROR_CODE="$?"
+
+    if [[ "${ERROR_CODE}" != "${EXIT_SUCCESS}" ]]; then
+        echo "${output}"
+        failure_msg="${output#*Fail : }"
+        ExitFailure "FW Update command: ${COMMAND} failed with error: ${failure_msg}"
+    fi
 }
 
 function GetAvailableFwVersion() {

--- a/platform/nvidia-bluefield/installer/install.sh.j2
+++ b/platform/nvidia-bluefield/installer/install.sh.j2
@@ -241,7 +241,12 @@ if [[ $fw_upgrade_is_needed == "true" ]]; then
 
 	ex mst start
 
-	ex $sonic_fs_mountpoint/usr/bin/mlnx-fw-upgrade.sh --update -v
+	if function_exists bfb_pre_fw_install; then
+		log "Running bfb_pre_fw_install from bf.cfg"
+		bfb_pre_fw_install
+	fi
+
+	ex $sonic_fs_mountpoint/usr/bin/mlnx-fw-upgrade.sh -v
 	if [[ $? != 0 ]]; then
 		log "ERROR: FW update failed"
 	fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Apply DPU NIC FW configuration after the FW upgrade to ensure that DPU runs with the required configuration.
The change is temporary and will be removed after the configuration becomes part of the FW.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Extend the FW upgrade script to apply the configuration after the FW installation.

#### How to verify it
Run sonic-mgmt tests.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

