### PR TITLE
[dualtor] Fix `mux` start failure due to pre operation timeout

### DIFF
--- a/files/build_templates/mux.service.j2
+++ b/files/build_templates/mux.service.j2
@@ -8,6 +8,7 @@ StartLimitIntervalSec=1200
 StartLimitBurst=3
 
 [Service]
+TimeoutStartSec=180
 User={{ sonicadmin_user }}
 ExecStartPre=/usr/local/bin/write_standby.py
 ExecStartPre=/usr/local/bin/mark_dhcp_packet.py

--- a/files/scripts/write_standby.py
+++ b/files/scripts/write_standby.py
@@ -136,7 +136,7 @@ class MuxStateWriter(object):
         tunnel_key_pattern = 'ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL:*'
         return len(self.asic_db.keys('ASIC_DB', tunnel_key_pattern)) > 0
 
-    def wait_for_tunnel(self, interval=1, timeout=90):
+    def wait_for_tunnel(self, interval=1, timeout=160):
         """
         Waits until the IP-in-IP tunnel has been created
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Mux service is observed not started due to pre operation timeout:
```
2025 Mar  6 12:39:46.192880 vlab-06 NOTICE switch_hash: 'reload' executing with command: config reload -y
2025 Mar  6 12:40:47.490091 vlab-06 INFO systemd[1]: Starting swss.service - switch state service…
2025 Mar  6 12:40:57.156019 vlab-06 INFO systemd[1]: Starting mux.service - MUX Cable Container…
2025 Mar  6 12:41:22.474031 vlab-06 NOTICE swss#tunnelmgrd: :- doTunnelTask: Tunnel MuxTunnel0 task, op SET
2025 Mar  6 12:42:27.344856 vlab-06 WARNING systemd[1]: mux.service: start-pre operation timed out. Terminating.
2025 Mar  6 12:42:27.346562 vlab-06 WARNING systemd[1]: mux.service: Control process exited, code=killed, status=15/TERM
2025 Mar  6 12:43:11.903374 vlab-06 NOTICE swss#orchagent: :- doDecapTunnelTask: Tunnel MuxTunnel0 added to ASIC_DB.
```
Two issues:
- The orchagent tunnel creation can takes up to 2mins after reload on kvm && mlnx platforms, so `write_standby.py` always timeout waiting for the tunnel to be ready.
- The default pre operation timeout is only 90s.


##### Work item tracking
- Microsoft ADO **(number only)**: 31745242

#### How I did it
Let's increase the tunnel wait time in `write_standby.py` to 160s, and make the `mux.service` pre operation timeout as 180s.


#### How to verify it
Reload with `mux` running:
```
2025 Mar 11 08:07:38.865006 INFO systemd[1]: Starting mux.service - MUX Cable Container...
2025 Mar 11 08:09:52.938199 WARNING write_standby: Applying state to interfaces {'Ethernet0': 'active', 'Ethernet16': 'active', 'Ethernet160': 'active', 'Ethernet168': 'active', 'Ethernet176': 'active', 'Ethernet184': 'active', 'Ethernet192': 'active', 'Ethernet200': 'active', 'Ethernet208': 'active', 'Ethernet216': 'active', 'Ethernet224': 'active', 'Ethernet232': 'active', 'Ethernet24': 'active', 'Ethernet240': 'active', 'Ethernet32': 'active', 'Ethernet40': 'active', 'Ethernet48': 'active', 'Ethernet56': 'active', 'Ethernet64': 'active', 'Ethernet72': 'active', 'Ethernet8': 'active', 'Ethernet80': 'active', 'Ethernet88': 'active'}
2025 Mar 11 08:09:54.159939 INFO systemd[1]: Started mux.service - MUX Cable Container.
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202411
#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

