### PR TITLE
Improve existing core_cleanup.py to clean old dump/kernel dump. 

### DIFF
--- a/files/scripts/core_cleanup.py
+++ b/files/scripts/core_cleanup.py
@@ -9,7 +9,7 @@ from sonic_py_common.logger import Logger
 SYSLOG_IDENTIFIER = 'core_cleanup.py'
 CORE_FILE_DIR = '/var/core/'
 MAX_CORE_FILES = 4
-
+EXPIRE_DAYS = 90
 
 def main():
     logger = Logger(SYSLOG_IDENTIFIER)
@@ -18,18 +18,29 @@ def main():
     if os.getuid() != 0:
         logger.log_error('Root required to clean up core files')
         return
+        
+    expire_date = date.today() + timedelta(days=EXPIRE_DAYS)
 
     logger.log_info('Cleaning up core files')
     core_files = [f for f in os.listdir(CORE_FILE_DIR) if os.path.isfile(os.path.join(CORE_FILE_DIR, f))]
 
     core_files_by_process = defaultdict(list)
     for f in core_files:
+        # delete expired core files
+        file_date = datetime.utcfromtimestamp(int(x.split('.')[1]))
+        if file_date < expire_date:
+        try:
+            os.remove(os.path.join(CORE_FILE_DIR, f))
+        except:
+            logger.log_error('Unexpected error occured trying to delete {}'.format(f))
+            
+        # for none expired core files, only keep recent MAX_CORE_FILES
         process = f.split('.')[0]
         curr_files = core_files_by_process[process]
         curr_files.append(f)
 
         if len(curr_files) > MAX_CORE_FILES:
-            curr_files.sort(reverse=True, key=lambda x: datetime.utcfromtimestamp(int(x.split('.')[1])))
+            curr_files.sort(reverse = True, key = lambda x: datetime.utcfromtimestamp(int(x.split('.')[1])))
             oldest_core = curr_files[MAX_CORE_FILES]
             logger.log_info('Deleting {}'.format(oldest_core))
             try:
@@ -39,7 +50,6 @@ def main():
             core_files_by_process[process] = curr_files[0:MAX_CORE_FILES]
 
     logger.log_info('Finished cleaning up core files')
-
 
 if __name__ == '__main__':
     main()

--- a/files/scripts/core_cleanup.py
+++ b/files/scripts/core_cleanup.py
@@ -3,7 +3,7 @@
 import os
 import re
 from collections import defaultdict
-from datetime import datetime, date
+from datetime import datetime, date, timedelta
 
 from sonic_py_common.logger import Logger
 
@@ -23,7 +23,7 @@ def get_dump_timestamp(file_name):
     match = re.search(r'sonic_dump_.*_(\d\d\d\d)(\d\d)(\d\d)_(\d\d)(\d\d)(\d\d).tar.gz', file_name)
     if match:
         groups = match.groups()
-        dump_date = datetime(int(groups[0]), int(groups[1]), int(groups[2]), int(groups[3]), int(groups[4]), int(groups[5]))
+        return datetime(int(groups[0]), int(groups[1]), int(groups[2]), int(groups[3]), int(groups[4]), int(groups[5]))
     
     return None
 
@@ -34,8 +34,8 @@ def main():
     if os.getuid() != 0:
         logger.log_error('Root required to clean up core files')
         return
-        
-    expire_date = date.today() + timedelta(days=EXPIRE_DAYS)
+
+    expire_date = datetime.now() - timedelta(days=EXPIRE_DAYS)
 
     logger.log_info('Cleaning up core files')
     core_files = [f for f in os.listdir(CORE_FILE_DIR) if os.path.isfile(os.path.join(CORE_FILE_DIR, f))]
@@ -61,11 +61,12 @@ def main():
             core_files_by_process[process] = curr_files[0:MAX_CORE_FILES]
 
     logger.log_info('Finished cleaning up core files')
-    
+
     # cleanup kernel dumps
     logger.log_info('Cleaning up kernel dump files')
-
     kernel_dumps = [f for f in os.listdir(KERNEL_DUMP_DIR) if os.path.isfile(os.path.join(KERNEL_DUMP_DIR, f))]
+    # Sort kernel dumps from new to old
+    kernel_dumps.sort(reverse = True, key = lambda x: get_dump_timestamp(x))
     not_expired_dumps = []
     for kernel_dump in kernel_dumps:
         # delete expired kernel dump
@@ -79,13 +80,12 @@ def main():
             delete_dump(os.path.join(KERNEL_DUMP_DIR, kernel_dump))
             continue
 
