### PR TITLE
Fix config and syncd command line for credo gbsyncd warm-reboot

### DIFF
--- a/device/arista/x86_64-arista_7060dx5_64s/Arista-7060DX5-64S/blackhawk.xml
+++ b/device/arista/x86_64-arista_7060dx5_64s/Arista-7060DX5-64S/blackhawk.xml
@@ -42,11 +42,6 @@
         <lane id="14" tx-polarity="0" rx-polarity="0" />
         <lane id="15" tx-polarity="0" rx-polarity="0" />
 
-        <port-connector>
-            <macsec-mode>bypass</macsec-mode>
-            <system-side lane-number="0,1,2,3,4,5,6,7" speed="400000" fec="rs544" />
-            <line-side lane-number="8,9,10,11,12,13,14,15" speed="400000" fec="rs544" />
-        </port-connector>
     </phy>
 
     <phy context_id="2">
@@ -88,11 +83,6 @@
         <lane id="14" tx-polarity="0" rx-polarity="0" />
         <lane id="15" tx-polarity="0" rx-polarity="0" />
 
-        <port-connector>
-            <macsec-mode>bypass</macsec-mode>
-            <system-side lane-number="0,1,2,3,4,5,6,7" speed="400000" fec="rs544" />
-            <line-side lane-number="8,9,10,11,12,13,14,15" speed="400000" fec="rs544" />
-        </port-connector>
     </phy>
 
     <phy context_id="3">
@@ -135,11 +125,6 @@
         <lane id="14" tx-polarity="0" rx-polarity="0" />
         <lane id="15" tx-polarity="0" rx-polarity="0" />
 
-        <port-connector>
-            <macsec-mode>bypass</macsec-mode>
-            <system-side lane-number="0,1,2,3,4,5,6,7" speed="400000" fec="rs544" />
-            <line-side lane-number="8,9,10,11,12,13,14,15" speed="400000" fec="rs544" />
-        </port-connector>
     </phy>
 
     <phy context_id="4">
@@ -182,11 +167,6 @@
         <lane id="14" tx-polarity="0" rx-polarity="0" />
         <lane id="15" tx-polarity="0" rx-polarity="0" />
 
-        <port-connector>
-            <macsec-mode>bypass</macsec-mode>
-            <system-side lane-number="0,1,2,3,4,5,6,7" speed="400000" fec="rs544" />
-            <line-side lane-number="8,9,10,11,12,13,14,15" speed="400000" fec="rs544" />
-        </port-connector>
     </phy>
 
     <phy context_id="5">
@@ -229,11 +209,6 @@
         <lane id="14" tx-polarity="0" rx-polarity="0" />
         <lane id="15" tx-polarity="0" rx-polarity="0" />
 
-        <port-connector>
-            <macsec-mode>bypass</macsec-mode>
-            <system-side lane-number="0,1,2,3,4,5,6,7" speed="400000" fec="rs544" />
-            <line-side lane-number="8,9,10,11,12,13,14,15" speed="400000" fec="rs544" />
-        </port-connector>
     </phy>
 
     <phy context_id="6">
@@ -275,11 +250,6 @@
         <lane id="14" tx-polarity="0" rx-polarity="0" />
         <lane id="15" tx-polarity="0" rx-polarity="0" />
 
-        <port-connector>
-            <macsec-mode>bypass</macsec-mode>
-            <system-side lane-number="0,1,2,3,4,5,6,7" speed="400000" fec="rs544" />
-            <line-side lane-number="8,9,10,11,12,13,14,15" speed="400000" fec="rs544" />
-        </port-connector>
     </phy>
 
     <phy context_id="7">
@@ -322,11 +292,6 @@
         <lane id="14" tx-polarity="0" rx-polarity="0" />
         <lane id="15" tx-polarity="0" rx-polarity="0" />
 
-        <port-connector>
-            <macsec-mode>bypass</macsec-mode>
-            <system-side lane-number="0,1,2,3,4,5,6,7" speed="400000" fec="rs544" />
-            <line-side lane-number="8,9,10,11,12,13,14,15" speed="400000" fec="rs544" />
-        </port-connector>
     </phy>
 
     <phy context_id="8">
@@ -369,11 +334,6 @@
         <lane id="14" tx-polarity="0" rx-polarity="0" />
         <lane id="15" tx-polarity="0" rx-polarity="0" />
 
-        <port-connector>
-            <macsec-mode>bypass</macsec-mode>
-            <system-side lane-number="0,1,2,3,4,5,6,7" speed="400000" fec="rs544" />
-            <line-side lane-number="8,9,10,11,12,13,14,15" speed="400000" fec="rs544" />
-        </port-connector>
     </phy>
 
 </root>

--- a/device/arista/x86_64-arista_7060px5_64s/Arista-7060PX5-64S/psai.profile
+++ b/device/arista/x86_64-arista_7060px5_64s/Arista-7060PX5-64S/psai.profile
@@ -1,1 +1,3 @@
 SAI_KEY_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/blackhawk.xml
+SAI_WARM_BOOT_READ_FILE=/var/warmboot/credo-sai-warmboot.bin
+SAI_WARM_BOOT_WRITE_FILE=/var/warmboot/credo-sai-warmboot.bin

--- a/platform/components/docker-gbsyncd-credo/supervisord.conf.j2
+++ b/platform/components/docker-gbsyncd-credo/supervisord.conf.j2
@@ -45,7 +45,7 @@ dependent_startup_wait_for=rsyslogd:running
 
 [program:syncd]
 environment=CREDO_DEVICE_PATH=/usr/lib
-command=/usr/bin/syncd -s -p /etc/sai.d/psai.profile -x /usr/share/sonic/hwsku/context_config.json -g 1
+command=stdbuf -oL /usr/bin/syncd -u -s -p /etc/sai.d/psai.profile -x /usr/share/sonic/hwsku/context_config.json -g 1
 priority=3
 autostart=false
 autorestart=false


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This change is part of the work to support warm-reboot for credo gbsyncd used on Arista x86_64-arista_7060dx5_64s

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
This change include multiple fixes to support the credo gbsyncd warm-reboot
1) fix issue where port object and port connector object were created twice by removing ports defined in blackhawk.xml
2) set warm-reboot dump file path by SAI_WARM_BOOT_READ_FILE and SAI_WARM_BOOT_WRITE_FILE
3) add -u to the credo syncd command to enable temporary view mode needed by warm-reboot
4) add stdbuf -oL to the credo syncd command to flush the log from stdout per line for better debugging

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

