### PR TITLE
J2cli deprecate. Use jinjanator instead for python3.12+

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -93,10 +93,10 @@ ifeq ($(USER), root)
 $(error Add your user account to docker group and use your user account to make. root or sudo are not supported!)
 endif
 
-# Check for j2cli availability
-J2_VER := $(shell j2 --version 2>&1 | grep j2cli | awk '{printf $$2}')
+# Check for j2 availability (https://github.com/kpfleming/jinjanator)
+J2_VER := $(shell j2 --version 2>&1 | grep j2 | awk '{printf $$2}')
 ifeq ($(J2_VER),)
-$(error Please install j2cli (sudo pip install j2cli))
+$(error Please install j2 (sudo pip install jinjanator))
 endif
 
 # Check for minimum Docker version on build host

--- a/README.md
+++ b/README.md
@@ -151,11 +151,11 @@ A good choice of OS for building SONiC is currently Ubuntu 20.04.
 ## Prerequisites
 
 * Install pip and jinja in host build machine, execute below commands
-   if j2/j2cli is not available:
+   if j2/jinjanator is not available:
 
 ```shell
 sudo apt install -y python3-pip
-pip3 install --user j2cli
+pip3 install --user jinjanator
 ```
 
 * Install [Docker](https://docs.docker.com/engine/install/) and configure your

--- a/dockers/docker-base-bookworm/Dockerfile.j2
+++ b/dockers/docker-base-bookworm/Dockerfile.j2
@@ -71,7 +71,7 @@ RUN pip3 install --upgrade pip
 RUN apt purge -y python3-pip
 
 # For templating
-RUN pip3 install j2cli
+RUN pip3 install jinjanator
 
 # Install supervisor
 RUN pip3 install supervisor==4.2.5

--- a/files/build/versions/dockers/docker-base-bookworm/versions-py3
+++ b/files/build/versions/dockers/docker-base-bookworm/versions-py3
@@ -1,4 +1,4 @@
-j2cli==0.3.10
+jinjanator==25.1.0
 jinja2==3.1.5
 markupsafe==3.0.2
 pip==25.0

--- a/files/build/versions/dockers/sonic-slave-bookworm/versions-deb-bookworm
+++ b/files/build/versions/dockers/sonic-slave-bookworm/versions-deb-bookworm
@@ -240,7 +240,7 @@ ipython3==8.5.0-4
 iso-codes==4.15.0-1
 isympy-common==1.11.1-1
 isympy3==1.11.1-1
-j2cli==0.3.12b-4
+jinjanator==25.1.0
 java-common==0.74
 java-wrappers==0.4
 javahelper==0.78

--- a/files/build/versions/dockers/sonic-slave-bookworm/versions-py3
+++ b/files/build/versions/dockers/sonic-slave-bookworm/versions-py3
@@ -56,7 +56,7 @@ incremental==21.3.0
 iniconfig==1.1.1
 ipython==8.5.0
 isort==5.6.4
-j2cli==0.3.12b0
+jinjanator==25.1.0
 jedi==0.18.2
 jinja2==3.1.2
 jsonpath-ng==1.7.0

--- a/files/build/versions/host-image/versions-deb-bookworm
+++ b/files/build/versions/host-image/versions-deb-bookworm
@@ -79,7 +79,7 @@ iptables==1.8.9-2
 iptables-persistent==1.0.20
 iputils-ping==3:20221126-1+deb12u1
 isc-dhcp-client==4.4.3-P1-2
-j2cli==0.3.12b-4
+jinjanator==25.1.0
 jq==1.6-2.1
 kdump-tools==1:1.8.1
 kernel-mft-dkms-modules-6.1.0-22-2-amd64==4.30.2

--- a/files/build/versions/host-image/versions-py3
+++ b/files/build/versions/host-image/versions-py3
@@ -24,7 +24,7 @@ ijson==3.2.3
 inotify==0.2.10
 ipaddr==2.2.0
 ipaddress==1.0.23
-j2cli==0.3.12b0
+jinjanator==25.1.0
 jinja2==3.1.2
 jsondiff==2.2.1
 jsonpatch==1.33

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -122,8 +122,8 @@ sudo dpkg --root=$FILESYSTEM_ROOT --force-confdef --force-confold -i $debs_path/
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install \
     python3-dev
 
-# Install j2cli for handling jinja template
-sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install j2cli
+# Install jinjanator for handling jinja template
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install jinjanator
 
 # Install Python client for Redis
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "redis==3.5.3"

--- a/platform/nvidia-bluefield/installer/create_sonic_image
+++ b/platform/nvidia-bluefield/installer/create_sonic_image
@@ -354,7 +354,7 @@ main() {
     echo $@
     parse_args $@
     . $CDIR/onie-image-arm64.conf
-    # Export ENV Variables for j2cli
+    # Export ENV Variables for jinjanator
     CHROOT_DIR=$CDIR/$FILESYSTEM_ROOT
     if [[ ! -d "$CHROOT_DIR" ]]; then
         echo "[create_sonic_image] Error! Path to CHROOT not found"

--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -306,7 +306,7 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
 {%- if CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" %}
         libxslt-dev \
 {%- endif %}
-        j2cli \
+        jinjanator \
 # For lockfile
         procmail \
 # For gtest


### PR DESCRIPTION
j2cli is archived and no longer compatible with Python3.12+ (https://github.com/kolypto/j2cli/issues/80)

jinjanator is an alternative tool https://github.com/kpfleming/jinjanator

#### Why I did it

j2cli is incompatible with python3.12 + 

https://github.com/kolypto/j2cli/issues/80

#### How I did it

#### How to verify it


#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305


```