### PR TITLE
Fix buffer configs for TH5 C224 SKU

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C224O8/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C224O8/buffers_defaults_t0.j2
@@ -5,12 +5,12 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossy_pool": {
-            "size": "166607744",
+            "size": "166266368",
             "type": "ingress",
             "mode": "dynamic"
         },
         "egress_lossy_pool": {
-            "size": "166607744",
+            "size": "166266368",
             "type": "egress",
             "mode": "dynamic"
         }
@@ -27,4 +27,14 @@
             "dynamic_th": "1"
         }
     },
+{%- endmacro %}
+{%- macro generate_queue_buffers(ports) %}
+    "BUFFER_QUEUE": {
+    {% for port in ports.split(',') %}
+        "{{ port }}|0-9": {
+            "profile" : "egress_lossy_profile"
+        }
+    {%- if not loop.last -%},{% endif %}
+    {% endfor %}
+    }
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C224O8/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C224O8/buffers_defaults_t1.j2
@@ -5,12 +5,12 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossy_pool": {
-            "size": "166607744",
+            "size": "166266368",
             "type": "ingress",
             "mode": "dynamic"
         },
         "egress_lossy_pool": {
-            "size": "166607744",
+            "size": "166266368",
             "type": "egress",
             "mode": "dynamic"
         }
@@ -27,4 +27,14 @@
             "dynamic_th": "1"
         }
     },
+{%- endmacro %}
+{%- macro generate_queue_buffers(ports) %}
+    "BUFFER_QUEUE": {
+    {% for port in ports.split(',') %}
+        "{{ port }}|0-9": {
+            "profile" : "egress_lossy_profile"
+        }
+    {%- if not loop.last -%},{% endif %}
+    {% endfor %}
+    }
 {%- endmacro %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The values in this config were found to be incorrect when testing. With fewer interfaces than the C256, the reserved buffer space is smaller and therefore the shared limit in this config must be smaller.

The BUFFER_QUEUE macro was also not present, causing the defaults to be used which referenced lossless profiles.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

