### PR TITLE
[swss] ecmp hash seed configurable from config_db

### DIFF
--- a/dockers/docker-orchagent/switch.json.j2
+++ b/dockers/docker-orchagent/switch.json.j2
@@ -4,7 +4,9 @@
 {% set hash_seed_offset = 0 %}
 {% set ecmp_hash_offset_value = 0 %}
 {% set lag_hash_offset_value = 0 %}
-{% if DEVICE_METADATA.localhost.type %}
+{% if DEVICE_METADATA.localhost.ecmp_hash_seed %}
+{% set hash_seed = DEVICE_METADATA.localhost.ecmp_hash_seed | int %}
+{% elif DEVICE_METADATA.localhost.type %}
 {% if "ToRRouter" in DEVICE_METADATA.localhost.type or DEVICE_METADATA.localhost.type in ["EPMS", "MgmtTsToR"] %}
 {% set hash_seed = 0 %}
 {% elif "LeafRouter" in DEVICE_METADATA.localhost.type %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Before this commit, the ECMP hash seed could only be changed through indirect parameters in DEVICE_METADATA:
- type (10 for LeafRouter, 25 for SpineRouter, etc...)
- namespace_id: the value is used as an offset

This commit brings the possibility to enforce the ECMP hash seed from config_db.json via the new 'ecmp_hash_seed' field. If defined:
- the value inferred from the 'type' is ignored
- the namespace_id is still used as an offset

It is particularly useful to fix ECMP polarization issue, especially when having more than 3 layers in a clos matrix.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

The `switch.json.j2` template already gets the DEVICE_METADATA. The new `ecmp_hash_seed` field is directly accessible from it.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

```
sudo vim /etc/sonic/config_db.json
# add the field: DEVICE_METADATA > localhost > ecmp_hash_seed = 15
redis-cli HGET "SWITCH_TABLE:switch" "ecmp_hash_seed"
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Configurable ECMP hash seed

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

