### PR TITLE
Optimize M2-W6520-24DC8QC routing capacity

### DIFF
--- a/device/micas/x86_64-micas_m2-w6520-24dc8qc-r0/M2-W6520-24DC8QC/td4-m2-w6520-24dc8qc-24x200G+8x400G-copper.yml
+++ b/device/micas/x86_64-micas_m2-w6520-24dc8qc-r0/M2-W6520-24DC8QC/td4-m2-w6520-24dc8qc-24x200G+8x400G-copper.yml
@@ -4,7 +4,7 @@ bcm_device:
         global:
             bcm_tunnel_term_compatible_mode: 1
             vlan_flooding_l2mc_num_reserved: 2048
-            l3_alpm_template: 2
+            l3_alpm_template: 1
             l3_alpm2_bnk_threshold: 100
             uft_mode: 1
             l3_enable: 1

--- a/device/micas/x86_64-micas_m2-w6520-24dc8qc-r0/M2-W6520-24DC8QC/td4-m2-w6520-24dc8qc-24x200G+8x400G.yml
+++ b/device/micas/x86_64-micas_m2-w6520-24dc8qc-r0/M2-W6520-24DC8QC/td4-m2-w6520-24dc8qc-24x200G+8x400G.yml
@@ -5,7 +5,7 @@ bcm_device:
             bcm_tunnel_term_compatible_mode: 1
             vlan_flooding_l2mc_num_reserved: 0
             shared_block_mask_section: uc_bc
-            l3_alpm_template: 2
+            l3_alpm_template: 1
             l3_alpm2_bnk_threshold: 100
             svi_my_station_optimization: 1
             sai_nbr_bcast_ifp_optimized: 2


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Optimize M2-W6520-24DC8QC routing capacity
The routing capacity can be increased from 174K to 349K.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

