### PR TITLE
[FRR]: Verifying static SRv6 SIDs parameters

### DIFF
--- a/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
+++ b/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
@@ -1035,33 +1035,29 @@ static ssize_t netlink_srv6_localsid_msg_encode(int cmd,
 		nl_attr_nest(&req->n, datalen, 
 					FPM_SRV6_LOCALSID_FORMAT);
 
-	if (nexthop->nh_srv6->seg6local_ctx.block_len)
-		if (!nl_attr_put8(
-				&req->n, datalen, 
-				FPM_SRV6_LOCALSID_FORMAT_BLOCK_LEN,
-				nexthop->nh_srv6->seg6local_ctx.block_len))
-			return -1;
+	if (!nl_attr_put8(
+			&req->n, datalen, 
+			FPM_SRV6_LOCALSID_FORMAT_BLOCK_LEN,
+			nexthop->nh_srv6->seg6local_ctx.block_len))
+		return -1;
 
-	if (nexthop->nh_srv6->seg6local_ctx.node_len)
-		if (!nl_attr_put8(
-				&req->n, datalen, 
-				FPM_SRV6_LOCALSID_FORMAT_NODE_LEN,
-				nexthop->nh_srv6->seg6local_ctx.node_len))
-			return -1;
+	if (!nl_attr_put8(
+			&req->n, datalen, 
+			FPM_SRV6_LOCALSID_FORMAT_NODE_LEN,
+			nexthop->nh_srv6->seg6local_ctx.node_len))
+		return -1;
 
-	if (nexthop->nh_srv6->seg6local_ctx.function_len)
-		if (!nl_attr_put8(
-				&req->n, datalen, 
-				FPM_SRV6_LOCALSID_FORMAT_FUNC_LEN,
-				nexthop->nh_srv6->seg6local_ctx.function_len))
-			return -1;
+	if (!nl_attr_put8(
+			&req->n, datalen, 
+			FPM_SRV6_LOCALSID_FORMAT_FUNC_LEN,
+			nexthop->nh_srv6->seg6local_ctx.function_len))
+		return -1;
 
-	if (nexthop->nh_srv6->seg6local_ctx.argument_len)
-		if (!nl_attr_put8(
-				&req->n, datalen, 
-				FPM_SRV6_LOCALSID_FORMAT_ARG_LEN,
-				nexthop->nh_srv6->seg6local_ctx.argument_len))
-			return -1;
+	if (!nl_attr_put8(
+			&req->n, datalen, 
+			FPM_SRV6_LOCALSID_FORMAT_ARG_LEN,
+			nexthop->nh_srv6->seg6local_ctx.argument_len))
+		return -1;
 
 	nl_attr_nest_end(&req->n, nest);
 

--- a/src/sonic-frr/patch/0079-staticd-add-support-for-srv6.patch
+++ b/src/sonic-frr/patch/0079-staticd-add-support-for-srv6.patch
@@ -14,7 +14,7 @@ Signed-off-by: Carmine Scarpitta <cscarpit@cisco.com>
  staticd/static_srv6.h                         | 125 ++++
  staticd/static_vrf.c                          |   2 +
  staticd/static_vty.c                          | 320 +++++++++
- staticd/static_zebra.c                        | 636 ++++++++++++++++++
+ staticd/static_zebra.c                        | 698 ++++++++++++++++++
  staticd/static_zebra.h                        |  12 +-
  staticd/subdir.am                             |   2 +
  tests/topotests/static_srv6_sids/__init__.py  |   0
@@ -1136,7 +1136,7 @@ index d76befc131..f86fd3b48a 100644
  	return 0;
  }
  
-@@ -530,10 +537,639 @@ extern void static_zebra_route_add(struct static_path *pn, bool install)
+@@ -529,10 +536,701 @@ extern void static_zebra_route_add(struct static_path *pn, bool install)
  			   zclient, &api);
  }
  
@@ -1218,6 +1218,9 @@ index d76befc131..f86fd3b48a 100644
 +	struct seg6local_context ctx = {};
 +	struct interface *ifp = NULL;
 +	struct vrf *vrf;
++	struct prefix_ipv6 sid_block = {};
++	struct prefix_ipv6 locator_block = {};
++	struct prefix_ipv6 sid_locator = {};
 +
 +	if (!sid)
 +		return;
@@ -1291,10 +1294,38 @@ index d76befc131..f86fd3b48a 100644
 +		break;
 +	}
 +
