### PR TITLE
Add ACL yang changes for INNER SRC MAC REWRITE 

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -345,14 +345,8 @@
             "SRC-MAC-REWRITE-TABLE|RULE0": {
                 "PRIORITY": "999960",
                 "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",                     
-                "INNER_SRC_IP": "10.176.0.0/15",
+                "INNER_SRC_IP": "1.1.1.1/32",
                 "VNI": "45"
-            },
-            "SRC-MAC-REWRITE-TABLE|RULE1": {
-                "PRIORITY": "999970",
-                "INNER_SRC_MAC_REWRITE_ACTION": "60:46:BD:08:19:68",                     
-                "INNER_SRC_IP": "10.177.0.0/15",
-                "VNI": "48"
             }
         },
         "SWITCH_HASH": {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -341,6 +341,18 @@
                 "PACKET_ACTION": "FORWARD",
                 "TUNNEL_TERM": "true",
                 "DST_IP": "1.1.1.1/32"
+            },
+            "SRC-MAC-REWRITE-TABLE|RULE0": {
+                "PRIORITY": "999960",
+                "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",                     
+                "INNER_SRC_IP": "10.176.0.0/15",
+                "VNI": "45"
+            },
+            "SRC-MAC-REWRITE-TABLE|RULE1": {
+                "PRIORITY": "999970",
+                "INNER_SRC_MAC_REWRITE_ACTION": "60:46:BD:08:19:68",                     
+                "INNER_SRC_IP": "10.177.0.0/15",
+                "VNI": "48"
             }
         },
         "SWITCH_HASH": {
@@ -1104,9 +1116,42 @@
                     "Ethernet0",
                     "PortChannel0003"
                 ]
+            },
+            "SRC-MAC-REWRITE-TABLE": {
+                "ports": [
+                    "Ethernet14",
+                    "Ethernet15",
+                    "Ethernet23",
+                    "Ethernet30",
+                    "Ethernet31",
+                    "Ethernet18",
+                    "Ethernet19",
+                    "Ethernet25",
+                    "Ethernet24",
+                    "PortChannel0003"
+                ],
+                "stage": "EGRESS",
+                "type": "INNER_SRC_MAC_REWRITE_TABLE_TYPE"
             }
-
         },
