### PR TITLE
Add disk full event to sonic-events-host yang model.

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-events-host.yang
+++ b/src/sonic-yang-models/yang-models/sonic-events-host.yang
@@ -93,6 +93,7 @@ module sonic-events-host {
             leaf fail_type {
                 type enumeration {
                     enum "read_only";
+                    enum "disk_full";
                 }
                 description "Type of failure";
             }


### PR DESCRIPTION
Add disk full event to sonic-events-host yang model.

#### Why I did it
This PR need publish disk full event:
https://github.com/sonic-net/sonic-utilities/pull/3700

##### Work item tracking
- Microsoft ADO: 30608100

#### How I did it
Add disk full event to yang model.

#### How to verify it
Pass all UT.


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [] 

#### Description for the changelog
Add disk full event to sonic-events-host yang model.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

