### PR TITLE
Yang model additions for PFC Stat History

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1612,7 +1612,8 @@
             "Ethernet9": {
                "action": "drop",
                "detection_time": "100",
-               "restoration_time": "400"
+               "restoration_time": "400",
+               "pfc_stat_history": "enable"
             }
         },
         "PFC_WD": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/pfc.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/pfc.json
@@ -46,5 +46,12 @@
     "PFC_WDOG_WITH_INVALID_RESTORATION_TIME": {
         "desc": "PFC_WDOG_WITH_INVALID_RESTORATION_TIME",
         "eStr": ["restoration_time must be greater than or equal to POLL_INTERVAL"]
+    },
+    "PFC_WDOG_WITH_VALID_PFC_STAT_HISTORY": {
+        "desc": "PFC_WDOG_WITH_VALID_PFC_STAT_HISTORY"
+    },
+    "PFC_WDOG_WITH_INVALID_PFC_STAT_HISTORY": {
+        "desc": "PFC_WDOG_WITH_INVALID_PFC_STAT_HISTORY",
+        "eStr": ["pfc_stat_history must be either enable or disable"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/pfc.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/pfc.json
@@ -329,5 +329,51 @@
                 ]
             }
         }
+    },
+    "PFC_WDOG_WITH_VALID_PFC_STAT_HISTORY": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet4",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet4",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "drop",
+                        "detection_time": 400,
+                        "restoration_time": 800,
+                        "pfc_stat_history": "enable"
+                    }
+                ]
+            }
+        }
+    },
+    "PFC_WDOG_WITH_INVALID_PFC_STAT_HISTORY": {
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "drop",
+                        "detection_time": 400,
+                        "restoration_time": 800,
+                        "pfc_stat_history": "down"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-pfcwd.yang
+++ b/src/sonic-yang-models/yang-models/sonic-pfcwd.yang
@@ -71,6 +71,17 @@ module sonic-pfcwd {
                     description
                         "Time delay before resuming normal PFC operation in msec.";
                 }
+                leaf pfc_stat_history {
+                    must "../ifname != 'GLOBAL'";
+                    type string {
+                        pattern "enable|disable" {
+                            error-message "pfc_stat_history must be either enable or disable";
+                            error-app-tag pfc-stat-history-invalid-status;
+                        }
+                    }
+                    description
+                        "Toggle for PFC Historical Statistics estimation.";
+                }
                 leaf POLL_INTERVAL {
                     must "../ifname = 'GLOBAL'";
                     type uint32 {


### PR DESCRIPTION
New pfc_stat_history leaf attribute for toggling history estimation per-interface in CONFIG_DB

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
PFC Historical Statistics feature https://github.com/sonic-net/SONiC/issues/1904

##### Work item tracking
https://github.com/sonic-net/sonic-buildimage/issues/21847

#### How I did it

#### How to verify it
- Run the test cases in tests/ and ensure they pass.
- Deploy the changes to a SONiC device and verify the configuration and monitoring functionality using CLI commands.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202411

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Addition of PFC_STAT_HISTORY table and Flex Counter group.
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

