### PR TITLE
[Broadcom] Fix syncd crash issue and upgrade xgs SAI to 12.3.2.2

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,6 +1,6 @@
 LIBSAIBCM_XGS_VERSION = 12.3.2.2
 LIBSAIBCM_DNX_VERSION = 11.2.13.1-1
-LIBSAIBCM_XGS_BRANCH_NAME = SAI_12.3.0_GA
+LIBSAIBCM_XGS_BRANCH_NAME = zitingguo/SAI_12.3.0_master
 LIBSAIBCM_DNX_BRANCH_NAME = SAI_11.2.0_GA
 LIBSAIBCM_XGS_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/sai-broadcom/$(LIBSAIBCM_XGS_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)/xgs"
 LIBSAIBCM_DNX_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/sai-broadcom/$(LIBSAIBCM_DNX_BRANCH_NAME)/$(LIBSAIBCM_DNX_VERSION)/dnx"

--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,6 +1,6 @@
 LIBSAIBCM_XGS_VERSION = 12.3.2.2
 LIBSAIBCM_DNX_VERSION = 11.2.13.1-1
-LIBSAIBCM_XGS_BRANCH_NAME = zitingguo/SAI_12.3.0_master
+LIBSAIBCM_XGS_BRANCH_NAME = SAI_12.3.0_master
 LIBSAIBCM_DNX_BRANCH_NAME = SAI_11.2.0_GA
 LIBSAIBCM_XGS_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/sai-broadcom/$(LIBSAIBCM_XGS_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)/xgs"
 LIBSAIBCM_DNX_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/sai-broadcom/$(LIBSAIBCM_DNX_BRANCH_NAME)/$(LIBSAIBCM_DNX_VERSION)/dnx"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix #21680 
##### Work item tracking
- Microsoft ADO **(number only)**: 31426582

#### How I did it
- Re-compile SAI 12.3 with SAI header from https://github.com/opencomputeproject/SAI/tree/054085547c2042b95ab0fa1a75a44da3288b26bf

