### PR TITLE
[chassis-packet][SNMP] Enable SNMP dynamic frequency on packet chassis

### DIFF
--- a/dockers/docker-snmp/Dockerfile.j2
+++ b/dockers/docker-snmp/Dockerfile.j2
@@ -76,4 +76,5 @@ COPY ["critical_processes", "/etc/supervisor"]
 # Although exposing ports is not needed for host net mode, keep it for possible bridge mode
 EXPOSE 161/udp 162/udp
 
+RUN chmod +x /usr/bin/docker-snmp-init.sh
 ENTRYPOINT ["/usr/bin/docker-snmp-init.sh"]

--- a/dockers/docker-snmp/Dockerfile.j2
+++ b/dockers/docker-snmp/Dockerfile.j2
@@ -66,9 +66,9 @@ RUN apt-get -y purge     \
     find / | grep -E "__pycache__" | xargs rm -rf && \
     rm -rf /debs /python-wheels ~/.cache
 
+COPY ["docker-snmp-init.sh", "/usr/bin/"]
 COPY ["start.sh", "/usr/bin/"]
 COPY ["snmp_yml_to_configdb.py", "/usr/bin/"]
-COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["*.j2", "/usr/share/sonic/templates/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
@@ -76,4 +76,4 @@ COPY ["critical_processes", "/etc/supervisor"]
 # Although exposing ports is not needed for host net mode, keep it for possible bridge mode
 EXPOSE 161/udp 162/udp
 
-ENTRYPOINT ["/usr/local/bin/supervisord"]
+ENTRYPOINT ["/usr/bin/docker-snmp-init.sh"]

--- a/dockers/docker-snmp/docker-snmp-init.sh
+++ b/dockers/docker-snmp/docker-snmp-init.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#Generate supervisord.conf based on device metadata
+mkdir -p /etc/supervisor/conf.d/
+sonic-cfggen -d -t /usr/share/sonic/templates/supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
+exec /usr/local/bin/supervisord

--- a/dockers/docker-snmp/supervisord.conf.j2
+++ b/dockers/docker-snmp/supervisord.conf.j2
@@ -50,7 +50,11 @@ dependent_startup=true
 dependent_startup_wait_for=start:exited
 
 [program:snmp-subagent]
+{% if DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
+command=/usr/bin/env python3 -m sonic_ax_impl --enable_dynamic_frequency
+{% else %}
 command=/usr/bin/env python3 -m sonic_ax_impl
+{% endif %}
 priority=4
 autostart=false
 autorestart=false


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
It's one part of the fixes of https://github.com/sonic-net/sonic-buildimage/issues/21314
SNMP walker request will always timeout when 100% CPU utilization.
##### Work item tracking
- Microsoft ADO **30112399**:

#### How I did it
Enable SNMP dynamic frequency on packet chassis.
#### How to verify it
snmp/test_snmp_cpu.py(https://github.com/sonic-net/sonic-mgmt/blob/master/tests/snmp/test_snmp_cpu.py) tests the scenario.

And the test case passes in my local run.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
For issue:
https://github.com/sonic-net/sonic-buildimage/issues/21314

Change of SNMP-AgentX https://github.com/sonic-net/sonic-snmpagent/pull/345 will fix the issue.
But we want to limit the scope of the change, since we only see this issue on packet-chassis and old devices with low performance CPUs.


<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

