### PR TITLE
Update management interface related configuration in MGMT_PORT_TABLE STATE_DB

### DIFF
--- a/files/image_config/monit/mgmt_oper_status.py
+++ b/files/image_config/monit/mgmt_oper_status.py
@@ -6,7 +6,6 @@ import sys
 import subprocess
 import syslog
 
-from sonic_py_common import multi_asic, device_info
 from swsscommon.swsscommon import SonicV2Connector
 
 
@@ -14,25 +13,39 @@ def main():
     db = SonicV2Connector(use_unix_socket_path=True)
     db.connect('CONFIG_DB')
     db.connect('STATE_DB')
-    mgmt_ports_keys = db.keys(db.CONFIG_DB, 'MGMT_PORT|*' )
+    mgmt_ports_keys = db.keys(db.CONFIG_DB, 'MGMT_PORT|*')
     if not mgmt_ports_keys:
         syslog.syslog(syslog.LOG_DEBUG, 'No management interface found')
     else:
         try:
-            mgmt_ports = [key.split('MGMT_PORT|')[-1] for key in mgmt_ports_keys]
+            mgmt_ports = [key.split('MGMT_PORT|')[-1] for key
+                          in mgmt_ports_keys]
             for port in mgmt_ports:
-                state_db_mgmt_port = db.keys(db.STATE_DB, 'MGMT_PORT_TABLE|*' )
+                state_db_mgmt_keys = db.keys(db.STATE_DB, 'MGMT_PORT_TABLE|*')
                 state_db_key = "MGMT_PORT_TABLE|{}".format(port)
-                prev_oper_status = 'unknown'
-                if state_db_key in state_db_mgmt_port:
-                    prev_oper_status = db.get(db.STATE_DB, state_db_key, 'oper_status')
+                config_db_key = "MGMT_PORT|{}".format(port)
+                config_db_mgmt = db.get_all(db.CONFIG_DB, config_db_key)
+                state_db_mgmt = db.get_all(db.STATE_DB, state_db_key) if state_db_key in state_db_mgmt_keys else {}
+
+                # Sync fields from CONFIG_DB MGMT_PORT table to STATE_DB MGMT_PORT_TABLE
+                for field in config_db_mgmt:
+                        if field != 'oper_status':
+                            # Update STATE_DB if port is not present or value differs from
+                            # CONFIG_DB
+                            if (field in state_db_mgmt and state_db_mgmt[field] != config_db_mgmt[field]) \
+                            or field not in state_db_mgmt:
+                                db.set(db.STATE_DB, state_db_key, field, config_db_mgmt[field])
+
+                # Update oper status if modified
+                prev_oper_status = state_db_mgmt.get('oper_status', 'unknown')
                 port_operstate_path = '/sys/class/net/{}/operstate'.format(port)
                 oper_status = subprocess.run(['cat', port_operstate_path], capture_output=True, text=True)
                 current_oper_status = oper_status.stdout.strip()
                 if current_oper_status != prev_oper_status:
                     db.set(db.STATE_DB, state_db_key, 'oper_status', current_oper_status)
-                    log_level = syslog.LOG_INFO if current_oper_status == 'up' else syslog.LOG_WARNING 
+                    log_level = syslog.LOG_INFO if current_oper_status == 'up' else syslog.LOG_WARNING
                     syslog.syslog(log_level, "mgmt_oper_status: {}".format(current_oper_status))
+
         except Exception as e:
             syslog.syslog(syslog.LOG_ERR, "mgmt_oper_status exception : {}".format(str(e)))
             db.set(db.STATE_DB, state_db_key, 'oper_status', 'unknown')


### PR DESCRIPTION
…in STATE_DB

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently Management interface related data is present in CONFIG_DB and 'oper_status' is present in STATE_DB MGMT_PORT_TABLE.
This PR change is made to ensure that all telemetry data related to management interface is present in STATE_DB.

##### Work item tracking
- Microsoft ADO **27597775**:

#### How I did it
Update mgmt_oper_status monit script to update all fields from CONFIG_DB MGMT_PORT table.

#### How to verify it
Unit test added for the change and passed:
```
/sonic/files/image_config/monit$ pytest-3 tests/test_mgmt_oper_status.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0+repack
rootdir: /sonic/files/image_config/monit
plugins: pyfakefs-5.6.0, cov-4.0.0
collected 4 items                                                                                                                                                                                                 

tests/test_mgmt_oper_status.py ....                                                                                                                                                                         [100%]

================================================================================================ 4 passed in 0.09s ================================================================================================
```
Before Change:
```
sonic-db-cli STATE_DB hgetall "MGMT_PORT_TABLE|eth0"
{'oper_status': 'up'}
```
After change:
```
sonic-db-cli STATE_DB hgetall "MGMT_PORT_TABLE|eth0"
{'oper_status': 'up', 'admin_status': 'up', 'alias': 'eth0'}
sonic-db-cli CONFIG_DB hgetall "MGMT_PORT|eth0"
{'admin_status': 'up', 'alias': 'eth0'}
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