#### How to verify it
Load image on a DUT, all dockers are up and running.
```
admin@bjw2-can-7260-7:~$ show ver

SONiC Software Version: SONiC.master-21746.772945-f8fc18c02
SONiC OS Version: 12
Distribution: Debian 12.9
Kernel: 6.1.0-22-2-amd64
Build commit: f8fc18c02
Build date: Fri Feb 14 13:38:43 UTC 2025
Built by: azureuser@92044be7c000000

Platform: x86_64-arista_7260cx3_64
HwSKU: Arista-7260CX3-D108C8
ASIC: broadcom
ASIC Count: 1
Serial Number: JPA2403P2YQ
Model Number: DCS-7260CX3-64
Hardware Revision: 03.00
Uptime: 11:34:43 up 6 min,  1 user,  load average: 1.05, 1.28, 0.69
Date: Sun 16 Feb 2025 11:34:43

Docker images:
REPOSITORY                    TAG                             IMAGE ID       SIZE
docker-syncd-brcm             latest                          a2b02f4e43f9   763MB
docker-syncd-brcm             master-21746.772945-f8fc18c02   a2b02f4e43f9   763MB
docker-sonic-restapi          latest                          687395e382c6   332MB
docker-sonic-restapi          master-21746.772945-f8fc18c02   687395e382c6   332MB
docker-gbsyncd-broncos        latest                          30962939a4ca   352MB
docker-gbsyncd-broncos        master-21746.772945-f8fc18c02   30962939a4ca   352MB
docker-gbsyncd-credo          latest                          41d577433d16   326MB
docker-gbsyncd-credo          master-21746.772945-f8fc18c02   41d577433d16   326MB
docker-macsec                 latest                          8224e04520e9   346MB
docker-teamd                  latest                          e0d37744eba9   343MB
docker-teamd                  master-21746.772945-f8fc18c02   e0d37744eba9   343MB
docker-sflow                  latest                          5be6f593cba4   344MB
docker-sflow                  master-21746.772945-f8fc18c02   5be6f593cba4   344MB
docker-orchagent              latest                          e2f8fcc7088c   356MB
docker-orchagent              master-21746.772945-f8fc18c02   e2f8fcc7088c   356MB
docker-fpm-frr                latest                          30714a7c5c96   377MB
docker-fpm-frr                master-21746.772945-f8fc18c02   30714a7c5c96   377MB
docker-nat                    latest                          012824756b0e   346MB
docker-nat                    master-21746.772945-f8fc18c02   012824756b0e   346MB
docker-sonic-bmp              latest                          f4aff466feb9   315MB
docker-sonic-bmp              master-21746.772945-f8fc18c02   f4aff466feb9   315MB
docker-dhcp-relay             latest                          ef5d164d61c5   322MB
docker-snmp                   latest                          0d63ff630eb7   358MB
docker-snmp                   master-21746.772945-f8fc18c02   0d63ff630eb7   358MB
docker-platform-monitor       latest                          f9d98d92a276   434MB
docker-platform-monitor       master-21746.772945-f8fc18c02   f9d98d92a276   434MB
docker-router-advertiser      latest                          44badc938601   314MB
docker-router-advertiser      master-21746.772945-f8fc18c02   44badc938601   314MB
docker-mux                    latest                          c05f8c8fa477   365MB
docker-mux                    master-21746.772945-f8fc18c02   c05f8c8fa477   365MB
docker-lldp                   latest                          a06da5432771   359MB
docker-lldp                   master-21746.772945-f8fc18c02   a06da5432771   359MB
docker-sonic-gnmi             latest                          344aa388593b   425MB
docker-sonic-gnmi             master-21746.772945-f8fc18c02   344aa388593b   425MB
docker-eventd                 latest                          5d7458a58831   314MB
docker-eventd                 master-21746.772945-f8fc18c02   5d7458a58831   314MB
docker-database               latest                          14b513518291   322MB
docker-database               master-21746.772945-f8fc18c02   14b513518291   322MB
docker-sonic-mgmt-framework   latest                          ef7f2fde1a8f   402MB
docker-sonic-mgmt-framework   master-21746.772945-f8fc18c02   ef7f2fde1a8f   402MB

admin@bjw2-can-7260-7:~$ docker ps -a
CONTAINER ID   IMAGE                                COMMAND                  CREATED         STATUS         PORTS     NAMES
367f12ba9c12   docker-snmp:latest                   "/usr/bin/docker-snm…"   3 minutes ago   Up 3 minutes             snmp
150b8a46c1f8   docker-platform-monitor:latest       "/usr/bin/docker_ini…"   3 minutes ago   Up 3 minutes             pmon
ff203735f7c5   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe…"   3 minutes ago   Up 3 minutes             mgmt-framework
0b270a4f6e7a   docker-lldp:latest                   "/usr/bin/docker-lld…"   4 minutes ago   Up 4 minutes             lldp
b943612abca6   docker-sonic-gnmi:latest             "/usr/local/bin/supe…"   4 minutes ago   Up 4 minutes             gnmi
60272be19711   ef5d164d61c5                         "/usr/bin/docker_ini…"   4 minutes ago   Up 4 minutes             dhcp_relay
61c445f1815e   docker-router-advertiser:latest      "/usr/bin/docker-ini…"   5 minutes ago   Up 5 minutes             radv
a282dbbe17bb   docker-eventd:latest                 "/usr/local/bin/supe…"   6 minutes ago   Up 5 minutes             eventd
ffd12764d3d9   docker-syncd-brcm:latest             "/usr/local/bin/supe…"   6 minutes ago   Up 5 minutes             syncd
e5466e116cf2   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   6 minutes ago   Up 5 minutes             bgp
a23b3cbd7f37   docker-teamd:latest                  "/usr/local/bin/supe…"   6 minutes ago   Up 5 minutes             teamd
845fd2341cd1   docker-orchagent:latest              "/usr/bin/docker-ini…"   6 minutes ago   Up 6 minutes             swss
074d1a164f75   docker-sonic-restapi:latest          "/usr/local/bin/supe…"   6 minutes ago   Up 6 minutes             restapi
ab5e4d2de5b2   docker-database:latest               "/usr/local/bin/dock…"   6 minutes ago   Up 6 minutes             database
admin@bjw2-can-7260-7:~$ show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 4200065100 vrf-id 0
BGP table version 19203
RIB entries 12807, using 1639296 bytes of memory
Peers 4, using 82368 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V          AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  ----------  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.33      4  4200064600       3359       3358     19203      0       0  00:07:35             6400  ARISTA01T1
10.0.0.35      4  4200064600       3356       3356     19203      0       0  00:07:34             6400  ARISTA02T1
10.0.0.37      4  4200064600       3357       3360     19203      0       0  00:07:36             6400  ARISTA03T1
10.0.0.39      4  4200064600       3359       3357     19203      0       0  00:07:34             6400  ARISTA04T1

Total number of neighbors 4
admin@bjw2-can-7260-7:~$ 
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

