### PR TITLE
[Bgpcfgd] Update bgpcfgd to handle SRV6_MY_SIDS table's key as an ipv6 prefix

### DIFF
--- a/src/sonic-bgpcfgd/tests/test_srv6.py
+++ b/src/sonic-bgpcfgd/tests/test_srv6.py
@@ -87,7 +87,8 @@ def test_uN_add():
         'sid fcbb:bbbb:1::/48 locator loc1 behavior uN'
     ])
 
-    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1::/48")
+    print(loc_mgr.directory.data)
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1::\\48")
 
 def test_uDT46_add_vrf1():
     loc_mgr, sid_mgr = constructor()
@@ -103,7 +104,8 @@ def test_uDT46_add_vrf1():
         'sid fcbb:bbbb:1:f2::/64 locator loc1 behavior uDT46 vrf Vrf1'
     ])
 
-    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:f2::/64")
+    print(loc_mgr.directory.data)
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:f2::\\64")
 
 def test_uN_del():
     loc_mgr, sid_mgr = constructor()
@@ -123,7 +125,7 @@ def test_uN_del():
             'no sid fcbb:bbbb:1::/48 locator loc1 behavior uN'
     ])
 
-    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1::/48")
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1::\\48")
 
 def test_uDT46_del_vrf1():
     loc_mgr, sid_mgr = constructor()
@@ -149,8 +151,8 @@ def test_uDT46_del_vrf1():
             'no sid fcbb:bbbb:1:f2::/64 locator loc1 behavior uDT46 vrf Vrf1'
     ])
 
-    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1::/48")
-    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:f2::/64")
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1::\\48")
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:f2::\\64")
 
 def test_invalid_add():
     _, sid_mgr = constructor()
@@ -160,4 +162,4 @@ def test_invalid_add():
         'action': 'uN'
     }), expected_ret=False, expected_cmds=[])
 
-    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21:f1::/64")
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21:f1::\\64")

--- a/src/sonic-bgpcfgd/tests/test_srv6.py
+++ b/src/sonic-bgpcfgd/tests/test_srv6.py
@@ -78,22 +78,22 @@ def test_uN_add():
     loc_mgr, sid_mgr = constructor()
     assert loc_mgr.set_handler("loc1", {'prefix': 'fcbb:bbbb:1::'})
 
-    op_test(sid_mgr, 'SET', ("loc1|FCBB:BBBB:1:F1::", {
+    op_test(sid_mgr, 'SET', ("loc1|FCBB:BBBB:1::/48", {
         'action': 'uN'
     }), expected_ret=True, expected_cmds=[
         'segment-routing',
         'srv6',
         'static-sids',
-        'sid fcbb:bbbb:1:f1::/64 locator loc1 behavior uN'
+        'sid fcbb:bbbb:1::/48 locator loc1 behavior uN'
     ])
 
-    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:f1::")
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1::/48")
 
 def test_uDT46_add_vrf1():
     loc_mgr, sid_mgr = constructor()
     assert loc_mgr.set_handler("loc1", {'prefix': 'fcbb:bbbb:1::'})
 
-    op_test(sid_mgr, 'SET', ("loc1|FCBB:BBBB:1:F2::", {
+    op_test(sid_mgr, 'SET', ("loc1|FCBB:BBBB:1:F2::/64", {
         'action': 'uDT46',
         'decap_vrf': 'Vrf1'
     }), expected_ret=True, expected_cmds=[
@@ -103,45 +103,45 @@ def test_uDT46_add_vrf1():
         'sid fcbb:bbbb:1:f2::/64 locator loc1 behavior uDT46 vrf Vrf1'
     ])
 
-    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:f2::")
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:f2::/64")
 
 def test_uN_del():
     loc_mgr, sid_mgr = constructor()
     assert loc_mgr.set_handler("loc1", {'prefix': 'fcbb:bbbb:1::'})
     
     # add uN function first
-    assert sid_mgr.set_handler("loc1|FCBB:BBBB:1:F1::", {
+    assert sid_mgr.set_handler("loc1|FCBB:BBBB:1::/48", {
         'action': 'uN'
     })
 
     # test the deletion
-    op_test(sid_mgr, 'DEL', ("loc1|FCBB:BBBB:1:F1::",),
+    op_test(sid_mgr, 'DEL', ("loc1|FCBB:BBBB:1::/48",),
             expected_ret=True, expected_cmds=[
             'segment-routing',
             'srv6',
             'static-sids',
-            'no sid fcbb:bbbb:1:f1::/64 locator loc1 behavior uN'
+            'no sid fcbb:bbbb:1::/48 locator loc1 behavior uN'
     ])
 
-    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:f1::")
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1::/48")
 
 def test_uDT46_del_vrf1():
     loc_mgr, sid_mgr = constructor()
     assert loc_mgr.set_handler("loc1", {'prefix': 'fcbb:bbbb:1::'})
     
     # add a uN action first to make the uDT46 action not the last function
-    assert sid_mgr.set_handler("loc1|FCBB:BBBB:1:F1::", {
+    assert sid_mgr.set_handler("loc1|FCBB:BBBB:1::/48", {
         'action': 'uN'
     })
 
     # add the uDT46 action
-    assert sid_mgr.set_handler("loc1|FCBB:BBBB:1:F2::", {
+    assert sid_mgr.set_handler("loc1|FCBB:BBBB:1:F2::/64", {
         'action': 'uDT46',
         "decap_vrf": "Vrf1"
     })
 
     # test the deletion of uDT46
-    op_test(sid_mgr, 'DEL', ("loc1|FCBB:BBBB:1:F2::",),
+    op_test(sid_mgr, 'DEL', ("loc1|FCBB:BBBB:1:F2::/64",),
             expected_ret=True, expected_cmds=[
             'segment-routing',
             'srv6',
@@ -149,15 +149,15 @@ def test_uDT46_del_vrf1():
             'no sid fcbb:bbbb:1:f2::/64 locator loc1 behavior uDT46 vrf Vrf1'
     ])
 
-    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:f1::")
-    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:f2::")
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1::/48")
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:f2::/64")
 
 def test_invalid_add():
     _, sid_mgr = constructor()
 
     # test the addition of a SID with a non-existent locator
-    op_test(sid_mgr, 'SET', ("loc2|FCBB:BBBB:21:F1::", {
+    op_test(sid_mgr, 'SET', ("loc2|FCBB:BBBB:21:F1::/64", {
         'action': 'uN'
     }), expected_ret=False, expected_cmds=[])
 
-    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21:f1::")
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21:f1::/64")


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To adapt bgpcfgd to the new schema of SRV6_MY_SIDS

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

