### PR TITLE
Mgmt EOF disconnect error log msg

### DIFF
--- a/src/sonic-frr/patch/0085-This-error-happens-when-we-try-to-write-to-a-socket.patch
+++ b/src/sonic-frr/patch/0085-This-error-happens-when-we-try-to-write-to-a-socket.patch
@@ -1,0 +1,36 @@
+From b6588aa5aba1531277e78bb2824334acc52493eb Mon Sep 17 00:00:00 2001
+From: sudhanshukumar22 <sudhanshu.kumar@broadcom.com>
+Date: Wed, 5 Mar 2025 00:55:58 -0800
+Subject: [PATCH] [MGMTD] This error happens when we try to write to a socket or pipe
+ which is already closed by peer.  For e.g., the other side may have been
+ killed during warmboot or using pkill. Hence, changing the log level to INFO
+
+---
+ lib/mgmt_msg.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/lib/mgmt_msg.c b/lib/mgmt_msg.c
+index aff9af7e8..0a0f17ffe 100644
+--- a/lib/mgmt_msg.c
++++ b/lib/mgmt_msg.c
+@@ -28,6 +28,8 @@
+ #define MGMT_MSG_ERR(ms, fmt, ...)                                             \
+ 	zlog_err("%s: %s: " fmt, (ms)->idtag, __func__, ##__VA_ARGS__)
+ 
++#define MGMT_MSG_INFO(ms, fmt, ...)                                             \
++	zlog_info("%s: %s: " fmt, (ms)->idtag, __func__, ##__VA_ARGS__)
+ DEFINE_MTYPE(LIB, MSG_CONN, "msg connection state");
+ 
+ /**
+@@ -70,7 +72,7 @@ enum mgmt_msg_rsched mgmt_msg_read(struct mgmt_msg_state *ms, int fd,
+ 		}
+ 		if (n <= 0) {
+ 			if (n == 0)
+-				MGMT_MSG_ERR(ms, "got EOF/disconnect");
++				MGMT_MSG_INFO(ms, "got EOF/disconnect");
+ 			else
+ 				MGMT_MSG_ERR(ms,
+ 					     "got error while reading: '%s'",
+-- 
+2.39.4
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -65,3 +65,4 @@
 0082-Revert-bgpd-upon-if-event-evaluate-bnc-with-matching.patch
 0083-staticd-add-cli-to-support-steering-of-ipv4-traffic-over-srv6-sid-list.patch
 0084-lib-Return-duplicate-prefix-list-entry-test.patch
+0085-This-error-happens-when-we-try-to-write-to-a-socket.patch


### PR DESCRIPTION
#### Why I did it
mgmtd: Change log level to INFO for EOF disconnect error, which can also happen in a valid scenario
Description: This error happens when we try to write to a socket or pipe
 which is already closed by peer.  For e.g., the other side may have been
 killed during warmboot or using pkill. Hence, changing the log level to INFO.

Note: I have avoided changing bgp.sh script because the error could be seen in other scenarios also(apart from warmboot/fast boot, for e.g., if we just kill zebra, we will see this log). 

Signed-off-by: sudhanshukumar22 (sudhanshu.kumar@broadcom.com)
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

2025 Mar  5 10:22:59.234007 sonic INFO bgp#mgmtd[33]: [GR5PJ-Q2R72] BE-adapter: mgmt_msg_read: got EOF/disconnect
2025 Mar  5 10:22:59.234845 sonic INFO bgp#supervisord 2025-03-05 10:22:59,234 WARN exited: zebra (terminated by SIGKILL; not expected)
2025 Mar  5 10:22:59.235034 sonic INFO bgp#supervisord: fpmsyncd Connection lost, reconnecting...
2025 Mar  5 10:22:59.235078 sonic INFO bgp#supervisord: fpmsyncd Waiting for fpm-client connection...
2025 Mar  5 10:22:59.239697 sonic INFO bgp#supervisor-proc-exit-listener: Process 'zebra' exited unexpectedly. Terminating supervisor 'bgp'
2025 Mar  5 10:22:59.239987 sonic NOTICE bgp#supervisor-proc-exit-listener: :- publish: EVENT_PUBLISHED: {"sonic-events-host:process-exited-unexpectedly":{"ctr_name":"bgp","process_name":"zebra","timestamp":"2025-03-05T10:22:59.239786Z"}}
2025 Mar  5 10:22:59.241330 sonic INFO bgp#supervisord 2025-03-05 10:22:59,241 WARN received SIGTERM indicating exit request
2025 Mar  5 10:22:59.241770 sonic INFO bgp#supervisord 2025-03-05 10:22:59,241 INFO waiting for supervisor-proc-exit-listener, rsyslogd, mgmtd, staticd, bgpd, bgpcfgd, bgpmon, fpmsyncd, staticroutebfd to die
2025 Mar  5 10:23:00.244898 sonic INFO bgp#supervisord 2025-03-05 10:23:00,244 INFO stopped: staticroutebfd (exit status 0)
2025 Mar  5 10:23:00.246125 sonic INFO bgp#supervisord 2025-03-05 10:23:00,245 WARN stopped: fpmsyncd (terminated by SIGTERM)
2025 Mar  5 10:23:00.247716 sonic INFO bgp#supervisord 2025-03-05 10:23:00,247 WARN stopped: bgpmon (terminated by SIGTERM)
2025 Mar  5 10:23:02.251113 sonic INFO bgp#supervisord 2025-03-05 10:23:02,250 INFO waiting for supervisor-proc-exit-listener, rsyslogd, mgmtd, staticd, bgpd, bgpcfgd to die
2025 Mar  5 10:23:05.255125 sonic INFO bgp#supervisord 2025-03-05 10:23:05,254 INFO waiting for supervisor-proc-exit-listener, rsyslogd, mgmtd, staticd, bgpd, bgpcfgd to die
2025 Mar  5 10:23:08.258691 sonic INFO bgp#supervisord 2025-03-05 10:23:08,258 INFO waiting for supervisor-proc-exit-listener, rsyslogd, mgmtd, staticd, bgpd, bgpcfgd to die
2025 Mar  5 10:23:10.261208 sonic INFO bgp#supervisord 2025-03-05 10:23:10,260 WARN killing 'bgpcfgd' (50) with SIGKILL
2025 Mar  5 10:23:10.264011 sonic INFO bgp#supervisord 2025-03-05 10:23:10,263 WARN stopped: bgpcfgd (terminated by SIGKILL)
2025 Mar  5 10:23:10.266753 sonic INFO bgp#supervisord 2025-03-05 10:23:10,266 WARN stopped: bgpd (terminated by SIGKILL)
2025 Mar  5 10:23:11.268288 sonic INFO bgp#supervisord 2025-03-05 10:23:11,267 INFO waiting for supervisor-proc-exit-listener, rsys

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

