### PR TITLE
[Marvell][arm64] Installer optimization 

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -35,7 +35,7 @@ create_partition()
 {
 
     # Install demo on same block device as ONIE
-    if [ "$install_env" != "build" ]; then
+    if [ "$install_env" != "build" ] && [ -z "$blk_dev" ]; then
         onie_dev=$(blkid | grep ONIE-BOOT | head -n 1 | awk '{print $1}' |  sed -e 's/:.*$//')
         blk_dev=$(echo $onie_dev | sed -e 's/[1-9][0-9]*$//' | sed -e 's/\([0-9]\)\(p\)/\1/')
 
@@ -154,13 +154,15 @@ create_demo_gpt_partition()
     last_part=$(echo "$all_part" | tail -n 1 | awk '{print $1}')
     # Find next available partition
     demo_part=1
-    echo "$all_part" > $tmpfifo &
-    # Find the first available partition number
-    while read -r used_part; do
-        echo "Partition #$used_part is in use."
-        if [ "$used_part" -ne "$demo_part" ]; then break; fi
-        demo_part=`expr $demo_part + 1`
-    done < $tmpfifo
+    if [ ! -z "$all_part" ]; then
+        echo "$all_part" > $tmpfifo &
+        # Find the first available partition number
+        while read -r used_part; do
+            echo "Partition #$used_part is in use."
+            if [ "$used_part" -ne "$demo_part" ]; then break; fi
+            demo_part=`expr $demo_part + 1`
+        done < $tmpfifo
+    fi
     echo "Partition #$demo_part is available"
 
     # Create new partition

--- a/platform/marvell/platform_arm64.conf
+++ b/platform/marvell/platform_arm64.conf
@@ -53,6 +53,7 @@ elif [ $PLATFORM_7215_A1 -eq 1 ]; then
     fit_addr=0x20000000
     VAR_LOG=4096
     FW_ENV_DEFAULT='/dev/mtd1 0x0 0x10000 0x10000'
+    demo_part=2
 elif [ $PLATFORM_CN9131 -eq 1 ]; then
     fdt_addr=0x1000000
     fit_addr=0x8000000
@@ -106,6 +107,60 @@ get_install_device()
 }
 
 get_install_device
+
+if [ $PLATFORM_7215_A1 -eq 1 ]; then
+    # 7215_A1 to use custom logic for backward compatibility
+
+    demo_dev=${blk_dev}p${demo_part}
+
+    remove_dev_partitions() {
+        echo "Remove all existing partitions starting partnum: ${demo_part} from ${blk_dev}"
+        local dev_to_install=${blk_dev}p
+        for p in $(seq ${demo_part} 9) ; do
+            if [[ -e ${dev_to_install}${p} ]]; then
+                echo "Removing partition ${dev_to_install}${p}"
+                sgdisk -d ${p} ${blk_dev} || true
+            fi
+        done
+        partprobe ${blk_dev}
+    }
+
+    create_demo_partition() {
+        # SD CARD
+        remove_dev_partitions
+
+        # Create sonic partition
+        sgdisk --new ${demo_part}:: \
+            --change-name=${demo_part}:${demo_volume_label} \
+            --typecode=${demo_part}:8300 -p ${blk_dev}
+
+        partprobe
+    }
+
+    create_partition() {
+        get_install_device
+        if [ $? -ne 0 ]; then
+            echo "Error: Unable to detect $blk_dev $demo_dev"
+            exit 1
+        fi
+
+        # Platform specific partition
+        create_demo_partition
+    }
+
+    mount_partition() {
+        # Make filesystem
+        echo "demo label: $demo_volume_label. $demo_dev..."
+        mkfs.ext4 -L $demo_volume_label $demo_dev
+
+        demo_mnt=/tmp
+
+        mount -t ext4 -o defaults,rw $demo_dev $demo_mnt || {
+            echo "Error: Unable to mount $demo_dev on $demo_mnt"
+            exit 1
+        }
+    }
+fi
 
 prepare_boot_menu() {
     echo "Sync up cache ..."

--- a/platform/marvell/platform_arm64.conf
+++ b/platform/marvell/platform_arm64.conf
@@ -13,10 +13,6 @@ kernel_version=6.1.0-22-2-arm64
 kernel_fname="/boot/vmlinuz-$kernel_version"
 initrd_fname="/boot/initrd.img-$kernel_version"
 fit_fname="/boot/sonic_arm64.fit"
-demo_volume_label=SONiC-OS
-
-# global mount defines
-demo_mnt=/tmp
 
 if [ "$install_env" = "onie" ]; then
     MACH_FILE="/etc/machine.conf"
@@ -29,15 +25,20 @@ echo "Intalling SONiC from $install_env on Platform $PLATFORM"
 
 PLATFORM_AC5X=0
 PLATFORM_CN9131=0
+PLATFORM_7215_A1=0
+disk_interface="mmc"
 
 case $PLATFORM in
     arm64-nokia_ixs7215_52xb-r0) PLATFORM_7215_A1=1;