+        "ACL_TABLE_TYPE": {
+            "ACL_TABLE_TYPE_LIST": [
+                {
+                    "ACL_TABLE_TYPE_NAME": "INNER_SRC_MAC_REWRITE_TABLE_TYPE",
+                    "ACTIONS": [
+                        "INNER_SRC_MAC_REWRITE_ACTION"
+                    ],
+                    "MATCHES": [
+                        "INNER_SRC_IP",
+                        "VNI"
+                    ],
+                    "BIND_POINTS": [
+                        "PORT",
+                        "PORTCHANNEL"
+                    ]
+                }
+            ]
+        }, 
         "PBH_HASH_FIELD": {
             "inner_ip_proto": {
                 "hash_field": "INNER_IP_PROTOCOL",

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1133,24 +1133,6 @@
                 "stage": "EGRESS",
                 "type": "INNER_SRC_MAC_REWRITE_TABLE_TYPE"
             }
-        },
-        "ACL_TABLE_TYPE": {
-            "ACL_TABLE_TYPE_LIST": [
-                {
-                    "ACL_TABLE_TYPE_NAME": "INNER_SRC_MAC_REWRITE_TABLE_TYPE",
-                    "ACTIONS": [
-                        "INNER_SRC_MAC_REWRITE_ACTION"
-                    ],
-                    "MATCHES": [
-                        "INNER_SRC_IP",
-                        "VNI"
-                    ],
-                    "BIND_POINTS": [
-                        "PORT",
-                        "PORTCHANNEL"
-                    ]
-                }
-            ]
         }, 
         "PBH_HASH_FIELD": {
             "inner_ip_proto": {
@@ -2652,7 +2634,20 @@
                      "PORT",
                      "PORTCHANNEL"
                  ]
-             }
+             },
+             "INNER_SRC_MAC_REWRITE_TABLE_TYPE": {
+                "ACTIONS": [
+                    "INNER_SRC_MAC_REWRITE_ACTION"
+                ],
+                "MATCHES": [
+                    "INNER_SRC_IP",
+                    "VNI"
+                ],
+                "BIND_POINTS": [
+                    "PORT",
+                    "PORTCHANNEL"
+                ]
+            }
         },
 
         "SNMP": {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -343,8 +343,8 @@
                 "DST_IP": "1.1.1.1/32"
             },
             "SRC-MAC-REWRITE-TABLE|RULE0": {
-                "PRIORITY": "999960",
-                "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",                     
+                "PRIORITY": "960",
+                "INNER_SRC_MAC_REWRITE_ACTION": "22:33:44:55:66:11",                     
                 "INNER_SRC_IP": "1.1.1.1/32",
                 "VNI": "45"
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -182,18 +182,8 @@
     "ACL_RULE_WITH_TUNNEL_TERMINATION": {
         "desc": "ACL Rule with Tunnel Termination"
     },
-    "ACL_TABLE_INNERSRCMACREWRITE_TABLE_TYPE": {
-        "desc": "ACL_TABLE Validate type INNERSRCMACREWRITE"
-    },
-    "ACL_INNERSRCMACREWRITE_NO_ACTION": {
-        "desc": "Configure INNERSRCMACREWRITE ACL TABLE with no action type",
-        "eStrKey" : "Must",
-        "eStr": ["INNERSRCMACREWRITE", "INNER_SRC_MAC_REWRITE_ACTION"]
-    },
-    "ACL_INNERSRCMACREWRITE_REQUIRES_INNER_SRC_MAC_REWRITE_ACTION": {
-        "desc": "Configure INNERSRCMACREWRITE ACL TABLE with wrong action type",
-        "eStrKey" : "Must",
-        "eStr": ["INNERSRCMACREWRITE", "INNER_SRC_MAC_REWRITE_ACTION"]
+    "ACL_TABLE_INNERSRCMACREWRITE_TABLE": {
+        "desc": "ACL_TABLE Validate type INNERSRCMACREWRITE."
     },
     "ACL_INNERSRCMACREWRITE_INVALID_INNER_SRC_MAC_REWRITE_ACTION": {
         "desc": "Configure INNERSRCMACREWRITE ACL TABLE with invalid rewrite action",
@@ -208,21 +198,12 @@
         "eStrKey": "Pattern"
     },
     "ACL_INNERSRCMACREWRITE_NO_VNI": {
-        "desc": "Configure INNERSRCMACREWRITE ACL with no VNI ID",
-        "eStrKey": "Must",
-        "eStr": ["INNERSRCMACREWRITE", "VNI_ID"]
+        "desc": "Configure INNERSRCMACREWRITE ACL with no VNI ID"
     },
     "ACL_RULE_WITH_VNI":{
         "desc": "Configure a ACL rule with VNI ID"
     },
-    "ACL_INNERSRCMACREWRITE_NO_SRCIP": {
-        "desc": "Configure INNERSRCMACREWRITE ACL with no src IP",
-        "eStrKey": "Must",
-        "eStr": ["INNERSRCMACREWRITE", "SRC_IP"]
-    },
-    "ACL_INNERSRCMACREWRITE_STAGE_INGRESS": {
-        "desc": "Configure INNERSRCMACREWRITE ACL with stage as INGRESS",
-        "eStrKey": "Must",
-        "eStr": ["INNERSRCMACREWRITE", "EGRESS"]
+    "ACL_INNERSRCMACREWRITE_NO_INNERSRCIP": {
+        "desc": "Configure INNERSRCMACREWRITE ACL with no inner src IP"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -183,6 +183,46 @@
         "desc": "ACL Rule with Tunnel Termination"
     },
     "ACL_TABLE_INNERSRCMACREWRITE_TABLE_TYPE": {
-        "desc": "ACL_TABLE Validate type INNERSRCMACREWRITE."
+        "desc": "ACL_TABLE Validate type INNERSRCMACREWRITE"
+    },
+    "ACL_INNERSRCMACREWRITE_NO_ACTION": {
+        "desc": "Configure INNERSRCMACREWRITE ACL TABLE with no action type",
+        "eStrKey" : "Must",
+        "eStr": ["INNERSRCMACREWRITE", "INNER_SRC_MAC_REWRITE_ACTION"]
+    },
+    "ACL_INNERSRCMACREWRITE_REQUIRES_INNER_SRC_MAC_REWRITE_ACTION": {
+        "desc": "Configure INNERSRCMACREWRITE ACL TABLE with wrong action type",
+        "eStrKey" : "Must",
+        "eStr": ["INNERSRCMACREWRITE", "INNER_SRC_MAC_REWRITE_ACTION"]
+    },
+    "ACL_INNERSRCMACREWRITE_INVALID_INNER_SRC_MAC_REWRITE_ACTION": {
+        "desc": "Configure INNERSRCMACREWRITE ACL TABLE with invalid rewrite action",
+        "eStrKey" : "Pattern"
+    },
+    "ACL_INNER_SRC_MAC_REWRITE_ACTION_INVALID_MAC": {
+        "desc": "Configure INNERSRCMACREWRITE ACL TABLE with invalid MAC address format",
+        "eStrKey": "Pattern"
+    },
+    "ACL_INNERSRCMACREWRITE_INVALID_VNI": {
+        "desc": "Configure INNERSRCMACREWRITE ACL with invalid VNI ID",
+        "eStrKey": "Pattern"
+    },
+    "ACL_INNERSRCMACREWRITE_NO_VNI": {
+        "desc": "Configure INNERSRCMACREWRITE ACL with no VNI ID",
+        "eStrKey": "Must",
+        "eStr": ["INNERSRCMACREWRITE", "VNI_ID"]
+    },
+    "ACL_RULE_WITH_VNI":{
+        "desc": "Configure a ACL rule with VNI ID"
+    },
+    "ACL_INNERSRCMACREWRITE_NO_SRCIP": {
+        "desc": "Configure INNERSRCMACREWRITE ACL with no src IP",
+        "eStrKey": "Must",
+        "eStr": ["INNERSRCMACREWRITE", "SRC_IP"]
+    },
+    "ACL_INNERSRCMACREWRITE_STAGE_INGRESS": {
+        "desc": "Configure INNERSRCMACREWRITE ACL with stage as INGRESS",
+        "eStrKey": "Must",
+        "eStr": ["INNERSRCMACREWRITE", "EGRESS"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -197,9 +197,6 @@
         "desc": "Configure INNERSRCMACREWRITE ACL with invalid VNI ID",
         "eStrKey": "Pattern"
     },
-    "ACL_INNERSRCMACREWRITE_NO_VNI": {
-        "desc": "Configure INNERSRCMACREWRITE ACL with no VNI ID"
-    },
     "ACL_RULE_WITH_VNI":{
         "desc": "Configure a ACL rule with VNI ID"
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -181,5 +181,8 @@
     },
     "ACL_RULE_WITH_TUNNEL_TERMINATION": {
         "desc": "ACL Rule with Tunnel Termination"
+    },
+    "ACL_TABLE_INNERSRCMACREWRITE_TABLE_TYPE": {
+        "desc": "ACL_TABLE Validate type INNERSRCMACREWRITE."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -1763,10 +1763,10 @@
                     },
                     {
                         "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE",
-                        "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
                         "PRIORITY": 999960,
                         "RULE_NAME": "Rule_9",
                         "INNER_SRC_IP": "10.166.0.0/15",
+                        "INNER_SRC_MAC_REWRITE_ACTION": "60:46:BD:08:19:68",
                         "VNI": 47
                     }
                 ]
@@ -1781,14 +1781,14 @@
                             "Ethernet1"
                         ],
                         "stage": "EGRESS",
-                        "type": "L2"
+                        "type": "INNER_SRC_MAC_REWRITE_TABLE_TYPE"
                     }
                 ]
             },
             "sonic-acl:ACL_TABLE_TYPE": {
                 "ACL_TABLE_TYPE_LIST": [
                     {
-                        "ACL_TABLE_TYPE_NAME": "L2",
+                        "ACL_TABLE_TYPE_NAME": "INNER_SRC_MAC_REWRITE_TABLE_TYPE",
                         "ACTIONS": [
                             "INNER_SRC_MAC_REWRITE_ACTION"
                         ],
@@ -1853,7 +1853,25 @@
                             "Ethernet1"
                         ],
                         "stage": "EGRESS",
-                        "type": "L2"
+                        "type": "INNER_SRC_MAC_REWRITE_TABLE_TYPE"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE_TYPE": {
+                "ACL_TABLE_TYPE_LIST": [
+                    {
+                        "ACL_TABLE_TYPE_NAME": "INNER_SRC_MAC_REWRITE_TABLE_TYPE",
+                        "ACTIONS": [
+                            "INNER_SRC_MAC_REWRITE_ACTION"
+                        ],
+                        "MATCHES": [
+                            "INNER_SRC_IP",
+                            "VNI"
+                        ],
+                        "BIND_POINTS": [
+                            "PORT",
+                            "PORTCHANNEL"
+                        ]
                     }
                 ]
             }
@@ -1907,7 +1925,25 @@
                             "Ethernet1"
                         ],
                         "stage": "EGRESS",
