### PR TITLE
Build fix for ptf-py3 issue on bullseye

### DIFF
--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -535,7 +535,7 @@ RUN apt-get purge -y python3-pip python3-yaml
 
 # For building Python packages
 RUN pip3 install setuptools==49.6.00
-RUN pip3 install setuptools-scm=8.1.0
+RUN pip3 install setuptools-scm==8.1.0
 RUN pip3 install wheel==0.38.1
 
 {%- if CONFIGURED_ARCH == "armhf" %}


### PR DESCRIPTION
The latest version of setuptools-scm i.e. 8.2.0 does not support bdist_wheel. Hence there is a failure in target docker-syncd-rpc.gz due to ptf-py3 build failure. On further investigation found that bookworm installs 8.0.4 version of this package. Hence added this to the current Dockerfile.j2 of sonic-slave-bullseye. This will make it consistent with the earlier build process for ptf-py3 which used 8.1.0 version of setuptools-scm and also the sonic-slave-bookworm
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To fix build failure of ptf-py3 on Bullseye
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Investigated the build failure and found that the recent update i.e. 8.2.0 of setuptools-scm python package does not support bdist_wheel
#### How to verify it
Built ptf-py3 and subsequently docker-syncd-rpc.gz with these changes. After the build sanity testing also has been done,
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405
- [x] 202411

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

