### PR TITLE
Update O128S2 port_config.ini

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-O128S2/port_config.ini
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-O128S2/port_config.ini
@@ -116,14 +116,14 @@ Ethernet452  477,478,479,480                  Ethernet57/5  57     400000  rs
 Ethernet456  457,458,459,460                  Ethernet58/1  58     400000  rs
 Ethernet460  461,462,463,464                  Ethernet58/5  58     400000  rs
 Ethernet464  449,450,451,452                  Ethernet59/1  59     400000  rs
-Ethernet468  453,454,453,454                  Ethernet59/5  59     400000  rs
+Ethernet468  453,454,455,456                  Ethernet59/5  59     400000  rs
 Ethernet472  465,466,467,468                  Ethernet60/1  60     400000  rs
 Ethernet476  469,470,471,472                  Ethernet60/5  60     400000  rs
 Ethernet480  505,506,507,508                  Ethernet61/1  61     400000  rs
 Ethernet484  509,510,511,512                  Ethernet61/5  61     400000  rs
 Ethernet488  489,490,491,492                  Ethernet62/1  62     400000  rs
 Ethernet492  493,494,495,496                  Ethernet62/5  62     400000  rs
-Ethernet496  481,482,483,483                  Ethernet63/1  63     400000  rs
+Ethernet496  481,482,483,484                  Ethernet63/1  63     400000  rs
 Ethernet500  485,486,487,488                  Ethernet63/5  63     400000  rs
 Ethernet504  497,498,499,500                  Ethernet64/1  64     400000  rs
 Ethernet508  501,502,503,504                  Ethernet64/5  64     400000  rs

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-O128S2/port_config.ini
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-O128S2/port_config.ini
@@ -110,7 +110,7 @@ Ethernet428  429,430,431,432                  Ethernet54/5  54     400000  rs
 Ethernet432  417,418,419,420                  Ethernet55/1  55     400000  rs
 Ethernet436  421,422,423,424                  Ethernet55/5  55     400000  rs
 Ethernet440  433,434,435,436                  Ethernet56/1  56     400000  rs
-Ethernet444  437,438,439,430                  Ethernet56/5  56     400000  rs
+Ethernet444  437,438,439,440                  Ethernet56/5  56     400000  rs
 Ethernet448  473,474,475,476                  Ethernet57/1  57     400000  rs
 Ethernet452  477,478,479,480                  Ethernet57/5  57     400000  rs
 Ethernet456  457,458,459,460                  Ethernet58/1  58     400000  rs


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Microsoft requested that we update port_config.ini - we use hwsku.json so didnt see this locally - but some tools are being used that require port_config.ini

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Changed the lanes to match platform.json

#### How to verify it
Generate a config_db.json using the port_config.ini

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 202411

#### Tested branch (Please provide the tested image version)
202411
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update 7060X64PEO128S2 hwsku port_config.ini

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

