### PR TITLE
[Bgpcfgd]Add correct terminating commands at the end of BGP config command groups

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_advertise_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_advertise_rt.py
@@ -100,6 +100,8 @@ class AdvertiseRouteMgr(Manager):
                 "BGPAdvertiseRouteMgr:: %sbgp %s network %s"
                 % ("Remove " if op == self.OP_DELETE else "Update ", bgp_asn, vrf + "|" + ip_prefix)
             )
+        cmd_list.append(" exit-address-family")
+        cmd_list.append("exit")
 
         self.cfg_mgr.push_list(cmd_list)
         log_debug("BGPAdvertiseRouteMgr::Done")
@@ -112,6 +114,7 @@ class AdvertiseRouteMgr(Manager):
         else:
             cmd_list.append("router bgp %s vrf %s" % (bgp_asn, vrf))
         cmd_list.append(" %sbgp network import-check" % ("" if op == self.OP_DELETE else "no "))
+        cmd_list.append("exit")
 
         self.cfg_mgr.push_list(cmd_list)
 

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
@@ -158,6 +158,8 @@ class BBRMgr(Manager):
                     if peer_group_name.startswith(pg_name) and af in self.bbr_enabled_pgs[pg_name]:
                         cmds.append("  %sneighbor %s allowas-in 1" % (prefix_of_commands, peer_group_name))
                         peer_groups_to_restart.add(peer_group_name)
+            cmds.append(" exit-address-family")
+        cmds.append("exit")
         return cmds, list(peer_groups_to_restart)
 
     def __get_available_peer_groups(self):

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
@@ -65,9 +65,9 @@ class BGPPeerGroupMgr(object):
             return False
 
         if kwargs['vrf'] == 'default':
-            cmd = ('router bgp %s\n' % kwargs['bgp_asn']) + pg + tsa_rm + idf_isolation_rm
+            cmd = ('router bgp %s\n' % kwargs['bgp_asn']) + pg + tsa_rm + idf_isolation_rm + "\nexit"
         else:
-            cmd = ('router bgp %s vrf %s\n' % (kwargs['bgp_asn'], kwargs['vrf'])) + pg + tsa_rm + idf_isolation_rm
+            cmd = ('router bgp %s vrf %s\n' % (kwargs['bgp_asn'], kwargs['vrf'])) + pg + tsa_rm + idf_isolation_rm + "\nexit"
         self.update_entity(cmd, "Peer-group for peer '%s'" % name)
         return True
 
@@ -314,9 +314,9 @@ class BGPPeerMgrBase(Manager):
         bgp_asn = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]["bgp_asn"]
         enable_bgp_suppress_fib_pending_cmd = 'bgp suppress-fib-pending'
         if vrf == 'default':
-            cmd = ('router bgp %s\n %s\n' % (bgp_asn, enable_bgp_suppress_fib_pending_cmd)) + cmd
+            cmd = ('router bgp %s\n %s\n' % (bgp_asn, enable_bgp_suppress_fib_pending_cmd)) + cmd + "\nexit"
         else:
-            cmd = ('router bgp %s vrf %s\n %s\n' % (bgp_asn, vrf, enable_bgp_suppress_fib_pending_cmd)) + cmd
+            cmd = ('router bgp %s vrf %s\n %s\n' % (bgp_asn, vrf, enable_bgp_suppress_fib_pending_cmd)) + cmd + "\nexit"
         self.cfg_mgr.push(cmd)
         return True
 

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
@@ -43,7 +43,7 @@ class StaticRouteMgr(Manager):
         dist_list   = arg_list(data['distance']) if 'distance' in data else None
         nh_vrf_list = arg_list(data['nexthop-vrf']) if 'nexthop-vrf' in data else None
         bfd_enable  = arg_list(data['bfd']) if 'bfd' in data else None
-        route_tag   = self.ROUTE_ADVERTISE_DISABLE_TAG if 'advertise' in data and data['advertise'] == "false" else self.ROUTE_ADVERTISE_ENABLE_TAG 
+        route_tag   = self.ROUTE_ADVERTISE_DISABLE_TAG if 'advertise' in data and data['advertise'] == "false" else self.ROUTE_ADVERTISE_ENABLE_TAG
 
         # bfd enabled route would be handled in staticroutebfd, skip here
         if bfd_enable and bfd_enable[0].lower() == "true":
