### PR TITLE
[build] Fix debian mirror snapshot timestamp not work issue. (#21758)

### DIFF
--- a/scripts/build_mirror_config.sh
+++ b/scripts/build_mirror_config.sh
@@ -11,7 +11,7 @@ export APT_RETRIES_COUNT
 
 DEFAULT_MIRROR_URL_PREFIX=http://packages.trafficmanager.net
 MIRROR_VERSION_FILE=
-[[ "$SONIC_VERSION_CONTROL_COMPONENTS" == *deb* || $SONIC_VERSION_CONTROL_COMPONENTS == *all* ]] && MIRROR_VERSION_FILE=files/build/versions/default/versions-mirror && MIRROR_SNAPSHOT=y
+[[ "$MIRROR_SNAPSHOT" == "y" ]] && MIRROR_VERSION_FILE=files/build/versions/default/versions-mirror
 [ -f target/versions/default/versions-mirror ] && MIRROR_VERSION_FILE=target/versions/default/versions-mirror
 
 # The default mirror urls


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
[PR21366](https://github.com/sonic-net/sonic-buildimage/pull/21366/files) wants to use debian snapshot instead of version pinning to improve image quality. But it missed this change. Build is using latest debian snapshot instead of validated snapshot.
Now validated snapshot is '20250130'. details in this [link](https://github.com/sonic-net/sonic-buildimage/blob/master/files/build/versions/default/versions-mirror). But we can find build is using '20250216', which is a bad snapshot. It breaks SONiC build since Feb 16.
```
Get:18 http://packages.trafficmanager.net/snapshot/debian-security/20250216T001420Z bullseye-security/non-free amd64 Packages [1164 B]
Get:19 http://packages.trafficmanager.net/snapshot/debian-security/20250216T001420Z bullseye-security/main amd64 Packages [346 kB]
Fetched 17.9 MB in 5s (3789 kB/s)
Reading package lists...
E: Failed to fetch http://packages.trafficmanager.net/snapshot/debian-security/20250216T001420Z/dists/bullseye-security/main/source/Sources.xz  File has unexpected size (234932 != 234820). Mirror sync in progress? [IP: 13.107.246.71 80]
   Hashes of expected file:
    - Filesize:234820 [weak]
    - SHA256:99cbb6795504058c2b3b2355ad128d8ca7879c136ba8fc00f2813ea4d5e7d147
   Release file created at: Sat, 15 Feb 2025 17:04:32 +0000
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Fix debian mirror snapshot timestamp generate script.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