+		mmc_bus="mmc0:0001";
 		fdt_fname="/usr/lib/linux-image-${kernel_version}/marvell/7215-ixs-a1.dtb";
 		fit_conf_name="#conf_7215_a1";;
     arm64-marvell_rd98DX35xx-r0) PLATFORM_AC5X=1;
+		mmc_bus="mmc0:0001";
 		fdt_fname="/usr/lib/linux-image-$kernel_version/marvell/ac5-98dx35xx-rd.dtb";
 		fit_conf_name="#conf_ac5x";;
     arm64-marvell_rd98DX35xx_cn9131-r0) PLATFORM_CN9131=1;
+		mmc_bus="mmc0:0001";
 		fdt_fname="/boot/cn9131-db-comexpress.dtb";
 		fit_conf_name="#conf_cn9131";;
 esac
@@ -48,21 +49,15 @@ if [ $PLATFORM_AC5X -eq 1 ]; then
     initrd_addr=0x206000000
 
     FW_ENV_DEFAULT='/dev/mtd0 0x400000 0x10000 0x10000'
-    demo_part=2
-    mmc_bus="mmc0:0001"
 elif [ $PLATFORM_7215_A1 -eq 1 ]; then
     fit_addr=0x20000000
     VAR_LOG=4096
     FW_ENV_DEFAULT='/dev/mtd1 0x0 0x10000 0x10000'
-    demo_part=2
-    mmc_bus="mmc0:0001"
 elif [ $PLATFORM_CN9131 -eq 1 ]; then
     fdt_addr=0x1000000
     fit_addr=0x8000000
     initrd_addr=0x2000000
-    demo_part=2
     FW_ENV_DEFAULT='/dev/mtd1 0x1F0000 0x10000 0x10000'
-    mmc_bus="mmc0:0001"
 else
     fdt_addr=0x1000000
     fit_addr=0x8000000
@@ -71,83 +66,46 @@ else
     fdt_fname="/usr/lib/linux-image-$kernel_version/marvell/armada-7020-comexpress.dtb"
 
     FW_ENV_DEFAULT='/dev/mtd1 0x0 0x10000 0x100000'
-    demo_part=1
     mmc_bus="mmc0:aaaa"
 fi
 
 # Skip VID Header in UBIFS
 LINUX_MISC_CMD='apparmor=1 security=apparmor usbcore.autosuspend=-1'
 
-#Get block device
-#Default block device is eMMC, if not look for usb storage
+# Get block device
+# default_platform.conf will by default install SONIC on same block device as ONIE
+# This funtion looks to override SONIC install target disk, with optional eMMC or SCSI disk.
 get_install_device()
 {
-    for i in 0 1 2 ; do
-        if $(ls -l /sys/block/mmcblk$i/device 2>/dev/null | grep -q "$mmc_bus") ; then
-            echo "/dev/mmcblk$i"
-            blk_dev=/dev/mmcblk$i
-            echo "Selected mmc $blk_dev"
-            return 0
-        fi
-    done
+    if [ ! -z "$mmc_bus" ]; then
+        for i in 0 1 2 ; do
+            if $(ls -l /sys/block/mmcblk$i/device 2>/dev/null | grep -q "$mmc_bus") ; then
+                echo "/dev/mmcblk$i"
+                blk_dev=/dev/mmcblk$i
+                disk_interface="mmc"
+                echo "Selected mmc $blk_dev"
+                return
+            fi
+        done
+    fi
 
-    echo "ERROR storage not found"
-    return 1
+    if [ ! -z "$scsi_bus" ]; then
+        for i in a b c d ; do
+            if $(ls -l /sys/block/sd$i/device 2>/dev/null | grep -q "$scsi_bus") ; then
+                echo "/dev/sd$i"
+                blk_dev=/dev/sd$i
+                disk_interface="scsi"
+                disk_scan="scsi scan;"
+                echo "Selected disk $blk_dev"
+                return
+            fi
+        done
+    fi
+
+    echo "Waring: Storage not found. Will try installing on the same disk as ONIE."
 }
 
 get_install_device