-                        "type": "L2"
+                        "type": "INNER_SRC_MAC_REWRITE_TABLE_TYPE"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE_TYPE": {
+                "ACL_TABLE_TYPE_LIST": [
+                    {
+                        "ACL_TABLE_TYPE_NAME": "INNER_SRC_MAC_REWRITE_TABLE_TYPE",
+                        "ACTIONS": [
+                            "INNER_SRC_MAC_REWRITE_ACTION"
+                        ],
+                        "MATCHES": [
+                            "INNER_SRC_IP",
+                            "VNI"
+                        ],
+                        "BIND_POINTS": [
+                            "PORT",
+                            "PORTCHANNEL"
+                        ]
                     }
                 ]
             }
@@ -1961,7 +1997,25 @@
                             "Ethernet1"
                         ],
                         "stage": "EGRESS",
-                        "type": "L2"
+                        "type": "INNER_SRC_MAC_REWRITE_TABLE_TYPE"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE_TYPE": {
+                "ACL_TABLE_TYPE_LIST": [
+                    {
+                        "ACL_TABLE_TYPE_NAME": "INNER_SRC_MAC_REWRITE_TABLE_TYPE",
+                        "ACTIONS": [
+                            "INNER_SRC_MAC_REWRITE_ACTION"
+                        ],
+                        "MATCHES": [
+                            "INNER_SRC_IP",
+                            "VNI"
+                        ],
+                        "BIND_POINTS": [
+                            "PORT",
+                            "PORTCHANNEL"
+                        ]
                     }
                 ]
             }
@@ -2055,7 +2109,7 @@
                         "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
                         "PRIORITY": 999960,
                         "RULE_NAME": "Rule_16",
-                        "VNI": "16777213"
+                        "VNI": 16777213
                     }
                 ]
             },
@@ -2069,10 +2123,29 @@
                             "Ethernet1"
                         ],
                         "stage": "EGRESS",
-                        "type": "L2"
+                        "type": "INNER_SRC_MAC_REWRITE_TABLE_TYPE"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE_TYPE": {
+                "ACL_TABLE_TYPE_LIST": [
+                    {
+                        "ACL_TABLE_TYPE_NAME": "INNER_SRC_MAC_REWRITE_TABLE_TYPE",
+                        "ACTIONS": [
+                            "INNER_SRC_MAC_REWRITE_ACTION"
+                        ],
+                        "MATCHES": [
+                            "INNER_SRC_IP",
+                            "VNI"
+                        ],
+                        "BIND_POINTS": [
+                            "PORT",
+                            "PORTCHANNEL"
+                        ]
                     }
                 ]
             }
+            
         },
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -1749,7 +1749,7 @@
             }
         }
     },
