### PR TITLE
Adding YANG model for TC_TO_DSCP_MAP

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -18,7 +18,8 @@ Type_1_list_maps_model = [
     'DSCP_TO_FC_MAP_LIST',
     'EXP_TO_FC_MAP_LIST',
     'CABLE_LENGTH_LIST',
-    'MPLS_TC_TO_TC_MAP_LIST'
+    'MPLS_TC_TO_TC_MAP_LIST',
+    'TC_TO_DSCP_MAP_LIST'
 ]
 
 # Workaround for those fields who is defined as leaf-list in YANG model but have string value in config DB.

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -196,6 +196,7 @@ setup(
                          './yang-models/sonic-tc-priority-group-map.yang',
                          './yang-models/sonic-tc-queue-map.yang',
                          './yang-models/sonic-peer-switch.yang',
+                         './yang-models/sonic-tc-dscp-map.yang',
                          './yang-models/sonic-pfc-priority-queue-map.yang',
                          './yang-models/sonic-pfc-priority-priority-group-map.yang',
                          './yang-models/sonic-logger.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2278,6 +2278,17 @@
             }
         },
 
+        "TC_TO_DSCP_MAP": {
+           "tc_to_dscp_map1": {
+              "1": "1",
+              "2": "2"
+            },
+           "tc_to_dscp_map2": {
+              "3": "3",
+              "4": "4"
+            }
+        },
+
         "MAP_PFC_PRIORITY_TO_QUEUE": {
            "pfc_prio_to_q_map1": {
               "1": "1",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/qosmaps.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/qosmaps.json
@@ -109,5 +109,19 @@
     "PORT_QOS_MAP_APPLY_INVALID_PFC": {
         "desc": "Configure port pfc enable with invalid pfc priority.",
         "eStrKey": "Pattern"
+    },
+
+    "TC_TO_DSCP_MAP_CRETAE": {
+        "desc": "Configure a Traffic class to DSCP map."
+    },
+
+    "TC_TO_DSCP_MAP_CREATE_INVALID_TC": {
+        "desc": "Configure a Traffic class to DSCP with invalid key.",
+        "eStr": "Invalid Traffic Class"
+    },
+
+    "TC_TO_DSCP_MAP_CREATE_INVALID_DSCP": {
+        "desc": "Configure a Traffic class to DSCP map with invalid value.",
+        "eStr": "Invalid DSCP"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/qosmaps.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/qosmaps.json
@@ -855,6 +855,92 @@
                 ]
             }
         }
-    }
+    },
 
+    "TC_TO_DSCP_MAP_CRETAE": {
+        "sonic-tc-dscp-map:sonic-tc-dscp-map": {
+            "sonic-tc-dscp-map:TC_TO_DSCP_MAP": {
+                "TC_TO_DSCP_MAP_LIST": [
+                    {
+                        "name": "map1",
+                        "TC_TO_DSCP_MAP": [
+                            {
+                                "tc": "1",
+                                "dscp": "1"
+                            },
+                            {
+                                "tc":"2",
+                                "dscp":"2"
+                            },
+                            {
+                                "tc": "8",
+                                "dscp": "8"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "map2",
+                        "TC_TO_DSCP_MAP": [
+                            {
+                                "tc": "1",
+                                "dscp": "1"
+                            },
+                            {
+                                "tc":"2",
+                                "dscp":"2"
+                            },
+                            {
+                                "tc": "8",
+                                "dscp": "8"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+
+    "TC_TO_DSCP_MAP_CREATE_INVALID_TC": {
+        "sonic-tc-dscp-map:sonic-tc-dscp-map": {
+            "sonic-tc-dscp-map:TC_TO_DSCP_MAP": {
+                "TC_TO_DSCP_MAP_LIST": [
+                    {
+                        "name": "map3",
+                        "TC_TO_DSCP_MAP": [
+                            {
+                                "tc": "16",
+                                "dscp": "1"
+                            },
+                            {
+                                "tc":"2",
+                                "dscp":"2"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+
+    "TC_TO_DSCP_MAP_CREATE_INVALID_DSCP": {
+        "sonic-tc-dscp-map:sonic-tc-dscp-map": {
+            "sonic-tc-dscp-map:TC_TO_DSCP_MAP": {
+                "TC_TO_DSCP_MAP_LIST": [
+                    {
+                        "name": "map3",
+                        "TC_TO_DSCP_MAP": [
+                            {
+                                "tc": "1",
+                                "dscp": "64"
+                            },
+                            {
+                                "tc":"2",
+                                "dscp":"2"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
 }

--- a/src/sonic-yang-models/yang-models/sonic-tc-dscp-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tc-dscp-map.yang
@@ -1,0 +1,67 @@
+module sonic-tc-dscp-map {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/sonic-net/sonic-tc-dscp-map";
+
+    prefix dtm;
+
+    import sonic-types {
+        prefix stypes;
+    }
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "TC_TO_DSCP_MAP yang Module for SONiC OS";
+
+    revision 2025-01-10 {
+        description
+            "Initial revision.";
+    }
+
+    container sonic-tc-dscp-map {
+
+        container TC_TO_DSCP_MAP {
+
+            description "TC_TO_DSCP_MAP part of config_db.json";
+
+            list TC_TO_DSCP_MAP_LIST {
+
+                key "name";
+
+                leaf name {
+                    type string {
+                        pattern '[a-zA-Z0-9]{1}([-a-zA-Z0-9_]{0,31})';
+                        length 1..32 {
+                            error-message "Invalid length for map name.";
+                            error-app-tag map-name-invalid-length;
+                        }
+                    }
+                }
+
+                list TC_TO_DSCP_MAP { //this is list inside list for storing mapping between two fields
+
+                    key "tc";
+
+                    leaf tc {
+                        type stypes:tc_type;
+                    }
+
+                    leaf dscp {
+                        type string {
+                            pattern "6[0-3]|[1-5][0-9]?|[0-9]?" {
+                                error-message "Invalid DSCP";
+                                error-app-tag dscp-invalid;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-tc-dscp-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tc-dscp-map.yang
@@ -4,7 +4,7 @@ module sonic-tc-dscp-map {
 
     namespace "http://github.com/sonic-net/sonic-tc-dscp-map";
 
-    prefix dtm;
+    prefix tdm;
 
     import sonic-types {
         prefix stypes;


### PR DESCRIPTION
issue : https://github.com/sonic-net/sonic-buildimage/issues/20575

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
"config-reload" in dualtor topologies were failing due to absence of TC_TO_DSCP Yang model.
The above failure was seen after the the PR https://github.com/sonic-net/sonic-utilities/pull/3102

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

Step-1: In DUT add the yang file to "/usr/local/yang-models/sonic-tc-dscp-map.yang" to this path.
Step-2: config reload -y

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202411

#### Description for the changelog
Adding YANG model for TC_TO_DSCP_MAP along with test files.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

