### PR TITLE
[Mellanox] Update PSU sensors data file

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/psu_sensors.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/psu_sensors.json
@@ -246,6 +246,18 @@
                 }
             }
         },
+        "SN4280": {
+            "default": {
+                "bus": [
+                    "i2c-4",
+                    "i2c-1-mux (chan_id 3)"
+                ],
+                "chip": {
+                    "dps460-i2c-*-58": ["2", "R"],
+                    "dps460-i2c-*-59": ["1", "L"]
+                }
+            }
+        },
         "SN5400": {
             "default": {
                 "bus": [
@@ -267,7 +279,34 @@
                     "dps460-i2c-*-5a": ["2", "R"]
                 }
             }
+        },
+        "SN5610N": {
+            "default": {
+                "bus": [
+
+                ],
+                "chip": {
+                    "dps460-i2c-*-58": ["2", "R"],
+                    "dps460-i2c-*-59": ["1", "L"],
+                    "dps460-i2c-*-5a": ["4", "R"],
+                    "dps460-i2c-*-5b": ["3", "R"]
+                }
+            }
+        },
+        "SN5640": {
+            "default": {
+                "bus": [
+
+                ],
+                "chip": {
+                    "dps460-i2c-*-58": ["2", "L"],
+                    "dps460-i2c-*-59": ["1", "L"],
+                    "dps460-i2c-*-5a": ["4", "R"],
+                    "dps460-i2c-*-5b": ["3", "R"]
+                }
+            }
         }
+        
     },
 
     "psu": {
@@ -335,7 +374,7 @@
         "MTEF-AC-E": {
             "label": [
                 "in1 PSU 220V Rail (in)",
-                "in3 PSU 12V Rail (out)",
+                "in2 PSU 12V Rail (out)",
                 "fan1 PSU Fan 1",
                 "temp1 PSU Temp 1",
                 "temp2 PSU Temp 2",
@@ -411,6 +450,25 @@
                 "power3"
             ]
         },
+        "930-9SPSU-00RA-00A" :{
+            "label": [
+                "in1 PSU 220V Rail (in)",
+                "in3 PSU 12V Rail (out)", 
+                "fan1 PSU Fan 1",
+                "temp1 PSU Temp 1",
+                "temp2 PSU Temp 2",
+                "temp3 PSU Temp 3",
+                "power1 PSU 220V Rail Pwr (in)",
+                "power2 PSU 12V Rail Pwr (out)",
+                "curr1 PSU 220V Rail Curr (in)",
+                "curr2 PSU 12V Rail Curr (out)"
+            ],
+            "ignore": [
+                "in2",
+                "fan2",
+                "fan3"
+            ]
+        },
         "930-9SPSU-00RA-00B" :{
             "label": [
                 "in1 PSU 220V Rail (in)",
@@ -425,6 +483,28 @@
             ],
             "ignore": [
                 "in2"
+            ],
+            "set": [
+                "power2_cap 0"
+            ]
+        },
+        "930-9SPSU-00RA-00C" :{
+            "label": [
+                "in1 PSU 220V Rail (in)",
+                "in3 PSU 54V Rail (out)",
+                "fan1 PSU Fan 1", 
+                "temp1 PSU Temp 1",
+                "temp2 PSU Temp 2",
+                "temp3 PSU Temp 3",
+                "power1 PSU 220V Rail Pwr (in)",
+                "power2 PSU 54V Rail Pwr (out)",
+                "curr1 PSU 220V Rail Curr (in)",
+                "curr2 PSU 54V Rail Curr (out)"
+            ],
+            "ignore": [
+                "in2",
+                "fan2",
+                "fan3"
             ],
             "set": [
                 "power2_cap 0"

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/sensors.conf
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/sensors.conf
@@ -4,6 +4,8 @@
 # Platform specific sensors config for SN4280
 ###########################################################################
 
+# Hardware revision default
+
 # Temperature sensors
 bus "i2c-2" "i2c-1-mux (chan_id 1)"
     chip "mlxsw-i2c-*-48"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

1. Add new platform's sensors data
2. Correct PSU model AC-E rail out label

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

use `sensors` command and confirm the output is labeled correctly

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202411
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

