### PR TITLE
Modify decode-syseeprom to get serial number from redis-db

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -111,7 +111,7 @@ function preStartAction()
         systemctl stop watchdog-control.service
     fi
 {%- elif docker_container_name == "snmp" %}
-    $SONIC_DB_CLI STATE_DB HSET 'DEVICE_METADATA|localhost' chassis_serial_number $(decode-syseeprom -s)
+    $SONIC_DB_CLI STATE_DB HSET 'DEVICE_METADATA|localhost' chassis_serial_number $(decode-syseeprom -d -s)
 {%- else %}
     : # nothing
 {%- endif %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
During runtime, if snmp service is restarted, it can fail to come up while /usr/bin/snmp.sh is waiting to read device serial number at this command: decode-syseeprom -s. This can cause snmp service to fail but snmp dockers to be up.
This can happen because at runtime if the eeprom becomes inaccessible due to HW issue.
To avoid snmp crash pass "-d" option in decode-syseeprom to read data from redis-db
decode-syseeprom -d -s

decode-syseeprom script reads the data from EEPROM_INFO STATE_DB table, the right information is extracted to get device serial number: https://github.com/sonic-net/sonic-utilities/blob/3c50deeb9dd8786ec6c73833f80f5701e2a0c648/scripts/decode-syseeprom#L167
In sonic-snmpagent, chassis_serial_number is used in:
https://github.com/sonic-net/sonic-snmpagent/blob/9e2c50ad77f8ba65e48f993631a48f4d666aeec9/src/sonic_ax_impl/mibs/ietf/rfc2737.py#L298
        if not device_metadata or not device_metadata.get("chassis_serial_number"):


##### Work item tracking
- Microsoft ADO **31454008**:

#### How I did it
To avoid snmp crash pass "-d" option in decode-syseeprom to read data from redis-db
#### How to verify it
verified on Pizza box device:
After fix, reboot the device, once SNMP docker comes up, DEVICE_METADATA will be updated with serial number.
```
foo$ sonic-db-cli STATE_DB hgetall 'DEVICE_METADATA|localhost'
{}
foo$ docker ps
CONTAINER ID   IMAGE                             COMMAND                  CREATED        STATUS              PORTS     NAMES
397c38f33729   docker-lldp:latest                "/usr/bin/docker-lldâ€¦"   21 hours ago   Up 5 seconds                  lldp
77bb2f85e149   docker-sonic-gnmi:latest          "/usr/local/bin/supeâ€¦"   21 hours ago   Up 10 seconds                 gnmi
5536b3cd5416   docker-sonic-restapi:latest       "/usr/local/bin/supeâ€¦"   21 hours ago   Up About a minute             restapi
96345021e646   78eda70fec8c                      "/usr/bin/docker_iniâ€¦"   21 hours ago   Up About a minute             dhcp_relay
ce06892d670d   docker-router-advertiser:latest   "/usr/bin/docker-iniâ€¦"   21 hours ago   Up About a minute             radv
8658e06b7279   docker-fpm-frr:latest             "/usr/bin/docker_iniâ€¦"   21 hours ago   Up About a minute             bgp
abafa5b7c4d8   docker-syncd-brcm:latest          "/usr/local/bin/supeâ€¦"   21 hours ago   Up About a minute             syncd
6c946de02e3b   docker-teamd:latest               "/usr/local/bin/supeâ€¦"   21 hours ago   Up About a minute             teamd
06d1f337ffc9   docker-orchagent:latest           "/usr/bin/docker-iniâ€¦"   21 hours ago   Up About a minute             swss
9d36a4e31a1d   docker-acms:latest                "/usr/local/bin/supeâ€¦"   21 hours ago   Up About a minute             acms
b4b7b91c7921   docker-database:latest            "/usr/local/bin/dockâ€¦"   21 hours ago   Up About a minute             database
foo$ docker ps
CONTAINER ID   IMAGE                             COMMAND                  CREATED        STATUS              PORTS     NAMES
0e07f1e18db0   docker-snmp:latest                "/usr/bin/docker-snmâ€¦"   21 hours ago   Up 27 seconds                 snmp
0f407593a6ee   docker-platform-monitor:latest    "/usr/bin/docker_iniâ€¦"   21 hours ago   Up 35 seconds                 pmon
397c38f33729   docker-lldp:latest                "/usr/bin/docker-lldâ€¦"   21 hours ago   Up 41 seconds                 lldp
77bb2f85e149   docker-sonic-gnmi:latest          "/usr/local/bin/supeâ€¦"   21 hours ago   Up 46 seconds                 gnmi
5536b3cd5416   docker-sonic-restapi:latest       "/usr/local/bin/supeâ€¦"   21 hours ago   Up 2 minutes                  restapi
96345021e646   78eda70fec8c                      "/usr/bin/docker_iniâ€¦"   21 hours ago   Up About a minute             dhcp_relay
ce06892d670d   docker-router-advertiser:latest   "/usr/bin/docker-iniâ€¦"   21 hours ago   Up About a minute             radv
8658e06b7279   docker-fpm-frr:latest             "/usr/bin/docker_iniâ€¦"   21 hours ago   Up About a minute             bgp
abafa5b7c4d8   docker-syncd-brcm:latest          "/usr/local/bin/supeâ€¦"   21 hours ago   Up About a minute             syncd
6c946de02e3b   docker-teamd:latest               "/usr/local/bin/supeâ€¦"   21 hours ago   Up About a minute             teamd
06d1f337ffc9   docker-orchagent:latest           "/usr/bin/docker-iniâ€¦"   21 hours ago   Up 2 minutes                  swss
9d36a4e31a1d   docker-acms:latest                "/usr/local/bin/supeâ€¦"   21 hours ago   Up 2 minutes                  acms
b4b7b91c7921   docker-database:latest            "/usr/local/bin/dockâ€¦"   21 hours ago   Up 2 minutes                  database
foo$ sonic-db-cli STATE_DB hgetall 'DEVICE_METADATA|localhost'
{'chassis_serial_number': 'SSJ17111898'}
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

