### PR TITLE
skip ipinip tunnel creation if many interfaces

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -52,11 +52,10 @@
         {%- set ipv6_vlan_addresses = ipv6_vlan_addresses.append(prefix) %}
     {%- endif %}
 {% endfor %}
-{# FIXME: SAI report tunnel TABLE_FULL with large interfaces. Disable it temporarily if over 128 ports. #}
-{% if PORT|length <= 128 %}
 {%- set ipv4_addresses = ipv4_addresses + ipv4_vlan_addresses %}
 {%- set ipv6_addresses = ipv6_addresses + ipv6_vlan_addresses %}
-{% else %}
+{# FIXME: SAI report tunnel TABLE_FULL for large topo. Disable it temporarily if over 128 IPv4/IPv6 tunnels. #}
+{% if ipv4_addresses|length + ipv6_addresses|length > 128 %}
 {%- set ipv4_addresses = [] %}
 {%- set ipv6_addresses = [] %}
 {% endif %}

--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -52,8 +52,14 @@
         {%- set ipv6_vlan_addresses = ipv6_vlan_addresses.append(prefix) %}
     {%- endif %}
 {% endfor %}
+{# FIXME: SAI report tunnel TABLE_FULL with large interfaces. Disable it temporarily if over 128 ports. #}
+{% if PORT|length <= 128 %}
 {%- set ipv4_addresses = ipv4_addresses + ipv4_vlan_addresses %}
 {%- set ipv6_addresses = ipv6_addresses + ipv6_vlan_addresses %}
+{% else %}
+{%- set ipv4_addresses = [] %}
+{%- set ipv6_addresses = [] %}
+{% endif %}
 [
 {% if ipv4_loopback_addresses %}
 {% if subnet_decap.enable %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Temporary workaround for #21516. Issue is seen with 200+ interface. So, used >128 as condition instead of >256.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Reset the address list if port count is over 128.  So no more IPv4/IPv6 IPinIP tunnel will be created for interfaces.
tunnel interfaces on loopback and vlan MP2MP are still there.

#### How to verify it
Loaded the image with more than 200 interfaces, not seeing TABLE_FULL issue anymore.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

