### PR TITLE
Revert "[202411] Disabling ports by adding parameter ‘-P 0’"

### DIFF
--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -30,7 +30,7 @@ stderr_logfile=syslog
 dependent_startup=true
 
 [program:mgmtd]
-command=/usr/lib/frr/mgmtd -A 127.0.0.1 -P 0
+command=/usr/lib/frr/mgmtd -A 127.0.0.1
 priority=4
 autostart=false
 autorestart=true
@@ -63,7 +63,7 @@ dependent_startup=true
 dependent_startup_wait_for=zebra:running
 
 [program:staticd]
-command=/usr/lib/frr/staticd -A 127.0.0.1 -P 0
+command=/usr/lib/frr/staticd -A 127.0.0.1
 priority=4
 autostart=false
 autorestart=false
@@ -75,7 +75,7 @@ dependent_startup_wait_for=zsocket:exited
 
 {% if DEVICE_METADATA.localhost.frr_mgmt_framework_config is defined and DEVICE_METADATA.localhost.frr_mgmt_framework_config == "true" %}
 [program:bfdd]
-command=/usr/lib/frr/bfdd -A 127.0.0.1 -P 0
+command=/usr/lib/frr/bfdd -A 127.0.0.1
 priority=4
 stopsignal=KILL
 autostart=false
@@ -89,9 +89,9 @@ dependent_startup_wait_for=zebra:running
 
 [program:bgpd]
 {% if FEATURE is defined and FEATURE.bmp is defined and FEATURE.bmp.state is defined and FEATURE.bmp.state == "enabled" %}
-command=/usr/lib/frr/bgpd -A 127.0.0.1 -P 0 -M snmp -M bmp
+command=/usr/lib/frr/bgpd -A 127.0.0.1 -M snmp -M bmp
 {% else %}
-command=/usr/lib/frr/bgpd -A 127.0.0.1 -P 0 -M snmp
+command=/usr/lib/frr/bgpd -A 127.0.0.1 -M snmp
 {% endif %}
 priority=5
 stopsignal=KILL
@@ -105,7 +105,7 @@ dependent_startup_wait_for=zsocket:exited
 
 {% if DEVICE_METADATA.localhost.frr_mgmt_framework_config is defined and DEVICE_METADATA.localhost.frr_mgmt_framework_config == "true" %}
 [program:ospfd]
-command=/usr/lib/frr/ospfd -A 127.0.0.1 -P 0 -M snmp
+command=/usr/lib/frr/ospfd -A 127.0.0.1 -M snmp
 priority=5
 stopsignal=KILL
 autostart=false
@@ -117,7 +117,7 @@ dependent_startup=true
 dependent_startup_wait_for=zebra:running
 
 [program:pimd]
-command=/usr/lib/frr/pimd -A 127.0.0.1 -P 0
+command=/usr/lib/frr/pimd -A 127.0.0.1
 priority=5
 stopsignal=KILL
 autostart=false
@@ -211,7 +211,7 @@ dependent_startup_wait_for=bgpd:running
 
 {% if DEVICE_METADATA.localhost.frr_mgmt_framework_config is defined and DEVICE_METADATA.localhost.frr_mgmt_framework_config == "true" %}
 [program:pathd]
-command=/usr/lib/frr/pathd -A 127.0.0.1 -P 0
+command=/usr/lib/frr/pathd -A 127.0.0.1
 priority=5
 stopsignal=KILL
 autostart=false


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#21795

Due to sanity failures:

------------------------------ live log teardown -------------------------------
21:03:52 memory_utilization.handle_memory_thresho L0089 WARNING| [ALARM]: monit:memory_usage, Current memory usage 92.0 exceeds high threshold 90.0

route/test_route_perf.py::test_perf_add_remove_routes[4-vlab-03-None] ERROR [ 50%]Sunday 23 February 2025  21:03:52 +0000 (0:00:00.622)       0:06:13.756 ******* 