### PR TITLE
Add link requirement per sku before enabling traffic on a fap

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -863,3 +863,5 @@ dma_desc_aggregator_enable_specific_MDB_FEC.BCM8869X=1
 sai_pfc_dlr_init_capability=0 
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
+appl_param_active_links_thr_high=58
+appl_param_active_links_thr_low=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1017,3 +1017,5 @@ xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=2
 sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
+appl_param_active_links_thr_high=91
+appl_param_active_links_thr_low=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1017,3 +1017,5 @@ xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=2
 sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
+appl_param_active_links_thr_high=91
+appl_param_active_links_thr_low=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1034,3 +1034,5 @@ xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
 sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
+appl_param_active_links_thr_high=91
+appl_param_active_links_thr_low=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1034,3 +1034,5 @@ xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
 sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
+appl_param_active_links_thr_high=91
+appl_param_active_links_thr_low=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1054,3 +1054,5 @@ xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
 sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
+appl_param_active_links_thr_high=91
+appl_param_active_links_thr_low=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1054,3 +1054,5 @@ xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
 sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
+appl_param_active_links_thr_high=91
+appl_param_active_links_thr_low=1

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -353,3 +353,5 @@ flowtracker_ipfix_observation_domain_id
 flowtracker_num_unique_user_entry_keys
 sai_mmu_tc_to_pg_config
 sai_hostif_netif_iff_up_set
+appl_param_active_links_thr_high
+appl_param_active_links_thr_low


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
With the current fap initialization sequence, multiple faps in a modular system could come up with  stand alone mode. This is not a recommended configuration.  It might mess up the global clock and might ends up with traffic issue.  
https://github.com/sonic-net/sonic-buildimage/issues/21866


This change adds a required minimum number of links have to be ready before enabling traffic on a fap, which based on the guidance should be able to guarantee the faps in a modular system can form a proper topology.

We manually tested image on a modular system and the topology after boot up looks correct, and there is no more than 1 fap come up with stand alone mode.  We also tested traffic on our system setup and all looks good so far. 

**This change also need to go to 202405.** 

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

