### PR TITLE
Add freeRADIUS package to docker-ptf 

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -91,7 +91,8 @@ RUN apt-get update          \
         gdb                 \
         automake            \
         iproute2            \
-        wireshark-common
+        wireshark-common    \
+        freeradius
 
 {% if PTF_ENV_PY_VER == "py3" %}
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \


### PR DESCRIPTION
Adding freeradius package to docker-ptf to help with RADIUS sonic-mgmt testing.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

In a subsequent PR in the sonic-mgmt repo, I will add RADIUS tests, and there needs to be a consumable RADIUS server in the infrastructure. 



#### How I did it

Added the `freeradius` package the ptf docker j2 file. 

#### How to verify it

I build the new docker image locally and then ran few succesfull app-topo tasks inside of sonic-mgmt.  Also verifed that freeradius is installed.

```
make target/docker-ptf.gz
docker load < target/docker-ptf.gz
docker start docker-ptf:lastest

Then inside the docker image:

dt@usschq-asser-t002:~/sonic-buildimage/target$ docker exec -it fe bash
root@fe0000e7dfd0:~# freeradius -v
radiusd: FreeRADIUS Version 3.0.17, for host x86_64-pc-linux-gnu, built on Feb 24 2023 at 12:52:21
FreeRADIUS Version 3.0.17
Copyright (C) 1999-2017 The FreeRADIUS server project and contributors
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE
You may redistribute copies of FreeRADIUS under the terms of the
GNU General Public License
For more information about these matters, see the file named COPYRIGHT
root@fe0000e7dfd0:~#
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

Tested against both 202405 sonic-mgmt and tip of master. 

#### Description for the changelog
Adding freeradius to docker-ptf

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->


#### A picture of a cute animal (not mandatory but encouraged)

![bmd jgp](https://github.com/user-attachments/assets/cb31e2ed-b586-425e-8afe-308829cd6d5b)