-    "ACL_TABLE_INNERSRCMACREWRITE_TABLE_TYPE": {
+    "ACL_TABLE_INNERSRCMACREWRITE_TABLE": {
         "sonic-acl:sonic-acl": {
             "sonic-acl:ACL_RULE": {
                 "ACL_RULE_LIST": [
@@ -1758,16 +1758,16 @@
                         "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
                         "PRIORITY": 999960,
                         "RULE_NAME": "Rule_10",
-                        "SRC_IP": "10.176.0.0/15",
-                        "VNI_ID": 45
+                        "INNER_SRC_IP": "10.176.0.0/15",
+                        "VNI": 45
                     },
                     {
                         "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE",
                         "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
                         "PRIORITY": 999960,
                         "RULE_NAME": "Rule_9",
-                        "SRC_IP": "10.166.0.0/15",
-                        "VNI_ID": 47
+                        "INNER_SRC_IP": "10.166.0.0/15",
+                        "VNI": 47
                     }
                 ]
             },
@@ -1781,132 +1781,25 @@
                             "Ethernet1"
                         ],
                         "stage": "EGRESS",
-                        "type": "INNERSRCMACREWRITE"
+                        "type": "L2"
                     }
                 ]
             },
             "sonic-acl:ACL_TABLE_TYPE": {
                 "ACL_TABLE_TYPE_LIST": [
                     {
-                        "ACL_TABLE_TYPE_NAME": "INNERSRCMACREWRITE",
+                        "ACL_TABLE_TYPE_NAME": "L2",
                         "ACTIONS": [
                             "INNER_SRC_MAC_REWRITE_ACTION"
                         ],
                         "MATCHES": [
-                            "SRC_IP",
-                            "VNI_ID"
+                            "INNER_SRC_IP",
+                            "VNI"
                         ],
                         "BIND_POINTS": [
                             "PORT",
                             "PORTCHANNEL"
                         ]
-                    }
-                ]
-            }
-        },
-        "sonic-port:sonic-port": {
-            "sonic-port:PORT": {
-                "PORT_LIST": [
-                    {
-                        "admin_status": "up",
-                        "alias": "eth0",
-                        "description": "Ethernet0",
-                        "mtu": 9000,
-                        "lanes": "0,1,2,3",
-                        "name": "Ethernet0",
-                        "speed": 25000
-                    },
-                    {
-                        "admin_status": "up",
-                        "alias": "eth1",
-                        "description": "Ethernet1",
-                        "mtu": 9000,
-                        "lanes": "10,11,12,13",
-                        "name": "Ethernet1",
-                        "speed": 25000
-                    }
-                ]
-            }
-        }
-    },
-    "ACL_INNERSRCMACREWRITE_NO_ACTION": {
-        "sonic-acl:sonic-acl": {
-            "sonic-acl:ACL_RULE": {
-                "ACL_RULE_LIST": [
-                    {
-                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-NO-ACTION",
-                        "PRIORITY": 999961,
-                        "RULE_NAME": "Rule_11",
-                        "SRC_IP": "10.176.0.0/15",
-                        "VNI_ID": 45
-                    }
-                ]
-            },
-            "sonic-acl:ACL_TABLE": {
-                "ACL_TABLE_LIST": [
-                    {
-                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-NO-ACTION",
-                        "policy_desc":"No action type",
-                        "ports": [
-                            "Ethernet0",
-                            "Ethernet1"
-                        ],
-                        "stage": "EGRESS",
-                        "type": "INNERSRCMACREWRITE"
-                    }
-                ]
-            }
-        },
-        "sonic-port:sonic-port": {
-            "sonic-port:PORT": {
-                "PORT_LIST": [
-                    {
-                        "admin_status": "up",
-                        "alias": "eth0",
-                        "description": "Ethernet0",
-                        "mtu": 9000,
-                        "lanes": "0,1,2,3",
-                        "name": "Ethernet0",
-                        "speed": 25000
-                    },
-                    {
-                        "admin_status": "up",
-                        "alias": "eth1",
-                        "description": "Ethernet1",
-                        "mtu": 9000,
-                        "lanes": "10,11,12,13",
-                        "name": "Ethernet1",
-                        "speed": 25000
-                    }
-                ]
-            }
-        }
-    },
-    "ACL_INNERSRCMACREWRITE_REQUIRES_INNER_SRC_MAC_REWRITE_ACTION": {
-        "sonic-acl:sonic-acl": {
-            "sonic-acl:ACL_RULE": {
-                "ACL_RULE_LIST": [
-                    {
-                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-WRONG-ACTION",
-                        "PACKET_ACTION": "DROP",
-                        "PRIORITY": 999962,
-                        "RULE_NAME": "Rule_12",
-                        "SRC_IP": "10.176.0.0/15",
-                        "VNI_ID": 45
-                    }
-                ]
-            },
-            "sonic-acl:ACL_TABLE": {
-                "ACL_TABLE_LIST": [
-                    {
-                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-WRONG-ACTION",
-                        "policy_desc":"Replace src MAC with ENI MAC",
-                        "ports": [
-                            "Ethernet0",
-                            "Ethernet1"
-                        ],
-                        "stage": "EGRESS",
-                        "type": "INNERSRCMACREWRITE"
                     }
                 ]
             }
@@ -1945,8 +1838,8 @@
                         "INNER_SRC_MAC_REWRITE_ACTION": "",
                         "PRIORITY": 999963,
                         "RULE_NAME": "Rule_13",
-                        "SRC_IP": "10.176.0.0/15",
-                        "VNI_ID": "45"
+                        "INNER_SRC_IP": "10.176.0.0/15",
+                        "VNI": "45"
                     }
                 ]
             },
@@ -1960,7 +1853,7 @@
                             "Ethernet1"
                         ],
                         "stage": "EGRESS",
-                        "type": "INNERSRCMACREWRITE"
+                        "type": "L2"
                     }
                 ]
             }
@@ -1999,8 +1892,8 @@
                         "INNER_SRC_MAC_REWRITE_ACTION": "60.45.BD.08:19:68",
                         "PRIORITY": 999964,
                         "RULE_NAME": "Rule_14",
-                        "SRC_IP": "10.176.0.0/15",
-                        "VNI_ID": 45
+                        "INNER_SRC_IP": "10.176.0.0/15",
+                        "VNI": 45
                     }
                 ]
             },
@@ -2014,7 +1907,7 @@
                             "Ethernet1"
                         ],
                         "stage": "EGRESS",
-                        "type": "INNERSRCMACREWRITE"
+                        "type": "L2"
                     }
                 ]
             }