-        not_expired_dumps.append(f)
-        if len(not_expired_dumps) > MAX_CORE_FILES:
-            not_expired_dumps.sort(reverse = True, key = lambda x: get_dump_timestamp(kernel_dump))
-            oldest_dump = not_expired_dumps[MAX_CORE_FILES]
-            logger.log_info('Deleting {}'.format(oldest_dump))
-            delete_dump(os.path.join(KERNEL_DUMP_DIR, oldest_dump))
-            not_expired_dumps = not_expired_dumps[0:MAX_CORE_FILES]
+        # Only keep recent MAX_CORE_FILES kernel dumps
+        if len(not_expired_dumps) < MAX_CORE_FILES:
+            not_expired_dumps.append(kernel_dump)
+        else:
+            logger.log_info('Deleting {}'.format(kernel_dump))
+            delete_dump(os.path.join(KERNEL_DUMP_DIR, kernel_dump))
 
     logger.log_info('Finished cleaning up kernel dump files')
 

--- a/files/scripts/core_cleanup.py
+++ b/files/scripts/core_cleanup.py
@@ -13,7 +13,7 @@ KERNEL_DUMP_DIR = '/var/dump/'
 MAX_CORE_FILES = 4
 EXPIRE_DAYS = 90
 
-def delete_dump(file_path):
+def delete_file(file_path):
     try:
         os.remove(file_path)
     except:
@@ -45,7 +45,7 @@ def main():
         # delete expired core files
         dump_date = datetime.utcfromtimestamp(int(f.split('.')[1]))
         if dump_date < expire_date:
-            delete_dump(os.path.join(CORE_FILE_DIR, f))
+            delete_file(os.path.join(CORE_FILE_DIR, f))
             continue
             
         # for none expired core files, only keep recent MAX_CORE_FILES
@@ -54,10 +54,10 @@ def main():
         curr_files.append(f)
 
         if len(curr_files) > MAX_CORE_FILES:
-            curr_files.sort(reverse = True, key = lambda x: datetime.utcfromtimestamp(int(x.split('.')[1])))
+            curr_files.sort(reverse=True, key=lambda x: datetime.utcfromtimestamp(int(x.split('.')[1])))
             oldest_core = curr_files[MAX_CORE_FILES]
             logger.log_info('Deleting {}'.format(oldest_core))
-            delete_dump(os.path.join(CORE_FILE_DIR, oldest_core))
+            delete_file(os.path.join(CORE_FILE_DIR, oldest_core))
             core_files_by_process[process] = curr_files[0:MAX_CORE_FILES]
 
     logger.log_info('Finished cleaning up core files')
@@ -77,7 +77,7 @@ def main():
 
         if dump_date < expire_date:
             # Kernel dump expired
-            delete_dump(os.path.join(KERNEL_DUMP_DIR, kernel_dump))
+            delete_file(os.path.join(KERNEL_DUMP_DIR, kernel_dump))
             continue
 
         # Only keep recent MAX_CORE_FILES kernel dumps
@@ -85,7 +85,7 @@ def main():
             not_expired_dumps.append(kernel_dump)
         else:
             logger.log_info('Deleting {}'.format(kernel_dump))
-            delete_dump(os.path.join(KERNEL_DUMP_DIR, kernel_dump))
+            delete_file(os.path.join(KERNEL_DUMP_DIR, kernel_dump))
 
     logger.log_info('Finished cleaning up kernel dump files')
 

--- a/files/scripts/core_cleanup.py
+++ b/files/scripts/core_cleanup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import shutil
 from collections import defaultdict
 from datetime import datetime
 
@@ -8,8 +9,15 @@ from sonic_py_common.logger import Logger
 
 SYSLOG_IDENTIFIER = 'core_cleanup.py'
 CORE_FILE_DIR = '/var/core/'
+KERNEL_DUMP_DIR = '/var/dump/'
 MAX_CORE_FILES = 4
 EXPIRE_DAYS = 90
+
+def delete_dump(file_path)
+    try:
+        os.remove(file_path)
+    except:
+        logger.log_error('Unexpected error occured trying to delete {}'.format(file_path))
 
 def main():
     logger = Logger(SYSLOG_IDENTIFIER)
@@ -27,12 +35,10 @@ def main():
     core_files_by_process = defaultdict(list)
     for f in core_files:
         # delete expired core files
