### PR TITLE
[yang] BGP support `autort` in address family

### DIFF
--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -129,6 +129,8 @@ bgp_globals_data = [
                                                                   'ibgp_route_distance': '115',
                                                                   'local_route_distance': '238'},
                        conf_bgp_af_cmd('default', 100, 'ipv4') + ['{}distance bgp 100 115 238']),
+        CmdMapTestInfo('BGP_GLOBALS_AF', 'default|ipv6_unicast', {'autort': 'rfc8365-compatible'},
+                       conf_bgp_af_cmd('default', 100, 'ipv6') + ['{}autort rfc8365-compatible']),
         CmdMapTestInfo('BGP_GLOBALS_AF', 'default|ipv6_unicast', {'advertise-all-vni': 'true'},
                        conf_bgp_af_cmd('default', 100, 'ipv6') + ['{}advertise-all-vni']),
         CmdMapTestInfo('BGP_GLOBALS', 'Vrf_red', {'local_asn': 200},

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1780,6 +1780,7 @@
                 "max_ibgp_paths": "2"
             },
             "default|l2vpn_evpn": {
+                "autort": "rfc8365-compatible",
                 "advertise-all-vni": "true"
             }
         },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
@@ -2,6 +2,13 @@
     "BGP_GLOBAL_VALID": {
         "desc": "Configure BGP global table."
     },
+    "BGP_GLOBALS_AF_AUTORT_VALID": {
+        "desc": "BGP Address Family l2vpn_evpn with autort set to rfc8365-compatible"
+    },
+    "BGP_GLOBALS_AF_AUTORT_INVALID": {
+        "desc": "BGP Address Family l2vpn_evpn with autort set to an invalid value",
+        "eStr": "Invalid value \"invalid\" in \"autort\" element."
+    },
     "BGP_GLOBALS_AF_ADVERTISE_ALL_VNI_TRUE": {
         "desc": "BGP Address Family l2vpn_evpn with advertise-all-vni set to true"
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
@@ -81,6 +81,48 @@
             }
         }
     },
+    "BGP_GLOBALS_AF_AUTORT_VALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "autort": "rfc8365-compatible"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_AUTORT_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "autort": "invalid"
+                }
+                ]
+            }
+        }
+    },
     "BGP_GLOBALS_AF_ADVERTISE_ALL_VNI_TRUE": {
         "sonic-bgp-global:sonic-bgp-global": {
             "sonic-bgp-global:BGP_GLOBALS": {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
@@ -446,6 +446,13 @@ module sonic-bgp-global {
                     description "Maximum duration to suppress a stable route";
                 }
 
+                leaf autort {
+                    type enumeration {
+                        enum rfc8365-compatible;
+                    }
+                    description "L2VPN derive route targets as per rfc8365 for interoperability with other implementations.";
+                }
+
                 leaf advertise-all-vni {
                     type boolean;
                     description "L2VPN advertise all VNIs";


### PR DESCRIPTION
#### Why I did it
`autort` is a supported option in the frr-mgmt-framework as can be seen in https://github.com/sonic-net/sonic-buildimage/blob/3d8c940997c3855b650fc0eea7f9db46546b17ac/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py#L1830 and
https://github.com/sonic-net/sonic-buildimage/blob/3d8c940997c3855b650fc0eea7f9db46546b17ac/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.addr_family.evpn.j2#L4-L5

However, the yang models do not allow this so when adding this value to `config_db.json` then running `config replace` a validation issue is encountered.

##### Work item tracking

#### How I did it

This adds yang support and validates the only known valid value of `rfc8365-compatible` is set.

#### How to verify it

Test cases have been updated to validate the behavior.

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [X] 202411

Just backport to current stable branch, doesn't appear any one is really using this with yang validation.

#### Tested branch (Please provide the tested image version)

Master as of 20250130

#### Description for the changelog

[yang] BGP support `autort` in address family

#### Link to config_db schema for YANG module changes

N/A pre-existing, just adding yang validation

#### A picture of a cute animal (not mandatory but encouraged)

Signed-off-by: Brad House (@bradh352)
