### PR TITLE
fix M2-W6510-48GT4V port_config.ini

### DIFF
--- a/device/micas/x86_64-micas_m2-w6510-48gt4v-r0/M2-W6510-48GT4V/port_config.ini
+++ b/device/micas/x86_64-micas_m2-w6510-48gt4v-r0/M2-W6510-48GT4V/port_config.ini
@@ -1,53 +1,53 @@
-# name          lanes                alias                     index      speed
-Ethernet1       26                  gigabitE0/1                 0          1000
-Ethernet2       25                  gigabitE0/2                 1          1000
-Ethernet3       28                  gigabitE0/3                 2          1000
-Ethernet4       27                  gigabitE0/4                 3          1000
-Ethernet5       30                  gigabitE0/5                 4          1000
-Ethernet6       29                  gigabitE0/6                 5          1000
-Ethernet7       32                  gigabitE0/7                 6          1000
-Ethernet8       31                  gigabitE0/8                 7          1000
-Ethernet9       34                  gigabitE0/9                 8          1000
-Ethernet10      33                  gigabitE0/10                9          1000
-Ethernet11      36                  gigabitE0/11                10         1000
-Ethernet12      35                  gigabitE0/12                11         1000
-Ethernet13      38                  gigabitE0/13                12         1000
-Ethernet14      37                  gigabitE0/14                13         1000
-Ethernet15      40                  gigabitE0/15                14         1000
-Ethernet16      39                  gigabitE0/16                15         1000
-Ethernet17      42                  gigabitE0/17                16         1000
-Ethernet18      41                  gigabitE0/18                17         1000
-Ethernet19      44                  gigabitE0/19                18         1000
-Ethernet20      43                  gigabitE0/20                19         1000
-Ethernet21      50                  gigabitE0/21                20         1000
-Ethernet22      49                  gigabitE0/22                21         1000
-Ethernet23      52                  gigabitE0/23                22         1000
-Ethernet24      51                  gigabitE0/24                23         1000
-Ethernet25      1                   gigabitE0/25                24         1000
-Ethernet26      2                   gigabitE0/26                25         1000
-Ethernet27      3                   gigabitE0/27                26         1000
-Ethernet28      4                   gigabitE0/28                27         1000
-Ethernet29      5                   gigabitE0/29                28         1000
-Ethernet30      6                   gigabitE0/30                29         1000
-Ethernet31      7                   gigabitE0/31                30         1000
-Ethernet32      8                   gigabitE0/32                31         1000
-Ethernet33      9                   gigabitE0/33                32         1000
-Ethernet34      10                  gigabitE0/34                33         1000
-Ethernet35      11                  gigabitE0/35                34         1000
-Ethernet36      12                  gigabitE0/36                35         1000
-Ethernet37      13                  gigabitE0/37                36         1000
-Ethernet38      14                  gigabitE0/38                37         1000
-Ethernet39      15                  gigabitE0/39                38         1000
-Ethernet40      16                  gigabitE0/40                39         1000
-Ethernet41      17                  gigabitE0/41                40         1000
-Ethernet42      18                  gigabitE0/42                41         1000
-Ethernet43      19                  gigabitE0/43                42         1000
-Ethernet44      20                  gigabitE0/44                43         1000
-Ethernet45      21                  gigabitE0/45                44         1000
-Ethernet46      22                  gigabitE0/46                45         1000
-Ethernet47      23                  gigabitE0/47                46         1000
-Ethernet48      24                  gigabitE0/48                47         1000
-Ethernet49      58               twentyfiveGigE0/1              48         25000
-Ethernet50      57               twentyfiveGigE0/2              49         25000
-Ethernet51      60               twentyfiveGigE0/3              50         25000
-Ethernet52      59               twentyfiveGigE0/4              51         25000
+# name          lanes                alias                     index      speed        autoneg
+Ethernet1       26                  gigabitE0/1                 0          1000        on
+Ethernet2       25                  gigabitE0/2                 1          1000        on
+Ethernet3       28                  gigabitE0/3                 2          1000        on
+Ethernet4       27                  gigabitE0/4                 3          1000        on
+Ethernet5       30                  gigabitE0/5                 4          1000        on
+Ethernet6       29                  gigabitE0/6                 5          1000        on
+Ethernet7       32                  gigabitE0/7                 6          1000        on
+Ethernet8       31                  gigabitE0/8                 7          1000        on
+Ethernet9       34                  gigabitE0/9                 8          1000        on
+Ethernet10      33                  gigabitE0/10                9          1000        on
+Ethernet11      36                  gigabitE0/11                10         1000        on
+Ethernet12      35                  gigabitE0/12                11         1000        on
+Ethernet13      38                  gigabitE0/13                12         1000        on
+Ethernet14      37                  gigabitE0/14                13         1000        on
+Ethernet15      40                  gigabitE0/15                14         1000        on
+Ethernet16      39                  gigabitE0/16                15         1000        on
+Ethernet17      42                  gigabitE0/17                16         1000        on
+Ethernet18      41                  gigabitE0/18                17         1000        on
+Ethernet19      44                  gigabitE0/19                18         1000        on
+Ethernet20      43                  gigabitE0/20                19         1000        on
+Ethernet21      50                  gigabitE0/21                20         1000        on
+Ethernet22      49                  gigabitE0/22                21         1000        on
+Ethernet23      52                  gigabitE0/23                22         1000        on
+Ethernet24      51                  gigabitE0/24                23         1000        on
+Ethernet25      1                   gigabitE0/25                24         1000        on
+Ethernet26      2                   gigabitE0/26                25         1000        on
+Ethernet27      3                   gigabitE0/27                26         1000        on
+Ethernet28      4                   gigabitE0/28                27         1000        on
+Ethernet29      5                   gigabitE0/29                28         1000        on
+Ethernet30      6                   gigabitE0/30                29         1000        on
+Ethernet31      7                   gigabitE0/31                30         1000        on
+Ethernet32      8                   gigabitE0/32                31         1000        on
+Ethernet33      9                   gigabitE0/33                32         1000        on
+Ethernet34      10                  gigabitE0/34                33         1000        on
+Ethernet35      11                  gigabitE0/35                34         1000        on
+Ethernet36      12                  gigabitE0/36                35         1000        on
+Ethernet37      13                  gigabitE0/37                36         1000        on
+Ethernet38      14                  gigabitE0/38                37         1000        on
+Ethernet39      15                  gigabitE0/39                38         1000        on
+Ethernet40      16                  gigabitE0/40                39         1000        on
+Ethernet41      17                  gigabitE0/41                40         1000        on
+Ethernet42      18                  gigabitE0/42                41         1000        on
+Ethernet43      19                  gigabitE0/43                42         1000        on
+Ethernet44      20                  gigabitE0/44                43         1000        on
+Ethernet45      21                  gigabitE0/45                44         1000        on
+Ethernet46      22                  gigabitE0/46                45         1000        on
+Ethernet47      23                  gigabitE0/47                46         1000        on
+Ethernet48      24                  gigabitE0/48                47         1000        on
+Ethernet49      58               twentyfiveGigE0/1              48         25000       off
+Ethernet50      57               twentyfiveGigE0/2              49         25000       off
+Ethernet51      60               twentyfiveGigE0/3              50         25000       off
+Ethernet52      59               twentyfiveGigE0/4              51         25000       off


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The default state of 1G ports for auto-negotiation is not unified, the first 24 ports are enabled, while the remaining 24 ports are disabled.

##### Work item tracking
- Microsoft ADO **(number only)**:
- After the merge, Microsoft will be asked to cherry-pick to the 202411 branch.


#### How I did it
The default value for auto-negotiation on the electrical ports is set to enabled.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

