### PR TITLE
Disabling ports by adding parameter ‘-P 0’

### DIFF
--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -32,7 +32,7 @@ stderr_syslog=true
 dependent_startup=true
 
 [program:mgmtd]
-command=/usr/lib/frr/mgmtd -A 127.0.0.1
+command=/usr/lib/frr/mgmtd -A 127.0.0.1 -P 0
 priority=4
 autostart=false
 autorestart=true
@@ -69,7 +69,7 @@ dependent_startup=true
 dependent_startup_wait_for=zebra:running
 
 [program:staticd]
-command=/usr/lib/frr/staticd -A 127.0.0.1
+command=/usr/lib/frr/staticd -A 127.0.0.1 -P 0
 priority=4
 autostart=false
 autorestart=false
@@ -83,7 +83,7 @@ dependent_startup_wait_for=zsocket:exited
 
 {% if DEVICE_METADATA.localhost.frr_mgmt_framework_config is defined and DEVICE_METADATA.localhost.frr_mgmt_framework_config == "true" %}
 [program:bfdd]
-command=/usr/lib/frr/bfdd -A 127.0.0.1
+command=/usr/lib/frr/bfdd -A 127.0.0.1 -P 0
 priority=4
 stopsignal=KILL
 autostart=false
@@ -99,9 +99,9 @@ dependent_startup_wait_for=zebra:running
 
 [program:bgpd]
 {% if FEATURE is defined and FEATURE.bmp is defined and FEATURE.bmp.state is defined and FEATURE.bmp.state == "enabled" %}
-command=/usr/lib/frr/bgpd -A 127.0.0.1 -M snmp -M bmp
+command=/usr/lib/frr/bgpd -A 127.0.0.1 -P 0 -M snmp -M bmp
 {% else %}
-command=/usr/lib/frr/bgpd -A 127.0.0.1 -M snmp
+command=/usr/lib/frr/bgpd -A 127.0.0.1 -P 0 -M snmp
 {% endif %}
 priority=5
 stopsignal=KILL
@@ -117,7 +117,7 @@ dependent_startup_wait_for=zsocket:exited
 
 {% if DEVICE_METADATA.localhost.frr_mgmt_framework_config is defined and DEVICE_METADATA.localhost.frr_mgmt_framework_config == "true" %}
 [program:ospfd]
-command=/usr/lib/frr/ospfd -A 127.0.0.1 -M snmp
+command=/usr/lib/frr/ospfd -A 127.0.0.1 -P 0 -M snmp
 priority=5
 stopsignal=KILL
 autostart=false
@@ -131,7 +131,7 @@ dependent_startup=true
 dependent_startup_wait_for=zebra:running
 
 [program:pimd]
-command=/usr/lib/frr/pimd -A 127.0.0.1
+command=/usr/lib/frr/pimd -A 127.0.0.1 -P 0
 priority=5
 stopsignal=KILL
 autostart=false
@@ -239,7 +239,7 @@ dependent_startup_wait_for=bgpd:running
 
 {% if DEVICE_METADATA.localhost.frr_mgmt_framework_config is defined and DEVICE_METADATA.localhost.frr_mgmt_framework_config == "true" %}
 [program:pathd]
-command=/usr/lib/frr/pathd -A 127.0.0.1
+command=/usr/lib/frr/pathd -A 127.0.0.1 -P 0
 priority=5
 stopsignal=KILL
 autostart=false


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
There are several TCP ports bound to localhost that need to be disabled to enhance system security.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
By adding -P 0 in supervisord.conf.j2 to disable the ports.

#### How to verify it
Check the file for -P 0 changes, and confirm port behaviour using netstat.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

