### PR TITLE
[YANG] Add missing field in port qos map

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2341,6 +2341,7 @@
            "Ethernet0": {
                "dot1p_to_tc_map" : "Dot1p_to_tc_map1",
                "dscp_to_tc_map": "Dscp_to_tc_map1",
+               "tc_to_dscp_map": "tc_to_dscp_map1",
                "tc_to_queue_map": "tc_to_q_map1",
                "tc_to_pg_map": "tc_to_pg_map1",
                "pfc_to_queue_map": "pfc_prio_to_q_map1",
@@ -2352,12 +2353,13 @@
             "Ethernet4": {
               "dot1p_to_tc_map" : "Dot1p_to_tc_map2",
               "dscp_to_tc_map": "Dscp_to_tc_map2",
-	          "tc_to_queue_map": "tc_to_q_map2",
-	          "tc_to_pg_map": "tc_to_pg_map2",
-	          "pfc_to_queue_map": "pfc_prio_to_q_map2",
-	          "pfc_to_pg_map"   : "pfc_prio_to_pg_map2",
-	          "pfc_enable"      : "3,4",
-	          "pfcwd_sw_enable" : "3,4"
+              "tc_to_dscp_map": "tc_to_dscp_map2",
+              "tc_to_queue_map": "tc_to_q_map2",
+              "tc_to_pg_map": "tc_to_pg_map2",
+              "pfc_to_queue_map": "pfc_prio_to_q_map2",
+              "pfc_to_pg_map"   : "pfc_prio_to_pg_map2",
+              "pfc_enable"      : "3,4",
+              "pfcwd_sw_enable" : "3,4"
             }
         },
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/qosmaps.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/qosmaps.json
@@ -530,6 +530,30 @@
             }
         },
 
+        "sonic-tc-dscp-map:sonic-tc-dscp-map": {
+            "sonic-tc-dscp-map:TC_TO_DSCP_MAP": {
+                "TC_TO_DSCP_MAP_LIST": [
+                    {
+                        "name": "map1",
+                        "TC_TO_DSCP_MAP": [
+                            {
+                                "tc": "1",
+                                "dscp": "1"
+                            },
+                            {
+                                "tc":"2",
+                                "dscp":"2"
+                            },
+                            {
+                                "tc": "8",
+                                "dscp": "8"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+
         "sonic-dot1p-tc-map:sonic-dot1p-tc-map": {
             "sonic-dot1p-tc-map:DOT1P_TO_TC_MAP": {
                 "DOT1P_TO_TC_MAP_LIST": [
@@ -681,11 +705,11 @@
                     {
                         "ifname": "Ethernet0",
                         "dscp_to_tc_map": "map1",
+                        "tc_to_dscp_map": "map1",
                         "tc_to_pg_map": "map1",
                         "tc_to_queue_map": "map1",
                         "pfc_to_queue_map": "map1",
                         "pfc_to_pg_map": "map1",
-                        "dscp_to_tc_map": "map1",
                         "dot1p_to_tc_map": "map1",
                         "pfc_enable": "2,3,4,6",
                         "pfcwd_sw_enable" : "2,3,4,6",

--- a/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
@@ -38,6 +38,11 @@ module sonic-port-qos-map {
         prefix sch;
     }
 
+    import sonic-tc-dscp-map {
+        prefix tdm;
+    }
+
+
     organization
         "SONiC";
 
@@ -115,6 +120,13 @@ module sonic-port-qos-map {
                         path "/dtm:sonic-dscp-tc-map/dtm:DSCP_TO_TC_MAP/dtm:DSCP_TO_TC_MAP_LIST/dtm:name";
                     }
                 }
+
+                leaf tc_to_dscp_map {
+                    type leafref {
+                        path "/tdm:sonic-tc-dscp-map/tdm:TC_TO_DSCP_MAP/tdm:TC_TO_DSCP_MAP_LIST/tdm:name";
+                    }
+                }
+
 
                 leaf dot1p_to_tc_map {
                     type leafref {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add missing field introduced from PR: https://github.com/sonic-net/sonic-buildimage/pull/21395
##### Work item tracking
- Microsoft ADO **(number only)**: 31313829

#### How I did it
Add the missing field
#### How to verify it
UT in sample_config_db.json
Also test in specific DUT after merge this change.
before:
```
sonic_yang(3):All Keys are not parsed in PORT_QOS_MAP
dict_keys(['Ethernet16'])
sonic_yang(3):exceptionList:["'tc_to_dscp_map'"]
```
after:
```
sonic_yang(6):Note: Below table(s) have no YANG models: bgpraw
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

