### PR TITLE
update psu sensors data file

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/psu_sensors.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/psu_sensors.json
@@ -246,6 +246,32 @@
                 }
             }
         },
+        "SN4280": {
+            "default": {
+                "bus": [
+                    "i2c-4",
+                    "i2c-1-mux (chan_id 3)"
+                ],
+                "chip": {
+                    "dps460-i2c-*-58": ["2", "R"],
+                    "dps460-i2c-*-59": ["1", "L"]
+                }
+            }
+        },
+        "SN4800": {
+            "default": {
+                "bus": [
+                    "i2c-4",
+                    "i2c-1-mux (chan_id 3)"
+                ],
+                "chip": {
+                    "dps460-i2c-*-58": ["2", "R"],
+                    "dps460-i2c-*-59": ["1", "R"],
+                    "dps460-i2c-*-5a": ["4", "L"],
+                    "dps460-i2c-*-5b": ["3", "L"]
+                }
+            }
+        },
         "SN5400": {
             "default": {
                 "bus": [
@@ -267,7 +293,34 @@
                     "dps460-i2c-*-5a": ["2", "R"]
                 }
             }
+        },
+        "SN5610n": {
+            "default": {
+                "bus": [
+
+                ],
+                "chip": {
+                    "dps460-i2c-*-58": ["2", "R"],
+                    "dps460-i2c-*-59": ["1", "L"],
+                    "dps460-i2c-*-5a": ["4", "R"],
+                    "dps460-i2c-*-5b": ["3", "R"]
+                }
+            }
+        },
+        "SN5640": {
+            "default": {
+                "bus": [
+
+                ],
+                "chip": {
+                    "dps460-i2c-*-58": ["2", "L"],
+                    "dps460-i2c-*-59": ["1", "L"],
+                    "dps460-i2c-*-5a": ["4", "R"],
+                    "dps460-i2c-*-5b": ["3", "R"]
+                }
+            }
         }
+        
     },
 
     "psu": {
@@ -335,7 +388,7 @@
         "MTEF-AC-E": {
             "label": [
                 "in1 PSU 220V Rail (in)",
-                "in3 PSU 12V Rail (out)",
+                "in2 PSU 12V Rail (out)",
                 "fan1 PSU Fan 1",
                 "temp1 PSU Temp 1",
                 "temp2 PSU Temp 2",


### PR DESCRIPTION
1. add new platform's sensors data
2. correct psu model AC-E rail out label

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

