### PR TITLE
[Smartswitch] Add `SonicDpu` to the type in DEVICE_METADATA yang model

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -45,6 +45,9 @@
     "DEVICE_METADATA_TYPE_BMC_MGMT_TOR_PATTERN": {
         "desc": "DEVICE_METADATA value as BmcMgmtToRRouter for Type field"
     },
+    "DEVICE_METADATA_TYPE_SONIC_DPU_PATTERN": {
+        "desc": "DEVICE_METADATA value as SonicDpu for Type field"
+    },
     "DEVICE_METADATA_TYPE_SONIC_HOST_PATTERN": {
         "desc": "DEVICE_METADATA value as SonicHost for Type field"
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -92,6 +92,16 @@
             }
         }
     },
+    "DEVICE_METADATA_TYPE_SONIC_DPU_PATTERN": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "bgp_asn": "65002",
+                    "type": "SonicDpu"
+                }
+            }
+        }
+    },
     "DEVICE_METADATA_TYPE_SONIC_HOST_PATTERN": {
         "sonic-device_metadata:sonic-device_metadata": {
             "sonic-device_metadata:DEVICE_METADATA": {

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -100,7 +100,7 @@ module sonic-device_metadata {
                 leaf type {
                     type string {
                         length 1..255;
-                        pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC|MgmtToRRouter|SpineRouter|BackEndToRRouter|BackEndLeafRouter|EPMS|MgmtTsToR|BmcMgmtToRRouter|SonicHost|not-provisioned";
+                        pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC|MgmtToRRouter|SpineRouter|BackEndToRRouter|BackEndLeafRouter|EPMS|MgmtTsToR|BmcMgmtToRRouter|SonicHost|SonicDpu|not-provisioned";
                     }
                 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This change is done because the DPUs are initalized with the `SonicDpu` type from sonic-config-engine https://github.com/sonic-net/sonic-buildimage/blob/9b9da85f5072e2b7e6ff3058ab816b73e7cb491c/src/sonic-config-engine/config_samples.py#L148
This is added to the yang models in order to yang validation doesn't fail
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/21111
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added `SonicDpu` type in src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

