### PR TITLE
[Mellanox][Smartswitch] Fix for DPU force Power On

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -322,6 +322,9 @@ class DpuCtlPlat():
                 return_value = True
             elif forced:
                 return_value = self._power_on_force()
+            elif self.read_force_power_path() == int(OperationType.CLR.value):
+                self.log_info(f"Power on with Force=True since power off force sysfs is cleared")
+                return_value = self._power_on_force()
             else:
                 return_value = self._power_on()
             self.dpu_post_startup()
@@ -336,9 +339,6 @@ class DpuCtlPlat():
                 self.log_info(f"Skipping DPU power off as DPU is already powered off")
                 return True
             elif forced:
-                return self._power_off_force()
-            elif self.read_boot_prog() != BootProgEnum.OS_RUN.value:
-                self.log_info(f"Power off with force = True since since OS is not in running state on DPU")
                 return self._power_off_force()
             return self._power_off()
 
@@ -372,9 +372,6 @@ class DpuCtlPlat():
                 self.dpu_pre_shutdown()
             self.log_info(f"Reboot with force = {forced}")
             if forced:
-                return_value = self._reboot_force(no_wait)
-            elif self.read_boot_prog() != BootProgEnum.OS_RUN.value:
-                self.log_info(f"Reboot with force = True since OS is not in running state on DPU")
                 return_value = self._reboot_force(no_wait)
             else:
                 return_value = self._reboot(no_wait)
@@ -429,6 +426,9 @@ class DpuCtlPlat():
 
     def read_boot_prog(self):
         return utils.read_int_from_file(self.boot_prog_path, raise_exception=True)
+
+    def read_force_power_path(self):
+        return utils.read_int_from_file(self.pwr_f_path, raise_exception=True)
 
     def update_boot_prog_once(self, poll_var):
         """Read boot_progress and update the value once """


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Changes performed:
- Force power on is performed if previously we have performed force power on
- Removed case where DPU undergoes force power off if the boot progress is not at `OS Running` state, same for DPU reboot

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Change in dpuctlplat.py for force power on , force power off and force reset

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

