### PR TITLE
[chassis-packet] Allow Fallback Route to get programmed on Downstream LC

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/internal/policies.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/internal/policies.conf.j2
@@ -39,8 +39,9 @@ route-map FROM_BGP_INTERNAL_PEER_V4 permit 2
   on-match next
 !
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'DownstreamLC' %}
-route-map FROM_BGP_INTERNAL_PEER_V4 deny 3
+route-map FROM_BGP_INTERNAL_PEER_V4 permit 3
   match community DEVICE_INTERNAL_FALLBACK_COMMUNITY
+  set comm-list DEVICE_INTERNAL_FALLBACK_COMMUNITY delete
 {% else %}
 route-map FROM_BGP_INTERNAL_PEER_V4 permit 3
   match community DEVICE_INTERNAL_FALLBACK_COMMUNITY
@@ -63,8 +64,9 @@ route-map FROM_BGP_INTERNAL_PEER_V6 permit 3
   on-match next
 !
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'DownstreamLC' %}
-route-map FROM_BGP_INTERNAL_PEER_V6 deny 4
+route-map FROM_BGP_INTERNAL_PEER_V6 permit 4
   match community DEVICE_INTERNAL_FALLBACK_COMMUNITY
+  set comm-list DEVICE_INTERNAL_FALLBACK_COMMUNITY delete
 {% else %}
 route-map FROM_BGP_INTERNAL_PEER_V6 permit 4
   match community DEVICE_INTERNAL_FALLBACK_COMMUNITY

--- a/src/sonic-bgpcfgd/tests/data/internal/policies.conf/result_chasiss_packet.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/policies.conf/result_chasiss_packet.conf
@@ -15,8 +15,9 @@ route-map FROM_BGP_INTERNAL_PEER_V4 permit 2
   set local-preference 80
   on-match next
 !
-route-map FROM_BGP_INTERNAL_PEER_V4 deny 3
+route-map FROM_BGP_INTERNAL_PEER_V4 permit 3
   match community DEVICE_INTERNAL_FALLBACK_COMMUNITY
+  set comm-list DEVICE_INTERNAL_FALLBACK_COMMUNITY delete
 !
 route-map FROM_BGP_INTERNAL_PEER_V6 permit 1
  set ipv6 next-hop prefer-global
@@ -32,8 +33,9 @@ route-map FROM_BGP_INTERNAL_PEER_V6 permit 3
   set local-preference 80
   on-match next
 !
-route-map FROM_BGP_INTERNAL_PEER_V6 deny 4
+route-map FROM_BGP_INTERNAL_PEER_V6 permit 4
   match community DEVICE_INTERNAL_FALLBACK_COMMUNITY
+  set comm-list DEVICE_INTERNAL_FALLBACK_COMMUNITY delete
 !
 route-map TO_BGP_INTERNAL_PEER_V4 permit 1
   match ip address prefix-list PL_LoopbackV4


### PR DESCRIPTION
What/Why I did:
Initially I made the change that Fallback Route [routes from AH on Upstream LC] not to get programmed [mark them as deny]  on Downstream LC's as reasoning was that on Downstream LC's can forward them based on Default-route. However that assumption is correct for example we have topology like this:

RH is connected to ASIC0 of Upstream LC
AH is connected to ASIC1 of Upstream LC

Downstream LC will learn route from RH [including default-route] and will only forward to ASIC0 of upstream LC .  Above assumption was fine if we always have AH and RH connected to same ASIC of Upstream LC.

How I verify:
UT updated
Manual Verification.