-+	ctx.block_len = sid->locator->block_bits_length;
-+	ctx.node_len = sid->locator->node_bits_length;
-+	ctx.function_len = sid->locator->function_bits_length;
-+	ctx.argument_len = sid->locator->argument_bits_length;
++	ctx.block_len = 0;
++	ctx.node_len = 0;
++	ctx.function_len = 0;
++	ctx.argument_len = 0;
++
++	sid_block = sid->addr;
++	sid_block.prefixlen = sid->locator->block_bits_length;
++	apply_mask(&sid_block);
++
++	locator_block = sid->locator->prefix;
++	locator_block.prefixlen = sid->locator->block_bits_length;
++	apply_mask(&locator_block);
++
++	if (prefix_same(&sid_block, &locator_block))
++		ctx.block_len = sid->locator->block_bits_length;
++	else {
++		zlog_warn("SID block %pFX does not match locator block %pFX", &sid_block, &locator_block);
++		return;
++	}
++
++	sid_locator = sid->addr;
++	sid_locator.prefixlen = sid->locator->block_bits_length + sid->locator->node_bits_length;
++	apply_mask(&sid_locator);
++
++	if (prefix_same(&sid_locator, &sid->locator->prefix))
++		ctx.node_len = sid->locator->node_bits_length;
++	else {
++		zlog_warn("SID locator %pFX does not match the specified locator %pFX", &sid_locator, &sid->locator->prefix);
++		return;
++	}
++
++	ctx.function_len = sid->addr.prefixlen - (ctx.block_len + ctx.node_len);
 +
 +	/* Attach the SID to the SRv6 interface */
 +	if (!ifp) {
@@ -1318,6 +1349,9 @@ index d76befc131..f86fd3b48a 100644
 +	struct interface *ifp = NULL;
 +	struct seg6local_context ctx = {};
 +	struct vrf *vrf;
++	struct prefix_ipv6 sid_block = {};
++	struct prefix_ipv6 locator_block = {};
++	struct prefix_ipv6 sid_locator = {};
 +
 +	if (!sid)
 +		return;
@@ -1387,10 +1421,38 @@ index d76befc131..f86fd3b48a 100644
 +		}
 +	}
 +
-+	ctx.block_len = sid->locator->block_bits_length;
-+	ctx.node_len = sid->locator->node_bits_length;
-+	ctx.function_len = sid->locator->function_bits_length;
-+	ctx.argument_len = sid->locator->argument_bits_length;
++	ctx.block_len = 0;
++	ctx.node_len = 0;
++	ctx.function_len = 0;
++	ctx.argument_len = 0;
++
++	sid_block = sid->addr;
++	sid_block.prefixlen = sid->locator->block_bits_length;
++	apply_mask(&sid_block);
++
++	locator_block = sid->locator->prefix;
++	locator_block.prefixlen = sid->locator->block_bits_length;
++	apply_mask(&locator_block);
++
++	if (prefix_same(&sid_block, &locator_block))
++		ctx.block_len = sid->locator->block_bits_length;
++	else {
++		zlog_warn("SID block %pFX does not match locator block %pFX", &sid_block, &locator_block);
++		return;
++	}
++
++	sid_locator = sid->addr;
++	sid_locator.prefixlen = sid->locator->block_bits_length + sid->locator->node_bits_length;
++	apply_mask(&sid_locator);
++
++	if (prefix_same(&sid_locator, &sid->locator->prefix))
++		ctx.node_len = sid->locator->node_bits_length;
++	else {
++		zlog_warn("SID locator %pFX does not match the specified locator %pFX", &sid_locator, &sid->locator->prefix);
++		return;
++	}
++
++	ctx.function_len = sid->addr.prefixlen - (ctx.block_len + ctx.node_len);
 +
 +	zlog_info("delete SID %pFX",
 +		 &sid->addr);


### PR DESCRIPTION
The FRR CLI to support SRv6 Static SIDs has been merged in FRR mainline in this PR (https://github.com/FRRouting/frr/pull/16894). The CLI has been ported into SONiC mainline in this PR (https://github.com/sonic-net/sonic-buildimage/pull/21380).
This PR verifies the SRv6 Static SIDs configured by the above FRR CLI. It verifies that the block and node parts of the configured SID matches block and node parts of the locator it belongs to. The PR computes the parameters that will be installed with the SID into APPL DB. The changes in this PR will be also added into FRR mainline.