### PR TITLE
Upgrade SymCrypt version to 1.5.2

### DIFF
--- a/rules/sonic-fips.mk
+++ b/rules/sonic-fips.mk
@@ -1,7 +1,7 @@
 # fips packages
 
 ifeq ($(BLDENV), bookworm)
-FIPS_VERSION = 1.4.3-1
+FIPS_VERSION = 1.5.2
 FIPS_OPENSSL_VERSION = 3.0.11-1~deb12u2+fips
 FIPS_OPENSSH_VERSION = 9.2p1-2+deb12u3+fips
 FIPS_PYTHON_MAIN_VERSION = 3.11


### PR DESCRIPTION
Upgrade SymCrypt version to 1.5.2

#### Why I did it
SymCrypt release new version:

upstream SymCrypt upgrade to v103.8.0
upstream SymCrypt-Openssl upgrade to1.7.0

##### Work item tracking
- Microsoft ADO: 31063369

#### How I did it
Upgrade SymCrypt and SymCrypt-Openssl to latest version

#### How to verify it
Pass all UT.


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [] 

#### Description for the changelog
Upgrade SymCrypt version to 1.5.2

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)


