### PR TITLE
[202411][Smartswitch][Mellanox] Aligned platform with 202411 changes

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
@@ -23,7 +23,7 @@
 
 try:
     from sonic_platform_base.platform_base import PlatformBase
-    from .chassis import Chassis, ModularChassis, SmartSwitchChassis
+    from .chassis import Chassis, ModularChassis
     from .device_data import DeviceDataManager
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -31,9 +31,7 @@ except ImportError as e:
 class Platform(PlatformBase):
     def __init__(self):
         PlatformBase.__init__(self)
-        if DeviceDataManager.get_dpu_count():
-            self._chassis = SmartSwitchChassis()
-        elif DeviceDataManager.get_linecard_count() == 0:
+        if DeviceDataManager.get_linecard_count() == 0:
             self._chassis = Chassis()
         else:
             self._chassis = ModularChassis()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Since the 202411 branch will not have the PMON changes for Smartswitch, the changes which are already merged need to be reverted (Only the chassis is changed back to original chassis) so that the behaviour is consistent to 202405
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Removed `SmartSwitchChassis` from platform initialization

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

