### PR TITLE
Add support for MtFuji elba dpu image build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ files/Aboot/boot0
 files/dsc/MANIFEST
 files/dsc/install_debian
 files/dsc/fs.zip
-files/dsc/pensando-sonic-artifacts
 files/initramfs-tools/arista-convertfs
 files/initramfs-tools/union-mount
 
@@ -94,6 +93,7 @@ platform/broadcom/sonic-platform-modules-dell/z9100/modules/dell_ich.c
 platform/broadcom/sonic-platform-modules-dell/z9100/modules/dell_mailbox.c
 platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/ipmihelper.py
 platform/cisco-8000
+platform/pensando/pensando-sonic-artifacts
 
 # buildinfo
 files/build/buildinfo

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ files/Aboot/boot0
 files/dsc/MANIFEST
 files/dsc/install_debian
 files/dsc/fs.zip
+files/dsc/pensando-sonic-artifacts
 files/initramfs-tools/arista-convertfs
 files/initramfs-tools/union-mount
 

--- a/files/dsc/install_debian.j2
+++ b/files/dsc/install_debian.j2
@@ -15,7 +15,7 @@ image_dir=image-$image_version
 
 INSTALLER_PAYLOAD=fs.zip
 DOCKERFS_DIR=docker
-{% if BUILD_REDUCE_IMAGE_SIZE == "y" -%}
+{% if BUILD_REDUCE_IMAGE_SIZE | default("n") == "y" -%}
 FILESYSTEM_DOCKERFS=dockerfs.tar.zstd
 {%- else -%}
 FILESYSTEM_DOCKERFS=dockerfs.tar.gz

--- a/platform/checkout/pensando.ini
+++ b/platform/checkout/pensando.ini
@@ -1,4 +1,4 @@
 [module]
 repo=git@github.com:pensando/pensando-sonic-artifacts.git
 ref=1.87.0-SS-14
-path=files/dsc/pensando-sonic-artifacts
+path=platform/pensando/pensando-sonic-artifacts

--- a/platform/checkout/pensando.ini
+++ b/platform/checkout/pensando.ini
@@ -1,0 +1,4 @@
+[module]
+repo=git@github.com:pensando/pensando-sonic-artifacts.git
+ref=1.87.0-SS-14
+path=files/dsc/pensando-sonic-artifacts

--- a/platform/checkout/pensando.ini
+++ b/platform/checkout/pensando.ini
@@ -1,4 +1,4 @@
 [module]
 repo=git@github.com:pensando/pensando-sonic-artifacts.git
-ref=1.87.0-SS-14
+ref=1.87.0-SS-14-release
 path=platform/pensando/pensando-sonic-artifacts

--- a/platform/checkout/template.j2
+++ b/platform/checkout/template.j2
@@ -1,4 +1,8 @@
+{% if module.path is defined %}
+{% set path = module.path %}
+{% else %}
 {% set path = env('PLATFORM_PATH') %}
+{% endif %}
 if [ ! -d {{ path }} ]; then git clone {{ module.repo }} {{ path }}; fi;
 if [ -d {{ path }}/.git ]; then cd {{ path }} &&
 

--- a/platform/pensando/docker-dpu-base.dep
+++ b/platform/pensando/docker-dpu-base.dep
@@ -1,4 +1,4 @@
-DEP_FILES := rules/docker-dpu-base.dep rules/docker-dpu-base.mk
+DEP_FILES := rules/docker-dpu-base.dep rules/docker-dpu-base.mk platform/checkout/template.j2 platform/checkout/pensando.ini
 
 $(DOCKER_DPU_BASE)_CACHE_MODE  := none
 $(DOCKER_DPU_BASE)_DEP_FILES   := $(DEP_FILES)

--- a/platform/pensando/docker-dpu-base.mk
+++ b/platform/pensando/docker-dpu-base.mk
@@ -4,7 +4,7 @@ DOCKER_DPU_BASE_STEM = docker-dpu-base
 
 DOCKER_DPU_BASE = $(DOCKER_DPU_BASE_STEM).gz
 
-$(DOCKER_DPU_BASE)_URL = https://github.com/pensando/dsc-artifacts/blob/main/docker-dpu-base.gz?raw=true
+$(DOCKER_DPU_BASE)_PATH = $(PLATFORM_PATH)/pensando-sonic-artifacts
 
-DOWNLOADED_DOCKER_IMAGES += $(DOCKER_DPU_BASE)
+COPY_DOCKER_IMAGES += $(DOCKER_DPU_BASE)
 

--- a/platform/pensando/sdk.mk
+++ b/platform/pensando/sdk.mk
@@ -1,8 +1,8 @@
 # Pensando SAI
 PENSANDO_SAI = libsai_1.10.1-0_arm64.deb
 PENSANDO_SAI_DEV = libsai-dev_1.10.1-0_arm64.deb
-$(PENSANDO_SAI)_PATH = files/dsc/pensando-sonic-artifacts
-$(PENSANDO_SAI_DEV)_PATH = files/dsc/pensando-sonic-artifacts
+$(PENSANDO_SAI)_PATH = $(PLATFORM_PATH)/pensando-sonic-artifacts
+$(PENSANDO_SAI_DEV)_PATH = $(PLATFORM_PATH)/pensando-sonic-artifacts
 
 $(eval $(call add_conflict_package,$(PENSANDO_SAI_DEV),$(LIBSAIVS_DEV)))
 

