### PR TITLE
Fix the issue of no INFO level syslog for caclmgrd

### DIFF
--- a/src/sonic-py-common/sonic_py_common/daemon_base.py
+++ b/src/sonic-py-common/sonic_py_common/daemon_base.py
@@ -1,7 +1,5 @@
-import logging
 import signal
 import sys
-import syslog
 
 from . import device_info
 from .general import load_module_from_source

--- a/src/sonic-py-common/sonic_py_common/daemon_base.py
+++ b/src/sonic-py-common/sonic_py_common/daemon_base.py
@@ -55,25 +55,6 @@ class DaemonBase(Logger):
         if not signal.getsignal(signal.SIGTERM):
             signal.signal(signal.SIGTERM, self.signal_handler)
 
-    def log(self, priority, message, also_print_to_console=False):
-        self.logger_instance.log(priority, message, also_print_to_console)
-
-    def log_error(self, message, also_print_to_console=False):
-        self.logger_instance.log_error(message, also_print_to_console)
-
-    def log_warning(self, message, also_print_to_console=False):
-        self.logger_instance.log_warning(message, also_print_to_console)
-
-    def log_notice(self, message, also_print_to_console=False):
-        self.logger_instance.log_notice(message, also_print_to_console)
-
-    def log_info(self, message, also_print_to_console=False):
-        self.logger_instance.log_info(message, also_print_to_console)
-
-    def log_debug(self, message, also_print_to_console=False):
-        self.logger_instance.log_debug(message, also_print_to_console)
-
-    
     # Default signal handler; can be overridden by subclass
     def signal_handler(self, sig, frame):
         if sig == signal.SIGHUP:

--- a/src/sonic-py-common/sonic_py_common/syslogger.py
+++ b/src/sonic-py-common/sonic_py_common/syslogger.py
@@ -21,7 +21,7 @@ class SysLogger:
     """
 
     DEFAULT_LOG_FACILITY = SysLogHandler.LOG_USER
-    DEFAULT_LOG_LEVEL = logging.INFO
+    DEFAULT_LOG_LEVEL = logging.NOTICE
 
     def __init__(self, log_identifier=None, log_facility=DEFAULT_LOG_FACILITY, log_level=DEFAULT_LOG_LEVEL, enable_runtime_config=False):
         self.log_identifier = log_identifier if log_identifier else os.path.basename(sys.argv[0]) 
@@ -42,7 +42,7 @@ class SysLogger:
         
         if enable_runtime_config:
             self.update_log_level()
-                            
+
     def update_log_level(self):
         """Refresh log level.
 

