### PR TITLE
Add pytest-stress to sonic-mgmt image

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -92,6 +92,7 @@ RUN python3 -m pip install aiohttp \
                  pytest-xdist==1.28.0 \
                  python-dateutil \
                  pytest==7.4.0 \
+                 pytest-stress \
                  PyYAML \
                  redis \
                  requests \
@@ -175,6 +176,7 @@ RUN python2 -m pip install allure-pytest==2.8.22 \
                 pytest-repeat \
                 pytest-html \
                 pytest-xdist==1.28.0 \
+                pytest-stress \
                 python-dateutil \
                 PyYAML \
                 redis \


### PR DESCRIPTION
#### Why I did it

Adding pytest-stress to sonic-mgmt image will help in running stress tests.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

pip install pytest-stress plugin

#### How to verify it

Manually tested the image with DUT

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

Not applicable.

#### Description for the changelog

Adds pytest-stress to sonic-mgmt image
- Adding pytest-stress to sonic-mgmt image will help in running stress tests.

#### Link to config_db schema for YANG module changes

Not applicable

#### A picture of a cute animal (not mandatory but encouraged)