### PR TITLE
[Arista] Update flex counters config for Arista-7060X6-64PE-C256S2

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C256S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C256S2/th5-a7060x6-64pe.config.bcm
@@ -1907,14 +1907,25 @@ bcm_device:
     0:
         global:
             ftem_mem_entries: 65536
+            sai_stats_support_mask: 0
+            global_flexctr_ing_action_num_reserved: 20
+            global_flexctr_ing_pool_num_reserved: 8
+            global_flexctr_ing_op_profile_num_reserved: 20
+            global_flexctr_ing_group_num_reserved: 2
+            global_flexctr_egr_action_num_reserved: 8
+            global_flexctr_egr_pool_num_reserved: 5
+            global_flexctr_egr_op_profile_num_reserved: 10
+            global_flexctr_egr_group_num_reserved: 1
 ...
 ---
 device:
     0:
         # Per pipe flex counter configuration
         CTR_EFLEX_CONFIG:
-            CTR_ING_EFLEX_OPERMODE_PIPEUNIQUE: 0
-            CTR_EGR_EFLEX_OPERMODE_PIPEUNIQUE: 0
+            CTR_ING_EFLEX_OPERMODE_PIPEUNIQUE: 1
+            CTR_ING_EFLEX_OPERMODE_PIPE_INSTANCE_UNIQUE: 1
+            CTR_EGR_EFLEX_OPERMODE_PIPEUNIQUE: 1
+            CTR_EGR_EFLEX_OPERMODE_PIPE_INSTANCE_UNIQUE: 1
 
         # IFP mode
         FP_CONFIG:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Arista-7060X6-64PE-C256S2 is missing flex counters configs.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update flex counters config for Arista-7060X6-64PE-C256S2

#### How to verify it
Test it locally on Arista-7060X6-64PE-C256S2.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 202405
- [x] 202411


#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
