### PR TITLE
flashrom build fix: incorrect tag name

### DIFF
--- a/src/flashrom/Makefile
+++ b/src/flashrom/Makefile
@@ -12,7 +12,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	pushd ./flashrom-$(FLASHROM_VERSION_FULL)
 
 	# Check out tag: tags/0.9.7
-	git checkout -b flashrom-src tags/$(FLASHROM_VERSION_FULL)
+	git checkout -b flashrom-src v$(FLASHROM_VERSION_FULL)
 
 	# Apply patch series
 	stg init


### PR DESCRIPTION
#### Why I did it

flashrom recently started failing to build with the below error:
```
Cloning into 'flashrom-0.9.7'...
/sonic/src/flashrom/flashrom-0.9.7 /sonic/src/flashrom
fatal: 'tags/0.9.7' is not a commit and a branch 'flashrom-src' cannot be created from it
```

Nothing in sonic-buildimage has changed in relation to this so presumably flashrom upstream renamed their tags.

##### Work item tracking

#### How I did it

This commit just fixes the formatting of the tag name to use the new format.

#### How to verify it

Build sonic from scratch with no cached packages.

#### Which release branch to backport (provide reason below if selected)

- [x] 202411

#### Tested branch (Please provide the tested image version)

master as of 20250119

#### Description for the changelog

flashrom build fix: incorrect tag name

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

Signed-off-by: Brad House (@bradh352)
