### PR TITLE
Enable gnmi/telemetry user authorization by config_db

### DIFF
--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -126,7 +126,7 @@ if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
         fi
 
         CRL_EXPIRE_DURATION=$(echo $GNMI | jq -r '.crl_expire_duration')
-        if [ ! -z "$CRL_EXPIRE_DURATI"ON ] && [ $CRL_EXPIRE_DURATION != "null" ]; then
+        if [ ! -z "$CRL_EXPIRE_DURATION" ] && [ $CRL_EXPIRE_DURATION != "null" ]; then
             TELEMETRY_ARGS+=" --crl_expire_duration $CRL_EXPIRE_DURATION"
         fi
     fi

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -66,7 +66,12 @@ if [ -z "$GNMI" ]; then
     PORT=8080
 else
     PORT=$(extract_field "$GNMI" '.port')
+    if ! [[ $PORT =~ ^[0-9]+$ ]]; then
+        echo "Incorrect port value ${PORT}, expecting positive integers" >&2
+        exit $INCORRECT_TELEMETRY_VALUE
+    fi
 fi
+
 TELEMETRY_ARGS+=" --port '$PORT'"
 
 CLIENT_AUTH=$(extract_field "$GNMI" '.client_auth')

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -39,7 +39,7 @@ if [ -n "$CERTS" ]; then
     fi
 
     USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
-    if [ ! -z $USER_AUTH ] then
+    if [ ! -z $USER_AUTH ]; then
         TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
         TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
     fi

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -72,7 +72,7 @@ else
     fi
 fi
 
-TELEMETRY_ARGS+=" --port '$PORT'"
+TELEMETRY_ARGS+=" --port $PORT"
 
 CLIENT_AUTH=$(extract_field "$GNMI" '.client_auth')
 if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -69,7 +69,7 @@ fi
 
 USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
 if [ ! -z $USER_AUTH ] then
