### PR TITLE
 [Mellanox] Update the method of reading model number for MLNX platforms

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -963,7 +963,7 @@ class Chassis(ChassisBase):
             Returns True if spectrum version is higher than Spectrum-4 according to sku number
         """
         sku = device_info.get_hwsku()
-        sku_num = re.search('[0-9]{4}', out).group()
+        sku_num = re.search('[0-9]{4}', sku).group()
         return int(sku_num) >= 5000
 
     def _verify_reboot_cause(self, filename):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -27,6 +27,7 @@ try:
     from sonic_platform_base.chassis_base import ChassisBase
     from sonic_py_common.logger import Logger
     import os
+    from subprocess import check_output
     from functools import reduce
     from .utils import extract_RJ45_ports_index
     from . import module_host_mgmt_initializer
@@ -56,6 +57,9 @@ REBOOT_CAUSE_READY_FILE = '/run/hw-management/config/reset_attr_ready'
 REBOOT_TYPE_KEXEC_FILE = "/proc/cmdline"
 REBOOT_TYPE_KEXEC_PATTERN_WARM = ".*SONIC_BOOT_TYPE=(warm|fastfast).*"
 REBOOT_TYPE_KEXEC_PATTERN_FAST = ".*SONIC_BOOT_TYPE=(fast|fast-reboot).*"
+
+SPC_RETRIEVAL = "lspci | grep 'Mellanox Technologies'"
+SYS_DISPLAY = "SYS_DISPLAY"
 
 # Global logger class instance
 logger = Logger()
@@ -742,8 +746,15 @@ class Chassis(ChassisBase):
         Returns:
             string: Model/part number of device
         """
-        self.initialize_eeprom()
-        return self._eeprom.get_part_number()
+        model = None
+        if self._read_model_from_vpd():
+            if not self.vpd_data:
+                self.vpd_data = self._parse_vpd_data(VPD_DATA_FILE)
+            model = self.vpd_data.get(SYS_DISPLAY, "N/A")
+        else:
+            self.initialize_eeprom()
+            model = self._eeprom.get_part_number()
+        return model
 
     def get_base_mac(self):
         """
@@ -943,6 +954,30 @@ class Chassis(ChassisBase):
             logger.log_error("Fail to decode vpd_data {} due to {}".format(filename, repr(e)))
 
         return result
+
+    def _get_spectrum_version(self):
+        """
+        Returns spectrum version of the platform
+
+        Returns:
+            Returns spectrum version of the platform
+        """
+        out = check_output(SPC_RETRIEVAL, shell=True)
+        spc_version = 1
+        spc_match = re.search('Spectrum-([1-9](?!\d))', out.decode("utf-8"))
+        if spc_match is not None:
+            spc_version = int(spc_match.group(1))
+        return spc_version
+
+    def _read_model_from_vpd(self):
+        """
+        Returns if model number should be returned from VPD file
+
+        Returns:
+            Returns True if spectrum version is higher than Spectrum-4
+        """
+        spc_version = self._get_spectrum_version()
+        return (spc_version >= 4)
 
     def _verify_reboot_cause(self, filename):
         '''

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -58,7 +58,6 @@ REBOOT_TYPE_KEXEC_FILE = "/proc/cmdline"
 REBOOT_TYPE_KEXEC_PATTERN_WARM = ".*SONIC_BOOT_TYPE=(warm|fastfast).*"
 REBOOT_TYPE_KEXEC_PATTERN_FAST = ".*SONIC_BOOT_TYPE=(fast|fast-reboot).*"
 
-GET_HWSKU_CMD = ["sonic-cfggen", "-d", "-v", "DEVICE_METADATA.localhost.hwsku"]
 SYS_DISPLAY = "SYS_DISPLAY"
 
 # Global logger class instance
@@ -964,6 +963,9 @@ class Chassis(ChassisBase):
         """
         sku = device_info.get_hwsku()
         sku_num = re.search('[0-9]{4}', sku).group()
+        # fallback to spc1 in case sku number is not available
+        if sku_num is None:
+            sku_num = 2700
         return int(sku_num) >= 5000
 
     def _verify_reboot_cause(self, filename):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -27,7 +27,7 @@ try:
     from sonic_platform_base.chassis_base import ChassisBase
     from sonic_py_common.logger import Logger
     import os
-    import subprocess
+    from sonic_py_common import device_info
     from functools import reduce
     from .utils import extract_RJ45_ports_index
     from . import module_host_mgmt_initializer
@@ -962,9 +962,7 @@ class Chassis(ChassisBase):
         Returns:
             Returns True if spectrum version is higher than Spectrum-4 according to sku number
         """
-        p = subprocess.Popen(GET_HWSKU_CMD, universal_newlines=True, stdout=subprocess.PIPE)
-        out, err = p.communicate()
-        out.rstrip('\n')
+        sku = device_info.get_hwsku()
         sku_num = re.search('[0-9]{4}', out).group()
         return int(sku_num) >= 5000
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -962,7 +962,7 @@ class Chassis(ChassisBase):
         Returns:
             Returns True if spectrum version is higher than Spectrum-4 according to sku number
         """
