### PR TITLE
Fixing Wolverine LC's incorrect symlinks

### DIFF
--- a/device/arista/x86_64-arista_7800r3a_36d_lc/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7800r3a_36d_lc/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control.json
+../x86_64-arista_common/pmon_daemon_control_linecard.json

--- a/device/arista/x86_64-arista_7800r3a_36d_lc/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7800r3a_36d_lc/system_health_monitoring_config.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/system_health_monitoring_config.json
+../x86_64-arista_common/system_health_monitoring_config_linecard.json

--- a/device/arista/x86_64-arista_7800r3a_36d_lc/thermal_policy.json
+++ b/device/arista/x86_64-arista_7800r3a_36d_lc/thermal_policy.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/thermal_policy.json
+../x86_64-arista_common/thermal_policy_linecard.json

--- a/device/arista/x86_64-arista_7800r3a_36dm2_lc/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7800r3a_36dm2_lc/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control.json
+../x86_64-arista_common/pmon_daemon_control_linecard.json

--- a/device/arista/x86_64-arista_7800r3a_36dm2_lc/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7800r3a_36dm2_lc/system_health_monitoring_config.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/system_health_monitoring_config.json
+../x86_64-arista_common/system_health_monitoring_config_linecard.json

--- a/device/arista/x86_64-arista_7800r3a_36dm2_lc/thermal_policy.json
+++ b/device/arista/x86_64-arista_7800r3a_36dm2_lc/thermal_policy.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/thermal_policy.json
+../x86_64-arista_common/thermal_policy_linecard.json

--- a/device/arista/x86_64-arista_7800r3a_36p_lc/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7800r3a_36p_lc/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control.json
+../x86_64-arista_common/pmon_daemon_control_linecard.json

--- a/device/arista/x86_64-arista_7800r3a_36p_lc/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7800r3a_36p_lc/system_health_monitoring_config.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/system_health_monitoring_config.json
+../x86_64-arista_common/system_health_monitoring_config_linecard.json

--- a/device/arista/x86_64-arista_7800r3a_36p_lc/thermal_policy.json
+++ b/device/arista/x86_64-arista_7800r3a_36p_lc/thermal_policy.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/thermal_policy.json
+../x86_64-arista_common/thermal_policy_linecard.json

--- a/device/arista/x86_64-arista_7800r3ak_36d2_lc/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7800r3ak_36d2_lc/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control.json
+../x86_64-arista_common/pmon_daemon_control_linecard.json

--- a/device/arista/x86_64-arista_7800r3ak_36d2_lc/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7800r3ak_36d2_lc/system_health_monitoring_config.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/system_health_monitoring_config.json
+../x86_64-arista_common/system_health_monitoring_config_linecard.json

--- a/device/arista/x86_64-arista_7800r3ak_36d2_lc/thermal_policy.json
+++ b/device/arista/x86_64-arista_7800r3ak_36d2_lc/thermal_policy.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/thermal_policy.json
+../x86_64-arista_common/thermal_policy_linecard.json

--- a/device/arista/x86_64-arista_7800r3ak_36dm2_lc/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7800r3ak_36dm2_lc/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control.json
+../x86_64-arista_common/pmon_daemon_control_linecard.json

--- a/device/arista/x86_64-arista_7800r3ak_36dm2_lc/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7800r3ak_36dm2_lc/system_health_monitoring_config.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/system_health_monitoring_config.json
+../x86_64-arista_common/system_health_monitoring_config_linecard.json

--- a/device/arista/x86_64-arista_7800r3ak_36dm2_lc/thermal_policy.json
+++ b/device/arista/x86_64-arista_7800r3ak_36dm2_lc/thermal_policy.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/thermal_policy.json
+../x86_64-arista_common/thermal_policy_linecard.json


### PR DESCRIPTION
In https://github.com/sonic-net/sonic-buildimage/pull/21512 we created separate directories for the different Wolverine SKUs but the `pmon_daemon_control.json` symlink was moved to the non-LC file in `x86_64-arista_common`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405
- [x] 202411