@@ -231,6 +231,8 @@ class StaticRouteMgr(Manager):
         for af in ["ipv4", "ipv6"]:
             cmd_list.append(" address-family %s" % af)
             cmd_list.append("  redistribute static route-map STATIC_ROUTE_FILTER")
+            cmd_list.append(" exit-address-family")
+        cmd_list.append("exit")
         return cmd_list
 
     def disable_redistribution_command(self, vrf):
@@ -244,6 +246,8 @@ class StaticRouteMgr(Manager):
         for af in ["ipv4", "ipv6"]:
             cmd_list.append(" address-family %s" % af)
             cmd_list.append("  no redistribute static route-map STATIC_ROUTE_FILTER")
+            cmd_list.append(" exit-address-family")
+        cmd_list.append("exit")
         cmd_list.append("no route-map STATIC_ROUTE_FILTER")
         return cmd_list
 

--- a/src/sonic-bgpcfgd/tests/test_advertise_rt.py
+++ b/src/sonic-bgpcfgd/tests/test_advertise_rt.py
@@ -52,10 +52,13 @@ def test_set_del():
         True,
         [
             ["router bgp 65100",
-             " no bgp network import-check"],
+             " no bgp network import-check",
+             "exit"],
             ["router bgp 65100",
              " address-family ipv4 unicast",
-             "  network 10.1.0.0/24"]
+             "  network 10.1.0.0/24",
+             " exit-address-family",
+             "exit"]
         ]
     )
 
@@ -67,7 +70,9 @@ def test_set_del():
         [
             ["router bgp 65100",
              " address-family ipv6 unicast",
-             "  network fc00:10::/64"]
+             "  network fc00:10::/64",
+             " exit-address-family",
+             "exit"]
         ]
     )
 
@@ -79,7 +84,9 @@ def test_set_del():
         [
             ["router bgp 65100",
              " address-family ipv4 unicast",
-             "  no network 10.1.0.0/24"]
+             "  no network 10.1.0.0/24",
+             " exit-address-family",
+             "exit"]
         ]
     )
 
@@ -90,10 +97,13 @@ def test_set_del():
         True,
         [
             ["router bgp 65100",
-             " bgp network import-check"],
+             " bgp network import-check",
+             "exit"],
             ["router bgp 65100",
              " address-family ipv6 unicast",
-             "  no network fc00:10::/64"]
+             "  no network fc00:10::/64",
+             " exit-address-family",
+             "exit"]
         ]
     )
 
@@ -107,10 +117,13 @@ def test_set_del_vrf():
         True,
         [
             ["router bgp 65100 vrf vrfRED",
-             " no bgp network import-check"],
+             " no bgp network import-check",
+             "exit"],
             ["router bgp 65100 vrf vrfRED",
              " address-family ipv4 unicast",
-             "  network 10.2.0.0/24"]
+             "  network 10.2.0.0/24",
+             " exit-address-family",
+             "exit"]
         ]
     )
 
@@ -122,7 +135,9 @@ def test_set_del_vrf():
         [
             ["router bgp 65100 vrf vrfRED",
              " address-family ipv6 unicast",
-             "  network fc00:20::/64"]
+             "  network fc00:20::/64",
+             " exit-address-family",
+             "exit"]
         ]
     )
 
@@ -134,7 +149,9 @@ def test_set_del_vrf():
         [
             ["router bgp 65100 vrf vrfRED",
              " address-family ipv4 unicast",
-             "  no network 10.2.0.0/24"]
+             "  no network 10.2.0.0/24",
+             " exit-address-family",
+             "exit"]
         ]
     )
 
@@ -145,10 +162,13 @@ def test_set_del_vrf():
         True,
         [
             ["router bgp 65100 vrf vrfRED",
-             " bgp network import-check"],
+             " bgp network import-check",
+             "exit"],
             ["router bgp 65100 vrf vrfRED",
              " address-family ipv6 unicast",
-             "  no network fc00:20::/64"]
+             "  no network fc00:20::/64",
+             " exit-address-family",
+             "exit"]
         ]
     )
 