-        p = subprocess.Popen(self.GET_HWSKU_CMD, universal_newlines=True, stdout=subprocess.PIPE)
+        p = subprocess.Popen(GET_HWSKU_CMD, universal_newlines=True, stdout=subprocess.PIPE)
         out, err = p.communicate()
         out.rstrip('\n')
         sku_num = re.search('[0-9]{4}', out).group()

--- a/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
@@ -34,8 +34,7 @@ from sonic_platform.eeprom import Eeprom, EepromContentVisitor
 class TestEeprom:
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.path.islink', MagicMock(return_value=True))
-    @patch('sonic_platform.chassis.check_output',
-           MagicMock(return_value=b'Ethernet controller: Mellanox Technologies MT53100 [Spectrum-2]'))
+    @patch('sonic_platform.chassis.subprocess.Popen', MagicMock(return_value='MSN3700'))
     @patch('sonic_platform.eeprom.Eeprom.get_system_eeprom_info')
     @patch('sonic_platform.chassis.extract_RJ45_ports_index', MagicMock(return_value=[]))
     def test_chassis_eeprom(self, mock_eeprom_info):

--- a/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
@@ -35,7 +35,7 @@ from sonic_platform.eeprom import Eeprom, EepromContentVisitor
 class TestEeprom:
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.path.islink', MagicMock(return_value=True))
-    @patch('device_info.get_hwsku', MagicMock(return_value='MSN3420'))
+    @patch('sonic_py_common.device_info.get_hwsku', MagicMock(return_value='MSN3420'))
     @patch('sonic_platform.eeprom.Eeprom.get_system_eeprom_info')
     @patch('sonic_platform.chassis.extract_RJ45_ports_index', MagicMock(return_value=[]))
     def test_chassis_eeprom(self, mock_eeprom_info):

--- a/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
@@ -19,6 +19,7 @@
 import os
 import pytest
 import sys
+import subprocess
 if sys.version_info.major == 3:
     from unittest.mock import MagicMock, patch
 else:
@@ -34,10 +35,11 @@ from sonic_platform.eeprom import Eeprom, EepromContentVisitor
 class TestEeprom:
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.path.islink', MagicMock(return_value=True))
-    @patch('sonic_platform.chassis.subprocess.Popen', MagicMock(return_value='MSN3700'))
+    @patch('subprocess.Popen')
     @patch('sonic_platform.eeprom.Eeprom.get_system_eeprom_info')
     @patch('sonic_platform.chassis.extract_RJ45_ports_index', MagicMock(return_value=[]))
-    def test_chassis_eeprom(self, mock_eeprom_info):
+    def test_chassis_eeprom(self, mock_eeprom_info, mock_subprocess):
+        mock_subprocess.return_value.communicate.return_value = ('MSN3420', None)
         mock_eeprom_info.return_value = {
             hex(Eeprom._TLV_CODE_PRODUCT_NAME): 'MSN3420',
             hex(Eeprom._TLV_CODE_PART_NUMBER): 'MSN3420-CB2FO',

--- a/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +34,8 @@ from sonic_platform.eeprom import Eeprom, EepromContentVisitor
 class TestEeprom:
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.path.islink', MagicMock(return_value=True))
+    @patch('sonic_platform.chassis.check_output',
+           MagicMock(return_value=b'Ethernet controller: Mellanox Technologies MT53100 [Spectrum-2]'))
     @patch('sonic_platform.eeprom.Eeprom.get_system_eeprom_info')
     @patch('sonic_platform.chassis.extract_RJ45_ports_index', MagicMock(return_value=[]))
     def test_chassis_eeprom(self, mock_eeprom_info):

--- a/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
@@ -19,7 +19,7 @@
 import os
 import pytest
 import sys
-import subprocess
+from sonic_py_common import device_info
 if sys.version_info.major == 3:
     from unittest.mock import MagicMock, patch
 else:
@@ -35,11 +35,10 @@ from sonic_platform.eeprom import Eeprom, EepromContentVisitor
 class TestEeprom:
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.path.islink', MagicMock(return_value=True))
-    @patch('subprocess.Popen')
+    @patch('device_info.get_hwsku', MagicMock(return_value='MSN3420'))
     @patch('sonic_platform.eeprom.Eeprom.get_system_eeprom_info')
     @patch('sonic_platform.chassis.extract_RJ45_ports_index', MagicMock(return_value=[]))
-    def test_chassis_eeprom(self, mock_eeprom_info, mock_subprocess):
-        mock_subprocess.return_value.communicate.return_value = ('MSN3420', None)
+    def test_chassis_eeprom(self, mock_eeprom_info):
         mock_eeprom_info.return_value = {
             hex(Eeprom._TLV_CODE_PRODUCT_NAME): 'MSN3420',
             hex(Eeprom._TLV_CODE_PART_NUMBER): 'MSN3420-CB2FO',


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To return the correct Model Number for MLNX platforms rather than Part Number.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
For SPC1-3 read it from eeprom.part_number and for SPC4 and newer read it from VPD file, SYS_DISPLAY value.
#### How to verify it
Manual testing: 'show platform summary' for each spectrum.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

