### PR TITLE
allow func_len to be 0 in sonic-srv6.yang

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-srv6.yang
+++ b/src/sonic-yang-models/yang-models/sonic-srv6.yang
@@ -35,7 +35,7 @@ module sonic-srv6 {
                     type uint8 {
                         range "1..128";
                     }
-                    
+
                     default 32;
                 }
 
@@ -49,7 +49,7 @@ module sonic-srv6 {
 
                 leaf func_len {
                     type uint8 {
-                        range "1..128";
+                        range "0..128";
                     }
 
                     default 16;
@@ -127,6 +127,6 @@ module sonic-srv6 {
                                   substring-before(/srv6:sonic-srv6/SRV6_MY_LOCATORS/SRV6_MY_LOCATORS_LIST[current()/locator]/prefix, "::"))';
             }
         }
-        
+
     }
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Previously, we didn't allow the func_len to zero in YANG model, which conflicts with our use case.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Change the lower bound of the func_len's range.

#### How to verify it

Configure a locator entry in CONFIG_DB and then do a config reload.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202412

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

