### PR TITLE
Fix FIPS packages been overwrite by upstream package issue.

### DIFF
--- a/files/build/versions/host-image/versions-deb-bookworm
+++ b/files/build/versions/host-image/versions-deb-bookworm
@@ -166,7 +166,7 @@ libjansson4==2.14-2
 libjq1==1.6-2.1
 libjs-jquery==3.6.1+dfsg+~3.5.14-1
 libjson-c5==0.16-2
-libk5crypto3==1.20.1-2+deb12u2
+libk5crypto3==1.20.1-2+deb12u1+fips
 libkeyutils1==1.6.3-2
 libklibc==2.0.12-1
 libkmod2==30+20221128-1

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -1131,8 +1131,15 @@ sudo chmod a+x $FILESYSTEM_ROOT/tmp/mask_disabled_services.py
 sudo LANG=C chroot $FILESYSTEM_ROOT /tmp/mask_disabled_services.py
 sudo rm -rf $FILESYSTEM_ROOT/tmp/mask_disabled_services.py
 
+echo "check fips version before install"
+apt-cache madison openssl
+apt-cache madison libk5crypto3
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install python3-dbus
+
+echo "check fips version after install"
+apt-cache madison openssl
+apt-cache madison libk5crypto3
 
 # [Hua] remove this only for debug
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install debtree

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -1133,3 +1133,6 @@ sudo rm -rf $FILESYSTEM_ROOT/tmp/mask_disabled_services.py
 
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install python3-dbus
+
+# [Hua] remove this only for debug
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install debtree

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -1135,6 +1135,9 @@ echo "check fips version before install"
 apt-cache madison openssl
 apt-cache madison libk5crypto3
 
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark hold openssl
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark hold libk5crypto3
+
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install python3-dbus
 
 echo "check fips version after install"

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -1137,10 +1137,14 @@ apt-cache madison libk5crypto3
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark hold openssl
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark hold libk5crypto3
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark hold openssl
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark hold libk5crypto3
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install python3-dbus
 
 echo "check fips version after install"
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark unhold openssl
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark unhold libk5crypto3
 apt-cache madison openssl
 apt-cache madison libk5crypto3
 


### PR DESCRIPTION
Fix FIPS packages been overwrite by upstream package issue.

#### Why I did it
FIPS break on 202405 because not latest version, because:
1. Debian version higher than fips version
2. Some package version does not add to reproduceable build config file.

##### Work item tracking
- Microsoft ADO: 30945454

#### How I did it
Fix FIPS packages been overwrite by upstream package issue.

#### How to verify it
Pass all UT.


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [] 

#### Description for the changelog
Fix FIPS packages been overwrite by upstream package issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

