### PR TITLE
frr-mgmt-framework: Handle up/down as well as true/false as admin_status values for bgp neighbor in frrcfgd

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1870,7 +1870,7 @@ class BGPConfigDaemon:
     cmn_key_map = [('asn&peer_type',                        '{no:no-prefix}neighbor {} remote-as {}'),
                    (['local_asn', '+local_as_no_prepend',
                      '+local_as_replace_as'],               '{no:no-prefix}neighbor {} local-as {} {:no-prepend} {:replace-as}'),
-                   (['admin_status', '+shutdown_message'],  '{no:no-prefix}neighbor {} shutdown {:shutdown-msg}', ['false', 'true']),
+                   (['admin_status', '+shutdown_message'],  '{no:no-prefix}neighbor {} shutdown {:shutdown-msg}', hdl_admin_status),
                    ('local_addr',                           '{no:no-prefix}neighbor {} update-source {}'),
                    ('name',                                 '{no:no-prefix}neighbor {} description {}'),
                    (['ebgp_multihop', '+ebgp_multihop_ttl'],'{no:no-prefix}neighbor {} ebgp-multihop {}', ['true', 'false']),

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1483,6 +1483,32 @@ def hdl_static_route(daemon, cmd_str, op, st_idx, args, data):
     daemon.upd_nh_set = ip_nh_set
     return cmd_list
 
+def hdl_admin_status(daemon, cmd_str, op, st_idx, args, data):
+    if len(args) < 1:
+        return None
+
+    cmd_list = []
+    status = args[st_idx]
+
+    # Convert up/down to true/false if needed
+    if status == 'up':
+        status = 'true'
+    elif status == 'down':
+        status = 'false'
+    elif status not in ['true', 'false']:
+        return None
+
+    # For delete operation, treat as 'false'
+    if op == CachedDataWithOp.OP_DELETE:
+        status = 'false'
+
+    # Apply the command with appropriate no prefix
+    cmd_list.append(cmd_str.format(
+        CommandArgument(daemon, True, args[0]),
+        no=CommandArgument(daemon, (status == 'true'))))
+
+    return cmd_list
+
 class ExtConfigDBConnector(ConfigDBConnector):
     def __init__(self, ns_attrs = None):
         super(ExtConfigDBConnector, self).__init__()
@@ -1871,9 +1897,9 @@ class BGPConfigDaemon:
     nbr_key_map = [('peer_group_name',  '{no:no-prefix}neighbor {} peer-group {}')]
 
     nbr_af_key_map = [(['allow_as_in', '+allow_as_count&allow_as_origin'],  '{no:no-prefix}neighbor {} allowas-in {:allow-as-in}', ['true', 'false']),
-                      ('admin_status|ipv4',                                 '{no:no-prefix}neighbor {} activate', ['true', 'false', False]),
-                      ('admin_status|ipv6',                                 '{no:no-prefix}neighbor {} activate', ['true', 'false', False]),
-                      ('admin_status|l2vpn',                                '{no:no-prefix}neighbor {} activate', ['true', 'false', False]),
+                      ('admin_status|ipv4',                                 '{no:no-prefix}neighbor {} activate', hdl_admin_status),
+                      ('admin_status|ipv6',                                 '{no:no-prefix}neighbor {} activate', hdl_admin_status),
+                      ('admin_status|l2vpn',                                '{no:no-prefix}neighbor {} activate', hdl_admin_status),
                       (['send_default_route', '+default_rmap'],             '{no:no-prefix}neighbor {} default-originate {:default-rmap}', ['true', 'false']),
                       ('default_rmap',                                      '{no:no-prefix}neighbor {} default-originate route-map {}'),
                       (['max_prefix_limit', '++max_prefix_warning_threshold',

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_af.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_af.j2
@@ -2,9 +2,9 @@
 {# this is called with the "vrf" and "address-family matched    #}
 {# ------------------------------------------------------------ #}
 {% if 'admin_status' in n_af_val %}
-{% if n_af_val['admin_status'] == 'true' %}
+{% if n_af_val['admin_status'] in ['true', 'up'] %}
   neighbor {{nbr_name}} activate
-{% else %}
+{% elif n_af_val['admin_status'] in ['false', 'down'] %}
   no neighbor {{nbr_name}} activate
 {% endif %}
 {% endif %}

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_af.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_af.j2
@@ -4,7 +4,7 @@
 {% if 'admin_status' in n_af_val %}
 {% if n_af_val['admin_status'] in ['true', 'up'] %}
   neighbor {{nbr_name}} activate
-{% elif n_af_val['admin_status'] in ['false', 'down'] %}
+{% else %}
   no neighbor {{nbr_name}} activate
 {% endif %}
 {% endif %}

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_or_peer.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_or_peer.j2
@@ -30,7 +30,7 @@
 {% if 'name' in nbr_or_peer %}
  neighbor {{name_or_ip}} description {{nbr_or_peer['name']}}
 {% endif %}
-{% if 'admin_status' in nbr_or_peer and nbr_or_peer['admin_status'] == 'false' %}
+{% if 'admin_status' in nbr_or_peer and nbr_or_peer['admin_status'] in ['false', 'down'] %}
 {% if 'shutdown_message' in nbr_or_peer %}
  neighbor {{name_or_ip}} shutdown message {{nbr_or_peer['shutdown_message']}}
 {% else %}

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -190,6 +190,22 @@ def create_af_test_data(table_name):
 neighbor_af_data = create_af_test_data('BGP_NEIGHBOR_AF')
 peer_group_af_data = create_af_test_data('BGP_PEER_GROUP_AF')
 
+# Create test data for neighbor shutdown
+neighbor_shutdown_data = [
+    CmdMapTestInfo('BGP_NEIGHBOR', '10.1.1.1',
+                  {'admin_status': 'down', 'shutdown_message': 'maintenance'},
+                  conf_bgp_cmd('default', 100) + ['{}neighbor 10.1.1.1 shutdown maintenance']),
+    CmdMapTestInfo('BGP_NEIGHBOR', '10.1.1.2',
+                  {'admin_status': 'false', 'shutdown_message': 'planned outage'},
+                  conf_bgp_cmd('default', 100) + ['{}neighbor 10.1.1.2 shutdown planned outage']),
+    CmdMapTestInfo('BGP_NEIGHBOR', '10.1.1.4',
+                  {'admin_status': 'up'},
+                  conf_bgp_cmd('default', 100) + ['{}no neighbor 10.1.1.4 shutdown']),
+    CmdMapTestInfo('BGP_NEIGHBOR', '10.1.1.5',
+                  {'admin_status': 'true'},
+                  conf_bgp_cmd('default', 100) + ['{}no neighbor 10.1.1.5 shutdown'])
+]
+
 @patch.dict('sys.modules', **mockmapping)
 @patch('frrcfgd.frrcfgd.g_run_command')
 def data_set_del_test(test_data, run_cmd):
@@ -223,3 +239,6 @@ def test_bgp_neighbor_af():
 
 def test_bgp_peer_group_af():
     data_set_del_test(peer_group_af_data)
+
+def test_bgp_neighbor_shutdown():
+    data_set_del_test(neighbor_shutdown_data)


### PR DESCRIPTION
Handle up/down (in addition to true/false) as admin_status values for BGP_NEIGHBOR_AF and BGP_PEER_GROUP_AF. Currently only true/false is handled, whereas the yang model identifies up/down as valid values of admin_status

https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
```
grouping sonic-bgp-cmn-af {
        leaf afi_safi {
            type string;
            description "Address family";
        }
        leaf admin_status {
            type stypes:admin_status;
            description "Indicates address family active/inactive status";
        }
```

https://github.com/sonic-net/sonic-buildimage/blob/82956752ac0fd8e39c7fdd69d2afc3f8989fa37d/src/sonic-yang-models/yang-templates/sonic-types.yang.j2#L54
``` 
module sonic-types {
   typedef admin_status {
        type enumeration {
            enum up;
            enum down;
        }
    }
```


closes #20663 
closes #18865 
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

`frrcfgd` fails to convert bgp neighbor's (as well as bgp peer group's) admin_status value of up/down to correct vtysh command (`neighbor <ip> activate`). The same behavior is seen for the jinja template used to generate frr config files. Modified these to handle up/down (as well as true/false, so that existing working deployments are not broken).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Modified `frrcfgd` as well as the jinja template to handle `admin_status` values `up/down`. I didn't remove the handling of current `true/false`, so that existing working deployments do not get broken when image is upgraded.

#### How to verify it

Added unit tests to verify that both `up/down` and `true/false` values of `admin_status` get correctly converted to frr commands.

Also can be manually verified by writing `up/down` as `admin_status` to config_db, and seeing the `neighbor <ip|peergroup> activate` command in the generated vty config like this:

```
rtr1(bash)$ sonic-db-cli CONFIG_DB HGETALL "BGP_PEER_GROUP_AF|default|peer4|ipv4_unicast"
{'admin_status': 'up', 'route_map_in@': 'pfx', 'route_map_out@': 'all'}

rtr1(bash)$ show runningconfiguration bgp
Building configuration...

Current configuration:
...
router bgp 65100
 bgp router-id 10.0.0.1
 no bgp default ipv4-unicast
 neighbor peer4 peer-group
 neighbor peer4 remote-as 65001
 neighbor peer4 description peer4
 neighbor 10.1.0.2 peer-group peer4
 neighbor 10.1.0.2 description rtr2
 !
 address-family ipv4 unicast
  network 10.0.0.1/32
  neighbor peer4 activate 
  neighbor peer4 route-map pfx in
  neighbor peer4 route-map all out
 exit-address-family
exit



rtr1(bash)$ sonic-db-cli CONFIG_DB HSET "BGP_PEER_GROUP_AF|default|peer4|ipv4_unicast" admin_status down
0
rtr1(bash)$ show runningconfiguration bgp
Building configuration...

Current configuration:
!
...
!
router bgp 65100
 bgp router-id 10.0.0.1
 no bgp default ipv4-unicast
 neighbor peer4 peer-group
 neighbor peer4 remote-as 65001
 neighbor peer4 description peer4
 neighbor 10.1.0.2 peer-group peer4
 neighbor 10.1.0.2 description rtr2
 !
 address-family ipv4 unicast
  network 10.0.0.1/32
  neighbor peer4 route-map pfx in
  neighbor peer4 route-map all out
 exit-address-family
exit


rtr1(bash)$ sonic-db-cli CONFIG_DB HSET "BGP_PEER_GROUP_AF|default|peer4|ipv4_unicast" admin_status up
0
rtr1(bash)$ show runningconfiguration bgp
Building configuration...

Current configuration:
...
router bgp 65100
 bgp router-id 10.0.0.1
 no bgp default ipv4-unicast
 neighbor peer4 peer-group
 neighbor peer4 remote-as 65001
 neighbor peer4 description peer4
 neighbor 10.1.0.2 peer-group peer4
 neighbor 10.1.0.2 description rtr2
 !
 address-family ipv4 unicast
  network 10.0.0.1/32
  neighbor peer4 activate 
  neighbor peer4 route-map pfx in
  neighbor peer4 route-map all out
 exit-address-family
exit
```


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