@@ -2053,8 +1946,8 @@
                         "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
                         "PRIORITY": 999960,
                         "RULE_NAME": "Rule_15",
-                        "SRC_IP": "10.176.0.0/15",
-                        "VNI_ID": 16777216
+                        "INNER_SRC_IP": "10.176.0.0/15",
+                        "VNI": 16777216
                     }
                 ]
             },
@@ -2068,7 +1961,7 @@
                             "Ethernet1"
                         ],
                         "stage": "EGRESS",
-                        "type": "INNERSRCMACREWRITE"
+                        "type": "L2"
                     }
                 ]
             }
@@ -2098,35 +1991,6 @@
             }
         }
     },
-    "ACL_INNERSRCMACREWRITE_NO_VNI": {
-        "sonic-acl:sonic-acl": {
-            "sonic-acl:ACL_RULE": {
-                "ACL_RULE_LIST": [
-                    {
-                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-NO-VNI",
-                        "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
-                        "PRIORITY": 999960,
-                        "RULE_NAME": "Rule_16",
-                        "SRC_IP": "10.176.0.0/15"
-                    }
-                ]
-            },
-            "sonic-acl:ACL_TABLE": {
-                "ACL_TABLE_LIST": [
-                    {
-                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-NO-VNI",
-                        "policy_desc":"Replace src MAC with ENI MAC",
-                        "ports": [
-                            "Ethernet0",
-                            "Ethernet1"
-                        ],
-                        "stage": "EGRESS",
-                        "type": "INNERSRCMACREWRITE"
-                    }
-                ]
-            }
-        }
-    },
     "ACL_RULE_WITH_VNI": {
         "sonic-acl:sonic-acl": {
             "sonic-acl:ACL_RULE": {
@@ -2136,9 +2000,9 @@
                         "DST_IP": "10.186.72.0/26",
                         "IP_TYPE": "IPv4ANY",
                         "RULE_NAME": "Rule_20",
-                        "SRC_IP": "10.176.0.0/15",
+                        "INNER_SRC_IP": "10.176.0.0/15",
                         "PRIORITY": 1222,
-                        "VNI_ID": 16777213,
+                        "VNI": 16777213,
                         "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68"
                     }
                 ]
@@ -2182,7 +2046,7 @@
             }
         }
     },