@@ -169,10 +189,13 @@ def test_set_del_bgp_asn_change():
     test_set_del_bgp_asn_change.push_list_called = False
     expected_cmds = [
         ["router bgp 65100 vrf vrfRED",
-         " no bgp network import-check"],
+         " no bgp network import-check",
+         "exit"],
         ["router bgp 65100 vrf vrfRED",
          " address-family ipv4 unicast",
-         "  network 10.3.0.0/24 route-map FROM_SDN_SLB_ROUTES_RM"]
+         "  network 10.3.0.0/24 route-map FROM_SDN_SLB_ROUTES_RM",
+         " exit-address-family",
+         "exit"]
     ]
     def push_list(cmds):
         test_set_del_bgp_asn_change.push_list_called = True
@@ -197,10 +220,13 @@ def test_set_del_with_community():
         True,
         [
             ["router bgp 65100",
-             " no bgp network import-check"],
+             " no bgp network import-check",
+             "exit"],
             ["router bgp 65100",
              " address-family ipv4 unicast",
-             "  network 10.1.0.0/24 route-map FROM_SDN_SLB_ROUTES_RM"]
+             "  network 10.1.0.0/24 route-map FROM_SDN_SLB_ROUTES_RM",
+             " exit-address-family",
+             "exit"]
         ]
     )
 
@@ -214,7 +240,9 @@ def test_set_del_with_community():
         [
             ["router bgp 65100",
              " address-family ipv6 unicast",
-             "  network fc00:10::/64 route-map FROM_SDN_SLB_ROUTES_RM"]
+             "  network fc00:10::/64 route-map FROM_SDN_SLB_ROUTES_RM",
+             " exit-address-family",
+             "exit"]
         ]
     )
 
@@ -226,7 +254,9 @@ def test_set_del_with_community():
         [
             ["router bgp 65100",
              " address-family ipv4 unicast",
-             "  no network 10.1.0.0/24"]
+             "  no network 10.1.0.0/24",
+             " exit-address-family",
+             "exit"]
         ]
     )
 
@@ -237,9 +267,12 @@ def test_set_del_with_community():
         True,
         [
             ["router bgp 65100",
-             " bgp network import-check"],
+             " bgp network import-check",
+             "exit"],
             ["router bgp 65100",
              " address-family ipv6 unicast",
-             "  no network fc00:10::/64"]
+             "  no network fc00:10::/64",
+             " exit-address-family",
+             "exit"]
         ]
     )

--- a/src/sonic-bgpcfgd/tests/test_bbr.py
+++ b/src/sonic-bgpcfgd/tests/test_bbr.py
@@ -309,9 +309,12 @@ def test___set_prepare_config_enabled():
         'router bgp 65500',
         ' address-family ipv4',
         '  neighbor PEER_V4 allowas-in 1',
+        " exit-address-family",
         ' address-family ipv6',
         '  neighbor PEER_V4 allowas-in 1',
         '  neighbor PEER_V6 allowas-in 1',
+        " exit-address-family",
+        "exit"
         ])
 
 def test___set_prepare_config_disabled():
@@ -322,9 +325,12 @@ def test___set_prepare_config_disabled():
         'router bgp 65500',
         ' address-family ipv4',
         '  no neighbor PEER_V4 allowas-in 1',
+        " exit-address-family",
         ' address-family ipv6',
         '  no neighbor PEER_V4 allowas-in 1',
         '  no neighbor PEER_V6 allowas-in 1',
+        " exit-address-family",
+        "exit"
     ])
 
 def test___set_prepare_config_enabled_part():
@@ -336,9 +342,12 @@ def test___set_prepare_config_enabled_part():
         'router bgp 65500',
         ' address-family ipv4',
         '  neighbor PEER_V4 allowas-in 1',
+        " exit-address-family",
         ' address-family ipv6',
         '  neighbor PEER_V4 allowas-in 1',
         '  neighbor PEER_V6 allowas-in 1',
+        " exit-address-family",
+        "exit"
     ])
 
 def test___set_prepare_config_disabled_part():
@@ -350,9 +359,12 @@ def test___set_prepare_config_disabled_part():
         'router bgp 65500',
         ' address-family ipv4',
         '  no neighbor PEER_V4 allowas-in 1',
+        " exit-address-family",
         ' address-family ipv6',
         '  no neighbor PEER_V4 allowas-in 1',
         '  no neighbor PEER_V6 allowas-in 1',
