### PR TITLE
[Bgpcfgd] Add dependency callback logic in SRv6 Manager to handle out-of-order table processing

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/directory.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/directory.py
@@ -157,3 +157,10 @@ class Directory(object):
         for db, table, path in deps:
             slot = self.get_slot_name(db, table)
             self.notify[slot][path].append(handler)
+
+    def unsubscribe(self, deps):
+        for db, table, path in deps:
+            slot = self.get_slot_name(db, table)
+            if slot in self.notify:
+                if path in self.notify[slot]:
+                    del self.notify[slot][path]

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
@@ -104,8 +104,9 @@ class SRv6Mgr(Manager):
         self.cfg_mgr.push_list(cmd_list)
         log_debug("{} SRv6 static configuration {}|{} is scheduled for updates. {}".format(self.db_name, self.table_name, key, str(cmd_list)))
         self.directory.remove(self.db_name, self.table_name, key)
-        self.deps.remove((self.db_name, "SRV6_MY_LOCATORS", locator_name))
-        self.directory.unsubscribe([(self.db_name, "SRV6_MY_LOCATORS", locator_name)])
+        if (self.db_name, "SRV6_MY_LOCATORS", locator_name) in self.deps:
+            self.deps.remove((self.db_name, "SRV6_MY_LOCATORS", locator_name))
+            self.directory.unsubscribe([(self.db_name, "SRV6_MY_LOCATORS", locator_name)])
 
     def sids_del_handler(self, key):
         locator_name = key.split("|")[0]

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
@@ -22,7 +22,7 @@ class SRv6Mgr(Manager):
         """
         super(SRv6Mgr, self).__init__(
             common_objs,
-            [],
+            set(),
             db,
             table,
         )
@@ -59,9 +59,11 @@ class SRv6Mgr(Manager):
         prefix_len = int(ip_prefix.split("/")[1])
 
         if not self.directory.path_exist(self.db_name, "SRV6_MY_LOCATORS", locator_name):
-            log_err("Found a SRv6 SID config entry with a locator that does not exist: {} | {}".format(key, data))
+            log_warn("Found a SRv6 SID config entry with a locator that does not exist yet: {} | {}".format(key, data))
+            self.deps.add((self.db_name, "SRV6_MY_LOCATORS", locator_name))
+            self.directory.subscribe([(self.db_name, "SRV6_MY_LOCATORS", locator_name)], self.on_deps_change)
             return False
-        
+
         locator = self.directory.get(self.db_name, "SRV6_MY_LOCATORS", locator_name)
         if locator.block_len + locator.node_len > prefix_len:
             log_err("Found a SRv6 SID config entry with an invalid prefix length {} | {}".format(key, data))
@@ -70,11 +72,11 @@ class SRv6Mgr(Manager):
         if 'action' not in data:
             log_err("Found a SRv6 SID config entry that does not specify action: {} | {}".format(key, data))
             return False
-        
+
         if data['action'] not in supported_SRv6_behaviors:
             log_err("Found a SRv6 SID config entry associated with unsupported action: {} | {}".format(key, data))
             return False
-        
+
         sid = SID(locator_name, ip_prefix, data) # the information in data will be parsed into SID's attributes
 
         cmd_list = ['segment-routing', 'srv6', 'static-sids']
@@ -102,6 +104,8 @@ class SRv6Mgr(Manager):
         self.cfg_mgr.push_list(cmd_list)
         log_debug("{} SRv6 static configuration {}|{} is scheduled for updates. {}".format(self.db_name, self.table_name, key, str(cmd_list)))
         self.directory.remove(self.db_name, self.table_name, key)
+        self.deps.remove((self.db_name, "SRV6_MY_LOCATORS", locator_name))
+        self.directory.unsubscribe([(self.db_name, "SRV6_MY_LOCATORS", locator_name)])
 
     def sids_del_handler(self, key):
         locator_name = key.split("|")[0]
@@ -134,7 +138,7 @@ class SID:
     def __init__(self, locator, ip_prefix, data):
         self.locator_name = locator
         self.ip_prefix = ip_prefix
-        
+
         self.action = data['action']
         self.decap_vrf = data['decap_vrf'] if 'decap_vrf' in data else DEFAULT_VRF
         self.adj = data['adj'].split(',') if 'adj' in data else []

--- a/src/sonic-bgpcfgd/tests/test_srv6.py
+++ b/src/sonic-bgpcfgd/tests/test_srv6.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+import time
 
 from bgpcfgd.directory import Directory
 from bgpcfgd.template import TemplateFabric
@@ -110,7 +111,7 @@ def test_uDT46_add_vrf1():
 def test_uN_del():
     loc_mgr, sid_mgr = constructor()
     assert loc_mgr.set_handler("loc1", {'prefix': 'fcbb:bbbb:1::'})
-    
+
     # add uN function first
     assert sid_mgr.set_handler("loc1|FCBB:BBBB:1::/48", {
         'action': 'uN'
@@ -130,7 +131,7 @@ def test_uN_del():
 def test_uDT46_del_vrf1():
     loc_mgr, sid_mgr = constructor()
     assert loc_mgr.set_handler("loc1", {'prefix': 'fcbb:bbbb:1::'})
-    
+
     # add a uN action first to make the uDT46 action not the last function
     assert sid_mgr.set_handler("loc1|FCBB:BBBB:1::/48", {
         'action': 'uN'
@@ -163,3 +164,22 @@ def test_invalid_add():
     }), expected_ret=False, expected_cmds=[])
 
     assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21:f1::\\64")
+
+def test_out_of_order_add():
+    loc_mgr, sid_mgr = constructor()
+    loc_mgr.cfg_mgr.push_list = MagicMock()
+    sid_mgr.cfg_mgr.push_list = MagicMock()
+
+    # add the sid first, expect the addition to return false
+    assert not sid_mgr.handler(op='SET', key="loc2|FCBB:BBBB:21::/48", data={'action': 'uN'})
+
+    # verify that the sid is not added
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21::\\48")
+
+    # add the locator, expect the addition to return true
+    assert loc_mgr.handler(op='SET', key="loc2", data={'prefix': 'fcbb:bbbb:21::'})
+
+    time.sleep(3)
+
+    # verify that the sid is added after locator config was there
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21::\\48")

--- a/src/sonic-bgpcfgd/tests/test_srv6.py
+++ b/src/sonic-bgpcfgd/tests/test_srv6.py
@@ -170,14 +170,14 @@ def test_out_of_order_add():
     loc_mgr.cfg_mgr.push_list = MagicMock()
     sid_mgr.cfg_mgr.push_list = MagicMock()
 
-    # add the sid first, expect the addition to return false
-    assert not sid_mgr.handler(op='SET', key="loc2|FCBB:BBBB:21::/48", data={'action': 'uN'})
+    # add the sid first
+    sid_mgr.handler(op='SET', key="loc2|FCBB:BBBB:21::/48", data={'action': 'uN'})
 
     # verify that the sid is not added
     assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21::\\48")
 
-    # add the locator, expect the addition to return true
-    assert loc_mgr.handler(op='SET', key="loc2", data={'prefix': 'fcbb:bbbb:21::'})
+    # add the locator
+    loc_mgr.handler(op='SET', key="loc2", data={'prefix': 'fcbb:bbbb:21::'})
 
     time.sleep(3)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Previously, if the SRv6 manager received a config update that added a SRV6_MY_SID entry before its corresponding LOCATOR entry added, the SRv6 manager would not process the SRV6_MY_SID entry and print an ERR syslog. However, during testing, NVIDIA team found that it is possible to have such a scenario in normal operations, especially during config reload. So, we decide to add a dependency-based caching mechanism to handle out-of-order table processing.

This is the first use case where we will dynamically add/remove the dependency, so we also define a new unsubscribe function for the directory class. The reason why we need to remove the dependency in managers_srv6 is because the on_deps_change function will only process the cache when all dependencies are satisfied. If a locator is removed and the corresponding dependency is not removed, then the on_deps_change will never get to the satisfied condition.

Fix #21826 (Issue)

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202412

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202412

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

