### PR TITLE
[202411] Add a service to sync the system time with the RTC

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -431,6 +431,9 @@ sudo cp $IMAGE_CONFIGS/ntp/ntp.keys.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATE
 sudo cp $IMAGE_CONFIGS/ntp/ntp-systemd-wrapper $FILESYSTEM_ROOT/usr/libexec/ntpsec/
 sudo mkdir $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/ntpsec.service.d
 sudo cp $IMAGE_CONFIGS/ntp/sonic-target.conf $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/ntpsec.service.d/
+sudo cp $IMAGE_CONFIGS/ntp/hwclock.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/
+sudo cp $IMAGE_CONFIGS/ntp/hwclock.timer $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/
+sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable hwclock.timer
 echo "ntpsec.service" | sudo tee -a $GENERATED_SERVICE_FILE
 
 # Copy DNS templates

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -431,8 +431,8 @@ sudo cp $IMAGE_CONFIGS/ntp/ntp.keys.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATE
 sudo cp $IMAGE_CONFIGS/ntp/ntp-systemd-wrapper $FILESYSTEM_ROOT/usr/libexec/ntpsec/
 sudo mkdir $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/ntpsec.service.d
 sudo cp $IMAGE_CONFIGS/ntp/sonic-target.conf $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/ntpsec.service.d/
-sudo cp $IMAGE_CONFIGS/ntp/hwclock.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/
-sudo cp $IMAGE_CONFIGS/ntp/hwclock.timer $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/
+sudo cp $IMAGE_CONFIGS/ntp/hwclock.service $FILESYSTEM_ROOT/etc/systemd/system/
+sudo cp $IMAGE_CONFIGS/ntp/hwclock.timer $FILESYSTEM_ROOT/etc/systemd/system/
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable hwclock.timer
 echo "ntpsec.service" | sudo tee -a $GENERATED_SERVICE_FILE
 

--- a/files/image_config/ntp/hwclock.service
+++ b/files/image_config/ntp/hwclock.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Sync the system clock to the hardware clock
+ConditionPathExists=/dev/rtc0
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/hwclock --rtc=/dev/rtc0 --systohc

--- a/files/image_config/ntp/hwclock.timer
+++ b/files/image_config/ntp/hwclock.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Frequently sync the system clock to the hardware clock
+
+[Timer]
+OnBootSec=30min
+OnUnitActiveSec=1h
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Currently, during runtime, because of the options that we start ntpd with, ntpd will never tell the kernel that the time is synchronized. This means that during runtime, the hardware clock will never get updated with the current system clock, which means that if there's an unexpected power loss/reboot, then the device will come up with an incorrect time. (In our regular reboot scripts, we explicitly write the system time to the hardware clock, so that is covered.)

##### Work item tracking
- Microsoft ADO **(number only)**: 31121257

#### How I did it

To handle that, add a timer and service to update the hardware clock with the current system time every hour. This makes sure that if the device does get rebooted for whatever reason, then the time is close to correct. The first run will happen 30 minutes after bootup.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

```
admin@vlab-01:~$ systemctl list-timers
NEXT                        LEFT          LAST                        PASSED      UNIT                         ACTIVATES
Wed 2025-02-12 03:30:00 UTC 1min 40s left Wed 2025-02-12 03:20:18 UTC 8min ago    logrotate.timer              logrotate.service
Wed 2025-02-12 03:30:00 UTC 1min 40s left Wed 2025-02-12 03:20:18 UTC 8min ago    sysstat-collect.timer        sysstat-collect.service
Wed 2025-02-12 03:54:17 UTC 25min left    Wed 2025-02-12 02:54:17 UTC 34min ago   hwclock.timer                hwclock.service
Wed 2025-02-12 06:25:00 UTC 2h 56min left -                           -           ntpsec-rotate-stats.timer    ntpsec-rotate-stats.service
Wed 2025-02-12 06:47:35 UTC 3h 19min left -                           -           apt-daily-upgrade.timer      apt-daily-upgrade.service
Wed 2025-02-12 13:09:49 UTC 9h left       -                           -           apt-daily.timer              apt-daily.service
Thu 2025-02-13 00:00:00 UTC 20h left      -                           -           dpkg-db-backup.timer         dpkg-db-backup.service
Thu 2025-02-13 00:07:00 UTC 20h left      -                           -           sysstat-summary.timer        sysstat-summary.service
Thu 2025-02-13 02:39:17 UTC 23h left      Wed 2025-02-12 02:39:17 UTC 49min ago   systemd-tmpfiles-clean.timer systemd-tmpfiles-clean.service
Sun 2025-02-16 03:10:31 UTC 3 days left   -                           -           e2scrub_all.timer            e2scrub_all.service
Mon 2025-02-17 00:00:00 UTC 4 days left   Wed 2025-02-12 02:34:17 UTC 54min ago   fstrim.timer                 fstrim.service
-                           -             Wed 2025-02-12 02:25:48 UTC 1h 2min ago featured.timer               featured.service
-                           -             Wed 2025-02-12 02:25:48 UTC 1h 2min ago hostcfgd.timer               hostcfgd.service
-                           -             Wed 2025-02-12 02:25:50 UTC 1h 2min ago rasdaemon.timer              rasdaemon.service
-                           -             Wed 2025-02-12 02:29:48 UTC 58min ago   tacacs-config.timer          tacacs-config.service

15 timers listed.
Pass --all to see loaded but inactive timers, too.
admin@vlab-01:~$ uptime
 03:28:25 up  1:04,  1 user,  load average: 0.37, 0.50, 0.41
admin@vlab-01:~$ sudo systemctl status hwclock
○ hwclock.service - Sync the system clock to the hardware clock
     Loaded: loaded (/etc/systemd/system/hwclock.service; static)
     Active: inactive (dead) since Wed 2025-02-12 02:54:17 UTC; 34min ago
TriggeredBy: ● hwclock.timer
    Process: 8037 ExecStart=/sbin/hwclock --rtc=/dev/rtc0 --systohc (code=exited, status=0/SUCCESS)
   Main PID: 8037 (code=exited, status=0/SUCCESS)

Feb 12 02:54:17 vlab-01 systemd[1]: Starting hwclock.service - Sync the system clock to the hardware clock...
Feb 12 02:54:17 vlab-01 systemd[1]: hwclock.service: Deactivated successfully.
Feb 12 02:54:17 vlab-01 systemd[1]: Finished hwclock.service - Sync the system clock to the hardware clock.
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