--- a/platform/pensando/sdk.mk
+++ b/platform/pensando/sdk.mk
@@ -1,10 +1,10 @@
 # Pensando SAI
 PENSANDO_SAI = libsai_1.10.1-0_arm64.deb
 PENSANDO_SAI_DEV = libsai-dev_1.10.1-0_arm64.deb
-$(PENSANDO_SAI)_URL = https://github.com/pensando/dsc-artifacts/blob/main/libsai_1.10.1-0_arm64.deb?raw=true
-$(PENSANDO_SAI_DEV)_URL = https://github.com/pensando/dsc-artifacts/blob/main/libsai-dev_1.10.1-0_arm64.deb?raw=true
+$(PENSANDO_SAI)_PATH = files/dsc/pensando-sonic-artifacts
+$(PENSANDO_SAI_DEV)_PATH = files/dsc/pensando-sonic-artifacts
 
 $(eval $(call add_conflict_package,$(PENSANDO_SAI_DEV),$(LIBSAIVS_DEV)))
 
-SONIC_ONLINE_DEBS += $(PENSANDO_SAI)
-SONIC_ONLINE_DEBS += $(PENSANDO_SAI_DEV)
+SONIC_COPY_DEBS += $(PENSANDO_SAI)
+SONIC_COPY_DEBS += $(PENSANDO_SAI_DEV)

--- a/slave.mk
+++ b/slave.mk
@@ -1118,7 +1118,17 @@ $(addprefix $(TARGET_PATH)/,$(DOWNLOADED_DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz :
 	$(HEADER)
 
 	rm -rf $@ $@.log
-	cp files/dsc/pensando-sonic-artifacts/docker-dpu-base.gz target/docker-dpu-base.gz
+	wget "$($*.gz_URL)" -O target/$(DOWNLOADED_DOCKER_IMAGES) $(LOG)
+
+	$(FOOTER)
+
+# Targets for copy docker images
+$(addprefix $(TARGET_PATH)/,$(COPY_DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .platform \
+		$$(%.gz_DEP_FILES)
+	$(HEADER)
+
+	rm -rf $@ $@.log
+	cp "$($*.gz_PATH)/$*.gz"  target/$(DOWNLOADED_DOCKER_IMAGES) $(LOG) 
 
 	$(FOOTER)
 
@@ -1285,6 +1295,7 @@ SONIC_TARGET_LIST += $(addprefix $(TARGET_PATH)/, $(DOCKER_DBG_IMAGES))
 DOCKER_LOAD_TARGETS = $(addsuffix -load,$(addprefix $(TARGET_PATH)/, \
 		      $(SONIC_SIMPLE_DOCKER_IMAGES) \
 		      $(DOWNLOADED_DOCKER_IMAGES) \
+		      $(COPY_DOCKER_IMAGES) \
 		      $(DOCKER_IMAGES) \
 		      $(DOCKER_DBG_IMAGES)))
 

--- a/slave.mk
+++ b/slave.mk
@@ -1119,6 +1119,7 @@ $(addprefix $(TARGET_PATH)/,$(DOWNLOADED_DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz :
 
 	rm -rf $@ $@.log
 	wget "$($*.gz_URL)" -O target/$(DOWNLOADED_DOCKER_IMAGES) $(LOG)
+	cp files/dsc/pensando-sonic-artifacts/docker-dpu-base.gz target/docker-dpu-base.gz
 
 	$(FOOTER)
 

--- a/slave.mk
+++ b/slave.mk
@@ -1118,7 +1118,6 @@ $(addprefix $(TARGET_PATH)/,$(DOWNLOADED_DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz :
 	$(HEADER)
 
 	rm -rf $@ $@.log
-	wget "$($*.gz_URL)" -O target/$(DOWNLOADED_DOCKER_IMAGES) $(LOG)
 	cp files/dsc/pensando-sonic-artifacts/docker-dpu-base.gz target/docker-dpu-base.gz
 
 	$(FOOTER)

--- a/slave.mk
+++ b/slave.mk
@@ -1128,7 +1128,7 @@ $(addprefix $(TARGET_PATH)/,$(COPY_DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .plat
 	$(HEADER)
 
 	rm -rf $@ $@.log
-	cp "$($*.gz_PATH)/$*.gz"  target/$(DOWNLOADED_DOCKER_IMAGES) $(LOG) 
+	cp "$($*.gz_PATH)/$*.gz" target/$(COPY_DOCKER_IMAGES) $(LOG)
 
 	$(FOOTER)
 


### PR DESCRIPTION
#### Why I did it
- During make configure, if `pensando.ini` exists at `platform/checkout`, it runs `template.j2` to download pensando dpu build artifacts from `pensando/pensando-sonic-artifacts` repo at path
`$(PLATFORM_PATH)/pensando-sonic-artifacts` i.e (`platform/pensando/pensando-sonic-artifacts`)
- Modified `slave.mk` and `sdk.mk` to use downloaded artifacts at path `platform/pensando/pensando-sonic-artifacts`
- Introduced `COPY_DOCKER_IMAGES` in Makefile to copy Pensando elba firmware docker container image to `target/` which is getting used for `docker-dpu-base.mk` for Pensando
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
git clone https://github.com/sonic-net/sonic-buildimage.git

make init
make configure PLATFORM=pensando PLATFORM_ARCH=arm64
NOJESSIE=1 NOSTRETCH=1 NOBUSTER=0 NOBULLSEYE=0 make target/sonic-pensando.tar

#### How to verify it
Ensure, the platform/checkout/.ini file refers to the correct github page with the correct version tag that can be downloaded and artifacts are available at `platform/pensando/pensando-sonic-artifacts`

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

- [x] master

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