+        " exit-address-family",
+        "exit"
     ])
 def test___set_prepare_config_enabled_multiple_peers():
     __set_prepare_config_common("enabled", {
@@ -365,10 +377,13 @@ def test___set_prepare_config_enabled_multiple_peers():
         '  neighbor PEER_V4 allowas-in 1',
         '  neighbor PEER_V4_DEPLOYMENT_ID_0 allowas-in 1',
         '  neighbor PEER_V4_DEPLOYMENT_ID_1 allowas-in 1',
+        " exit-address-family",
         ' address-family ipv6',
         '  neighbor PEER_V6 allowas-in 1',
         '  neighbor PEER_V6_DEPLOYMENT_ID_0 allowas-in 1',
         '  neighbor PEER_V6_DEPLOYMENT_ID_1 allowas-in 1',
+        " exit-address-family",
+        "exit"
         ],
         {"PEER_V4", "PEER_V4_DEPLOYMENT_ID_0", "PEER_V4_DEPLOYMENT_ID_1", "PEER_V6", "PEER_V6_DEPLOYMENT_ID_0", "PEER_V6_DEPLOYMENT_ID_1"})
 
@@ -383,10 +398,13 @@ def test___set_prepare_config_disabled_multiple_peers():
         '  no neighbor PEER_V4 allowas-in 1',
         '  no neighbor PEER_V4_DEPLOYMENT_ID_0 allowas-in 1',
         '  no neighbor PEER_V4_DEPLOYMENT_ID_1 allowas-in 1',
+        " exit-address-family",
         ' address-family ipv6',
         '  no neighbor PEER_V6 allowas-in 1',
         '  no neighbor PEER_V6_DEPLOYMENT_ID_0 allowas-in 1',
         '  no neighbor PEER_V6_DEPLOYMENT_ID_1 allowas-in 1',
+        " exit-address-family",
+        "exit"
         ],
         {"PEER_V4", "PEER_V4_DEPLOYMENT_ID_0", "PEER_V4_DEPLOYMENT_ID_1", "PEER_V6", "PEER_V6_DEPLOYMENT_ID_0", "PEER_V6_DEPLOYMENT_ID_1"})
 

--- a/src/sonic-bgpcfgd/tests/test_static_rt.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt.py
@@ -426,7 +426,7 @@ def test_set_ipv6():
             "  redistribute static route-map STATIC_ROUTE_FILTER",
             " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
             " exit-address-family",
             "exit"
         ]
@@ -966,6 +966,7 @@ def test_set_del_bgp_asn_change():
         " address-family ipv6",
         "  redistribute static route-map STATIC_ROUTE_FILTER",
         " exit-address-family",
+        "exit"
     ]
     def push_list(cmds):
         set_del_test.push_list_called = True
@@ -1108,7 +1109,7 @@ def test_set_bfd_false():
             " address-family ipv6",
             "  no redistribute static route-map STATIC_ROUTE_FILTER",
             " exit-address-family",
-            "exit"
+            "exit",
             "no route-map STATIC_ROUTE_FILTER"
         ]
     )

--- a/src/sonic-bgpcfgd/tests/test_static_rt.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt.py
@@ -68,8 +68,11 @@ def test_set():
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -79,13 +82,13 @@ def test_del_for_appl(mocked_log_debug):
         def __init__(self, cache=dict()):
             self.cache = cache
             self.CONFIG_DB = "CONFIG_DB"
-    
+
         def get(self, db, key, field):
             if key in self.cache:
                 if field in self.cache[key]["value"]:
                     return self.cache[key]["value"][field]
             return None  # return nil
-    
+
     mgr = constructor()
 
     set_del_test(
@@ -102,8 +105,11 @@ def test_del_for_appl(mocked_log_debug):
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -164,8 +170,11 @@ def test_del_for_appl(mocked_log_debug):
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
     cfg_db_cache = {
@@ -189,8 +198,11 @@ def test_del_for_appl(mocked_log_debug):
             "router bgp 65100",
             " address-family ipv4",
             "  no redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
             "  no redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit",
             "no route-map STATIC_ROUTE_FILTER"
         ]
     )
@@ -210,8 +222,11 @@ def test_del_for_appl(mocked_log_debug):
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -228,8 +243,11 @@ def test_del_for_appl(mocked_log_debug):
             "router bgp 65100",
             " address-family ipv4",
             "  no redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
             "  no redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit",
             "no route-map STATIC_ROUTE_FILTER"
         ]
     )
