### PR TITLE
[202305][rsyslog]: Remote logging with the highest rule priority

### DIFF
--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -61,6 +61,11 @@ template(name="WelfRemoteFormat" type="string" string="%TIMESTAMP% id=firewall t
 #
 # Remote syslog logging
 #
+
+# The omfwd plug-in provides the core functionality of traditional message
+# forwarding via UDP and plain TCP. It is a built-in module that does not need
+# to be loaded.
+
 {% set servers = SYSLOG_SERVER | d({}) -%}
 {% for server in servers %}
 {% set conf = servers[server] | d({}) -%}

--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -59,41 +59,8 @@ template(name="WelfRemoteFormat" type="string" string="%TIMESTAMP% id=firewall t
 :::date-second%\" fw=\"{{ fw_name }}\" pri=%syslogpriority% msg=\"%syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\"\n")
 
 #
-# Set the default permissions for all log files.
-#
-$FileOwner root
-$FileGroup adm
-$FileCreateMode 0640
-$DirCreateMode 0755
-$Umask 0022
-
-#
-# Where to place spool and state files
-#
-$WorkDirectory /var/spool/rsyslog
-
-#
-# Include all config files in /etc/rsyslog.d/
-#
-$IncludeConfig /etc/rsyslog.d/*.conf
-
-#
-# Suppress duplicate messages and report "message repeated n times"
-#
-$RepeatedMsgReduction on
-
-###############
-#### RULES ####
-###############
-
-#
 # Remote syslog logging
 #
-
-# The omfwd plug-in provides the core functionality of traditional message
-# forwarding via UDP and plain TCP. It is a built-in module that does not need
-# to be loaded.
-
 {% set servers = SYSLOG_SERVER | d({}) -%}
 {% for server in servers %}
 {% set conf = servers[server] | d({}) -%}
@@ -128,3 +95,31 @@ $RepeatedMsgReduction on
 *.{{ severity }}
 action(type="omfwd" Target="{{ server }}" Port="{{ port }}" Protocol="{{ proto }}" Template="{{ template }}"{{ options }})
 {% endfor %}
+
+#
+# Set the default permissions for all log files.
+#
+$FileOwner root
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+
+#
+# Where to place spool and state files
+#
+$WorkDirectory /var/spool/rsyslog
+
+#
+# Include all config files in /etc/rsyslog.d/
+#
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+#
+# Suppress duplicate messages and report "message repeated n times"
+#
+$RepeatedMsgReduction on
+
+###############
+#### RULES ####
+###############

--- a/src/sonic-config-engine/setup.cfg
+++ b/src/sonic-config-engine/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/src/sonic-config-engine/tests/test_cfggen_from_yang.py
+++ b/src/sonic-config-engine/tests/test_cfggen_from_yang.py
@@ -104,12 +104,10 @@ class TestCfgGen(object):
         assert(output == \
             {'PortChannel1001': {'admin_status': 'up',
                       'lacp_key': 'auto',
-                      'members': ['Ethernet0', 'Ethernet4'],
                       'min_links': '1',
                       'mtu': '9100'},
             'PortChannel1002': {'admin_status': 'up',
                       'lacp_key': 'auto',
-                      'members': ['Ethernet16', 'Ethernet20'],
                       'min_links': '1',
                       'mtu': '9100'}})
 
@@ -194,7 +192,8 @@ class TestCfgGen(object):
             "EVERFLOW|Rule2": {
                 "DST_IP": "192.169.10.1/32",
                 "SRC_IP": "10.10.1.1/16",
-                "IP_TYPE": "IPV4"
+                "IP_TYPE": "IPV4",
+                "PRIORITY": "101"
             }
         })
 

--- a/src/sonic-config-engine/tests/test_yang_data.json
+++ b/src/sonic-config-engine/tests/test_yang_data.json
@@ -98,10 +98,6 @@
             "PORTCHANNEL_LIST": [
                 {
                     "admin_status": "up",
-                    "members": [
-                        "Ethernet0",
-                        "Ethernet4"
-                    ],
                     "min_links": "1",
                     "mtu": "9100",
                     "lacp_key": "auto",
@@ -109,10 +105,6 @@
                 },
                 {
                     "admin_status": "up",
-                    "members": [
-                        "Ethernet16",
-                        "Ethernet20"
-                    ],
                     "min_links": "1",
                     "mtu": "9100",
                     "lacp_key": "auto",
@@ -300,7 +292,8 @@
                     "DST_IP": "192.169.10.1/32",
                     "SRC_IP": "10.10.1.1/16",
                     "IP_TYPE": "IPV4",
-                    "RULE_NAME": "Rule2"
+                    "RULE_NAME": "Rule2",
+                    "PRIORITY": 101
                 }
             ]
         }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This fix resolves issue with missing certain types of messages while forwarding to the remote server.

Basically, this moves remote syslog forwarding rules to be executed before any other instructions take place,
so everything received by a local syslog instance will be forwarded to the remote machine.

The fix allows remote forwarding of messages defined as:
https://github.com/sonic-net/sonic-buildimage/blob/master/files/image_config/rsyslog/rsyslog.d/00-sonic.conf.j2

#### Work item tracking
* N/A

#### How I did it
* Moved `rsyslog` remote forwarding rules to be on top of other syslog instructions

#### How to verify it
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
1. Enable remote syslog forwarding
2. Check for message patterns defined as [00-sonic.conf.j2](https://github.com/sonic-net/sonic-buildimage/blob/master/files/image_config/rsyslog/rsyslog.d/00-sonic.conf.j2)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202305 <!-- image version 1 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
* N/A

#### Details if related
* Backport from `master`: https://github.com/sonic-net/sonic-buildimage/pull/21923

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```