-    TELEMETRY_ARGS+=" --user_auth $USER_AUTH"
+    TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
     TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
 fi
 

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -38,7 +38,6 @@ if [ -n "$CERTS" ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
 
-    TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
 elif [ -n "$X509" ]; then
     SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
     SERVER_KEY=$(echo $X509 | jq -r '.server_key')
@@ -74,18 +73,6 @@ if [[ $LOG_LEVEL =~ ^[0-9]+$ ]]; then
     TELEMETRY_ARGS+=" -v=$LOG_LEVEL"
 else
     TELEMETRY_ARGS+=" -v=2"
-fi
-
-if [ ! -z "$GNMI" ]; then
-    ENABLE_CRL=$(echo $GNMI | jq -r '.enable_crl')
-    if [ $ENABLE_CRL == "true" ]; then
-        TELEMETRY_ARGS+=" --enable_crl"
-    fi
-
-    CRL_EXPIRE_DURATION=$(echo $GNMI | jq -r '.crl_expire_duration')
-    if [ -n $CRL_EXPIRE_DURATION ]; then
-        TELEMETRY_ARGS+=" --crl_expire_duration $CRL_EXPIRE_DURATION"
-    fi
 fi
 
 # Enable ZMQ for SmartSwitch
@@ -129,6 +116,20 @@ fi
 USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
 if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
     TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
+
+    if [ $USER_AUTH == "cert" ]; then
+        TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
+
+        ENABLE_CRL=$(echo $GNMI | jq -r '.enable_crl')
+        if [ $ENABLE_CRL == "true" ]; then
+            TELEMETRY_ARGS+=" --enable_crl"
+        fi
+
+        CRL_EXPIRE_DURATION=$(echo $GNMI | jq -r '.crl_expire_duration')
+        if [ ! -z "$CRL_EXPIRE_DURATI"ON ] && [ $CRL_EXPIRE_DURATION != "null" ]; then
+            TELEMETRY_ARGS+=" --crl_expire_duration $CRL_EXPIRE_DURATION"
+        fi
+    fi
 fi
 
 echo "gnmi args: $TELEMETRY_ARGS"

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -5,7 +5,7 @@ INCORRECT_TELEMETRY_VALUE=2
 TELEMETRY_VARS_FILE=/usr/share/sonic/templates/telemetry_vars.j2
 ESCAPE_QUOTE="'\''"
 
-Extract_json_field() {
+extract_field() {
     value=$(echo $1 | jq -r $2)
     echo "${value//\'/${ESCAPE_QUOTE}}"
 }
@@ -31,29 +31,29 @@ TELEMETRY_ARGS=" -logtostderr"
 export CVL_SCHEMA_PATH=/usr/sbin/schema
 
 if [ -n "$CERTS" ]; then
-    SERVER_CRT=$(Extract_json_field "$CERTS" '.server_crt')
-    SERVER_KEY=$(Extract_json_field "$CERTS" '.server_key')
+    SERVER_CRT=$(extract_field "$CERTS" '.server_crt')
+    SERVER_KEY=$(extract_field "$CERTS" '.server_key')
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
         TELEMETRY_ARGS+=" --insecure"
     else
         TELEMETRY_ARGS+=" --server_crt '$SERVER_CRT' --server_key '$SERVER_KEY' "
     fi
 
-    CA_CRT=$(Extract_json_field "$CERTS" '.ca_crt')
+    CA_CRT=$(extract_field "$CERTS" '.ca_crt')
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt '$CA_CRT'"
     fi
 
 elif [ -n "$X509" ]; then
-    SERVER_CRT=$(Extract_json_field "$X509" '.server_crt')
-    SERVER_KEY=$(Extract_json_field "$X509" '.server_key')
+    SERVER_CRT=$(extract_field "$X509" '.server_crt')
+    SERVER_KEY=$(extract_field "$X509" '.server_key')
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
         TELEMETRY_ARGS+=" --insecure"
     else
         TELEMETRY_ARGS+=" --server_crt '$SERVER_CRT' --server_key '$SERVER_KEY' "
     fi
 
-    CA_CRT=$(Extract_json_field "$X509" '.ca_crt')
+    CA_CRT=$(extract_field "$X509" '.ca_crt')
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt '$CA_CRT'"
     fi
@@ -65,16 +65,16 @@ fi
 if [ -z "$GNMI" ]; then
     PORT=8080
 else
-    PORT=$(Extract_json_field "$GNMI" '.port')
+    PORT=$(extract_field "$GNMI" '.port')
 fi
 TELEMETRY_ARGS+=" --port '$PORT'"
 
-CLIENT_AUTH=$(Extract_json_field "$GNMI" '.client_auth')
+CLIENT_AUTH=$(extract_field "$GNMI" '.client_auth')
 if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then
     TELEMETRY_ARGS+=" --allow_no_client_auth"
 fi
 
-LOG_LEVEL=$(Extract_json_field "$GNMI" '.log_level')
+LOG_LEVEL=$(extract_field "$GNMI" '.log_level')
 if [[ $LOG_LEVEL =~ ^[0-9]+$ ]]; then
     TELEMETRY_ARGS+=" -v='$LOG_LEVEL'"
 else
@@ -94,7 +94,7 @@ if [[ x"${MGMT_VRF_ENABLED}" == x"true" ]]; then
 fi
 
 # Server will handle threshold connections consecutively
-THRESHOLD_CONNECTIONS=$(Extract_json_field "$GNMI" '.threshold')
+THRESHOLD_CONNECTIONS=$(extract_field "$GNMI" '.threshold')
 if [[ $THRESHOLD_CONNECTIONS =~ ^[0-9]+$ ]]; then
     TELEMETRY_ARGS+=" --threshold '$THRESHOLD_CONNECTIONS'"
 else
@@ -107,7 +107,7 @@ else
 fi
 
 # Close idle connections after certain duration (in seconds)
-IDLE_CONN_DURATION=$(Extract_json_field "$GNMI" '.idle_conn_duration')
+IDLE_CONN_DURATION=$(extract_field "$GNMI" '.idle_conn_duration')
 if [[ $IDLE_CONN_DURATION =~ ^[0-9]+$ ]]; then
     TELEMETRY_ARGS+=" --idle_conn_duration '$IDLE_CONN_DURATION'"
 else
@@ -119,7 +119,7 @@ else
     fi
 fi
 
-USER_AUTH=$(Extract_json_field "$GNMI" '.user_auth')
+USER_AUTH=$(extract_field "$GNMI" '.user_auth')
 if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
     TELEMETRY_ARGS+=" --client_auth '$USER_AUTH'"
 
@@ -131,7 +131,7 @@ if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
             TELEMETRY_ARGS+=" --enable_crl"
         fi
 
-        CRL_EXPIRE_DURATION=$(Extract_json_field "$GNMI" '.crl_expire_duration')
+        CRL_EXPIRE_DURATION=$(extract_field "$GNMI" '.crl_expire_duration')
         if [ ! -z "$CRL_EXPIRE_DURATION" ] && [ $CRL_EXPIRE_DURATION != "null" ]; then
             TELEMETRY_ARGS+=" --crl_expire_duration '$CRL_EXPIRE_DURATION'"
         fi

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -37,8 +37,6 @@ if [ -n "$CERTS" ]; then
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
-
-    TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
 elif [ -n "$X509" ]; then
     SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
     SERVER_KEY=$(echo $X509 | jq -r '.server_key')
@@ -67,6 +65,12 @@ TELEMETRY_ARGS+=" --port $PORT"
 CLIENT_AUTH=$(echo $GNMI | jq -r '.client_auth')
 if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then
     TELEMETRY_ARGS+=" --allow_no_client_auth"
+fi
+
+USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
+if [ ! -z $USER_AUTH ] then
+    TELEMETRY_ARGS+=" --user_auth $USER_AUTH"
+    TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
 fi
 
 LOG_LEVEL=$(echo $GNMI | jq -r '.log_level')

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -50,6 +50,12 @@ elif [ -n "$X509" ]; then
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
+
+    USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
+    if [ ! -z $USER_AUTH ] then
+        TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
+        TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
+    fi
 else
     TELEMETRY_ARGS+=" --noTLS"
 fi
@@ -65,12 +71,6 @@ TELEMETRY_ARGS+=" --port $PORT"
 CLIENT_AUTH=$(echo $GNMI | jq -r '.client_auth')
 if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then
     TELEMETRY_ARGS+=" --allow_no_client_auth"
-fi
-
-USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
-if [ ! -z $USER_AUTH ] then
-    TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
-    TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
 fi
 
 LOG_LEVEL=$(echo $GNMI | jq -r '.log_level')

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -76,7 +76,7 @@ else
     TELEMETRY_ARGS+=" -v=2"
 fi
 
-if [ -nz "$GNMI" ]; then
+if [ ! -z "$GNMI" ]; then
     ENABLE_CRL=$(echo $GNMI | jq -r '.enable_crl')
     if [ $ENABLE_CRL == "true" ]; then
         TELEMETRY_ARGS+=" --enable_crl"
@@ -127,7 +127,7 @@ else
 fi
 
 USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
-if [ ! -z $USER_AUTH ]; then
+if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
     TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
 fi
 

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -3,6 +3,12 @@
 EXIT_TELEMETRY_VARS_FILE_NOT_FOUND=1
 INCORRECT_TELEMETRY_VALUE=2
 TELEMETRY_VARS_FILE=/usr/share/sonic/templates/telemetry_vars.j2
+ESCAPE_QUOTE="'\''"
+
+Extract_json_field() {
+    value=$(echo $1 | jq -r $2)
+    echo "${value//\'/${ESCAPE_QUOTE}}"
+}
 
 if [ ! -f "$TELEMETRY_VARS_FILE" ]; then
     echo "Telemetry vars template file not found"
@@ -25,31 +31,31 @@ TELEMETRY_ARGS=" -logtostderr"
 export CVL_SCHEMA_PATH=/usr/sbin/schema
 
 if [ -n "$CERTS" ]; then
-    SERVER_CRT=$(echo $CERTS | jq -r '.server_crt')
-    SERVER_KEY=$(echo $CERTS | jq -r '.server_key')
+    SERVER_CRT=$(Extract_json_field "$CERTS" '.server_crt')
+    SERVER_KEY=$(Extract_json_field "$CERTS" '.server_key')
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
         TELEMETRY_ARGS+=" --insecure"
     else
-        TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
+        TELEMETRY_ARGS+=" --server_crt '$SERVER_CRT' --server_key '$SERVER_KEY' "
     fi
 
-    CA_CRT=$(echo $CERTS | jq -r '.ca_crt')
+    CA_CRT=$(Extract_json_field "$CERTS" '.ca_crt')
     if [ ! -z $CA_CRT ]; then
-        TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
+        TELEMETRY_ARGS+=" --ca_crt '$CA_CRT'"
     fi
 
 elif [ -n "$X509" ]; then
-    SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
-    SERVER_KEY=$(echo $X509 | jq -r '.server_key')
+    SERVER_CRT=$(Extract_json_field "$X509" '.server_crt')
+    SERVER_KEY=$(Extract_json_field "$X509" '.server_key')
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
         TELEMETRY_ARGS+=" --insecure"
     else
-        TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
+        TELEMETRY_ARGS+=" --server_crt '$SERVER_CRT' --server_key '$SERVER_KEY' "
     fi
 
-    CA_CRT=$(echo $X509 | jq -r '.ca_crt')
+    CA_CRT=$(Extract_json_field "$X509" '.ca_crt')
     if [ ! -z $CA_CRT ]; then
-        TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
+        TELEMETRY_ARGS+=" --ca_crt '$CA_CRT'"
     fi
 else
     TELEMETRY_ARGS+=" --noTLS"
@@ -59,18 +65,18 @@ fi
 if [ -z "$GNMI" ]; then
     PORT=8080
 else
-    PORT=$(echo $GNMI | jq -r '.port')
+    PORT=$(Extract_json_field "$GNMI" '.port')
 fi
-TELEMETRY_ARGS+=" --port $PORT"
+TELEMETRY_ARGS+=" --port '$PORT'"
 
-CLIENT_AUTH=$(echo $GNMI | jq -r '.client_auth')
+CLIENT_AUTH=$(Extract_json_field "$GNMI" '.client_auth')
 if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then
     TELEMETRY_ARGS+=" --allow_no_client_auth"
 fi
 
-LOG_LEVEL=$(echo $GNMI | jq -r '.log_level')
+LOG_LEVEL=$(Extract_json_field "$GNMI" '.log_level')
 if [[ $LOG_LEVEL =~ ^[0-9]+$ ]]; then
-    TELEMETRY_ARGS+=" -v=$LOG_LEVEL"
+    TELEMETRY_ARGS+=" -v='$LOG_LEVEL'"
 else
     TELEMETRY_ARGS+=" -v=2"
 fi
@@ -88,9 +94,9 @@ if [[ x"${MGMT_VRF_ENABLED}" == x"true" ]]; then
 fi
 
 # Server will handle threshold connections consecutively
-THRESHOLD_CONNECTIONS=$(echo $GNMI | jq -r '.threshold')
+THRESHOLD_CONNECTIONS=$(Extract_json_field "$GNMI" '.threshold')
 if [[ $THRESHOLD_CONNECTIONS =~ ^[0-9]+$ ]]; then
-    TELEMETRY_ARGS+=" --threshold $THRESHOLD_CONNECTIONS"
+    TELEMETRY_ARGS+=" --threshold '$THRESHOLD_CONNECTIONS'"
 else
     if [ -z "$GNMI" ] || [[ $THRESHOLD_CONNECTIONS == "null" ]]; then
         TELEMETRY_ARGS+=" --threshold 100"
@@ -101,9 +107,9 @@ else
 fi
 
 # Close idle connections after certain duration (in seconds)
-IDLE_CONN_DURATION=$(echo $GNMI | jq -r '.idle_conn_duration')
+IDLE_CONN_DURATION=$(Extract_json_field "$GNMI" '.idle_conn_duration')
 if [[ $IDLE_CONN_DURATION =~ ^[0-9]+$ ]]; then
-    TELEMETRY_ARGS+=" --idle_conn_duration $IDLE_CONN_DURATION"
+    TELEMETRY_ARGS+=" --idle_conn_duration '$IDLE_CONN_DURATION'"
 else
     if [ -z "$GNMI" ] || [[ $IDLE_CONN_DURATION == "null" ]]; then
         TELEMETRY_ARGS+=" --idle_conn_duration 5"
@@ -113,9 +119,9 @@ else
     fi
 fi
 
-USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
+USER_AUTH=$(Extract_json_field "$GNMI" '.user_auth')
 if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
-    TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
+    TELEMETRY_ARGS+=" --client_auth '$USER_AUTH'"
 
     if [ $USER_AUTH == "cert" ]; then
         TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
@@ -125,9 +131,9 @@ if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
             TELEMETRY_ARGS+=" --enable_crl"
         fi
 
-        CRL_EXPIRE_DURATION=$(echo $GNMI | jq -r '.crl_expire_duration')
+        CRL_EXPIRE_DURATION=$(Extract_json_field "$GNMI" '.crl_expire_duration')
         if [ ! -z "$CRL_EXPIRE_DURATION" ] && [ $CRL_EXPIRE_DURATION != "null" ]; then
-            TELEMETRY_ARGS+=" --crl_expire_duration $CRL_EXPIRE_DURATION"
+            TELEMETRY_ARGS+=" --crl_expire_duration '$CRL_EXPIRE_DURATION'"
         fi
     fi
 fi

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -38,11 +38,7 @@ if [ -n "$CERTS" ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
 
-    USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
-    if [ ! -z $USER_AUTH ]; then
-        TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
-        TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
-    fi
+    TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
 elif [ -n "$X509" ]; then
     SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
     SERVER_KEY=$(echo $X509 | jq -r '.server_key')
@@ -128,6 +124,11 @@ else
         echo "Incorrect idle_conn_duration value, expecting positive integers" >&2
         exit $INCORRECT_TELEMETRY_VALUE
     fi
+fi
+
+USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
+if [ ! -z $USER_AUTH ]; then
+    TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
 fi
 
 exec /usr/sbin/telemetry ${TELEMETRY_ARGS}

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -6,8 +6,7 @@ TELEMETRY_VARS_FILE=/usr/share/sonic/templates/telemetry_vars.j2
 ESCAPE_QUOTE="'\''"
 
 extract_field() {
-    value=$(echo $1 | jq -r $2)
-    echo "${value//\'/${ESCAPE_QUOTE}}"
+    echo $(echo $1 | jq -r $2)
 }
 
 if [ ! -f "$TELEMETRY_VARS_FILE" ]; then
@@ -36,12 +35,12 @@ if [ -n "$CERTS" ]; then
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
         TELEMETRY_ARGS+=" --insecure"
     else
-        TELEMETRY_ARGS+=" --server_crt '$SERVER_CRT' --server_key '$SERVER_KEY' "
+        TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
     fi
 
     CA_CRT=$(extract_field "$CERTS" '.ca_crt')
     if [ ! -z $CA_CRT ]; then
-        TELEMETRY_ARGS+=" --ca_crt '$CA_CRT'"
+        TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
 
 elif [ -n "$X509" ]; then
@@ -50,12 +49,12 @@ elif [ -n "$X509" ]; then
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
         TELEMETRY_ARGS+=" --insecure"
     else
-        TELEMETRY_ARGS+=" --server_crt '$SERVER_CRT' --server_key '$SERVER_KEY' "
+        TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
     fi
 
     CA_CRT=$(extract_field "$X509" '.ca_crt')
     if [ ! -z $CA_CRT ]; then
-        TELEMETRY_ARGS+=" --ca_crt '$CA_CRT'"
+        TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
 else
     TELEMETRY_ARGS+=" --noTLS"
@@ -81,7 +80,7 @@ fi
 
 LOG_LEVEL=$(extract_field "$GNMI" '.log_level')
 if [[ $LOG_LEVEL =~ ^[0-9]+$ ]]; then
-    TELEMETRY_ARGS+=" -v='$LOG_LEVEL'"
+    TELEMETRY_ARGS+=" -v=$LOG_LEVEL"
 else
     TELEMETRY_ARGS+=" -v=2"
 fi
@@ -101,7 +100,7 @@ fi
 # Server will handle threshold connections consecutively
 THRESHOLD_CONNECTIONS=$(extract_field "$GNMI" '.threshold')
 if [[ $THRESHOLD_CONNECTIONS =~ ^[0-9]+$ ]]; then
-    TELEMETRY_ARGS+=" --threshold '$THRESHOLD_CONNECTIONS'"
+    TELEMETRY_ARGS+=" --threshold $THRESHOLD_CONNECTIONS"
 else
     if [ -z "$GNMI" ] || [[ $THRESHOLD_CONNECTIONS == "null" ]]; then
         TELEMETRY_ARGS+=" --threshold 100"
@@ -114,7 +113,7 @@ fi
 # Close idle connections after certain duration (in seconds)
 IDLE_CONN_DURATION=$(extract_field "$GNMI" '.idle_conn_duration')
 if [[ $IDLE_CONN_DURATION =~ ^[0-9]+$ ]]; then
-    TELEMETRY_ARGS+=" --idle_conn_duration '$IDLE_CONN_DURATION'"
+    TELEMETRY_ARGS+=" --idle_conn_duration $IDLE_CONN_DURATION"
 else
     if [ -z "$GNMI" ] || [[ $IDLE_CONN_DURATION == "null" ]]; then
         TELEMETRY_ARGS+=" --idle_conn_duration 5"
@@ -126,7 +125,7 @@ fi
 
 USER_AUTH=$(extract_field "$GNMI" '.user_auth')
 if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
-    TELEMETRY_ARGS+=" --client_auth '$USER_AUTH'"
+    TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
 
     if [ $USER_AUTH == "cert" ]; then
         TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
@@ -138,7 +137,7 @@ if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
 
         CRL_EXPIRE_DURATION=$(extract_field "$GNMI" '.crl_expire_duration')
         if [ ! -z "$CRL_EXPIRE_DURATION" ] && [ $CRL_EXPIRE_DURATION != "null" ]; then
-            TELEMETRY_ARGS+=" --crl_expire_duration '$CRL_EXPIRE_DURATION'"
+            TELEMETRY_ARGS+=" --crl_expire_duration $CRL_EXPIRE_DURATION"
         fi
     fi
 fi

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -37,6 +37,12 @@ if [ -n "$CERTS" ]; then
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
+
+    USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
+    if [ ! -z $USER_AUTH ] then
+        TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
+        TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
+    fi
 elif [ -n "$X509" ]; then
     SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
     SERVER_KEY=$(echo $X509 | jq -r '.server_key')
@@ -49,12 +55,6 @@ elif [ -n "$X509" ]; then
     CA_CRT=$(echo $X509 | jq -r '.ca_crt')
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
-    fi
-
-    USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
-    if [ ! -z $USER_AUTH ] then
-        TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
-        TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
     fi
 else
     TELEMETRY_ARGS+=" --noTLS"

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -131,4 +131,5 @@ if [ ! -z $USER_AUTH ]; then
     TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
 fi
 
+echo "gnmi args: $TELEMETRY_ARGS"
 exec /usr/sbin/telemetry ${TELEMETRY_ARGS}

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -123,7 +123,7 @@ if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
         fi
 
         CRL_EXPIRE_DURATION=$(echo $GNMI | jq -r '.crl_expire_duration')
-        if [ ! -z "$CRL_EXPIRE_DURATI"ON ] && [ $CRL_EXPIRE_DURATION != "null" ]; then
+        if [ ! -z "$CRL_EXPIRE_DURATION" ] && [ $CRL_EXPIRE_DURATION != "null" ]; then
             TELEMETRY_ARGS+=" --crl_expire_duration $CRL_EXPIRE_DURATION"
         fi
     fi

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -70,7 +70,7 @@ else
         exit $INCORRECT_TELEMETRY_VALUE
     fi
 fi
-TELEMETRY_ARGS+=" --port '$PORT'"
+TELEMETRY_ARGS+=" --port $PORT"
 
 CLIENT_AUTH=$(extract_field "$GNMI" '.client_auth')
 if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -77,7 +77,7 @@ else
     TELEMETRY_ARGS+=" -v=2"
 fi
 
-if [ -nz "$GNMI" ]; then
+if [ ! -z "$GNMI" ]; then
     ENABLE_CRL=$(echo $GNMI | jq -r '.enable_crl')
     if [ $ENABLE_CRL == "true" ]; then
         TELEMETRY_ARGS+=" --enable_crl"
@@ -125,7 +125,7 @@ fi
 TELEMETRY_ARGS+=" -gnmi_native_write=false"
 
 USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
-if [ ! -z $USER_AUTH ]; then
+if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
     TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
 fi
 

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -50,6 +50,14 @@ elif [ -n "$X509" ]; then
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
+
+    USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
+    if [ ! -z $USER_AUTH ] then
+        TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
+
+        # Reuse GNMI_CLIENT_CERT for telemetry service
+        TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
+    fi
 else
     TELEMETRY_ARGS+=" --noTLS"
 fi
@@ -65,14 +73,6 @@ TELEMETRY_ARGS+=" --port $PORT"
 CLIENT_AUTH=$(echo $GNMI | jq -r '.client_auth')
 if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then
     TELEMETRY_ARGS+=" --allow_no_client_auth"
-fi
-
-USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
-if [ ! -z $USER_AUTH ] then
-    TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
-
-    # Reuse GNMI_CLIENT_CERT for telemetry service
-    TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
 fi
 
 LOG_LEVEL=$(echo $GNMI | jq -r '.log_level')

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -5,7 +5,7 @@ INCORRECT_TELEMETRY_VALUE=2
 TELEMETRY_VARS_FILE=/usr/share/sonic/templates/telemetry_vars.j2
 ESCAPE_QUOTE="'\''"
 
-Extract_json_field() {
+extract_field() {
     value=$(echo $1 | jq -r $2)
     echo "${value//\'/${ESCAPE_QUOTE}}"
 }
@@ -31,28 +31,28 @@ export CVL_SCHEMA_PATH=/usr/sbin/schema
 export GOTRACEBACK=crash
 
 if [ -n "$CERTS" ]; then
-    SERVER_CRT=$(Extract_json_field "$CERTS" '.server_crt')
-    SERVER_KEY=$(Extract_json_field "$CERTS" '.server_key')
+    SERVER_CRT=$(extract_field "$CERTS" '.server_crt')
+    SERVER_KEY=$(extract_field "$CERTS" '.server_key')
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
         TELEMETRY_ARGS+=" --insecure"
     else
         TELEMETRY_ARGS+=" --server_crt '$SERVER_CRT' --server_key '$SERVER_KEY' "
     fi
 
-    CA_CRT=$(Extract_json_field "$CERTS" '.ca_crt')
+    CA_CRT=$(extract_field "$CERTS" '.ca_crt')
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt '$CA_CRT'"
     fi
 elif [ -n "$X509" ]; then
-    SERVER_CRT=$(Extract_json_field "$X509" '.server_crt')
-    SERVER_KEY=$(Extract_json_field "$X509" '.server_key')
+    SERVER_CRT=$(extract_field "$X509" '.server_crt')
+    SERVER_KEY=$(extract_field "$X509" '.server_key')
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
         TELEMETRY_ARGS+=" --insecure"
     else
         TELEMETRY_ARGS+=" --server_crt '$SERVER_CRT' --server_key '$SERVER_KEY' "
     fi
 
-    CA_CRT=$(Extract_json_field "$X509" '.ca_crt')
+    CA_CRT=$(extract_field "$X509" '.ca_crt')
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt '$CA_CRT'"
     fi
@@ -64,16 +64,16 @@ fi
 if [ -z "$GNMI" ]; then
     PORT=8080
 else
-    PORT=$(Extract_json_field "$GNMI" '.port')
+    PORT=$(extract_field "$GNMI" '.port')
 fi
 TELEMETRY_ARGS+=" --port '$PORT'"
 
-CLIENT_AUTH=$(Extract_json_field "$GNMI" '.client_auth')
+CLIENT_AUTH=$(extract_field "$GNMI" '.client_auth')
 if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then
     TELEMETRY_ARGS+=" --allow_no_client_auth"
 fi
 
-LOG_LEVEL=$(Extract_json_field "$GNMI" '.log_level')
+LOG_LEVEL=$(extract_field "$GNMI" '.log_level')
 if [[ $LOG_LEVEL =~ ^[0-9]+$ ]]; then
     TELEMETRY_ARGS+=" -v='$LOG_LEVEL'"
 else
@@ -89,7 +89,7 @@ if [ ! -z "$SAVE_ON_SET" ]; then
 fi
 
 # Server will handle threshold connections consecutively
-THRESHOLD_CONNECTIONS=$(Extract_json_field "$GNMI" '.threshold')
+THRESHOLD_CONNECTIONS=$(extract_field "$GNMI" '.threshold')
 if [[ $THRESHOLD_CONNECTIONS =~ ^[0-9]+$ ]]; then
     TELEMETRY_ARGS+=" --threshold '$THRESHOLD_CONNECTIONS'"
 else
@@ -102,7 +102,7 @@ else
 fi
 
 # Close idle connections after certain duration (in seconds)
-IDLE_CONN_DURATION=$(Extract_json_field "$GNMI" '.idle_conn_duration')
+IDLE_CONN_DURATION=$(extract_field "$GNMI" '.idle_conn_duration')
 if [[ $IDLE_CONN_DURATION =~ ^[0-9]+$ ]]; then
     TELEMETRY_ARGS+=" --idle_conn_duration '$IDLE_CONN_DURATION'"
 else
@@ -115,7 +115,7 @@ else
 fi
 TELEMETRY_ARGS+=" -gnmi_native_write=false"
 
-USER_AUTH=$(Extract_json_field "$GNMI" '.user_auth')
+USER_AUTH=$(extract_field "$GNMI" '.user_auth')
 if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
     TELEMETRY_ARGS+=" --client_auth '$USER_AUTH'"
 
@@ -128,7 +128,7 @@ if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
             TELEMETRY_ARGS+=" --enable_crl"
         fi
 
-        CRL_EXPIRE_DURATION=$(Extract_json_field "$GNMI" '.crl_expire_duration')
+        CRL_EXPIRE_DURATION=$(extract_field "$GNMI" '.crl_expire_duration')
         if [ ! -z "$CRL_EXPIRE_DURATION" ] && [ $CRL_EXPIRE_DURATION != "null" ]; then
             TELEMETRY_ARGS+=" --crl_expire_duration '$CRL_EXPIRE_DURATION'"
         fi

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -65,6 +65,10 @@ if [ -z "$GNMI" ]; then
     PORT=8080
 else
     PORT=$(extract_field "$GNMI" '.port')
+    if ! [[ $PORT =~ ^[0-9]+$ ]]; then
+        echo "Incorrect port value ${PORT}, expecting positive integers" >&2
+        exit $INCORRECT_TELEMETRY_VALUE
+    fi
 fi
 TELEMETRY_ARGS+=" --port '$PORT'"
 

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -38,13 +38,8 @@ if [ -n "$CERTS" ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
 
-    USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
-    if [ ! -z $USER_AUTH ]; then
-        TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
-
-        # Reuse GNMI_CLIENT_CERT for telemetry service
-        TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
-    fi
+    # Reuse GNMI_CLIENT_CERT for telemetry service
+    TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
 elif [ -n "$X509" ]; then
     SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
     SERVER_KEY=$(echo $X509 | jq -r '.server_key')
@@ -128,5 +123,10 @@ else
     fi
 fi
 TELEMETRY_ARGS+=" -gnmi_native_write=false"
+
+USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
+if [ ! -z $USER_AUTH ]; then
+    TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
+fi
 
 exec /usr/sbin/telemetry ${TELEMETRY_ARGS}

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -6,8 +6,7 @@ TELEMETRY_VARS_FILE=/usr/share/sonic/templates/telemetry_vars.j2
 ESCAPE_QUOTE="'\''"
 
 extract_field() {
-    value=$(echo $1 | jq -r $2)
-    echo "${value//\'/${ESCAPE_QUOTE}}"
+    echo $(echo $1 | jq -r $2)
 }
 
 if [ ! -f "$TELEMETRY_VARS_FILE" ]; then
@@ -36,12 +35,12 @@ if [ -n "$CERTS" ]; then
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
         TELEMETRY_ARGS+=" --insecure"
     else
-        TELEMETRY_ARGS+=" --server_crt '$SERVER_CRT' --server_key '$SERVER_KEY' "
+        TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
     fi
 
     CA_CRT=$(extract_field "$CERTS" '.ca_crt')
     if [ ! -z $CA_CRT ]; then
-        TELEMETRY_ARGS+=" --ca_crt '$CA_CRT'"
+        TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
 elif [ -n "$X509" ]; then
     SERVER_CRT=$(extract_field "$X509" '.server_crt')
@@ -49,12 +48,12 @@ elif [ -n "$X509" ]; then
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
         TELEMETRY_ARGS+=" --insecure"
     else
-        TELEMETRY_ARGS+=" --server_crt '$SERVER_CRT' --server_key '$SERVER_KEY' "
+        TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
     fi
 
     CA_CRT=$(extract_field "$X509" '.ca_crt')
     if [ ! -z $CA_CRT ]; then
-        TELEMETRY_ARGS+=" --ca_crt '$CA_CRT'"
+        TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
 else
     TELEMETRY_ARGS+=" --noTLS"
@@ -79,7 +78,7 @@ fi
 
 LOG_LEVEL=$(extract_field "$GNMI" '.log_level')
 if [[ $LOG_LEVEL =~ ^[0-9]+$ ]]; then
-    TELEMETRY_ARGS+=" -v='$LOG_LEVEL'"
+    TELEMETRY_ARGS+=" -v=$LOG_LEVEL"
 else
     TELEMETRY_ARGS+=" -v=2"
 fi
@@ -95,7 +94,7 @@ fi
 # Server will handle threshold connections consecutively
 THRESHOLD_CONNECTIONS=$(extract_field "$GNMI" '.threshold')
 if [[ $THRESHOLD_CONNECTIONS =~ ^[0-9]+$ ]]; then
-    TELEMETRY_ARGS+=" --threshold '$THRESHOLD_CONNECTIONS'"
+    TELEMETRY_ARGS+=" --threshold $THRESHOLD_CONNECTIONS"
 else
     if [ -z "$GNMI" ] || [[ $THRESHOLD_CONNECTIONS == "null" ]]; then
         TELEMETRY_ARGS+=" --threshold 100"
@@ -108,7 +107,7 @@ fi
 # Close idle connections after certain duration (in seconds)
 IDLE_CONN_DURATION=$(extract_field "$GNMI" '.idle_conn_duration')
 if [[ $IDLE_CONN_DURATION =~ ^[0-9]+$ ]]; then
-    TELEMETRY_ARGS+=" --idle_conn_duration '$IDLE_CONN_DURATION'"
+    TELEMETRY_ARGS+=" --idle_conn_duration $IDLE_CONN_DURATION"
 else
     if [ -z "$GNMI" ] || [[ $IDLE_CONN_DURATION == "null" ]]; then
         TELEMETRY_ARGS+=" --idle_conn_duration 5"
@@ -121,7 +120,7 @@ TELEMETRY_ARGS+=" -gnmi_native_write=false"
 
 USER_AUTH=$(extract_field "$GNMI" '.user_auth')
 if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
-    TELEMETRY_ARGS+=" --client_auth '$USER_AUTH'"
+    TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
 
     if [ $USER_AUTH == "cert" ]; then
         # Reuse GNMI_CLIENT_CERT for telemetry service
@@ -134,7 +133,7 @@ if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
 
         CRL_EXPIRE_DURATION=$(extract_field "$GNMI" '.crl_expire_duration')
         if [ ! -z "$CRL_EXPIRE_DURATION" ] && [ $CRL_EXPIRE_DURATION != "null" ]; then
-            TELEMETRY_ARGS+=" --crl_expire_duration '$CRL_EXPIRE_DURATION'"
+            TELEMETRY_ARGS+=" --crl_expire_duration $CRL_EXPIRE_DURATION"
         fi
     fi
 fi

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -37,9 +37,6 @@ if [ -n "$CERTS" ]; then
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
-
-    # Reuse GNMI_CLIENT_CERT for telemetry service
-    TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
 elif [ -n "$X509" ]; then
     SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
     SERVER_KEY=$(echo $X509 | jq -r '.server_key')
@@ -68,6 +65,14 @@ TELEMETRY_ARGS+=" --port $PORT"
 CLIENT_AUTH=$(echo $GNMI | jq -r '.client_auth')
 if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then
     TELEMETRY_ARGS+=" --allow_no_client_auth"
+fi
+
+USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
+if [ ! -z $USER_AUTH ] then
+    TELEMETRY_ARGS+=" --user_auth $USER_AUTH"
+
+    # Reuse GNMI_CLIENT_CERT for telemetry service
+    TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
 fi
 
 LOG_LEVEL=$(echo $GNMI | jq -r '.log_level')

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -37,6 +37,14 @@ if [ -n "$CERTS" ]; then
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
+
+    USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
+    if [ ! -z $USER_AUTH ] then
+        TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
+
+        # Reuse GNMI_CLIENT_CERT for telemetry service
+        TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
+    fi
 elif [ -n "$X509" ]; then
     SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
     SERVER_KEY=$(echo $X509 | jq -r '.server_key')
@@ -49,14 +57,6 @@ elif [ -n "$X509" ]; then
     CA_CRT=$(echo $X509 | jq -r '.ca_crt')
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
-    fi
-
-    USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
-    if [ ! -z $USER_AUTH ] then
-        TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
-
-        # Reuse GNMI_CLIENT_CERT for telemetry service
-        TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
     fi
 else
     TELEMETRY_ARGS+=" --noTLS"

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -129,4 +129,5 @@ if [ ! -z $USER_AUTH ]; then
     TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
 fi
 
+echo "telemetry args: $TELEMETRY_ARGS"
 exec /usr/sbin/telemetry ${TELEMETRY_ARGS}

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -39,7 +39,7 @@ if [ -n "$CERTS" ]; then
     fi
 
     USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
-    if [ ! -z $USER_AUTH ] then
+    if [ ! -z $USER_AUTH ]; then
         TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
 
         # Reuse GNMI_CLIENT_CERT for telemetry service

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -69,7 +69,7 @@ fi
 
 USER_AUTH=$(echo $GNMI | jq -r '.user_auth')
 if [ ! -z $USER_AUTH ] then
-    TELEMETRY_ARGS+=" --user_auth $USER_AUTH"
+    TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
 
     # Reuse GNMI_CLIENT_CERT for telemetry service
     TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"

--- a/src/sonic-yang-models/yang-models/sonic-gnmi.yang
+++ b/src/sonic-yang-models/yang-models/sonic-gnmi.yang
@@ -88,6 +88,7 @@ module sonic-gnmi {
 
                 leaf user_auth {
                     type string;
+                    pattern "password|jwt|cert";
                     description "GNMI service user authorization type.";
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-gnmi.yang
+++ b/src/sonic-yang-models/yang-models/sonic-gnmi.yang
@@ -87,8 +87,9 @@ module sonic-gnmi {
                 }
 
                 leaf user_auth {
-                    type string;
-                    pattern "password|jwt|cert";
+                    type string {
+                        pattern 'password|jwt|cert';
+                    }
                     description "GNMI service user authorization type.";
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-gnmi.yang
+++ b/src/sonic-yang-models/yang-models/sonic-gnmi.yang
@@ -99,7 +99,6 @@ module sonic-gnmi {
             description "GNMI client cert list";
 
             list GNMI_CLIENT_CERT_LIST {
-                max-elements 8;
                 key "cert_cname";
 
                 leaf cert_cname {

--- a/src/sonic-yang-models/yang-models/sonic-gnmi.yang
+++ b/src/sonic-yang-models/yang-models/sonic-gnmi.yang
@@ -85,6 +85,11 @@ module sonic-gnmi {
                     type uint32;
                     description "Certificate revocation list cache expire duration.";
                 }
+
+                leaf user_auth {
+                    type string;
+                    description "GNMI service user authorization type.";
+                }
             }
         }
 

--- a/src/sonic-yang-models/yang-models/sonic-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-telemetry.yang
@@ -88,6 +88,7 @@ module sonic-telemetry {
 
                 leaf user_auth {
                     type string;
+                    pattern "password|jwt|cert";
                     description "Telemetry service user authorization type.";
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-telemetry.yang
@@ -85,6 +85,11 @@ module sonic-telemetry {
                     type uint32;
                     description "Certificate revocation list cache expire duration.";
                 }
+
+                leaf user_auth {
+                    type string;
+                    description "GNMI service user authorization type.";
+                }
             }
 
         }

--- a/src/sonic-yang-models/yang-models/sonic-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-telemetry.yang
@@ -87,8 +87,9 @@ module sonic-telemetry {
                 }
 
                 leaf user_auth {
-                    type string;
-                    pattern "password|jwt|cert";
+                    type string {
+                        pattern 'password|jwt|cert';
+                    }
                     description "Telemetry service user authorization type.";
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-telemetry.yang
@@ -88,7 +88,7 @@ module sonic-telemetry {
 
                 leaf user_auth {
                     type string;
-                    description "GNMI service user authorization type.";
+                    description "Telemetry service user authorization type.";
                 }
             }
 


### PR DESCRIPTION
Enable gnmi/telemetry user authorization by config_db.

#### Why I did it
gnmi/telemetry user authorization flag not used in SONiC and can't config by config_db

##### Work item tracking
- Microsoft ADO: 30808849

#### How I did it
Update Yang model and update gnmi/telemetry start script.

#### How to verify it
Pass all UT.


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [] 

#### Description for the changelog
Enable gnmi/telemetry user authorization by config_db.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

