### PR TITLE
[202411][YANG] Add yang model to `SUBNET_DECAP` table (#21118)

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -91,6 +91,7 @@ Table of Contents
          * [XCVRD_LOG](#xcvrd_log)
          * [PASSWORD_HARDENING](#password_hardening)
          * [SSH_SERVER](#ssh_server)
+         * [SUBNET_DECAP](#subnet_decap)
          * [SYSTEM_DEFAULTS table](#systemdefaults-table)
          * [RADIUS](#radius)
          * [Static DNS](#static-dns)
@@ -2811,6 +2812,20 @@ The method could be:
     },
     "accounting": {
        "login": "local"
+    }
+}
+```
+
+### SUBNET_DECAP
+
+The **SUBNET_DECAP** table is used for subnet decap configuration.
+
+```
+"SUBNET_DECAP": {
+    "AZURE": {
+        "status": "enable",
+        "src_ip": "10.10.10.0/24",
+        "src_ip_v6": "20c1:ba8::/64"
     }
 }
 ```

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -167,6 +167,7 @@ setup(
                          './yang-models/sonic-system-tacacs.yang',
                          './yang-models/sonic-system-radius.yang',
                          './yang-models/sonic-system-ldap.yang',
+                         './yang-models/sonic-subnet-decap.yang',
                          './yang-models/sonic-telemetry.yang',
                          './yang-models/sonic-telemetry_client.yang',
                          './yang-models/sonic-gnmi.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -5,6 +5,13 @@
                     "vni" : "100"
                 }
         },
+        "SUBNET_DECAP": {
+            "AZURE": {
+                "status": "enable",
+                "src_ip": "10.10.10.0/24",
+                "src_ip_v6": "20c1:ba8::/64"
+            }
+        },
         "DHCP_SERVER": {
             "192.0.0.8": {},
             "192.0.0.8": {},

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/subnet_decap.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/subnet_decap.json
@@ -1,0 +1,31 @@
+{
+    "SUBNET_DECAP_DEFAULT_TEST": {
+        "desc": "Configure SUBNET_DECAP table."
+    },
+    "SUBNET_DECAP_ENABLE_TEST": {
+        "desc": "Configure SUBNET_DECAP table with status as enable."
+    },
+    "SUBNET_DECAP_DISABLE_TEST": {
+        "desc": "Configure SUBNET_DECAP table with status as disable."
+    },
+    "SUBNET_DECAP_INVALID_STATUS_TEST": {
+        "desc": "Configure SUBNET_DECAP table with invalid status.",
+        "eStrKey": "InvalidValue"
+    },
+    "SUBNET_DECAP_INVALID_IPV4": {
+        "desc": "Configure SUBNET_DECAP table with invalid src ipv4 prefix.",
+        "eStrKey": "Pattern"
+    },
+    "SUBNET_DECAP_INVALID_IPV6": {
+        "desc": "Configure SUBNET_DECAP table with invalid src ipv6 prefix.",
+        "eStrKey": "Pattern"
+    },
+    "SUBNET_DECAP_NO_IPV4": {
+        "desc": "Configure SUBNET_DECAP table without src ipv4 prefix.",
+        "eStrKey": "Mandatory"
+    },
+    "SUBNET_DECAP_NO_IPV6": {
+        "desc": "Configure SUBNET_DECAP table without src ipv6 prefix.",
+        "eStrKey": "Mandatory"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/subnet_decap.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/subnet_decap.json
@@ -1,0 +1,111 @@
+{
+    "SUBNET_DECAP_DEFAULT_TEST": {
+        "sonic-subnet-decap:sonic-subnet-decap": {
+            "sonic-subnet-decap:SUBNET_DECAP": {
+                "SUBNET_DECAP_LIST": [
+                    {
+                        "name": "AZURE",
+                        "src_ip": "10.10.10.0/24",
+                        "src_ip_v6": "20c1:ba8::/64"
+                    }
+                ]
+            }
+        }
+    },
+    "SUBNET_DECAP_ENABLE_TEST": {
+        "sonic-subnet-decap:sonic-subnet-decap": {
+            "sonic-subnet-decap:SUBNET_DECAP": {
+                "SUBNET_DECAP_LIST": [
+                    {
+                        "name": "AZURE",
+                        "status": "enable",
+                        "src_ip": "10.10.10.0/24",
+                        "src_ip_v6": "20c1:ba8::/64"
+                    }
+                ]
+            }
+        }
+    },
+    "SUBNET_DECAP_DISABLE_TEST": {
+        "sonic-subnet-decap:sonic-subnet-decap": {
+            "sonic-subnet-decap:SUBNET_DECAP": {
+                "SUBNET_DECAP_LIST": [
+                    {
+                        "name": "AZURE",
+                        "status": "disable",
+                        "src_ip": "10.10.10.0/24",
+                        "src_ip_v6": "20c1:ba8::/64"
+                    }
+                ]
+            }
+        }
+    },
+    "SUBNET_DECAP_INVALID_STATUS_TEST": {
+        "sonic-subnet-decap:sonic-subnet-decap": {
+            "sonic-subnet-decap:SUBNET_DECAP": {
+                "SUBNET_DECAP_LIST": [
+                    {
+                        "name": "AZURE",
+                        "status": "enabled",
+                        "src_ip": "10.10.10.0/24",
+                        "src_ip_v6": "20c1:ba8::/64"
+                    }
+                ]
+            }
+        }
+    },
+    "SUBNET_DECAP_INVALID_IPV4": {
+        "sonic-subnet-decap:sonic-subnet-decap": {
+            "sonic-subnet-decap:SUBNET_DECAP": {
+                "SUBNET_DECAP_LIST": [
+                    {
+                        "name": "AZURE",
+                        "status": "enable",
+                        "src_ip": "10.10.10.01111/24",
+                        "src_ip_v6": "20c1:ba8::/64"
+                    }
+                ]
+            }
+        }
+    },
+    "SUBNET_DECAP_INVALID_IPV6": {
+        "sonic-subnet-decap:sonic-subnet-decap": {
+            "sonic-subnet-decap:SUBNET_DECAP": {
+                "SUBNET_DECAP_LIST": [
+                    {
+                        "name": "AZURE",
+                        "status": "enable",
+                        "src_ip": "10.10.10.0/24",
+                        "src_ip_v6": "20c1:ba8::01111/64"
+                    }
+                ]
+            }
+        }
+    },
+    "SUBNET_DECAP_NO_IPV4": {
+        "sonic-subnet-decap:sonic-subnet-decap": {
+            "sonic-subnet-decap:SUBNET_DECAP": {
+                "SUBNET_DECAP_LIST": [
+                    {
+                        "name": "AZURE",
+                        "status": "enable",
+                        "src_ip_v6": "20c1:ba8::/64"
+                    }
+                ]
+            }
+        }
+    },
+    "SUBNET_DECAP_NO_IPV6": {
+        "sonic-subnet-decap:sonic-subnet-decap": {
+            "sonic-subnet-decap:SUBNET_DECAP": {
+                "SUBNET_DECAP_LIST": [
+                    {
+                        "name": "AZURE",
+                        "status": "enable",
+                        "src_ip": "10.10.10.0/24"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-subnet-decap.yang
+++ b/src/sonic-yang-models/yang-models/sonic-subnet-decap.yang
@@ -1,0 +1,57 @@
+module sonic-subnet-decap {
+
+    yang-version 1.1;
+
+    namespace  "http://github.com/sonic-net/sonic-subnet-decap";
+
+    prefix subnet-decap;
+
+    import ietf-inet-types {
+        prefix inet;
+    }
+
+    import sonic-types {
+        prefix stypes;
+    }
+
+    description "Subnet decap configuration for SONiC OS.";
+
+    revision 2024-12-19 {
+        description "Initial version";
+    }
+
+    container sonic-subnet-decap {
+        container SUBNET_DECAP {
+
+            description "CONFIG_DB subnet decap configuration.";
+
+            list SUBNET_DECAP_LIST {
+
+                key "name";
+
+                leaf name {
+                    type string;
+                    description "Subnet Decap config name.";
+                }
+
+                leaf status {
+                    type stypes:mode-status;
+                    default disable;
+                    description "Subnet Decap status.";
+                }
+
+                leaf src_ip {
+                    type inet:ipv4-prefix;
+                    description "Subnet decap term source IPv4 prefix.";
+                    mandatory true;
+                }
+
+                leaf src_ip_v6 {
+                    type inet:ipv6-prefix;
+                    description "Subnet decap term source IPv6 prefix.";
+                    mandatory true;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cherry-pick https://github.com/sonic-net/sonic-buildimage/pull/21118 into 202411

##### Work item tracking
- Microsoft ADO **(number only)**: 30473162

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

