### PR TITLE
Add bgp template for voq disaggregate chassis

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
@@ -1,0 +1,36 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!
+  bgp bestpath as-path multipath-relax
+  bgp bestpath peer-type multipath-relax
+!
+{% if neighbor_addr | ipv4 %}
+  neighbor {{ neighbor_addr }} peer-group VOQ_CHASSIS_V4_PEER
+{% elif neighbor_addr | ipv6 %}
+  neighbor {{ neighbor_addr }} peer-group VOQ_CHASSIS_V6_PEER
+{% endif %}
+  neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
+  neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}
+  neighbor {{ neighbor_addr }} timers 2 7
+  neighbor {{ neighbor_addr }} timers connect 10
+!
+{% if 'admin_status' in bgp_session and bgp_session['admin_status'] == 'down' or 'admin_status' not in bgp_session and 'default_bgp_status' in CONFIG_DB__DEVICE_METADATA['localhost'] and CONFIG_DB__DEVICE_METADATA['localhost']['default_bgp_status'] == 'down' %}
+  neighbor {{ neighbor_addr }} shutdown
+{% endif %}
+!
+  address-family ipv4
+{% if constants.bgp.maximum_paths.enabled is defined and constants.bgp.maximum_paths.enabled %}
+    maximum-paths ibgp {{ constants.bgp.maximum_paths.ipv4 | default(64) }}
+{% endif %}
+!
+  exit-address-family
+!
+  address-family ipv6
+{% if constants.bgp.maximum_paths.enabled is defined and constants.bgp.maximum_paths.enabled %}
+    maximum-paths ibgp {{ constants.bgp.maximum_paths.ipv6 | default(64) }}
+{% endif %}
+!
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/voq_disaggregate_chassis/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/voq_disaggregate_chassis/peer-group.conf.j2
@@ -1,0 +1,30 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/peer-group.conf.j2
+!
+  neighbor VOQ_CHASSIS_V4_PEER peer-group
+  neighbor VOQ_CHASSIS_V6_PEER peer-group
+  address-family ipv4
+{% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
+    neighbor VOQ_CHASSIS_V4_PEER allowas-in 1
+{% endif %}
+    neighbor VOQ_CHASSIS_V4_PEER activate
+    neighbor VOQ_CHASSIS_V4_PEER addpath-tx-all-paths
+    neighbor VOQ_CHASSIS_V4_PEER soft-reconfiguration inbound
+    neighbor VOQ_CHASSIS_V4_PEER route-map FROM_VOQ_CHASSIS_V4_PEER in
+    neighbor VOQ_CHASSIS_V4_PEER route-map TO_VOQ_CHASSIS_V4_PEER out
+    neighbor VOQ_CHASSIS_V4_PEER send-community
+  exit-address-family
+  address-family ipv6
+{% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
+    neighbor VOQ_CHASSIS_V6_PEER allowas-in 1
+{% endif %}
+    neighbor VOQ_CHASSIS_V6_PEER activate
+    neighbor VOQ_CHASSIS_V6_PEER addpath-tx-all-paths
+    neighbor VOQ_CHASSIS_V6_PEER soft-reconfiguration inbound
+    neighbor VOQ_CHASSIS_V6_PEER route-map FROM_VOQ_CHASSIS_V6_PEER in
+    neighbor VOQ_CHASSIS_V6_PEER route-map TO_VOQ_CHASSIS_V6_PEER out
+    neighbor VOQ_CHASSIS_V6_PEER send-community
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/peer-group.conf.j2
+!

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/voq_disaggregate_chassis/policies.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/voq_disaggregate_chassis/policies.conf.j2
@@ -1,0 +1,46 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/policies.conf.j2
+!
+bgp community-list standard DEVICE_INTERNAL_COMMUNITY permit {{ constants.bgp.internal_community }}
+bgp community-list standard NO_EXPORT permit no-export
+!
+route-map FROM_VOQ_CHASSIS_V4_PEER permit 1
+  match community DEVICE_INTERNAL_COMMUNITY
+  set comm-list DEVICE_INTERNAL_COMMUNITY delete
+  set tag {{ constants.bgp.internal_community_match_tag }}
+!
+route-map FROM_VOQ_CHASSIS_V4_PEER permit 2
+  match community NO_EXPORT
+  set local-preference 80
+!
+route-map FROM_VOQ_CHASSIS_V4_PEER permit 100
+!
+route-map TO_VOQ_CHASSIS_V4_PEER permit 1
+  match ip address prefix-list PL_LoopbackV4
+  set community {{ constants.bgp.internal_community }}
+!
+route-map TO_VOQ_CHASSIS_V4_PEER permit 100
+!
+route-map FROM_VOQ_CHASSIS_V6_PEER permit 1
+ set ipv6 next-hop prefer-global
+ on-match next
+!
+route-map FROM_VOQ_CHASSIS_V6_PEER permit 2
+  match community DEVICE_INTERNAL_COMMUNITY
+  set comm-list DEVICE_INTERNAL_COMMUNITY delete
+  set tag {{ constants.bgp.internal_community_match_tag }}
+!
+route-map FROM_VOQ_CHASSIS_V6_PEER permit 3
+  match community NO_EXPORT
+  set local-preference 80
+!
+route-map FROM_VOQ_CHASSIS_V6_PEER permit 100
+!
+route-map TO_VOQ_CHASSIS_V6_PEER permit 1
+  match ipv6 address prefix-list PL_LoopbackV6
+  set community {{ constants.bgp.internal_community }}
+!
+route-map TO_VOQ_CHASSIS_V6_PEER permit 100
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/policies.conf.j2
+!

--- a/files/image_config/constants/constants.yml
+++ b/files/image_config/constants/constants.yml
@@ -64,6 +64,10 @@ constants:
         enabled: true
         db_table: "BGP_VOQ_CHASSIS_NEIGHBOR"
         template_dir: "voq_chassis"
+      voq_disaggregate_chassis: # peer_type
+        enabled: true
+        db_table: "BGP_VOQ_CHASSIS_NEIGHBOR"
+        template_dir: "voq_disaggregate_chassis"
       sentinels: # peer_type
         enabled: true
         db_table: "BGP_SENTINELS"

--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -63,7 +63,6 @@ def do_work():
         BGPPeerMgrBase(common_objs, "CONFIG_DB", swsscommon.CFG_BGP_INTERNAL_NEIGHBOR_TABLE_NAME, "internal", False),
         BGPPeerMgrBase(common_objs, "CONFIG_DB", "BGP_MONITORS", "monitors", False),
         BGPPeerMgrBase(common_objs, "CONFIG_DB", "BGP_PEER_RANGE", "dynamic", False),
-        BGPPeerMgrBase(common_objs, "CONFIG_DB", "BGP_VOQ_CHASSIS_NEIGHBOR", "voq_chassis", False),
         BGPPeerMgrBase(common_objs, "CONFIG_DB", "BGP_SENTINELS", "sentinels", False),
         # AllowList Managers
         BGPAllowListMgr(common_objs, "CONFIG_DB", "BGP_ALLOWED_PREFIXES"),
@@ -81,6 +80,10 @@ def do_work():
         SRv6Mgr(common_objs, "CONFIG_DB", "SRV6_MY_SIDS"),
         SRv6Mgr(common_objs, "CONFIG_DB", "SRV6_MY_LOCATORS")
     ]
+    if device_info.is_chassis():
+        managers.append(BGPPeerMgrBase(common_objs, "CONFIG_DB", "BGP_VOQ_CHASSIS_NEIGHBOR", "voq_chassis", False))
+    else:
+        managers.append(BGPPeerMgrBase(common_objs, "CONFIG_DB", "BGP_VOQ_CHASSIS_NEIGHBOR", "voq_disaggregate_chassis", False))
 
     if device_info.is_chassis():
         managers.append(ChassisAppDbMgr(common_objs, "CHASSIS_APP_DB", "BGP_DEVICE_GLOBAL"))

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_all_v4.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_all_v4.json
@@ -1,0 +1,22 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {}
+    },
+    "neighbor_addr": "10.10.10.10",
+    "bgp_session": {
+        "asn": "555",
+        "name": "internal1",
+        "keepalive": "5",
+        "holdtime": "30",
+        "admin_status": "down"
+    },
+    "constants": {
+        "bgp": {
+            "maximum_paths": {
+                "enabled": "true",
+                "ipv4": "32",
+                "ipv6": "24"
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_all_v6.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_all_v6.json
@@ -1,0 +1,22 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {}
+    },
+    "neighbor_addr": "fc00::01",
+    "bgp_session": {
+        "asn": "555",
+        "name": "internal1",
+        "keepalive": "5",
+        "holdtime": "30",
+        "admin_status": "down"
+    },
+    "constants": {
+        "bgp": {
+            "maximum_paths": {
+                "enabled": "true",
+                "ipv4": "32",
+                "ipv6": "24"
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_base_v4.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_base_v4.json
@@ -1,0 +1,17 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {}
+    },
+    "neighbor_addr": "10.10.10.10",
+    "bgp_session": {
+        "asn": "555",
+        "name": "internal1"
+    },
+    "constants": {
+        "bgp": {
+            "maximum_paths": {
+                "enabled": "true"
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_base_v6.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_base_v6.json
@@ -1,0 +1,17 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {}
+    },
+    "neighbor_addr": "fc00::01",
+    "bgp_session": {
+        "asn": "555",
+        "name": "internal1"
+    },
+    "constants": {
+        "bgp": {
+            "maximum_paths": {
+                "enabled": "true"
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_shutdown_v4_1.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_shutdown_v4_1.json
@@ -1,0 +1,19 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "default_bgp_status": "down"
+        }
+    },
+    "neighbor_addr": "10.10.10.10",
+    "bgp_session": {
+        "asn": "555",
+        "name": "internal1"
+    },
+    "constants": {
+        "bgp": {
+            "maximum_paths": {
+                "enabled": "true"
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_shutdown_v4_2.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_shutdown_v4_2.json
@@ -1,0 +1,19 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "default_bgp_status": "up"
+        }
+    },
+    "neighbor_addr": "10.10.10.10",
+    "bgp_session": {
+        "asn": "555",
+        "name": "internal1"
+    },
+    "constants": {
+        "bgp": {
+            "maximum_paths": {
+                "enabled": "true"
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_shutdown_v6_1.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_shutdown_v6_1.json
@@ -1,0 +1,19 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "default_bgp_status": "down"
+        }
+    },
+    "neighbor_addr": "fc00::01",
+    "bgp_session": {
+        "asn": "555",
+        "name": "internal1"
+    },
+    "constants": {
+        "bgp": {
+            "maximum_paths": {
+                "enabled": "true"
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_shutdown_v6_2.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_shutdown_v6_2.json
@@ -1,0 +1,19 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "default_bgp_status": "up"
+        }
+    },
+    "neighbor_addr": "fc00::01",
+    "bgp_session": {
+        "asn": "555",
+        "name": "internal1"
+    },
+    "constants": {
+        "bgp": {
+            "maximum_paths": {
+                "enabled": "true"
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_timers_v4_1.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_timers_v4_1.json
@@ -1,0 +1,18 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {}
+    },
+    "neighbor_addr": "10.10.10.10",
+    "bgp_session": {
+        "asn": "555",
+        "name": "internal1",
+        "keepalive": "5"
+    },
+    "constants": {
+        "bgp": {
+            "maximum_paths": {
+                "enabled": "true"
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_timers_v4_2.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_timers_v4_2.json
@@ -1,0 +1,18 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {}
+    },
+    "neighbor_addr": "10.10.10.10",
+    "bgp_session": {
+        "asn": "555",
+        "name": "internal1",
+        "holdtime": "240"
+    },
+    "constants": {
+        "bgp": {
+            "maximum_paths": {
+                "enabled": "true"
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_timers_v6_1.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_timers_v6_1.json
@@ -1,0 +1,18 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {}
+    },
+    "neighbor_addr": "fc00::01",
+    "bgp_session": {
+        "asn": "555",
+        "name": "internal1",
+        "keepalive": "5"
+    },
+    "constants": {
+        "bgp": {
+            "maximum_paths": {
+                "enabled": "true"
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_timers_v6_2.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/param_timers_v6_2.json
@@ -1,0 +1,18 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {}
+    },
+    "neighbor_addr": "fc00::01",
+    "bgp_session": {
+        "asn": "555",
+        "name": "internal1",
+        "holdtime": "240"
+    },
+    "constants": {
+        "bgp": {
+            "maximum_paths": {
+                "enabled": "true"
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_all_v4.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_all_v4.conf
@@ -1,0 +1,25 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!
+  bgp bestpath as-path multipath-relax
+  bgp bestpath peer-type multipath-relax
+!
+  neighbor 10.10.10.10 peer-group VOQ_CHASSIS_V4_PEER
+  neighbor 10.10.10.10 remote-as 555
+  neighbor 10.10.10.10 description internal1
+  neighbor 10.10.10.10 timers 2 7
+  neighbor 10.10.10.10 timers connect 10
+  neighbor 10.10.10.10 shutdown
+!
+  address-family ipv4
+    maximum-paths ibgp 32
+!
+  exit-address-family
+!
+  address-family ipv6
+    maximum-paths ibgp 24
+!
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_all_v6.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_all_v6.conf
@@ -1,0 +1,25 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!
+  bgp bestpath as-path multipath-relax
+  bgp bestpath peer-type multipath-relax
+!
+  neighbor fc00::01 peer-group VOQ_CHASSIS_V6_PEER
+  neighbor fc00::01 remote-as 555
+  neighbor fc00::01 description internal1
+  neighbor fc00::01 timers 2 7
+  neighbor fc00::01 timers connect 10
+  neighbor fc00::01 shutdown
+!
+  address-family ipv4
+    maximum-paths ibgp 32
+!
+  exit-address-family
+!
+  address-family ipv6
+    maximum-paths ibgp 24
+!
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_base_v4.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_base_v4.conf
@@ -1,0 +1,23 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!
+  bgp bestpath as-path multipath-relax
+  bgp bestpath peer-type multipath-relax
+!
+  neighbor 10.10.10.10 peer-group VOQ_CHASSIS_V4_PEER
+  neighbor 10.10.10.10 remote-as 555
+  neighbor 10.10.10.10 description internal1
+  neighbor 10.10.10.10 timers 2 7
+  neighbor 10.10.10.10 timers connect 10
+  address-family ipv4
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+  address-family ipv6
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_base_v6.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_base_v6.conf
@@ -1,0 +1,23 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!
+  bgp bestpath as-path multipath-relax
+  bgp bestpath peer-type multipath-relax
+!
+  neighbor fc00::01 peer-group VOQ_CHASSIS_V6_PEER
+  neighbor fc00::01 remote-as 555
+  neighbor fc00::01 description internal1
+  neighbor fc00::01 timers 2 7
+  neighbor fc00::01 timers connect 10
+  address-family ipv4
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+  address-family ipv6
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_shutdown_v4_1.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_shutdown_v4_1.conf
@@ -1,0 +1,25 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!
+  bgp bestpath as-path multipath-relax
+  bgp bestpath peer-type multipath-relax
+!
+  neighbor 10.10.10.10 peer-group VOQ_CHASSIS_V4_PEER
+  neighbor 10.10.10.10 remote-as 555
+  neighbor 10.10.10.10 description internal1
+  neighbor 10.10.10.10 timers 2 7
+  neighbor 10.10.10.10 timers connect 10
+  neighbor 10.10.10.10 shutdown
+!
+  address-family ipv4
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+  address-family ipv6
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_shutdown_v4_2.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_shutdown_v4_2.conf
@@ -1,0 +1,23 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!
+  bgp bestpath as-path multipath-relax
+  bgp bestpath peer-type multipath-relax
+!
+  neighbor 10.10.10.10 peer-group VOQ_CHASSIS_V4_PEER
+  neighbor 10.10.10.10 remote-as 555
+  neighbor 10.10.10.10 description internal1
+  neighbor 10.10.10.10 timers 2 7
+  neighbor 10.10.10.10 timers connect 10
+  address-family ipv4
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+  address-family ipv6
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_shutdown_v6_1.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_shutdown_v6_1.conf
@@ -1,0 +1,25 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!
+  bgp bestpath as-path multipath-relax
+  bgp bestpath peer-type multipath-relax
+!
+  neighbor fc00::01 peer-group VOQ_CHASSIS_V6_PEER
+  neighbor fc00::01 remote-as 555
+  neighbor fc00::01 description internal1
+  neighbor fc00::01 timers 2 7
+  neighbor fc00::01 timers connect 10
+  neighbor fc00::01 shutdown
+!
+  address-family ipv4
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+  address-family ipv6
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_shutdown_v6_2.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_shutdown_v6_2.conf
@@ -1,0 +1,23 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!
+  bgp bestpath as-path multipath-relax
+  bgp bestpath peer-type multipath-relax
+!
+  neighbor fc00::01 peer-group VOQ_CHASSIS_V6_PEER
+  neighbor fc00::01 remote-as 555
+  neighbor fc00::01 description internal1
+  neighbor fc00::01 timers 2 7
+  neighbor fc00::01 timers connect 10
+  address-family ipv4
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+  address-family ipv6
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_timers_v4_1.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_timers_v4_1.conf
@@ -1,0 +1,23 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!
+  bgp bestpath as-path multipath-relax
+  bgp bestpath peer-type multipath-relax
+!
+  neighbor 10.10.10.10 peer-group VOQ_CHASSIS_V4_PEER
+  neighbor 10.10.10.10 remote-as 555
+  neighbor 10.10.10.10 description internal1
+  neighbor 10.10.10.10 timers 2 7
+  neighbor 10.10.10.10 timers connect 10
+  address-family ipv4
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+  address-family ipv6
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_timers_v4_2.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_timers_v4_2.conf
@@ -1,0 +1,23 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!
+  bgp bestpath as-path multipath-relax
+  bgp bestpath peer-type multipath-relax
+!
+  neighbor 10.10.10.10 peer-group VOQ_CHASSIS_V4_PEER
+  neighbor 10.10.10.10 remote-as 555
+  neighbor 10.10.10.10 description internal1
+  neighbor 10.10.10.10 timers 2 7
+  neighbor 10.10.10.10 timers connect 10
+  address-family ipv4
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+  address-family ipv6
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_timers_v6_1.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_timers_v6_1.conf
@@ -1,0 +1,23 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!
+  bgp bestpath as-path multipath-relax
+  bgp bestpath peer-type multipath-relax
+!
+  neighbor fc00::01 peer-group VOQ_CHASSIS_V6_PEER
+  neighbor fc00::01 remote-as 555
+  neighbor fc00::01 description internal1
+  neighbor fc00::01 timers 2 7
+  neighbor fc00::01 timers connect 10
+  address-family ipv4
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+  address-family ipv6
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_timers_v6_2.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/instance.conf/result_timers_v6_2.conf
@@ -1,0 +1,23 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!
+  bgp bestpath as-path multipath-relax
+  bgp bestpath peer-type multipath-relax
+!
+  neighbor fc00::01 peer-group VOQ_CHASSIS_V6_PEER
+  neighbor fc00::01 remote-as 555
+  neighbor fc00::01 description internal1
+  neighbor fc00::01 timers 2 7
+  neighbor fc00::01 timers connect 10
+  address-family ipv4
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+  address-family ipv6
+    maximum-paths ibgp 64
+!
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/peer-group.conf/param_all.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/peer-group.conf/param_all.json
@@ -1,0 +1,7 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "type": "ToRRouter"
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/peer-group.conf/param_base.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/peer-group.conf/param_base.json
@@ -1,0 +1,5 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {}
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/peer-group.conf/result_all.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/peer-group.conf/result_all.conf
@@ -1,0 +1,26 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/peer-group.conf.j2
+!
+  neighbor VOQ_CHASSIS_V4_PEER peer-group
+  neighbor VOQ_CHASSIS_V6_PEER peer-group
+  address-family ipv4
+    neighbor VOQ_CHASSIS_V4_PEER allowas-in 1
+    neighbor VOQ_CHASSIS_V4_PEER activate
+    neighbor VOQ_CHASSIS_V4_PEER addpath-tx-all-paths
+    neighbor VOQ_CHASSIS_V4_PEER soft-reconfiguration inbound
+    neighbor VOQ_CHASSIS_V4_PEER route-map FROM_VOQ_CHASSIS_V4_PEER in
+    neighbor VOQ_CHASSIS_V4_PEER route-map TO_VOQ_CHASSIS_V4_PEER out
+    neighbor VOQ_CHASSIS_V4_PEER send-community
+  exit-address-family
+  address-family ipv6
+    neighbor VOQ_CHASSIS_V6_PEER allowas-in 1
+    neighbor VOQ_CHASSIS_V6_PEER activate
+    neighbor VOQ_CHASSIS_V6_PEER addpath-tx-all-paths
+    neighbor VOQ_CHASSIS_V6_PEER soft-reconfiguration inbound
+    neighbor VOQ_CHASSIS_V6_PEER route-map FROM_VOQ_CHASSIS_V6_PEER in
+    neighbor VOQ_CHASSIS_V6_PEER route-map TO_VOQ_CHASSIS_V6_PEER out
+    neighbor VOQ_CHASSIS_V6_PEER send-community
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/peer-group.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/peer-group.conf/result_base.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/peer-group.conf/result_base.conf
@@ -1,0 +1,24 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/peer-group.conf.j2
+!
+  neighbor VOQ_CHASSIS_V4_PEER peer-group
+  neighbor VOQ_CHASSIS_V6_PEER peer-group
+  address-family ipv4
+    neighbor VOQ_CHASSIS_V4_PEER activate
+    neighbor VOQ_CHASSIS_V4_PEER addpath-tx-all-paths
+    neighbor VOQ_CHASSIS_V4_PEER soft-reconfiguration inbound
+    neighbor VOQ_CHASSIS_V4_PEER route-map FROM_VOQ_CHASSIS_V4_PEER in
+    neighbor VOQ_CHASSIS_V4_PEER route-map TO_VOQ_CHASSIS_V4_PEER out
+    neighbor VOQ_CHASSIS_V4_PEER send-community
+  exit-address-family
+  address-family ipv6
+    neighbor VOQ_CHASSIS_V6_PEER activate
+    neighbor VOQ_CHASSIS_V6_PEER addpath-tx-all-paths
+    neighbor VOQ_CHASSIS_V6_PEER soft-reconfiguration inbound
+    neighbor VOQ_CHASSIS_V6_PEER route-map FROM_VOQ_CHASSIS_V6_PEER in
+    neighbor VOQ_CHASSIS_V6_PEER route-map TO_VOQ_CHASSIS_V6_PEER out
+    neighbor VOQ_CHASSIS_V6_PEER send-community
+  exit-address-family
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/peer-group.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/policies.conf/param_base.json
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/policies.conf/param_base.json
@@ -1,0 +1,16 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "type": "SpineRouter",
+            "subtype": "DownstreamLC"
+	}
+    },
+    "constants": {
+        "bgp": {
+            "internal_community": "12345:556",
+	    "internal_community_match_tag": "101",
+            "route_eligible_for_fallback_to_default_tag": "203",
+	    "internal_fallback_community": "1111:2222"
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/policies.conf/result_base.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_disaggregate_chassis/policies.conf/result_base.conf
@@ -1,0 +1,49 @@
+!
+! template: bgpd/templates/voq_disaggregate_chassis/policies.conf.j2
+!
+bgp community-list standard DEVICE_INTERNAL_COMMUNITY permit 12345:556
+bgp community-list standard DEVICE_INTERNAL_FALLBACK_COMMUNITY permit 1111:2222
+bgp community-list standard NO_EXPORT permit no-export
+!
+route-map FROM_VOQ_CHASSIS_V4_PEER permit 1
+  match community DEVICE_INTERNAL_COMMUNITY
+  set comm-list DEVICE_INTERNAL_COMMUNITY delete
+  set tag 101
+!
+route-map FROM_VOQ_CHASSIS_V4_PEER permit 2
+  match community NO_EXPORT
+  set local-preference 80
+  on-match next
+!
+route-map FROM_VOQ_CHASSIS_V4_PEER permit 100
+!
+route-map TO_VOQ_CHASSIS_V4_PEER permit 1
+  match ip address prefix-list PL_LoopbackV4
+  set community 12345:556
+!
+route-map TO_VOQ_CHASSIS_V4_PEER permit 100
+!
+route-map FROM_VOQ_CHASSIS_V6_PEER permit 1
+ set ipv6 next-hop prefer-global
+ on-match next
+!
+route-map FROM_VOQ_CHASSIS_V6_PEER permit 2
+  match community DEVICE_INTERNAL_COMMUNITY
+  set comm-list DEVICE_INTERNAL_COMMUNITY delete
+  set tag 101
+!
+route-map FROM_VOQ_CHASSIS_V6_PEER permit 3
+  match community NO_EXPORT
+  set local-preference 80
+  on-match next
+!
+route-map FROM_VOQ_CHASSIS_V6_PEER permit 100
+!
+route-map TO_VOQ_CHASSIS_V6_PEER permit 1
+  match ipv6 address prefix-list PL_LoopbackV6
+  set community 12345:556
+!
+route-map TO_VOQ_CHASSIS_V6_PEER permit 100
+!
+! end of template: bgpd/templates/voq_disaggregate_chassis/policies.conf.j2
+!


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The bgp template in voq_chassis has a route_map to not advertise the bgp routes to VOQ IBGP neighbors. But for Voq  multi-asic pizza box, we need to advertise the bgp routes to iBGP and hence can't have this route-map. 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Introduced a new bgp template voq-disaggregate-chassis for voq multi-asic pizzabox. The bgpcfgd loads voq-chassis bgp template for voq-chassis and voq-disaggregate-chassis for voq multi-asic pizzabox.

#### How to verify it
verified the changes in both chassis and voq multi-asic pizzabox.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
master
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

