### PR TITLE
[BGP] Set stopsignal to KILL for immediate termination frrcfgd/bgpcfgd and ensure proper SIGTERM handling for FRR services

### DIFF
--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -85,7 +85,7 @@ dependent_startup_wait_for=zsocket:exited
 [program:bfdd]
 command=/usr/lib/frr/bfdd -A 127.0.0.1 -P 0
 priority=4
-stopsignal=KILL
+stopsignal=TERM
 autostart=false
 autorestart=false
 startsecs=0
@@ -104,7 +104,7 @@ command=/usr/lib/frr/bgpd -A 127.0.0.1 -P 0 -M snmp -M bmp
 command=/usr/lib/frr/bgpd -A 127.0.0.1 -P 0 -M snmp
 {% endif %}
 priority=5
-stopsignal=KILL
+stopsignal=TERM
 autostart=false
 autorestart=false
 startsecs=0
@@ -119,7 +119,7 @@ dependent_startup_wait_for=zsocket:exited
 [program:ospfd]
 command=/usr/lib/frr/ospfd -A 127.0.0.1 -P 0 -M snmp
 priority=5
-stopsignal=KILL
+stopsignal=TERM
 autostart=false
 autorestart=false
 startsecs=0
@@ -133,7 +133,7 @@ dependent_startup_wait_for=zebra:running
 [program:pimd]
 command=/usr/lib/frr/pimd -A 127.0.0.1 -P 0
 priority=5
-stopsignal=KILL
+stopsignal=TERM
 autostart=false
 autorestart=false
 startsecs=0
@@ -166,6 +166,7 @@ command=/usr/local/bin/frrcfgd
 command=/usr/local/bin/bgpcfgd
 {% endif %}
 priority=6
+stopsignal=KILL
 autostart=false
 autorestart=false
 startsecs=0
@@ -252,7 +253,7 @@ dependent_startup_wait_for=bgpd:running
 [program:pathd]
 command=/usr/lib/frr/pathd -A 127.0.0.1 -P 0
 priority=5
-stopsignal=KILL
+stopsignal=TERM
 autostart=false
 autorestart=false
 startsecs=0


### PR DESCRIPTION
Set stopsignal to KILL for immediate termination frrcfgd/bgpcfgd and ensure proper SIGTERM handling for FRR services

#### Why I did it
FRR services were not shutting down properly, causing router services to fail in handling the shutdown process correctly. For example, in BGP, notifications were not sent to peers when the BGP service stopped or when a configuration reload occurred.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modified `frrcfgd` and `bgpcfgd` to use `stopsignal=KILL` to ensure immediate termination during container shutdown.

Additionally, updated most frr  services to use `stopsignal=TERM` to properly handle the shutdown process, allowing services like `bgpd` to send notifications to peers.

#### How to verify it
Before
```
INFO bgp#supervisord 2025-03-04 08:49:15,116 WARN received SIGTERM indicating exit request
INFO bgp#supervisord 2025-03-04 08:49:15,117 INFO waiting for supervisor-proc-exit-listener, rsyslogd, mgmtd, staticd, zebra, bgpd, bgpcfgd, bgpmon, fpmsyncd, staticroutebfd to die
INFO bgp#supervisord 2025-03-04 08:49:16,121 INFO stopped: staticroutebfd (exit status 0)
INFO bgp#supervisord 2025-03-04 08:49:16,123 WARN stopped: fpmsyncd (terminated by SIGTERM)
INFO bgp#supervisord 2025-03-04 08:49:16,126 WARN stopped: bgpmon (terminated by SIGTERM)
INFO bgp#supervisord 2025-03-04 08:49:18,129 INFO waiting for supervisor-proc-exit-listener, rsyslogd, mgmtd, staticd, zebra, bgpd, bgpcfgd to die
INFO bgp#supervisord 2025-03-04 08:49:21,133 INFO waiting for supervisor-proc-exit-listener, rsyslogd, mgmtd, staticd, zebra, bgpd, bgpcfgd to die
INFO bgp#supervisord 2025-03-04 08:49:24,137 INFO waiting for supervisor-proc-exit-listener, rsyslogd, mgmtd, staticd, zebra, bgpd, bgpcfgd to die
INFO container: docker cmd: wait for bgp
INFO container: docker cmd: stop for bgp
```

After
```
INFO bgp#supervisord 2025-03-04 08:54:17,638 WARN received SIGTERM indicating exit request
INFO bgp#supervisord 2025-03-04 08:54:17,639 INFO waiting for supervisor-proc-exit-listener, rsyslogd, mgmtd, staticd, zebra, bgpd, bgpcfgd, bgpmon, fpmsyncd, staticroutebfd to die
INFO bgp#supervisord 2025-03-04 08:54:18,642 INFO stopped: staticroutebfd (exit status 0)
INFO bgp#supervisord 2025-03-04 08:54:18,644 WARN stopped: fpmsyncd (terminated by SIGTERM)
INFO bgp#supervisord 2025-03-04 08:54:18,648 WARN stopped: bgpmon (terminated by SIGTERM)
INFO bgp#supervisord 2025-03-04 08:54:18,653 WARN stopped: bgpcfgd (terminated by SIGKILL)
INFO bgp#supervisord 2025-03-04 08:54:18,715 INFO stopped: bgpd (exit status 0)
INFO bgp#supervisord 2025-03-04 08:54:19,729 INFO stopped: zebra (exit status 0)
INFO bgp#supervisord 2025-03-04 08:54:19,734 INFO stopped: staticd (exit status 0)
INFO bgp#supervisord 2025-03-04 08:54:19,743 INFO stopped: mgmtd (exit status 0)
INFO container: docker cmd: wait for bgp
INFO container: docker cmd: stop for bgp
```


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

