### PR TITLE
[nvidia-bluefield] Load MFT drivers from the SONiC rootfs during BFB installation.

### DIFF
--- a/platform/nvidia-bluefield/installer/create_sonic_image
+++ b/platform/nvidia-bluefield/installer/create_sonic_image
@@ -292,15 +292,8 @@ create_bfb_image() {
         copy_bin $tool
     done
 
-    kernel_mft=$(dpkg -l | grep kernel-mft-dkms-modules | awk '/^ii/ {print $2}')
-    if [[ $kernel_mft == "" ]]; then
-        echo "ERROR: kernel-mft-dkms-modules package is not installed"
-        exit 1
-    fi
-
     for tool in `dpkg -L mft` \
             `dpkg -L mft-oem` \
-            `dpkg -L $kernel_mft` \
             `dpkg -L xmlstarlet | grep -v share`
     do
         if [ -d $tool ]; then

--- a/platform/nvidia-bluefield/installer/install.sh.j2
+++ b/platform/nvidia-bluefield/installer/install.sh.j2
@@ -235,6 +235,17 @@ if [[ $fw_upgrade_is_needed == "true" ]]; then
 	ex mkdir -p $sonic_fs_mountpoint
 	ex mount -t squashfs $sonic_fs_path $sonic_fs_mountpoint
 
+	kernel_mft=$(chroot $sonic_fs_mountpoint dpkg -l | grep kernel-mft-dkms-modules | awk '/^ii/ {print $2}')
+	mft_files=$(chroot $sonic_fs_mountpoint dpkg -L $kernel_mft)
+
+	for f in $mft_files; do
+		if [[ $sonic_fs_mountpoint/$f != *.ko ]]; then
+			continue
+		fi
+
+		insmod "$sonic_fs_mountpoint/$f"
+	done
+
 	ex mkdir -p /etc/mlnx/
 
 	ex ln -s /mnt/$image_dir/platform/fw/asic/fw-BF3.mfa /etc/mlnx/fw-BF3.mfa


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To ensure the Linux kernel and MFT drivers' signatures are aligned, load the MFT drivers in the BFB installer from the SONiC image root filesystem

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Mount SONiC image rootfs and load drives from the rootfs.

#### How to verify it
Compile and install BFB image. DPU NIC FW upgrade should finish successfully during the image installation 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