--- a/src/sonic-py-common/sonic_py_common/syslogger.py
+++ b/src/sonic-py-common/sonic_py_common/syslogger.py
@@ -21,7 +21,7 @@ class SysLogger:
     """
 
     DEFAULT_LOG_FACILITY = SysLogHandler.LOG_USER
-    DEFAULT_LOG_LEVEL = logging.NOTICE
+    DEFAULT_LOG_LEVEL = logging.INFO
 
     def __init__(self, log_identifier=None, log_facility=DEFAULT_LOG_FACILITY, log_level=DEFAULT_LOG_LEVEL, enable_runtime_config=False):
         self.log_identifier = log_identifier if log_identifier else os.path.basename(sys.argv[0]) 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix issue https://github.com/sonic-net/sonic-buildimage/issues/21290
1. No info level log found for systemctl caclmgrd service in syslog file in 202405 images, only warning log found in /var/log/syslog
2. set_min_log_priority_info fuction doesn't work


##### Work item tracking
- Microsoft ADO **(number only)**:
30611546
#### How I did it
After https://github.com/sonic-net/sonic-buildimage/pull/17171/, it added those log functions in `daemon_base.py`, actually, in those function, it didn't set priority, by default, it sets default level to `NOTICE`(https://github.com/sonic-net/sonic-buildimage/blame/9588a40abc27911a82aa2f116c17ce06c2cd7093/src/sonic-py-common/sonic_py_common/logger.py#L39), so even in `log_info`, without priority parameter, the default level is still `NOTICE`, the log which is printed with `INFO` level can't be printed into syslog.
Because both `src/sonic-py-common/sonic_py_common/syslogger.py` and `src/sonic-py-common/sonic_py_common/logger.py` implement these functions, we don't need to add those functions in `daemon_base.py`
The solution is remove them.
And by the way, in `caclmgrd`, it calls `caclmgr.set_min_log_priority_info()`, `caclmgrd` is an instance of `DaemonBase` whose parent class is `Logger`, `set_min_log_priority_info` both works for `use_syslogger=True` or `use_syslogger=Flase` in daemon_base.py init function.

```
  def log(self, priority, message, also_print_to_console=False):
        self.logger_instance.log(priority, message, also_print_to_console)

    def log_error(self, message, also_print_to_console=False):
        self.logger_instance.log_error(message, also_print_to_console)

    def log_warning(self, message, also_print_to_console=False):
        self.logger_instance.log_warning(message, also_print_to_console)

    def log_notice(self, message, also_print_to_console=False):
        self.logger_instance.log_notice(message, also_print_to_console)

    def log_info(self, message, also_print_to_console=False):
        self.logger_instance.log_info(message, also_print_to_console)

    def log_debug(self, message, also_print_to_console=False):
        self.logger_instance.log_debug(message, also_print_to_console)
```

https://github.com/sonic-net/sonic-buildimage/blame/9588a40abc27911a82aa2f116c17ce06c2cd7093/src/sonic-py-common/sonic_py_common/logger.py#L39
```
       # Set the default minimum log priority to LOG_PRIORITY_NOTICE
        self.set_min_log_priority(self.LOG_PRIORITY_NOTICE)
```
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Test evidence:

```
from sonic_py_common import daemon_base

SYSLOG_IDENTIFIER = "TestSysLogger"
log3 = daemon_base.DaemonBase(SYSLOG_IDENTIFIER, use_syslogger=False)
log3.set_min_log_priority_info()

log3.log_info("log3: This is a info message")
log3.log_notice("log3: This is a notice message")
log3.log_warning("log3: This is a warning message")
log3.log_debug("log3: This is a debug message")
log3.log_error("log3: This is a error message")

log3.log_info("log3: This is a info message, console", also_print_to_console=True)
log3.log_notice("log3: This is a notice message, console", also_print_to_console=True)
log3.log_warning("log3: This is a warning message,console", also_print_to_console=True)
log3.log_debug("log3: This is a debug message,console", also_print_to_console=True)
log3.log_error("log3: This is a error message,consle", also_print_to_console=True)
```

Console output:
```
log3: This is a info message, console
log3: This is a notice message, console
log3: This is a warning message,console
log3: This is a error message,consle
```

Syslog file output:
```
2025 Jan  6 10:16:49.077345 str2-7050cx3-acs-13 INFO TestSysLogger[723065]: log3: This is a info message
2025 Jan  6 10:16:49.077797 str2-7050cx3-acs-13 NOTICE TestSysLogger[723065]: log3: This is a notice message
2025 Jan  6 10:16:49.077910 str2-7050cx3-acs-13 WARNING TestSysLogger[723065]: log3: This is a warning message
2025 Jan  6 10:16:49.077994 str2-7050cx3-acs-13 ERR TestSysLogger[723065]: log3: This is a error message
2025 Jan  6 10:16:49.078074 str2-7050cx3-acs-13 INFO TestSysLogger[723065]: log3: This is a info message, console
2025 Jan  6 10:16:49.086310 str2-7050cx3-acs-13 NOTICE TestSysLogger[723065]: log3: This is a notice message, console
2025 Jan  6 10:16:49.086508 str2-7050cx3-acs-13 WARNING TestSysLogger[723065]: log3: This is a warning message,console
2025 Jan  6 10:16:49.086608 str2-7050cx3-acs-13 ERR TestSysLogger[723065]: log3: This is a error message,consle
```

set `use_syslogger=True`, same test results with `use_syslogger=False`.


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

