### PR TITLE
[Mellanox] Handle exception during Inotify import

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/inotify_helper.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/inotify_helper.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/inotify_helper.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/inotify_helper.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/inotify_helper.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/inotify_helper.py
@@ -18,6 +18,9 @@
 """Helper code for Inotify Implementation for reading file until timeout"""
 import os
 import errno
+# Inotify causes an exception when DEBUG env variable is set to a non-integer convertible
+# https://github.com/dsoprea/PyInotify/blob/0.2.10/inotify/adapters.py#L37
+os.environ['DEBUG'] = '0'
 import inotify.adapters
 
 try:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

During smartswitch initialization, an error is observed during switch bootup. ztp disable runs decode-eeprom.
```
sonic ERR decode-syseeprom: Failed to obtain EEPROM object due to ValueError("invalid literal for int() with base 10: ''"), 
Traceback: Traceback (most recent call last):
#012  File "/usr/local/bin/decode-syseeprom", line 35, in instantiate_eeprom_object#012    eeprom = sonic_platform.platform.Platform().get_chassis().get_eeprom()
#012             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#012  File "/usr/local/lib/python3.11/dist-packages/sonic_platform/platform.py", line 35, in __init__
#012    self._chassis = SmartSwitchChassis()#012                    ^^^^^^^^^^^^^^^^^^^^
#012  File "/usr/local/lib/python3.11/dist-packages/sonic_platform/chassis.py", line 1207, in __init__
#012    self.initialize_modules()#012  File "/usr/local/lib/python3.11/dist-packages/sonic_platform/chassis.py", line 1244, in initialize_modules
#012    self.initialize_single_module(index=index)
#012  File "/usr/local/lib/python3.11/dist-packages/sonic_platform/chassis.py", line 1235, in initialize_single_module
#012    from .module import DpuModule#012  File "/usr/local/lib/python3.11/dist-packages/sonic_platform/module.py", line 24, in <module>
#012    from .dpuctlplat import DpuCtlPlat, BootProgEnum
#012  File "/usr/local/lib/python3.11/dist-packages/sonic_platform/dpuctlplat.py", line 29, in <module>
#012    from .inotify_helper import InotifyHelper
#012  File "/usr/local/lib/python3.11/dist-packages/sonic_platform/inotify_helper.py", line 21, in <module>
#012    import inotify.adapters#012  File "/usr/local/lib/python3.11/dist-packages/inotify/adapters.py", line 37, in <module>
#012    _IS_DEBUG = bool(int(os.environ.get('DEBUG', '0')))
#012                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#012ValueError: invalid literal for int() with base 10: ''
```
Happens during ztp because, ztp sets DEBUG="" here https://github.com/sonic-net/sonic-ztp/blob/202411/src/etc/default/ztp#L6
 
#### How I did it

Fixed the import in inotify

#### How to verify it

Verified by running decode-eeprom during init 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