-if [ $? -ne 0 ]; then
-    echo "Error: Unable to detect $blk_dev $demo_dev"
-    exit 1
-fi
-
-demo_dev=${blk_dev}p${demo_part}
-
-remove_dev_partitions() {
-    echo "Remove all existing partitions starting partnum: ${demo_part} from ${blk_dev}"
-    local dev_to_install=${blk_dev}p
-    for p in $(seq ${demo_part} 9) ; do
-        if [[ -e ${dev_to_install}${p} ]]; then
-            echo "Removing partition ${dev_to_install}${p}"
-            sgdisk -d ${p} ${blk_dev} || true
-        fi
-    done
-    partprobe ${blk_dev}
-}
-
-create_demo_partition() {
-    # SD CARD
-    remove_dev_partitions
-
-    # Create sonic partition
-    sgdisk --new ${demo_part}:: \
-        --change-name=${demo_part}:${demo_volume_label} \
-        --typecode=${demo_part}:8300 -p ${blk_dev}
-
-    partprobe
-}
-
-create_partition() {
-    get_install_device
-    if [ $? -ne 0 ]; then
-        echo "Error: Unable to detect $blk_dev $demo_dev"
-        exit 1
-    fi
-
-    # Platform specific partition 
-    create_demo_partition
-}
-
-mount_partition() {
-    # Make filesystem
-    echo "demo label: $demo_volume_label. $demo_dev..."
-    mkfs.ext4 -L $demo_volume_label $demo_dev
-
-    mount -t ext4 -o defaults,rw $demo_dev $demo_mnt || {
-        echo "Error: Unable to mount $demo_dev on $demo_mnt"
-        exit 1
-    }
-}
 
 prepare_boot_menu() {
     echo "Sync up cache ..."
@@ -222,7 +180,8 @@ prepare_boot_menu() {
     fw_setenv ${FW_ARG} print_menu "$BORDER $BOOT1 $BOOT2 $BOOT3 $BORDER" > /dev/null
 
     fw_setenv ${FW_ARG} linuxargs "net.ifnames=0 loopfstype=squashfs loop=$image_dir/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG ${ONIE_PLATFORM_EXTRA_CMDLINE_LINUX}" > /dev/null
-    sonic_bootargs_old='setenv bootargs root='$demo_dev' rw rootwait panic=1 console=ttyS0,${baudrate} ${linuxargs_old}'
+    uuid=$(blkid | grep "$demo_volume_label" | sed -ne 's/.* UUID=\"\([^"]*\)\".*/\1/p')
+    sonic_bootargs_old='setenv bootargs root=UUID='$uuid' rw rootwait panic=1 console=ttyS0,${baudrate} ${linuxargs_old}'
     fw_setenv ${FW_ARG} sonic_bootargs_old "$sonic_bootargs_old" > /dev/null || true
     sonic_boot_load_old=$(fw_printenv -n sonic_boot_load || true)
     old_str="_old"
@@ -233,16 +192,17 @@ prepare_boot_menu() {
     fw_setenv ${FW_ARG} fit_addr $fit_addr > /dev/null
     fw_setenv ${FW_ARG} fit_conf_name $fit_conf_name > /dev/null
     fw_setenv ${FW_ARG} initrd_addr $initrd_addr > /dev/null
-    MMC_LOAD='ext4load mmc 0:'$demo_part' $fit_addr $fit_name'
-    fw_setenv ${FW_ARG} sonic_boot_load "$MMC_LOAD" > /dev/null
+    demo_part=$(sgdisk -p $blk_dev | grep -e "$demo_volume_label" | awk '{print $1}')
+    DISK_LOAD=''$disk_scan' ext4load '$disk_interface' 0:'$demo_part' $fit_addr $fit_name'
+    fw_setenv ${FW_ARG} sonic_boot_load "$DISK_LOAD" > /dev/null
     SONIC_BOOT_CMD='run sonic_bootargs; run sonic_boot_load; bootm $fit_addr${fit_conf_name}'
     SONIC_BOOT_CMD_OLD='run sonic_bootargs_old; run sonic_boot_load_old; bootm $fit_addr${fit_conf_name}'
-    BOOTARGS='setenv bootargs root='$demo_dev' rw rootwait panic=1 console=ttyS0,${baudrate} ${linuxargs}'
+    BOOTARGS='setenv bootargs root=UUID='$uuid' rw rootwait panic=1 console=ttyS0,${baudrate} ${linuxargs}'
     fw_setenv ${FW_ARG} sonic_bootargs "$BOOTARGS" > /dev/null
     fw_setenv ${FW_ARG} sonic_image_2 "$SONIC_BOOT_CMD_OLD" > /dev/null
     fw_setenv ${FW_ARG} sonic_image_1 "$SONIC_BOOT_CMD" > /dev/null
     fw_setenv ${FW_ARG} boot_next  'run sonic_image_1'> /dev/null
-    fw_setenv ${FW_ARG} bootcmd 'run print_menu; usb start; test -n "$boot_once" && setenv do_boot_once "$boot_once" && setenv boot_once "" && saveenv && run do_boot_once; run boot_next' > /dev/null
+    fw_setenv ${FW_ARG} bootcmd 'run print_menu; test -n "$boot_once" && setenv do_boot_once "$boot_once" && setenv boot_once "" && saveenv && run do_boot_once; run boot_next' > /dev/null
 
     echo "Installed SONiC base image SONiC-OS successfully"
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
* To optimization installer for marvell arm64 to use create and mount partition logic from default_platform.conf. 
* Given that current default_platform.conf only allows install on same disk as ONIE. Add support for install block device selection.
* Add support for scsi block devices. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
* Use implementation from default_platform.conf for create and mount partition and remove the implementation in platform_arm64.conf.
* Add option to override install block device in default_platform.conf. Also added logic to select the install block device from platform_arm64.conf.
* Added support for selecting scsi disk as install device in platform_arm64.conf. This also needed changes to u-boot env variable.
* Changed to UUID based 'root' disk selection to have a generic implementation.
* For backward compatibility using the existing functions for 7215_A1 platform.

#### How to verify it
Verified ONIE and SONIC to SONIC install using sonic-marvell.bin and sonic-marvell-arm64.bin.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202411

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

