### PR TITLE
Change DBConnector to connect redis with unix socket.

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -212,7 +212,7 @@ class SfpUtil(SfpUtilBase):
             from swsscommon import swsscommon
             self.state_db = swsscommon.DBConnector("STATE_DB",
                                                    REDIS_TIMEOUT_USECS,
-                                                   True)
+                                                   False)
 
             # Subscribe to state table for SFP change notifications
             self.db_sel = swsscommon.Select()

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -212,7 +212,7 @@ class SfpUtil(SfpUtilBase):
             from swsscommon import swsscommon
             self.state_db = swsscommon.DBConnector("STATE_DB",
                                                    REDIS_TIMEOUT_USECS,
-                                                   False)
+                                                   True)
 
             # Subscribe to state table for SFP change notifications
             self.db_sel = swsscommon.Select()

--- a/dockers/docker-sflow/port_index_mapper.py
+++ b/dockers/docker-sflow/port_index_mapper.py
@@ -24,7 +24,7 @@ class PortIndexMapper(object):
                    swsscommon.STATE_VLAN_TABLE_NAME]
         self.appl_db = swsscommon.DBConnector("STATE_DB",
                                               REDIS_TIMEOUT_MS,
-                                              True)
+                                              False)
 
         self.state_db = swsscommon.SonicV2Connector(host='127.0.0.1', decode_responses=True)
         self.state_db.connect(self.state_db.STATE_DB, False)

--- a/src/sonic-bgpcfgd/bgpcfgd/runner.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/runner.py
@@ -40,7 +40,7 @@ class Runner(object):
         db = swsscommon.SonicDBConfig.getDbId(db_name)
         if db not in self.db_connectors:
             if db_name == "CHASSIS_APP_DB":
-                self.db_connectors[db] = swsscommon.DBConnector(db_name, 0, True, '')
+                self.db_connectors[db] = swsscommon.DBConnector(db_name, 0, False, '')
             else:
                 self.db_connectors[db] = swsscommon.DBConnector(db_name, 0)
 

--- a/src/sonic-bgpcfgd/staticroutebfd/main.py
+++ b/src/sonic-bgpcfgd/staticroutebfd/main.py
@@ -111,9 +111,9 @@ class StaticRouteBfd(object):
         #assume only one ipv4  and/or one ipv6 for each interface
         self.local_db[LOCAL_INTERFACE_TABLE] = defaultdict(dict)
 
-        self.config_db  = swsscommon.DBConnector(CONFIG_DB_NAME, 0, True)
-        self.appl_db = swsscommon.DBConnector(APPL_DB_NAME, 0, True)
-        self.state_db = swsscommon.DBConnector(STATE_DB_NAME, 0, True)
+        self.config_db  = swsscommon.DBConnector(CONFIG_DB_NAME, 0, False)
+        self.appl_db = swsscommon.DBConnector(APPL_DB_NAME, 0, False)
+        self.state_db = swsscommon.DBConnector(STATE_DB_NAME, 0, False)
 
         self.bfd_appl_tbl = swsscommon.ProducerStateTable(self.appl_db, BFD_SESSION_TABLE_NAME)
 

--- a/src/sonic-eventd/src/eventd.cpp
+++ b/src/sonic-eventd/src/eventd.cpp
@@ -146,7 +146,7 @@ stats_collector::start()
 
     if (!s_unit_testing) {
         try {
-            m_counters_db = make_shared<swss::DBConnector>("COUNTERS_DB", 0, true);
+            m_counters_db = make_shared<swss::DBConnector>("COUNTERS_DB", 0, false);
         }
         catch (exception &e)
         {

--- a/src/sonic-py-common/sonic_py_common/daemon_base.py
+++ b/src/sonic-py-common/sonic_py_common/daemon_base.py
@@ -26,7 +26,7 @@ EMPTY_NAMESPACE = ''
 
 def db_connect(db_name, namespace=EMPTY_NAMESPACE):
     from swsscommon import swsscommon
-    return swsscommon.DBConnector(db_name, REDIS_TIMEOUT_MSECS, True, namespace)
+    return swsscommon.DBConnector(db_name, REDIS_TIMEOUT_MSECS, False, namespace)
 
 
 #

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -514,7 +514,7 @@ def get_asic_presence_list():
             # This is supervisor card. Some fabric cards may not be inserted.
             # Get asic list from CHASSIS_ASIC_TABLE which lists only the asics
             # present based on Fabric card detection by the platform.
-            db = swsscommon.DBConnector(CHASSIS_STATE_DB, 0, True)
+            db = swsscommon.DBConnector(CHASSIS_STATE_DB, 0, False)
             asic_table = swsscommon.Table(db, CHASSIS_FABRIC_ASIC_INFO_TABLE)
             if asic_table:
                 asics_presence_list = list(asic_table.getKeys())


### PR DESCRIPTION
Change DBConnector to connect redis with unix socket.

#### Why I did it
Improve SONiC Redis security by switch to unix socket connection.

##### Work item tracking
- Microsoft ADO: 30329015

#### How I did it
Change DBConnector parameter to connect redis with unix socket:
DBConnector(const std::string &dbName, unsigned int timeout_ms, bool isTcpConn = false);

#### How to verify it
Pass all UT.


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [] 

#### Description for the changelog
Change DBConnector to connect redis with unix socket.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