@@ -250,8 +268,11 @@ def test_set_nhportchannel():
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -265,8 +286,11 @@ def test_set_nhportchannel():
             "router bgp 65100",
             " address-family ipv4",
             "  no redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
             "  no redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit",
             "no route-map STATIC_ROUTE_FILTER"
         ]
     )
@@ -288,8 +312,11 @@ def test_set_several_nhportchannels():
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -313,8 +340,11 @@ def test_set_nhvrf():
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -338,8 +368,11 @@ def test_set_blackhole():
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -363,8 +396,11 @@ def test_set_vrf():
             "router bgp 65100 vrf vrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -388,8 +424,11 @@ def test_set_ipv6():
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
             "  redistribute static route-map STATIC_ROUTE_FILTER"
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -414,8 +453,11 @@ def test_set_nh_only():
             "router bgp 65100 vrf vrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -440,8 +482,11 @@ def test_set_ifname_only():
             "router bgp 65100 vrf vrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -467,8 +512,11 @@ def test_set_with_empty_ifname():
             "router bgp 65100 vrf vrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -494,8 +542,11 @@ def test_set_with_empty_nh():
             "router bgp 65100 vrf vrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -521,8 +572,11 @@ def test_set_del():
             "router bgp 65100 vrf vrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
     set_del_test(
@@ -537,8 +591,11 @@ def test_set_del():
             "router bgp 65100 vrf vrfRED",
             " address-family ipv4",
             "  no redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
             "  no redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit",
             "no route-map STATIC_ROUTE_FILTER"
         ]
     )
@@ -562,8 +619,11 @@ def test_set_del():
             "router bgp 65100 vrf vrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -589,8 +649,11 @@ def test_set_same_route():
             "router bgp 65100 vrf vrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
     set_del_test(
@@ -636,8 +699,11 @@ def test_set_add_del_nh():
             "router bgp 65100 vrf vrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
     set_del_test(
@@ -694,8 +760,11 @@ def test_set_add_del_nh_ethernet():
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
     set_del_test(
@@ -749,8 +818,11 @@ def test_set_no_action(mocked_log_debug):
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -810,8 +882,11 @@ def test_set_invalid_blackhole(mocked_log_err):
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
     mocked_log_err.assert_called_with("Mandatory attribute not found for nexthop")
@@ -887,8 +962,10 @@ def test_set_del_bgp_asn_change():
         "router bgp 65100 vrf vrfRED",
         " address-family ipv4",
         "  redistribute static route-map STATIC_ROUTE_FILTER",
+        " exit-address-family",
         " address-family ipv6",
-        "  redistribute static route-map STATIC_ROUTE_FILTER"
+        "  redistribute static route-map STATIC_ROUTE_FILTER",
+        " exit-address-family",
     ]
     def push_list(cmds):
         set_del_test.push_list_called = True
@@ -923,8 +1000,11 @@ def test_set_tag_enable():
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -944,8 +1024,11 @@ def test_set_tag_disable():
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -965,8 +1048,11 @@ def test_set_tag_change():
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -1000,8 +1086,11 @@ def test_set_bfd_false():
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 
@@ -1015,8 +1104,11 @@ def test_set_bfd_false():
             "router bgp 65100",
             " address-family ipv4",
             "  no redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
             "  no redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
             "no route-map STATIC_ROUTE_FILTER"
         ]
     )
@@ -1038,8 +1130,11 @@ def test_set_bfd_true():
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
     #do nothing for adding smae route second time
@@ -1083,8 +1178,11 @@ def test_set_bfd_true():
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
             " address-family ipv6",
-            "  redistribute static route-map STATIC_ROUTE_FILTER"
+            "  redistribute static route-map STATIC_ROUTE_FILTER",
+            " exit-address-family",
+            "exit"
         ]
     )
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Previously, Bgpcfgd generated groups of BGP configuration commands that did not have proper terminating commands. As a consequence, non-BGP configuration commands following the BGP configuration command may be rejected by the FRR because of FRR's context was not properly switched. You check the details in Issue #21829.

Fix #21829 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Add exit and exit-address-family command at the end of BGP configuration command groups.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

