### PR TITLE
Fix bmp critical_process duplicated bug

### DIFF
--- a/dockers/docker-sonic-bmp/critical_processes
+++ b/dockers/docker-sonic-bmp/critical_processes
@@ -1,3 +1,2 @@
-group:sonic-bmp
 program:openbmpd
 program:bmpcfgd

--- a/dockers/docker-sonic-bmp/supervisord.conf
+++ b/dockers/docker-sonic-bmp/supervisord.conf
@@ -43,9 +43,6 @@ stderr_syslog=true
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 
-[group:sonic-bmp]
-programs=openbmpd,bmpcfgd
-
 [program:bmpcfgd]
 command=python3 /usr/local/bin/bmpcfgd
 priority=3

--- a/src/sonic-bmpcfgd/bmpcfgd/bmpcfgd.py
+++ b/src/sonic-bmpcfgd/bmpcfgd/bmpcfgd.py
@@ -55,7 +55,7 @@ class BMPCfg(DaemonBase):
 
     def stop_bmp(self):
         logger.log_notice('bmpcfgd: stop bmp daemon')
-        subprocess.call(["supervisorctl", "stop", "sonic-bmp:openbmpd"])
+        subprocess.call(["supervisorctl", "stop", "openbmpd"])
 
 
     def reset_bmp_table(self):
@@ -67,7 +67,7 @@ class BMPCfg(DaemonBase):
 
     def start_bmp(self):
         logger.log_notice('bmpcfgd: start bmp daemon')
-        subprocess.call(["supervisorctl", "start", "sonic-bmp:openbmpd"])
+        subprocess.call(["supervisorctl", "start", "openbmpd"])
 
 
 class BMPCfgDaemon:

--- a/src/sonic-bmpcfgd/tests/bmpcfgd_test.py
+++ b/src/sonic-bmpcfgd/tests/bmpcfgd_test.py
@@ -53,8 +53,8 @@ class TestBMPCfgDaemon(TestCase):
         bmp_config_daemon.register_callbacks()
         bmp_config_daemon.bmp_handler("BMP", self.test_data)
         expected_calls = [
-            mock.call(["supervisorctl", "stop", "sonic-bmp:openbmpd"]),
-            mock.call(["supervisorctl", "start", "sonic-bmp:openbmpd"])
+            mock.call(["supervisorctl", "stop", "openbmpd"]),
+            mock.call(["supervisorctl", "start", "openbmpd"])
         ]
         mock_log_info.assert_has_calls(expected_calls)
 
@@ -66,8 +66,8 @@ class TestBMPCfgDaemon(TestCase):
         bmp_config_daemon = bmpcfgd.BMPCfgDaemon()
         bmp_config_daemon.bmp_handler("BMP", self.test_data)
         expected_calls = [
-            mock.call(["supervisorctl", "stop", "sonic-bmp:openbmpd"]),
-            mock.call(["supervisorctl", "start", "sonic-bmp:openbmpd"])
+            mock.call(["supervisorctl", "stop", "openbmpd"]),
+            mock.call(["supervisorctl", "start", "openbmpd"])
         ]
         mock_log_info.assert_has_calls(expected_calls)
 
@@ -79,7 +79,7 @@ class TestBMPCfgDaemon(TestCase):
         bmp_config_daemon = bmpcfgd.BMPCfgDaemon()
         bmp_config_daemon.bmp_handler("BMP", self.test_data)
         expected_calls = [
-            mock.call(["supervisorctl", "stop", "sonic-bmp:openbmpd"]),
-            mock.call(["supervisorctl", "start", "sonic-bmp:openbmpd"])
+            mock.call(["supervisorctl", "stop", "openbmpd"]),
+            mock.call(["supervisorctl", "start", "openbmpd"])
         ]
         mock_log_info.assert_has_calls(expected_calls)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Previously critical_process was defined duplicated like below:
group:sonic-bmp
program:openbmpd
program:bmpcfgd

which break some mgmt test cases.

##### Work item tracking
- Microsoft ADO **(number only)**:30807821

#### How I did it
Get rid of group and follow most of other dockers to define program directly.

#### How to verify it
verified on DUT, program could work correctly.
![image](https://github.com/user-attachments/assets/40f26cb0-d5d4-4a09-8635-a6942a47d9a0)

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

