### PR TITLE
Prevent FIPS packages been overwrite by official version

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -777,15 +777,15 @@ sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || sudo LANG=C DEBIAN_FRONTEND=noni
 # For some SONiC patch packages, Debian offcial version may higher than SONiC version
 # When install SONiC packages, fix broken install by 'apt-get -y install -f' may upgrade some installed SONiC packages to Debian offical version
 # Check and install upgraded SONiC package again, if install failed, need manually check and fix SONiC package version issue
-INSTALLED_VERSION=$(dpkg-query --showformat='${Version}' --show {{deb}})
-DEB_PACKAGE_VERSION=$(dpkg-deb -f {{deb}} Version)
-if [ "$INSTALLED_VERSION" != "$DEB_PACKAGE_VERSION" ]; then
+PACKAGE_NAME=$(dpkg-deb -f {{deb}} Package)
+PACKAGE_VERSION=$(dpkg-deb -f {{deb}} Version)
+INSTALLED_VERSION=$(dpkg-query --showformat='${Version}' --show $PACKAGE_NAME
+if [ "$INSTALLED_VERSION" != "$PACKAGE_VERSION" ]; then
     sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}}
 fi
 
 ## SONiC packages may have lower version than Debian offical package, install offical Debian package will break feature
 ## Hold installed packages to prevent these packages be upgrade by apt commands in this file
-PACKAGE_NAME=$(dpkg-deb -f {{deb}} Package)
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark hold $PACKAGE_NAME
 
 {% endfor %}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -767,19 +767,26 @@ fi
 
 {% if installer_debs.strip() -%}
 {% for deb in installer_debs.strip().split(' ') -%}
-install_failed=false
-sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || install_failed=true
+sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
+{% endfor %}
+{% endif %}
+
+{% if installer_debs.strip() -%}
+{% for deb in installer_debs.strip().split(' ') -%}
+
+# For some SONiC patch packages, Debian offcial version may higher than SONiC version
+# When install SONiC packages, fix broken install by 'apt-get -y install -f' may upgrade some installed SONiC packages to Debian offical version
+# Check and install upgraded SONiC package again, if install failed, need manually check and fix SONiC package version issue
+INSTALLED_VERSION=$(dpkg-query --showformat='${Version}' --show {{deb}})
+DEB_PACKAGE_VERSION=$(dpkg-deb -f {{deb}} Version)
+if [ "$INSTALLED_VERSION" != "$DEB_PACKAGE_VERSION" ]; then
+    sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}}
+fi
 
 ## SONiC packages may have lower version than Debian offical package, install offical Debian package will break feature
 ## Hold installed packages to prevent these packages be upgrade by apt commands in this file
 PACKAGE_NAME=$(dpkg-deb -f {{deb}} Package)
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark hold $PACKAGE_NAME
-
-if [ $install_failed == true ]; then
-    # Install debian package again, also install depency and fix unconfigured package, some SONiC packages inderectly depends on eachother, and both have lower version than Debian offical package
-    # So 'apt-get -y install -f' command will downgrade installed SONiC package
-    sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
-fi
 
 {% endfor %}
 {% endif %}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -768,6 +768,10 @@ fi
 {% if installer_debs.strip() -%}
 {% for deb in installer_debs.strip().split(' ') -%}
 sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
+## SONiC packages may have lower version than Debian offical package, install offical Debian package will break feature
+## Hold installed packages to prevent these packages be upgrade by apt commands in this file
+PACKAGE_NAME=$(dpkg-deb -f {{deb}} Package)
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark hold $PACKAGE_NAME
 {% endfor %}
 {% endif %}
 
@@ -1170,6 +1174,15 @@ sudo rm -rf $FILESYSTEM_ROOT/tmp/mask_disabled_services.py
 
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install python3-dbus
+
+
+{% if installer_debs.strip() -%}
+{% for deb in installer_debs.strip().split(' ') -%}
+## Unhold installed packages to allow these packages be upgrade after SONiC installed
+PACKAGE_NAME=$(dpkg-deb -f {{deb}} Package)
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark unhold $PACKAGE_NAME
+{% endfor %}
+{% endif %}
 
 ## Enable MULTIDB
 {% if ENABLE_MULTIDB == "y" %}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -768,8 +768,8 @@ fi
 {% if installer_debs.strip() -%}
 {% for deb in installer_debs.strip().split(' ') -%}
 install_failed=false
-sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || install_failed=true; true
-if [ install_failed ]; then
+sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || install_failed=true
+if [ $install_failed == true ]; then
     # Install debian package failed, install depency and fix unconfigured package
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
     # Install debian package again, some SONiC packages inderectly depends on eachother, and both have lower version than Debian offical package

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -767,11 +767,20 @@ fi
 
 {% if installer_debs.strip() -%}
 {% for deb in installer_debs.strip().split(' ') -%}
-sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
+sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}}
+if [ $? -ne 0 ]; then
+    # Install debian package failed, install depency and fix unconfigured package
+    sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
+    # Install debian package again, some SONiC packages inderectly depends on eachother, and both have lower version than Debian offical package
+    # So 'apt-get -y install -f' command will downgrade installed SONiC package
+    sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}}
+fi
+
 ## SONiC packages may have lower version than Debian offical package, install offical Debian package will break feature
 ## Hold installed packages to prevent these packages be upgrade by apt commands in this file
 PACKAGE_NAME=$(dpkg-deb -f {{deb}} Package)
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark hold $PACKAGE_NAME
+
 {% endfor %}
 {% endif %}
 

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -769,18 +769,17 @@ fi
 {% for deb in installer_debs.strip().split(' ') -%}
 install_failed=false
 sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || install_failed=true
-if [ $install_failed == true ]; then
-    # Install debian package failed, install depency and fix unconfigured package
-    sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
-    # Install debian package again, some SONiC packages inderectly depends on eachother, and both have lower version than Debian offical package
-    # So 'apt-get -y install -f' command will downgrade installed SONiC package
-    sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}}
-fi
 
 ## SONiC packages may have lower version than Debian offical package, install offical Debian package will break feature
 ## Hold installed packages to prevent these packages be upgrade by apt commands in this file
 PACKAGE_NAME=$(dpkg-deb -f {{deb}} Package)
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark hold $PACKAGE_NAME
+
+if [ $install_failed == true ]; then
+    # Install debian package again, also install depency and fix unconfigured package, some SONiC packages inderectly depends on eachother, and both have lower version than Debian offical package
+    # So 'apt-get -y install -f' command will downgrade installed SONiC package
+    sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
+fi
 
 {% endfor %}
 {% endif %}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -779,8 +779,8 @@ sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || sudo LANG=C DEBIAN_FRONTEND=noni
 # Check and install upgraded SONiC package again, if install failed, need manually check and fix SONiC package version issue
 PACKAGE_NAME=$(dpkg-deb -f {{deb}} Package)
 PACKAGE_VERSION=$(dpkg-deb -f {{deb}} Version)
-INSTALLED_VERSION=$(dpkg-query --showformat='${Version}' --show $PACKAGE_NAME)
-if [ "$INSTALLED_VERSION" != "$PACKAGE_VERSION" ]; then
+INSTALLED_VERSION=$(dpkg-query --showformat='${Version}' --show $PACKAGE_NAME || true)
+if [ "$INSTALLED_VERSION" != "" ] && [ "$INSTALLED_VERSION" != "$PACKAGE_VERSION" ]; then
     sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}}
 fi
 

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -779,7 +779,7 @@ sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || sudo LANG=C DEBIAN_FRONTEND=noni
 # Check and install upgraded SONiC package again, if install failed, need manually check and fix SONiC package version issue
 PACKAGE_NAME=$(dpkg-deb -f {{deb}} Package)
 PACKAGE_VERSION=$(dpkg-deb -f {{deb}} Version)
-INSTALLED_VERSION=$(dpkg-query --showformat='${Version}' --show $PACKAGE_NAME
+INSTALLED_VERSION=$(dpkg-query --showformat='${Version}' --show $PACKAGE_NAME)
 if [ "$INSTALLED_VERSION" != "$PACKAGE_VERSION" ]; then
     sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}}
 fi

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -767,8 +767,9 @@ fi
 
 {% if installer_debs.strip() -%}
 {% for deb in installer_debs.strip().split(' ') -%}
-sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}}
-if [ $? -ne 0 ]; then
+install_failed=false
+sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || install_failed=true; true
+if [ install_failed ]; then
     # Install debian package failed, install depency and fix unconfigured package
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
     # Install debian package again, some SONiC packages inderectly depends on eachother, and both have lower version than Debian offical package


### PR DESCRIPTION
Prevent SONiC packages been overwrite by official version

#### Why I did it
FIPS break on 202405 and later version, because openssl and libk5crypto3 Debian offical version higher than FIPS version, so FIPS openssl been upgrade when install python-dbus:

+ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot ./fsroot-mellanox apt-get -y install python3-dbus
Reading package lists...
Building dependency tree...
Reading state information...
python3-dbus is already the newest version (1.3.2-4+b1).
The following additional packages will be installed:
  libk5crypto3 openssl <== python3-dbus depends on  libk5crypto3 and openssl 
Suggested packages:
  krb5-doc krb5-user
The following packages will be upgraded:
  libk5crypto3 openssl
2 upgraded, 0 newly installed, 0 to remove and 17 not upgraded.
...
Unpacking libk5crypto3:amd64 (1.20.1-2+deb12u2) over (1.20.1-2+deb12u1+fips) ... <== debian version been installed
Unpacking openssl (3.0.15-1~deb12u1) over (3.0.11-1~deb12u2+fips) ...


This issue may happen on all SONiC package.

##### Work item tracking
- Microsoft ADO: 30945454

#### How I did it
Hold SONiC packaged during build image. and unhold after image ready.

#### How to verify it
Pass all UT.

Manually confirm the package upgrade issue fixed:

+ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot ./fsroot-mellanox apt-mark hold openssl
openssl set on hold.
...
+ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot ./fsroot-mellanox apt-get -y install python3-dbus
Reading package lists...
Building dependency tree...
Reading state information...
python3-dbus is already the newest version (1.3.2-4+b1).
0 upgraded, 0 newly installed, 0 to remove and 14 not **upgraded.** <== openssl not upgrade any more
+ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot ./fsroot-mellanox apt-mark unhold openssl
Canceled hold on openssl.


admin@vlab-01:~$ apt list | grep fips
libk5crypto3/now 1.20.1-2+deb12u1+fips amd64 [installed,local]
openssl/now 3.0.11-1~deb12u2+fips amd64 [installed,local]

check and confirm all packages installed in image:

admin@vlab-01:~$ apt list --installed | grep fips

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

libk5crypto3/now 1.20.1-2+deb12u1+fips amd64 [installed,local]
libssl-dev/now 3.0.11-1~deb12u2+fips amd64 [installed,local]
libssl3/now 3.0.11-1~deb12u2+fips amd64 [installed,local]
openssh-client/now 1:9.2p1-2+deb12u3+fips amd64 [installed,local]
openssh-server/now 1:9.2p1-2+deb12u3+fips amd64 [installed,local]
openssh-sftp-server/now 1:9.2p1-2+deb12u3+fips amd64 [installed,local]
openssl/now 3.0.11-1~deb12u2+fips amd64 [installed,local]
ssh/now 1:9.2p1-2+deb12u3+fips all [installed,local]
admin@vlab-01:~$


admin@vlab-01:~$ apt list --installed | grep symcrypt-openssl

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

symcrypt-openssl/now 0.1 all [installed,local]
admin@vlab-01:~$


  FIPS_BASEIMAGE_INSTALLERS = $(FIPS_OPENSSL_LIBSSL) $(FIPS_OPENSSL_LIBSSL_DEV) $(FIPS_OPENSSL) $(SYMCRYPT_OPENSSL) $(FIPS_OPENSSH_CLIENT) $(FIPS_OPENSSH) $(FIPS_OPENSSH_SFTP_SERVER) $(FIPS_OPENSSH_SERVER) $(FIPS_KRB5)


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 202405
- [x] 202411

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master-21530.757723-32de08bde

#### Description for the changelog
Prevent FIPS packages been overwrite by official version

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

