### PR TITLE
[FRR]: Fix `no srv6` command

### DIFF
--- a/src/sonic-frr/patch/0084-staticd-Fix-no-srv6-command.patch
+++ b/src/sonic-frr/patch/0084-staticd-Fix-no-srv6-command.patch
@@ -1,0 +1,204 @@
+From 24882c8e8335c0f8ec7f1f8f9b4f7dfea1dc7d58 Mon Sep 17 00:00:00 2001
+From: Carmine Scarpitta <cscarpit@cisco.com>
+Date: Wed, 26 Feb 2025 00:24:49 +0100
+Subject: [PATCH 1/3] staticd: Fix `no srv6` command
+
+A user can configure static SIDs as follows:
+
+[...]
+segment-routing
+ srv6
+  static-sids
+   sid fcbb:bbbb:1::/48 locator MAIN behavior uN
+   sid fcbb:bbbb:1:fe00::/64 locator MAIN behavior uDT46
+[...]
+
+When the user runs vtysh and executes the `no srv6` command, the
+expectation is that staticd will deallocate all SIDs.
+
+However, currently FRR does not behaves as expected. After the user
+executes `no srv6`, the SIDs are still present.
+
+The problem is that vtysh does not forward the `no srv6` command to
+mgmtd/staticd.
+
+The `no srv6` command is defined using the `DEFUN_YANG_NOSH` macro,
+which instructs `xref2vtysh.py` to skip the `no srv6` command during
+the generation of `vtysh_cmd.c`. As a result, vtysh is unaware that it
+should forward the `no srv6` command to mgmtd/staticd.
+
+This commit fixes the issue by replacing `DEFUN_YANG_NOSH` with
+`DEFUN_YANG`. This change ensures that `xref2vtysh.py` includes the
+`no srv6` command when generating `vtysh_cmd.c` and makes vtysh forward
+the `no srv6` command to mgmtd/staticd.
+
+Signed-off-by: Carmine Scarpitta <cscarpit@cisco.com>
+---
+ staticd/static_vty.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/staticd/static_vty.c b/staticd/static_vty.c
+index 01324e8d1..247f53b47 100644
+--- a/staticd/static_vty.c
++++ b/staticd/static_vty.c
+@@ -1219,7 +1219,7 @@ DEFUN_NOSH (static_srv6, static_srv6_cmd,
+ 	return CMD_SUCCESS;
+ }
+ 
+-DEFUN_YANG_NOSH (no_static_srv6, no_static_srv6_cmd,
++DEFUN_YANG (no_static_srv6, no_static_srv6_cmd,
+       "no srv6",
+       NO_STR
+       "Segment Routing SRv6\n")
+-- 
+2.34.1
+
+
+From b5fb98d30552c91475d891006908a8bcf653ed2b Mon Sep 17 00:00:00 2001
+From: Carmine Scarpitta <cscarpit@cisco.com>
+Date: Wed, 26 Feb 2025 16:08:17 +0100
+Subject: [PATCH 2/3] tests: Add test case to verify `no srv6` command
+
+Add a test case to verify that staticd removes all SIDs when the
+`no srv6` command is executed.
+
+Signed-off-by: Carmine Scarpitta <cscarpit@cisco.com>
+---
+ .../expected_srv6_sids_srv6_disable.json      |  1 +
+ .../static_srv6_sids/test_static_srv6_sids.py | 36 +++++++++++++++++++
+ 2 files changed, 37 insertions(+)
+ create mode 100644 tests/topotests/static_srv6_sids/expected_srv6_sids_srv6_disable.json
+
+diff --git a/tests/topotests/static_srv6_sids/expected_srv6_sids_srv6_disable.json b/tests/topotests/static_srv6_sids/expected_srv6_sids_srv6_disable.json
+new file mode 100644
+index 000000000..9e26dfeeb
+--- /dev/null
++++ b/tests/topotests/static_srv6_sids/expected_srv6_sids_srv6_disable.json
+@@ -0,0 +1 @@
++{}
+\ No newline at end of file
+diff --git a/tests/topotests/static_srv6_sids/test_static_srv6_sids.py b/tests/topotests/static_srv6_sids/test_static_srv6_sids.py
+index 25879a375..63dbdcb63 100755
+--- a/tests/topotests/static_srv6_sids/test_static_srv6_sids.py
++++ b/tests/topotests/static_srv6_sids/test_static_srv6_sids.py
+@@ -163,6 +163,42 @@ def test_srv6_static_sids_sid_readd_all():
+     check_srv6_static_sids(router, "expected_srv6_sids.json")
+ 
+ 
++def test_srv6_static_sids_srv6_disable():
++    """
++    Disable SRv6
++    """
++    tgen = get_topogen()
++    if tgen.routers_have_failure():
++        pytest.skip(tgen.errors)
++    router = tgen.gears["r1"]
++
++    def _check_srv6_static_sids(router, expected_route_file):
++        logger.info("checking zebra srv6 static sids")
++        output = json.loads(router.vtysh_cmd("show ipv6 route static json"))
++        expected = open_json_file("{}/{}".format(CWD, expected_route_file))
++        return topotest.json_cmp(output, expected, exact=True)
++
++    def check_srv6_static_sids(router, expected_file):
++        func = functools.partial(_check_srv6_static_sids, router, expected_file)
++        _, result = topotest.run_and_expect(func, None, count=15, wait=1)
++        assert result is None, "Failed"
++
++    router.vtysh_cmd(
++        """
++        configure terminal
++         segment-routing
++          no srv6
++        """
++    )
++
++    # FOR DEVELOPER:
++    # If you want to stop some specific line and start interactive shell,
++    # please use tgen.mininet_cli() to start it.
++
++    logger.info("Test for srv6 sids configuration")
++    check_srv6_static_sids(router, "expected_srv6_sids_srv6_disable.json")
++
++
+ if __name__ == "__main__":
+     args = ["-s"] + sys.argv[1:]
+     sys.exit(pytest.main(args))
+-- 
+2.34.1
+
+
+From 2a8e9db964c4893419f21f89882c220da9fb0542 Mon Sep 17 00:00:00 2001
+From: Carmine Scarpitta <cscarpit@cisco.com>
+Date: Wed, 26 Feb 2025 16:08:33 +0100
+Subject: [PATCH 3/3] tests: Add test case to verify that SIDs can be re-added
+
+Add a test case to verify that staticd is able to re-install all SIDs
+after disabling and re-enabling SRv6.
+
+Signed-off-by: Carmine Scarpitta <cscarpit@cisco.com>
+---
+ .../static_srv6_sids/test_static_srv6_sids.py | 47 +++++++++++++++++++
+ 1 file changed, 47 insertions(+)
+
+diff --git a/tests/topotests/static_srv6_sids/test_static_srv6_sids.py b/tests/topotests/static_srv6_sids/test_static_srv6_sids.py
+index 63dbdcb63..f575b1f62 100755
+--- a/tests/topotests/static_srv6_sids/test_static_srv6_sids.py
++++ b/tests/topotests/static_srv6_sids/test_static_srv6_sids.py
+@@ -199,6 +199,53 @@ def test_srv6_static_sids_srv6_disable():
+     check_srv6_static_sids(router, "expected_srv6_sids_srv6_disable.json")
+ 
+ 
++def test_srv6_static_sids_srv6_reenable():
++    """
++    Re-enable SRv6
++    """
++    tgen = get_topogen()
++    if tgen.routers_have_failure():
++        pytest.skip(tgen.errors)
++    router = tgen.gears["r1"]
++
++    def _check_srv6_static_sids(router, expected_route_file):
++        logger.info("checking zebra srv6 static sids")
++        output = json.loads(router.vtysh_cmd("show ipv6 route static json"))
++        expected = open_json_file("{}/{}".format(CWD, expected_route_file))
++        return topotest.json_cmp(output, expected)
++
++    def check_srv6_static_sids(router, expected_file):
++        func = functools.partial(_check_srv6_static_sids, router, expected_file)
++        _, result = topotest.run_and_expect(func, None, count=15, wait=1)
++        assert result is None, "Failed"
++
++    router.vtysh_cmd(
++        """
++        configure terminal
++         segment-routing
++          srv6
++           locators
++            locator MAIN
++             prefix fcbb:bbbb:1::/48 block-len 32 node-len 16 func-bits 16
++            !
++           !
++           static-sids
++            sid fcbb:bbbb:1::/48 locator MAIN behavior uN
++            sid fcbb:bbbb:1:fe10::/64 locator MAIN behavior uDT4 vrf Vrf10
++            sid fcbb:bbbb:1:fe20::/64 locator MAIN behavior uDT6 vrf Vrf20
++            sid fcbb:bbbb:1:fe30::/64 locator MAIN behavior uDT46 vrf Vrf30
++            sid fcbb:bbbb:1:fe40::/64 locator MAIN behavior uA interface sr0 nexthop 2001::2
++        """
++    )
++
++    # FOR DEVELOPER:
++    # If you want to stop some specific line and start interactive shell,
++    # please use tgen.mininet_cli() to start it.
++
++    logger.info("Test for srv6 sids configuration")
++    check_srv6_static_sids(router, "expected_srv6_sids.json")
++
++
+ if __name__ == "__main__":
+     args = ["-s"] + sys.argv[1:]
+     sys.exit(pytest.main(args))
+-- 
+2.34.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -62,3 +62,4 @@
 0079-staticd-add-support-for-srv6.patch
 0080-SRv6-vpn-route-and-sidlist-install.patch
 0082-Revert-bgpd-upon-if-event-evaluate-bnc-with-matching.patch
+0084-staticd-Fix-no-srv6-command.patch


### PR DESCRIPTION
Bring PR https://github.com/FRRouting/frr/pull/18289 from FRR mainline to SONiC to fix the `no srv6` command.

---

A user can configure static SIDs as follows:

```
[...]
segment-routing
 srv6
  static-sids
   sid fcbb:bbbb:1::/48 locator MAIN behavior uN
   sid fcbb:bbbb:1:fe00::/64 locator MAIN behavior uDT46
[...]
```
When the user runs vtysh and executes the no srv6 command, the expectation is that staticd will deallocate all SIDs.
However, currently FRR does not behaves as expected. After the user executes no srv6, the SIDs are still present.

This PR fixes the issue and makes the no srv6 command remove all SIDs as expected.