-        file_date = datetime.utcfromtimestamp(int(x.split('.')[1]))
-        if file_date < expire_date:
-        try:
-            os.remove(os.path.join(CORE_FILE_DIR, f))
-        except:
-            logger.log_error('Unexpected error occured trying to delete {}'.format(f))
+        dump_date = datetime.utcfromtimestamp(int(f.split('.')[1]))
+        if dump_date < expire_date:
+            delete_dump(os.path.join(CORE_FILE_DIR, f))
+            continue
             
         # for none expired core files, only keep recent MAX_CORE_FILES
         process = f.split('.')[0]
@@ -43,13 +49,32 @@ def main():
             curr_files.sort(reverse = True, key = lambda x: datetime.utcfromtimestamp(int(x.split('.')[1])))
             oldest_core = curr_files[MAX_CORE_FILES]
             logger.log_info('Deleting {}'.format(oldest_core))
-            try:
-                os.remove(os.path.join(CORE_FILE_DIR, oldest_core))
-            except:
-                logger.log_error('Unexpected error occured trying to delete {}'.format(oldest_core))
+            delete_dump(os.path.join(CORE_FILE_DIR, oldest_core))
             core_files_by_process[process] = curr_files[0:MAX_CORE_FILES]
 
     logger.log_info('Finished cleaning up core files')
+    
+    # cleanup kernel dumps
+    logger.log_info('Cleaning up kernel dump files')
+
+    kernel_dumps = [f for f in os.listdir(KERNEL_DUMP_DIR) if os.path.isfile(os.path.join(KERNEL_DUMP_DIR, f))]
+    not_expired_dumps = []
+    for kernel_dump in kernel_dumps:
+        # delete expired kernel dump
+        dump_date = datetime.utcfromtimestamp(int(kernel_dump.split('_')[3]))
+        if dump_date < expire_date:
+            delete_dump(os.path.join(KERNEL_DUMP_DIR, kernel_dump))
+            continue
+
+        not_expired_dumps.append(f)
+        if len(not_expired_dumps) > MAX_CORE_FILES:
+            not_expired_dumps.sort(reverse = True, key = lambda x: datetime.utcfromtimestamp(int(kernel_dump.split('_')[3])))
+            oldest_dump = not_expired_dumps[MAX_CORE_FILES]
+            logger.log_info('Deleting {}'.format(oldest_dump))
+            delete_dump(os.path.join(KERNEL_DUMP_DIR, oldest_dump))
+            not_expired_dumps = not_expired_dumps[0:MAX_CORE_FILES]
+
+    logger.log_info('Finished cleaning up kernel dump files')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Improve existing core_cleanup.py to clean old dump/kernel dump. 

#### Why I did it
On small disk device, dump file will cause disk full issue.

##### Work item tracking
- Microsoft ADO: 30847835

#### How I did it
Delete expired dump files
Only keep 4 kernel dump files.

#### How to verify it
Pass all UT.

Add new UT to cover this script.

Manually verified:


admin@vlab-01:~$ sudo ls /var/dump/
sonic_dump_bjw-can-7260-8_20230125_030042.tar.gz  sonic_dump_bjw-can-7260-8_20250125_030043.tar.gz  sonic_dump_bjw-can-7260-8_20250125_030045.tar.gz
sonic_dump_bjw-can-7260-8_20250125_030042.tar.gz  sonic_dump_bjw-can-7260-8_20250125_030044.tar.gz  sonic_dump_bjw-can-7260-8_20250125_030046.tar.gz
admin@vlab-01:~$ sudo ls /var/core/
orchagent.1644957238.46.core.gz  orchagent.1944957232.46.core.gz  orchagent.1944957234.46.core.gz  orchagent.1944957236.46.core.gz
orchagent.1944957231.46.core.gz  orchagent.1944957233.46.core.gz  orchagent.1944957235.46.core.gz

admin@vlab-01:~$ sudo python3 ./core_cleanup.py

admin@vlab-01:~$ sudo ls /var/dump/
sonic_dump_bjw-can-7260-8_20250125_030043.tar.gz  sonic_dump_bjw-can-7260-8_20250125_030045.tar.gz
sonic_dump_bjw-can-7260-8_20250125_030044.tar.gz  sonic_dump_bjw-can-7260-8_20250125_030046.tar.gz
admin@vlab-01:~$ sudo ls /var/core/
orchagent.1944957233.46.core.gz  orchagent.1944957234.46.core.gz  orchagent.1944957235.46.core.gz  orchagent.1944957236.46.core.gz

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [] 

#### Description for the changelog
Improve existing core_cleanup.py to clean old dump/kernel dump. 

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

