### PR TITLE
[dhcp_server] Support scenario that gatway is not configured

### DIFF
--- a/dockers/docker-dhcp-server/kea-dhcp4.conf.j2
+++ b/dockers/docker-dhcp-server/kea-dhcp4.conf.j2
@@ -63,10 +63,12 @@
                         "always-send": {{ config["always_send"] }}
                     },
     {%- endfor %}
+    {%- if "gateway" in subnet_info -%}
                     {
                         "name": "routers",
-                        "data": "{{ subnet_info["gateway"] if "gateway" in subnet_info else subnet_info["server_id"] }}"
+                        "data": "{{ subnet_info["gateway"] }}"
                     },
+    {%- endif -%}
                     {
                         "name": "dhcp-server-identifier",
                         "data": "{{ subnet_info["server_id"] }}"

--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_cfggen.py
@@ -229,11 +229,12 @@ class DhcpServCfgGenerator(object):
                         "id": MID_PLANE_BRIDGE_SUBNET_ID if smart_switch else dhcp_interface_name.replace("Vlan", ""),
                         "subnet": str(ipaddress.ip_network(dhcp_interface_ip, strict=False)),
                         "pools": pools,
-                        "gateway": dhcp_config["gateway"],
                         "server_id": dhcp_interface_ip.split("/")[0],
                         "lease_time": dhcp_config["lease_time"] if "lease_time" in dhcp_config else DEFAULT_LEASE_TIME,
                         "customized_options": curr_options
                     }
+                    if "gateway" in dhcp_config:
+                        subnet_obj["gateway"] = dhcp_config["gateway"]
                     subnets.append(subnet_obj)
         render_obj = {
             "subnets": subnets,

--- a/src/sonic-dhcp-utilities/tests/test_data/kea-dhcp4.conf.j2
+++ b/src/sonic-dhcp-utilities/tests/test_data/kea-dhcp4.conf.j2
@@ -63,10 +63,12 @@
                         "always-send": {{ config["always_send"] }}
                     },
     {%- endfor %}
+    {%- if "gateway" in subnet_info %}
                     {
                         "name": "routers",
-                        "data": "{{ subnet_info["gateway"] if "gateway" in subnet_info else subnet_info["server_id"] }}"
+                        "data": "{{ subnet_info["gateway"] }}"
                     },
+    {%- endif %}
                     {
                         "name": "dhcp-server-identifier",
                         "data": "{{ subnet_info["server_id"] }}"

--- a/src/sonic-dhcp-utilities/tests/test_data/mock_config_db.json
+++ b/src/sonic-dhcp-utilities/tests/test_data/mock_config_db.json
@@ -83,7 +83,6 @@
                 "option60",
                 "option223"
             ],
-            "gateway": "192.168.3.1",
             "lease_time": "900",
             "mode": "PORT",
             "netmask": "255.255.255.0",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
DHCP default route shoule be an optional config to DHCP client

##### Work item tracking
- Microsoft ADO **(number only)**: 30877295

#### How I did it
Support to do not send default route to dhcp client

#### How to verify it
1. UT
2. Install new image to test

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

