### PR TITLE
Use software_bfd instead of switch_type.

### DIFF
--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -206,7 +206,7 @@ dependent_startup_wait_for=bgpd:running
 
 {% endif %}
 
-{% if DEVICE_METADATA.localhost.switch_type is defined and DEVICE_METADATA.localhost.switch_type == "dpu" %}
+{% if FEATURE is defined and FEATURE.software_bfd is defined and FEATURE.software_bfd.state is defined and FEATURE.software_bfd.state == "enabled" %}
 [program:bfdmon]
 command=/usr/local/bin/bfdmon
 priority=6

--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -5,6 +5,7 @@ import syslog
 import threading
 import traceback
 
+from swsscommon.swsscommon import ConfigDBConnector
 from swsscommon import swsscommon
 from sonic_py_common import device_info
 
@@ -85,9 +86,11 @@ def do_work():
     if device_info.is_chassis():
         managers.append(ChassisAppDbMgr(common_objs, "CHASSIS_APP_DB", "BGP_DEVICE_GLOBAL"))
 
-    switch_type = device_info.get_localhost_info("switch_type")
-    if switch_type and switch_type == "dpu":
-        log_notice("switch type is dpu, starting bfd manager")
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    features = config_db.get_table('FEATURE')
+    if 'software_bfd' in features and 'state' in features['software_bfd'] and features['software_bfd']['state'] == 'enabled':
+        log_notice("software_bfd feature is enabled, starting bfd manager")
         managers.append(BfdMgr(common_objs, "STATE_DB", swsscommon.STATE_BFD_SOFTWARE_SESSION_TABLE_NAME))
 
     runner = Runner(common_objs['cfg_mgr'])


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Request in https://github.com/sonic-net/sonic-swss/pull/3406 to allow software BFD to be enabled independent of switch_type 'dpu'. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added checks for new config DB entry instead,
  "FEATURE": {
        "software_bfd": {
            "state": "enabled"
        }
  }


#### How to verify it

- pytest testcases
- Tested on vs platform by adding software_bfd to config DB. 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

