### PR TITLE
[YANG][Bugfix] Fix incorrect pattern of nexthop-vrf in sonic-static-route.yang

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/static_route.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/static_route.json
@@ -52,6 +52,10 @@
      "STATIC_ROUTE_TEST_ECMP_NEXTHOP_VRF_INVALID": {
         "desc": "Configure with invalid vrf for ECMP",
         "eStrKey": "Pattern"
+    },
+    "STATIC_ROUTE_TEST_NEXTHOP_EMPTY_VRF": {
+        "desc": "Configure with null value for VRF",
+        "eStrKey": "Pattern"
     }
 
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/static_route.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/static_route.json
@@ -54,8 +54,7 @@
         "eStrKey": "Pattern"
     },
     "STATIC_ROUTE_TEST_NEXTHOP_EMPTY_VRF": {
-        "desc": "Configure with null value for VRF",
-        "eStrKey": "Pattern"
+        "desc": "Configure with null value for VRF"
     }
 
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/static-route.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/static-route.json
@@ -1021,6 +1021,53 @@
                 }]
             }
         }
+    },
+    "STATIC_ROUTE_TEST_NEXTHOP_EMPTY_VRF": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "fec": "rs",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "family": "IPv4",
+                        "ip-prefix": "1.0.0.1/30",
+                        "name": "Ethernet0",
+                        "scope": "global"
+                    }
+                ],
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet0"
+                    }
+                ]
+            }
+        },
+        "sonic-static-route:sonic-static-route": {
+            "sonic-static-route:STATIC_ROUTE": {
+                "STATIC_ROUTE_LIST": [{
+                        "prefix": "16.16.16.0/24",
+                        "vrf_name": "default",
+                        "nexthop": "1.0.0.5",
+                        "distance": "1",
+                        "nexthop-vrf": "",
+                        "blackhole": "false"
+                }]
+            }
+        }
     }
 
 }

--- a/src/sonic-yang-models/yang-models/sonic-static-route.yang
+++ b/src/sonic-yang-models/yang-models/sonic-static-route.yang
@@ -111,7 +111,7 @@ module sonic-static-route {
         }
         leaf nexthop-vrf {
           type string {
-            pattern "(((Vrf[a-zA-Z0-9_-]+)|(default)|(mgmt)),)*((Vrf[a-zA-Z0-9_-]+)|(default)|(mgmt))";
+            pattern "((((Vrf[a-zA-Z0-9_-]+)|(default)|(mgmt)),)*((Vrf[a-zA-Z0-9_-]+)|(default)|(mgmt)))?";
           }
           description
             "VRF name of the nexthop. This is for vrf leaking";


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix issue #21352 
According to the Static Route HLD, the nexthop-vrf field should be optional:
<pre>
;Defines IP static route  table
;
;Status: stable

key                 = STATIC_ROUTE|vrf-name|prefix ;
vrf-name            = 1\*15VCHAR ; VRF name
prefix              = IPv4Prefix / IPv6prefix
nexthop             = string; List of gateway addresses;
ifname              = string; List of interfaces
distance            = string; {0..255};List of distances.
                      Its a Metric used to specify preference of next-hop
                      if this distance is not set, default value 0 will be set when this field is not configured for nexthop(s)
nexthop-vrf         = string; list of next-hop VRFs. It should be set only if ifname or nexthop IP  is not
                      in the current VRF . The value is set to VRF name
                      to which the interface or nexthop IP  belongs for route leaks.
blackhole           = string; List of boolean; true if the next-hop route is blackholed.
                      Default value false will be set when this field is not configured for nexthop(s)
</pre>
However, in the sonic-static-route.yang the pattern of nexthop-vrf implies the nexthop-vrf is mandatory.

<pre>
sonic-static-route.yang:
...
...
        leaf nexthop-vrf {
          type string {
            pattern "(((Vrf[a-zA-Z0-9_-]+)|(default)|(mgmt)),)*((Vrf[a-zA-Z0-9_-]+)|(default)|(mgmt))";
          }
          description
            "VRF name of the nexthop. This is for vrf leaking";
...
</pre>


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Correct the pattern of nexthop-vrf.

#### How to verify it
<pre>
admin@sonic:~$ sudo config route add prefix 0.0.0.0/0 nexthop 172.16.0.3
admin@sonic:~$ redis-cli -n 4
127.0.0.1:6379[4]> key *STATIC*
(error) ERR unknown command 'key', with args beginning with: '*STATIC*'
127.0.0.1:6379[4]> keys *STATIC*
1) "STATIC_ROUTE|default|0.0.0.0/0"
127.0.0.1:6379[4]> hgetall "STATIC_ROUTE|default|0.0.0.0/0"
 1) "blackhole"
 2) "false"
 3) "distance"
 4) "0"
 5) "ifname"
 6) ""
 7) "nexthop"
 8) "172.16.0.3"
 9) "nexthop-vrf"
10) ""
127.0.0.1:6379[4]> exit
admin@sonic:~$ sudo config interface breakout Ethernet8 4x100G -yf

Running Breakout Mode : 1x400G
Target Breakout Mode : 4x100G

Ports to be deleted :
 {
    "Ethernet8": "400000"
}
Ports to be added :
 {
    "Ethernet8": "100000",
    "Ethernet10": "100000",
    "Ethernet12": "100000",
    "Ethernet14": "100000"
}
Breakout process got successfully completed.
Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
</pre>
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405
- [x] 202411

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

