### PR TITLE
[SmartSwitch] [Nvidia] Remove PG 3 and 4 for Internal Ports

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O28/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O28/buffers_defaults_objects.j2
@@ -1,5 +1,6 @@
 {#
-    Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+    SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+    Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
     Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -92,8 +93,7 @@
     "BUFFER_PG": {
         "Dpc": {
             "active": {
-                "dynamic": "ingress_lossy_profile",
-                "static": "ingress_lossy_profile"
+                "dynamic": "NULL"
             },
             "inactive": {
                 "dynamic": "ingress_lossy_profile",
@@ -361,12 +361,6 @@
         "{{ port }}|3-4": {
             "profile" : {{find_profile_to_attach('BUFFER_PG', port, 'active', 'dynamic')}}
         },
-{% else %}
-{% if port in PORT_DPC %}
-        "{{ port }}|3-4": {
-            "profile" : {{find_profile_to_attach('BUFFER_PG', port, 'active', 'static')}}
-        },
-{% endif %}
 {% endif %}
         "{{ port }}|0": {
             "profile" : "ingress_lossy_profile"

--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -79,7 +79,9 @@ def
             {%- endif %}
         {%- endif %}
     {%- endfor %}
-    {%- if cable_len -%}
+    {%- if port_name in PORT_DPC -%}
+        {{ '0m' }}
+    {%- elif cable_len -%}
         {{ cable_len.0 }}
     {%- else %}
         {%- if 'torrouter' in switch_role.lower() and 'mgmt' not in switch_role.lower()%}

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -96,6 +96,18 @@
     {{- generate_tc_to_pg_map_per_sku() }}
 {% else %}
     "TC_TO_PRIORITY_GROUP_MAP": {
+{% if PORT_DPC %}
+        "AZURE_DPC": {
+            "0": "0",
+            "1": "0",
+            "2": "0",
+            "3": "0",
+            "4": "0",
+            "5": "0",
+            "6": "0",
+            "7": "7"
+        },
+{% endif %}
         "AZURE": {
             "0": "0",
             "1": "0",
@@ -351,7 +363,11 @@
 {% endif %}
             "pfcwd_sw_enable" : "3,4",
 {% endif %}
+{% if port not in PORT_DPC %}
             "tc_to_pg_map"    : "AZURE",
+{% else %}
+            "tc_to_pg_map"    : "AZURE_DPC",
+{% endif %}
             "pfc_to_queue_map": "AZURE"
         }{% if not loop.last %},{% endif %}
 

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-mellanox4700-o28-t1-smartswitch.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-mellanox4700-o28-t1-smartswitch.json
@@ -14,25 +14,25 @@
         "Ethernet224": {
             "dscp_to_tc_map": "AZURE",
             "tc_to_queue_map": "AZURE",
-            "tc_to_pg_map": "AZURE",
+            "tc_to_pg_map": "AZURE_DPC",
             "pfc_to_queue_map": "AZURE"
         },
         "Ethernet232": {
             "dscp_to_tc_map": "AZURE",
             "tc_to_queue_map": "AZURE",
-            "tc_to_pg_map": "AZURE",
+            "tc_to_pg_map": "AZURE_DPC",
             "pfc_to_queue_map": "AZURE"
         },
         "Ethernet240": {
             "dscp_to_tc_map": "AZURE",
             "tc_to_queue_map": "AZURE",
-            "tc_to_pg_map": "AZURE",
+            "tc_to_pg_map": "AZURE_DPC",
             "pfc_to_queue_map": "AZURE"
         },
         "Ethernet248": {
             "dscp_to_tc_map": "AZURE",
             "tc_to_queue_map": "AZURE",
-            "tc_to_pg_map": "AZURE",
+            "tc_to_pg_map": "AZURE_DPC",
             "pfc_to_queue_map": "AZURE"
         }
     },
@@ -415,25 +415,13 @@
         "Ethernet216|0": {
             "profile": "ingress_lossy_profile"
         },
-        "Ethernet224|3-4": {
-            "profile": "ingress_lossy_profile"
-        },
         "Ethernet224|0": {
-            "profile": "ingress_lossy_profile"
-        },
-        "Ethernet232|3-4": {
             "profile": "ingress_lossy_profile"
         },
         "Ethernet232|0": {
             "profile": "ingress_lossy_profile"
         },
-        "Ethernet240|3-4": {
-            "profile": "ingress_lossy_profile"
-        },
         "Ethernet240|0": {
-            "profile": "ingress_lossy_profile"
-        },
-        "Ethernet248|3-4": {
             "profile": "ingress_lossy_profile"
         },
         "Ethernet248|0": {

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-mellanox4700-o28-t1-smartswitch_dyn.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-mellanox4700-o28-t1-smartswitch_dyn.json
@@ -14,25 +14,25 @@
         "Ethernet224": {
             "dscp_to_tc_map": "AZURE",
             "tc_to_queue_map": "AZURE",
-            "tc_to_pg_map": "AZURE",
+            "tc_to_pg_map": "AZURE_DPC",
             "pfc_to_queue_map": "AZURE"
         },
         "Ethernet232": {
             "dscp_to_tc_map": "AZURE",
             "tc_to_queue_map": "AZURE",
-            "tc_to_pg_map": "AZURE",
+            "tc_to_pg_map": "AZURE_DPC",
             "pfc_to_queue_map": "AZURE"
         },
         "Ethernet240": {
             "dscp_to_tc_map": "AZURE",
             "tc_to_queue_map": "AZURE",
-            "tc_to_pg_map": "AZURE",
+            "tc_to_pg_map": "AZURE_DPC",
             "pfc_to_queue_map": "AZURE"
         },
         "Ethernet248": {
             "dscp_to_tc_map": "AZURE",
             "tc_to_queue_map": "AZURE",
-            "tc_to_pg_map": "AZURE",
+            "tc_to_pg_map": "AZURE_DPC",
             "pfc_to_queue_map": "AZURE"
         }
     },
@@ -391,25 +391,25 @@
             "profile": "ingress_lossy_profile"
         },
         "Ethernet224|3-4": {
-            "profile": "ingress_lossy_profile"
+            "profile": "NULL"
         },
         "Ethernet224|0": {
             "profile": "ingress_lossy_profile"
         },
         "Ethernet232|3-4": {
-            "profile": "ingress_lossy_profile"
+            "profile": "NULL"
         },
         "Ethernet232|0": {
             "profile": "ingress_lossy_profile"
         },
         "Ethernet240|3-4": {
-            "profile": "ingress_lossy_profile"
+            "profile": "NULL"
         },
         "Ethernet240|0": {
             "profile": "ingress_lossy_profile"
         },
         "Ethernet248|3-4": {
-            "profile": "ingress_lossy_profile"
+            "profile": "NULL"
         },
         "Ethernet248|0": {
             "profile": "ingress_lossy_profile"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
PG's 3 & 4 for Internal ports today have lossy buffer profiles attached, but this is redundant and can be removed as they occupy extra overhead even though it's not significant

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Make the cable length for Dpc ports to 0m and create a new TC_PG_MAP for internal ports

#### How to verify it
Run config qos reload --no-dynamic-buffer, config save -y and config reload -y
```
redis-cli -n 4 hget "CABLE_LENGTH|AZURE" Ethernet224
"0m"
redis-cli -n 4 hget "PORT_QOS_MAP|Ethernet232" tc_to_pg_map
"AZURE_DPC"

root@r-bobcat-01:/home/admin# sonic-db-cli CONFIG_DB HGETALL "TC_TO_PRIORITY_GROUP_MAP|AZURE_DPC"
{'0': '0', '1': '0', '2': '0', '3': '0', '4': '0', '5': '0', '6': '0', '7': '7'}

redis-cli -n 0 keys "BUFFER_PG*Ethernet232*"
1) "BUFFER_PG_TABLE:Ethernet232:0"

redis-cli -n 0 keys "BUFFER_PG*Ethernet88*"
1) "BUFFER_PG_TABLE:Ethernet88:3-4"
2) "BUFFER_PG_TABLE:Ethernet88:0"
```
```
2025 Feb 14 11:36:15.333024 sonic NOTICE swss#buffermgrd: :- doSpeedUpdateTask: Not creating/updating PG profile for port Ethernet224. Cable length is set to 0m
2025 Feb 14 11:36:15.333024 sonic NOTICE swss#buffermgrd: :- doSpeedUpdateTask: Not creating/updating PG profile for port Ethernet232. Cable length is set to 0m
2025 Feb 14 11:36:15.333142 sonic NOTICE swss#buffermgrd: :- doSpeedUpdateTask: Not creating/updating PG profile for port Ethernet240. Cable length is set to 0m
2025 Feb 14 11:36:15.333142 sonic NOTICE swss#buffermgrd: :- doSpeedUpdateTask: Not creating/updating PG profile for port Ethernet248. Cable length is set to 0m

```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