-    "ACL_INNERSRCMACREWRITE_NO_SRCIP": {
+    "ACL_INNERSRCMACREWRITE_NO_INNERSRCIP": {
         "sonic-acl:sonic-acl": {
             "sonic-acl:ACL_RULE": {
                 "ACL_RULE_LIST": [
@@ -2191,7 +2055,7 @@
                         "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
                         "PRIORITY": 999960,
                         "RULE_NAME": "Rule_16",
-                        "VNI_ID": "16777213"
+                        "VNI": "16777213"
                     }
                 ]
             },
@@ -2205,79 +2069,7 @@
                             "Ethernet1"
                         ],
                         "stage": "EGRESS",
-                        "type": "INNERSRCMACREWRITE"
-                    }
-                ]
-            }
-        },
-        "sonic-port:sonic-port": {
-            "sonic-port:PORT": {
-                "PORT_LIST": [
-                    {
-                        "admin_status": "up",
-                        "alias": "eth0",
-                        "description": "Ethernet0",
-                        "mtu": 9000,
-                        "lanes": "0,1,2,3",
-                        "name": "Ethernet0",
-                        "speed": 25000
-                    },
-                    {
-                        "admin_status": "up",
-                        "alias": "eth1",
-                        "description": "Ethernet1",
-                        "mtu": 9000,
-                        "lanes": "10,11,12,13",
-                        "name": "Ethernet1",
-                        "speed": 25000
-                    }
-                ]
-            }
-        }
-    },
-    "ACL_INNERSRCMACREWRITE_STAGE_INGRESS": {
-        "sonic-acl:sonic-acl": {
-            "sonic-acl:ACL_RULE": {
-                "ACL_RULE_LIST": [
-                    {
-                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-STAGE-INGRESS",
-                        "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
-                        "PRIORITY": 999960,
-                        "RULE_NAME": "Rule_10",
-                        "SRC_IP": "10.176.0.0/15",
-                        "VNI_ID": 45
-                    }
-                ]
-            },
-            "sonic-acl:ACL_TABLE": {
-                "ACL_TABLE_LIST": [
-                    {
-                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-STAGE-INGRESS",
-                        "policy_desc":"Replace src MAC with ENI MAC",
-                        "ports": [
-                            "Ethernet0",
-                            "Ethernet1"
-                        ],
-                        "stage": "INGRESS",
-                        "type": "INNERSRCMACREWRITE"
-                    }
-                ]
-            },
-            "sonic-acl:ACL_TABLE_TYPE": {
-                "ACL_TABLE_TYPE_LIST": [
-                    {
-                        "ACL_TABLE_TYPE_NAME": "INNERSRCMACREWRITE",
-                        "ACTIONS": [
-                            "INNER_SRC_MAC_REWRITE_ACTION"
-                        ],
-                        "MATCHES": [
-                            "SRC_IP",
-                            "VNI_ID"
-                        ],
-                        "BIND_POINTS": [
-                            "PORT",
-                            "PORTCHANNEL"
-                        ]
+                        "type": "L2"
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -1748,5 +1748,563 @@
                 ]
             }
         }
+    },
+    "ACL_TABLE_INNERSRCMACREWRITE_TABLE_TYPE": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE",
+                        "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
+                        "PRIORITY": 999960,
+                        "RULE_NAME": "Rule_10",
+                        "SRC_IP": "10.176.0.0/15",
+                        "VNI_ID": 45
+                    },
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE",
+                        "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
+                        "PRIORITY": 999960,
+                        "RULE_NAME": "Rule_9",
+                        "SRC_IP": "10.166.0.0/15",
+                        "VNI_ID": 47
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE",
+                        "policy_desc":"Replace src MAC with ENI MAC",
+                        "ports": [
+                            "Ethernet0",
+                            "Ethernet1"
+                        ],
+                        "stage": "EGRESS",
+                        "type": "INNERSRCMACREWRITE"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE_TYPE": {
+                "ACL_TABLE_TYPE_LIST": [
+                    {
+                        "ACL_TABLE_TYPE_NAME": "INNERSRCMACREWRITE",
+                        "ACTIONS": [
+                            "INNER_SRC_MAC_REWRITE_ACTION"
+                        ],
+                        "MATCHES": [
+                            "SRC_IP",
+                            "VNI_ID"
+                        ],
+                        "BIND_POINTS": [
+                            "PORT",
+                            "PORTCHANNEL"
+                        ]
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "0,1,2,3",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    },
+                    {
+                        "admin_status": "up",
+                        "alias": "eth1",
+                        "description": "Ethernet1",
+                        "mtu": 9000,
+                        "lanes": "10,11,12,13",
+                        "name": "Ethernet1",
+                        "speed": 25000
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_INNERSRCMACREWRITE_NO_ACTION": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-NO-ACTION",
+                        "PRIORITY": 999961,
+                        "RULE_NAME": "Rule_11",
+                        "SRC_IP": "10.176.0.0/15",
+                        "VNI_ID": 45
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-NO-ACTION",
+                        "policy_desc":"No action type",
+                        "ports": [
+                            "Ethernet0",
+                            "Ethernet1"
+                        ],
+                        "stage": "EGRESS",
+                        "type": "INNERSRCMACREWRITE"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "0,1,2,3",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    },
+                    {
+                        "admin_status": "up",
+                        "alias": "eth1",
+                        "description": "Ethernet1",
+                        "mtu": 9000,
+                        "lanes": "10,11,12,13",
+                        "name": "Ethernet1",
+                        "speed": 25000
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_INNERSRCMACREWRITE_REQUIRES_INNER_SRC_MAC_REWRITE_ACTION": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-WRONG-ACTION",
+                        "PACKET_ACTION": "DROP",
+                        "PRIORITY": 999962,
+                        "RULE_NAME": "Rule_12",
+                        "SRC_IP": "10.176.0.0/15",
+                        "VNI_ID": 45
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-WRONG-ACTION",
+                        "policy_desc":"Replace src MAC with ENI MAC",
+                        "ports": [
+                            "Ethernet0",
+                            "Ethernet1"
+                        ],
+                        "stage": "EGRESS",
+                        "type": "INNERSRCMACREWRITE"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "0,1,2,3",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    },
+                    {
+                        "admin_status": "up",
+                        "alias": "eth1",
+                        "description": "Ethernet1",
+                        "mtu": 9000,
+                        "lanes": "10,11,12,13",
+                        "name": "Ethernet1",
+                        "speed": 25000
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_INNERSRCMACREWRITE_INVALID_INNER_SRC_MAC_REWRITE_ACTION": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-INVALID-REWRITE-ACTION",
+                        "INNER_SRC_MAC_REWRITE_ACTION": "",
+                        "PRIORITY": 999963,
+                        "RULE_NAME": "Rule_13",
+                        "SRC_IP": "10.176.0.0/15",
+                        "VNI_ID": "45"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-INVALID-REWRITE-ACTION",
+                        "policy_desc":"Replace src MAC with ENI MAC",
+                        "ports": [
+                            "Ethernet0",
+                            "Ethernet1"
+                        ],
+                        "stage": "EGRESS",
+                        "type": "INNERSRCMACREWRITE"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "0,1,2,3",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    },
+                    {
+                        "admin_status": "up",
+                        "alias": "eth1",
+                        "description": "Ethernet1",
+                        "mtu": 9000,
+                        "lanes": "10,11,12,13",
+                        "name": "Ethernet1",
+                        "speed": 25000
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_INNER_SRC_MAC_REWRITE_ACTION_INVALID_MAC": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-INVALID-MAC",
+                        "INNER_SRC_MAC_REWRITE_ACTION": "60.45.BD.08:19:68",
+                        "PRIORITY": 999964,
+                        "RULE_NAME": "Rule_14",
+                        "SRC_IP": "10.176.0.0/15",
+                        "VNI_ID": 45
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-INVALID-MAC",
+                        "policy_desc":"Replace src MAC with ENI MAC",
+                        "ports": [
+                            "Ethernet0",
+                            "Ethernet1"
+                        ],
+                        "stage": "EGRESS",
+                        "type": "INNERSRCMACREWRITE"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "0,1,2,3",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    },
+                    {
+                        "admin_status": "up",
+                        "alias": "eth1",
+                        "description": "Ethernet1",
+                        "mtu": 9000,
+                        "lanes": "10,11,12,13",
+                        "name": "Ethernet1",
+                        "speed": 25000
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_INNERSRCMACREWRITE_INVALID_VNI": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-INVALID-VNI",
+                        "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
+                        "PRIORITY": 999960,
+                        "RULE_NAME": "Rule_15",
+                        "SRC_IP": "10.176.0.0/15",
+                        "VNI_ID": 16777216
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-INVALID-VNI",
+                        "policy_desc":"Replace src MAC with ENI MAC",
+                        "ports": [
+                            "Ethernet0",
+                            "Ethernet1"
+                        ],
+                        "stage": "EGRESS",
+                        "type": "INNERSRCMACREWRITE"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "0,1,2,3",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    },
+                    {
+                        "admin_status": "up",
+                        "alias": "eth1",
+                        "description": "Ethernet1",
+                        "mtu": 9000,
+                        "lanes": "10,11,12,13",
+                        "name": "Ethernet1",
+                        "speed": 25000
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_INNERSRCMACREWRITE_NO_VNI": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-NO-VNI",
+                        "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
+                        "PRIORITY": 999960,
+                        "RULE_NAME": "Rule_16",
+                        "SRC_IP": "10.176.0.0/15"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-NO-VNI",
+                        "policy_desc":"Replace src MAC with ENI MAC",
+                        "ports": [
+                            "Ethernet0",
+                            "Ethernet1"
+                        ],
+                        "stage": "EGRESS",
+                        "type": "INNERSRCMACREWRITE"
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_RULE_WITH_VNI": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "EVERFLOW",
+                        "DST_IP": "10.186.72.0/26",
+                        "IP_TYPE": "IPv4ANY",
+                        "RULE_NAME": "Rule_20",
+                        "SRC_IP": "10.176.0.0/15",
+                        "PRIORITY": 1222,
+                        "VNI_ID": 16777213,
+                        "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "EVERFLOW",
+                        "policy_desc": "Filter IPv4",
+                        "services": [
+                            "SNMP"
+                        ],
+                        "stage": "EGRESS",
+                        "type": "MIRROR"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "0,1,2,3",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    },
+                    {
+                        "admin_status": "up",
+                        "alias": "eth1",
+                        "description": "Ethernet1",
+                        "mtu": 9000,
+                        "lanes": "10,11,12,13",
+                        "name": "Ethernet1",
+                        "speed": 25000
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_INNERSRCMACREWRITE_NO_SRCIP": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-NO-SRCIP",
+                        "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
+                        "PRIORITY": 999960,
+                        "RULE_NAME": "Rule_16",
+                        "VNI_ID": "16777213"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-NO-SRCIP",
+                        "policy_desc":"Replace src MAC with ENI MAC",
+                        "ports": [
+                            "Ethernet0",
+                            "Ethernet1"
+                        ],
+                        "stage": "EGRESS",
+                        "type": "INNERSRCMACREWRITE"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "0,1,2,3",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    },
+                    {
+                        "admin_status": "up",
+                        "alias": "eth1",
+                        "description": "Ethernet1",
+                        "mtu": 9000,
+                        "lanes": "10,11,12,13",
+                        "name": "Ethernet1",
+                        "speed": 25000
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_INNERSRCMACREWRITE_STAGE_INGRESS": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-STAGE-INGRESS",
+                        "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
+                        "PRIORITY": 999960,
+                        "RULE_NAME": "Rule_10",
+                        "SRC_IP": "10.176.0.0/15",
+                        "VNI_ID": 45
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-STAGE-INGRESS",
+                        "policy_desc":"Replace src MAC with ENI MAC",
+                        "ports": [
+                            "Ethernet0",
+                            "Ethernet1"
+                        ],
+                        "stage": "INGRESS",
+                        "type": "INNERSRCMACREWRITE"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE_TYPE": {
+                "ACL_TABLE_TYPE_LIST": [
+                    {
+                        "ACL_TABLE_TYPE_NAME": "INNERSRCMACREWRITE",
+                        "ACTIONS": [
+                            "INNER_SRC_MAC_REWRITE_ACTION"
+                        ],
+                        "MATCHES": [
+                            "SRC_IP",
+                            "VNI_ID"
+                        ],
+                        "BIND_POINTS": [
+                            "PORT",
+                            "PORTCHANNEL"
+                        ]
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "0,1,2,3",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    },
+                    {
+                        "admin_status": "up",
+                        "alias": "eth1",
+                        "description": "Ethernet1",
+                        "mtu": 9000,
+                        "lanes": "10,11,12,13",
+                        "name": "Ethernet1",
+                        "speed": 25000
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -84,6 +84,13 @@ module sonic-acl {
 					}
 				}
 
+				leaf INNER_SRC_MAC_REWRITE_ACTION {
+					type stypes:mac-address;
+				}
+
+				/* Validating 'INNER_SRC_MAC_REWRITE_ACTION' exist if ACL type is 'INNERSRCMACREWRITE' */
+				must "(not(../../ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME=current()/ACL_TABLE_NAME]/type = 'INNERSRCMACREWRITE')) or (boolean(INNER_SRC_MAC_REWRITE_ACTION))";
+
 				leaf IP_TYPE {
 					type stypes:ip_type;
 				}
@@ -127,6 +134,9 @@ module sonic-acl {
 						}
 					}
 				}
+
+				/* Validating 'SRC_IP' exist if ACL type is 'INNERSRCMACREWRITE' */
+				must "(not(../../ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME=current()/ACL_TABLE_NAME]/type = 'INNERSRCMACREWRITE')) or (boolean(SRC_IP))";
 
 				leaf IN_PORTS {
 					/* Values is a list of SONiC port name (/port:sonic-port/port:PORT/port:PORT_LIST/port:name) joined by comma */
@@ -255,6 +265,15 @@ module sonic-acl {
 					}
 				}
 
+				leaf VNI_ID {
+					type uint32 {
+						range "1..16777215";
+					}
+				}
+
+				/* Validating 'VNI_ID' exist if ACL type is 'INNERSRCMACREWRITE' */
+				must "(not(../../ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME=current()/ACL_TABLE_NAME]/type = 'INNERSRCMACREWRITE')) or (boolean(VNI_ID))";
+
 				leaf PCP {
 					when "(/acl:sonic-acl/acl:ACL_TABLE/acl:ACL_TABLE_LIST[ACL_TABLE_NAME=current()/../acl:ACL_TABLE_NAME]/acl:type = 'L2')";
 					type string {
@@ -354,6 +373,9 @@ module sonic-acl {
 					}
 					default "INGRESS";
 				}
+
+				/* Validating stage is EGRESS exist if ACL type is 'INNERSRCMACREWRITE' */
+				must "(not(../../ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME=current()/ACL_TABLE_NAME]/type = 'INNERSRCMACREWRITE')) or (stage = 'EGRESS')";
 
 				leaf-list services {
 					type string;

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -93,9 +93,6 @@ module sonic-acl {
 					type yang:mac-address;
 				}
 
-				/* Validating 'INNER_SRC_MAC_REWRITE_ACTION' exist if ACL type is 'INNERSRCMACREWRITE' */
-				must "(not(../../ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME=current()/ACL_TABLE_NAME]/type = 'INNERSRCMACREWRITE')) or (boolean(INNER_SRC_MAC_REWRITE_ACTION))";
-
 				leaf IP_TYPE {
 					type stypes:ip_type;
 				}
@@ -126,6 +123,11 @@ module sonic-acl {
 						leaf DST_IP {
 							type inet:ipv4-prefix;
 						}
+
+						leaf INNER_SRC_IP {
+							description "Source IP prefix for inner packet";
+							type inet:ipv4-prefix;
+						}
 					}
 
 					case ip6_prefix {
@@ -139,9 +141,6 @@ module sonic-acl {
 						}
 					}
 				}
-
-				/* Validating 'SRC_IP' exist if ACL type is 'INNERSRCMACREWRITE' */
-				must "(not(../../ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME=current()/ACL_TABLE_NAME]/type = 'INNERSRCMACREWRITE')) or (boolean(SRC_IP))";
 
 				leaf IN_PORTS {
 					/* Values is a list of SONiC port name (/port:sonic-port/port:PORT/port:PORT_LIST/port:name) joined by comma */
@@ -270,15 +269,10 @@ module sonic-acl {
 					}
 				}
 
-				leaf VNI_ID {
+				leaf VNI {
 					description "VXLAN Network Identifier";
-					type uint32 {
-						range "1..16777215";
-					}
+					stypes:vnid_type;
 				}
-
-				/* Validating 'VNI_ID' exist if ACL type is 'INNERSRCMACREWRITE' */
-				must "(not(../../ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME=current()/ACL_TABLE_NAME]/type = 'INNERSRCMACREWRITE')) or (boolean(VNI_ID))";
 
 				leaf PCP {
 					when "(/acl:sonic-acl/acl:ACL_TABLE/acl:ACL_TABLE_LIST[ACL_TABLE_NAME=current()/../acl:ACL_TABLE_NAME]/acl:type = 'L2')";
@@ -379,9 +373,6 @@ module sonic-acl {
 					}
 					default "INGRESS";
 				}
-
-				/* Validating stage is EGRESS exist if ACL type is 'INNERSRCMACREWRITE' */
-				must "(not(../../ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME=current()/ACL_TABLE_NAME]/type = 'INNERSRCMACREWRITE')) or (stage = 'EGRESS')";
 
 				leaf-list services {
 					type string;

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -271,7 +271,7 @@ module sonic-acl {
 
 				leaf VNI {
 					description "VXLAN Network Identifier";
-					stypes:vnid_type;
+					type stypes:vnid_type;
 				}
 
 				leaf PCP {

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -13,6 +13,10 @@ module sonic-acl {
 	import ietf-inet-types {
 		prefix inet;
 	}
+	
+	import ietf-yang-types {
+		prefix yang;
+	}
 
 	import sonic-types {
 		prefix stypes;
@@ -85,7 +89,8 @@ module sonic-acl {
 				}
 
 				leaf INNER_SRC_MAC_REWRITE_ACTION {
-					type stypes:mac-address;
+					description "Inner Source Mac-adress rewrite action mapped to mac address";
+					type yang:mac-address;
 				}
 
 				/* Validating 'INNER_SRC_MAC_REWRITE_ACTION' exist if ACL type is 'INNERSRCMACREWRITE' */
@@ -266,6 +271,7 @@ module sonic-acl {
 				}
 
 				leaf VNI_ID {
+					description "VXLAN Network Identifier";
 					type uint32 {
 						range "1..16777215";
 					}

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -95,7 +95,6 @@ module sonic-types {
             enum MIRRORV6;
             enum MIRROR_DSCP;
             enum CTRLPLANE;
-            enum INNERSRCMACREWRITE;
         }
     }
 

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -95,6 +95,7 @@ module sonic-types {
             enum MIRRORV6;
             enum MIRROR_DSCP;
             enum CTRLPLANE;
+            enum INNERSRCMACREWRITE;
         }
     }
 

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -268,6 +268,12 @@ module sonic-types {
         }
     }
 
+    typedef mac-address {
+        type string {
+            pattern "[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}";
+        }
+    }
+
     typedef hostname {
         type string {
             length 1..63;

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -268,12 +268,6 @@ module sonic-types {
         }
     }
 
-    typedef mac-address {
-        type string {
-            pattern "[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}";
-        }
-    }
-
     typedef hostname {
         type string {
             length 1..63;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Yang changes for inner source mac rewrite feature in Smart switch(a new action and inner_src_ip and vni)

##### Work item tracking
- Microsoft ADO **(number only)**:https://msazure.visualstudio.com/One/_workitems/edit/31634070

#### How I did it
Added ACL table INNERSRCMACREWRITE, action type INNER_SRC_MAC_REWRITE_ACTION for this ACL type, VNI_ID
 
#### How to verify it
yang model tests
addition to sample config_db.json

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

