### PR TITLE
Fix broadcom build issue related with flashrom

### DIFF
--- a/rules/flashrom.mk
+++ b/rules/flashrom.mk
@@ -1,7 +1,7 @@
 # flashrom package
 #
 
-FLASHROM_VERSION_FULL = v0.9.7
+FLASHROM_VERSION_FULL = 0.9.7
 
 export FLASHROM_VERSION_FULL
 

--- a/rules/flashrom.mk
+++ b/rules/flashrom.mk
@@ -1,7 +1,7 @@
 # flashrom package
 #
 
-FLASHROM_VERSION_FULL = 0.9.7
+FLASHROM_VERSION_FULL = v0.9.7
 
 export FLASHROM_VERSION_FULL
 

--- a/src/flashrom/Makefile
+++ b/src/flashrom/Makefile
@@ -12,7 +12,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	pushd ./flashrom-$(FLASHROM_VERSION_FULL)
 
 	# Check out tag: tags/0.9.7
-	git checkout -b flashrom-src tags/$(FLASHROM_VERSION_FULL)
+	git checkout -b flashrom-src tags/v$(FLASHROM_VERSION_FULL)
 
 	# Apply patch series
 	stg init


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix build failure:
```
mv flashrom_0.9.7_amd64.deb /sonic/target/debs/bookworm/
Cloning into 'flashrom-0.9.7'...
/sonic/src/flashrom/flashrom-0.9.7 /sonic/src/flashrom
fatal: 'tags/0.9.7' is not a commit and a branch 'flashrom-src' cannot be created from it
make[1]: *** [Makefile:9: /sonic/target/debs/bookworm/flashrom_0.9.7_amd64.deb] Error 128
make[1]: Leaving directory '/sonic/src/flashrom'
```
[job link](https://dev.azure.com/mssonic/build/_build/results?buildId=749742&view=logs&j=88ce9a53-729c-5fa9-7b6e-3d98f2488e3f&t=b71397ab-4d88-53c1-4db7-b4fc5ec36f6f&l=1033)
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

