### PR TITLE
[SmartSwitch] is_smartswitch() is not required inside is_dpu() function

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -624,9 +624,6 @@ def is_dpu():
     if not platform:
         return False
 
-    if not is_smartswitch():
-        return False
-
     # Retrieve platform.json data
     platform_data = get_platform_json_data()
     if platform_data:


### PR DESCRIPTION
This pull request includes a small change to the `is_dpu` function in the `src/sonic-py-common/sonic_py_common/device_info.py` file. The change removes a conditional check for `is_smartswitch()` that previously returned `False` if the check failed.

* [`src/sonic-py-common/sonic_py_common/device_info.py`](diffhunk://#diff-b40a22d6ab8d9024c9c74bfeba8a9b2383fe36cbb2226e87a991028ceec7bf7dL627-L629): Removed the `is_smartswitch()` check from the `is_dpu` function.

#### Why I did it
The condition `if platform_data: return 'DPU' in platform_data` is sufficient to determine whether the platform is a DPU.

Additionally, is_smartswitch() returns False because "DPUS" is not present in platform.json on a DPU.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

