### PR TITLE
[frr-mgmt-framework]: VXLAN EVPN should support advertise-svi-ip

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1822,6 +1822,7 @@ class BGPConfigDaemon:
                            '+route_flap_dampen_suppress_threshold',
                            '+route_flap_dampen_max_suppress'],          '{no:no-prefix}bgp dampening {} {} {} {}', ['true', 'false']),
                          ('advertise-all-vni',                      '{no:no-prefix}advertise-all-vni', ['true','false']),
+                         ('advertise-svi-ip',                       '{no:no-prefix}advertise-svi-ip', ['true','false']),
                          ('advertise-default-gw',                   '{no:no-prefix}advertise-default-gw', ['true','false']),
                          ('advertise-ipv4-unicast',                      '{no:no-prefix}advertise ipv4 unicast', ['true','false']),
                          ('advertise-ipv6-unicast',                      '{no:no-prefix}advertise ipv6 unicast', ['true','false']),

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.addr_family.evpn.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.addr_family.evpn.j2
@@ -1,6 +1,9 @@
 {% if 'advertise-all-vni' in af_val and af_val['advertise-all-vni'] == 'true' %}
   advertise-all-vni
 {% endif %}
+{% if 'advertise-svi-ip' in af_val and af_val['advertise-svi-ip'] == 'true' %}
+  advertise-svi-ip
+{% endif %}
 {% if 'autort' in af_val %}
   autort {{af_val['autort']}}
 {% endif %}

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -131,6 +131,8 @@ bgp_globals_data = [
                        conf_bgp_af_cmd('default', 100, 'ipv4') + ['{}distance bgp 100 115 238']),
         CmdMapTestInfo('BGP_GLOBALS_AF', 'default|ipv6_unicast', {'advertise-all-vni': 'true'},
                        conf_bgp_af_cmd('default', 100, 'ipv6') + ['{}advertise-all-vni']),
+        CmdMapTestInfo('BGP_GLOBALS_AF', 'default|ipv6_unicast', {'advertise-svi-ip': 'true'},
+                       conf_bgp_af_cmd('default', 100, 'ipv6') + ['{}advertise-svi-ip']),
         CmdMapTestInfo('BGP_GLOBALS', 'Vrf_red', {'local_asn': 200},
                        conf_bgp_dft_cmd('Vrf_red', 200), False, conf_no_bgp_cmd('Vrf_red', 200), None, None, None),
         CmdMapTestInfo('BGP_GLOBALS', 'Vrf_red', {'med_confed': 'true'},

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1780,7 +1780,8 @@
                 "max_ibgp_paths": "2"
             },
             "default|l2vpn_evpn": {
-                "advertise-all-vni": "true"
+                "advertise-all-vni": "true",
+                "advertise-svi-ip": "true"
             }
         },
         "BGP_GLOBALS_AF_AGGREGATE_ADDR": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
@@ -12,6 +12,16 @@
         "desc": "BGP Address Family l2vpn_evpn with advertise-all-vni set to an invalid value",
         "eStr": "Invalid value \"invalid value\" in \"advertise-all-vni\" element."
     },
+    "BGP_GLOBALS_AF_ADVERTISE_SVI_IP_TRUE": {
+        "desc": "BGP Address Family l2vpn_evpn with advertise-svi-ip set to true"
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_SVI_IP_FALSE": {
+        "desc": "BGP Address Family l2vpn_evpn with advertise-svi-ip set to false"
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_SVI_IP_INVALID": {
+        "desc": "BGP Address Family l2vpn_evpn with advertise-svi-ip set to an invalid value",
+        "eStr": "Invalid value \"invalid value\" in \"advertise-svi-ip\" element."
+    },
     "BGP_NEIGHBOR_ALL_VALID": {
         "desc": "Configure BGP neighbor table."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
@@ -144,6 +144,69 @@
             }
         }
     },
+    "BGP_GLOBALS_AF_ADVERTISE_SVI_IP_TRUE": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "advertise-svi-ip": "true"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_SVI_IP_FALSE": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "advertise-svi-ip": "false"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_SVI_IP_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "advertise-svi-ip": "invalid value"
+                }
+                ]
+            }
+        }
+    },
     "BGP_NEIGHBOR_ALL_VALID": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
@@ -450,6 +450,11 @@ module sonic-bgp-global {
                     type boolean;
                     description "L2VPN advertise all VNIs";
                 }
+
+                leaf advertise-svi-ip {
+                    type boolean;
+                    description "L2VPN advertise the local SVI IP address so that it can be accessible from remote VTEPs";
+                }
             }
         }
 


### PR DESCRIPTION
#### Why I did it

advertise-svi-ip allows the switch to participate in the L2 VXLAN via its unique IP address.

https://docs.frrouting.org/en/latest/bgp.html#evpn-advertise-svi-ip

##### Work item tracking

#### How I did it

Updated yang models, frr-mgmt-framework, jinja2 templates, and test cases.

#### How to verify it

Test cases have been updated for verification purposes.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202411

#### Tested branch (Please provide the tested image version)

- [x] master as of 20250106
- [x] 202411  

#### Description for the changelog

[frr-mgmt-framework]: VXLAN EVPN should support advertise-svi-ip

#### Link to config_db schema for YANG module changes
No relevant section exists in Configuration.md to document change. 

#### A picture of a cute animal (not mandatory but encouraged)

Signed-off-by: Brad House (@bradh352)

