### PR TITLE
Removed check to allow BGP peer in a vnet

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/dynamic/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/dynamic/instance.conf.j2
@@ -3,15 +3,6 @@
 !
 {% from "common/functions.conf.j2" import get_ipv4_loopback_address %}
 !
-{% if operation is defined and operation == 'update' %}
-{% for ip_range in delete_ranges %}
-  no bgp listen range {{ ip_range }} peer-group {{ bgp_session['name'] }}
-{% endfor %}
-{% for ip_range in add_ranges %}
-  bgp listen range {{ ip_range }} peer-group {{ bgp_session['name'] }}
-{% endfor %}
-{% else %}
-!
   neighbor {{ bgp_session['name'] }} peer-group
   neighbor {{ bgp_session['name'] }} passive
   neighbor {{ bgp_session['name'] }} ebgp-multihop 255
@@ -42,8 +33,6 @@
   address-family ipv6
     neighbor {{ bgp_session['name'] }} activate
   exit-address-family
-!
-{% endif %}
 !
 ! end of template: bgpd/templates/dynamic/instance.conf.j2
 !

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/dynamic/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/dynamic/instance.conf.j2
@@ -3,6 +3,15 @@
 !
 {% from "common/functions.conf.j2" import get_ipv4_loopback_address %}
 !
+{% if operation is defined and operation == 'update' %}
+{% for ip_range in delete_ranges %}
+  no bgp listen range {{ ip_range }} peer-group {{ bgp_session['name'] }}
+{% endfor %}
+{% for ip_range in add_ranges %}
+  bgp listen range {{ ip_range }} peer-group {{ bgp_session['name'] }}
+{% endfor %}
+{% else %}
+!
   neighbor {{ bgp_session['name'] }} peer-group
   neighbor {{ bgp_session['name'] }} passive
   neighbor {{ bgp_session['name'] }} ebgp-multihop 255
@@ -33,6 +42,8 @@
   address-family ipv6
     neighbor {{ bgp_session['name'] }} activate
   exit-address-family
+!
+{% endif %}
 !
 ! end of template: bgpd/templates/dynamic/instance.conf.j2
 !

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
@@ -187,19 +187,12 @@ class BGPPeerMgrBase(Manager):
         if "local_addr" not in data:
             log_warn("Peer %s. Missing attribute 'local_addr'" % nbr)
         else:
-            # The bgp session that belongs to a vnet cannot be advertised as the default BGP session.
-            # So we need to check whether this bgp session belongs to a vnet.
             data["local_addr"] = str(netaddr.IPNetwork(str(data["local_addr"])).ip)
             interface = self.get_local_interface(data["local_addr"])
             if not interface:
                 print_data = nbr, data["local_addr"]
                 log_debug("Peer '%s' with local address '%s' wait for the corresponding interface to be set" % print_data)
                 return False
-            vnet = self.get_vnet(interface)
-            if vnet:
-                # Ignore the bgp session that is in a vnet
-                log_info("Ignore the BGP peer '%s' as the interface '%s' is in vnet '%s'" % (nbr, interface, vnet))
-                return True
 
         kwargs = {
             'CONFIG_DB__DEVICE_METADATA': self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME),

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
@@ -242,8 +242,6 @@ class BGPPeerMgrBase(Manager):
         """
         if "admin_status" in data:
             self.change_admin_status(vrf, nbr, data)
-        elif "ip_range" in data and self.peer_type == 'dynamic':
-            self.change_ip_range(vrf, nbr, data)
         else:
             log_err("Peer '(%s|%s)': Can't update the peer. Only 'admin_status' attribute is supported" % (vrf, nbr))
 
@@ -280,94 +278,6 @@ class BGPPeerMgrBase(Manager):
             log_info("Peer '%s|%s' admin state is set to '%s'" % print_data)
         else:
             log_err("Can't set peer '%s|%s' admin state to '%s'." % print_data)
-    
-    def change_ip_range(self, vrf, nbr, data):
-        """
-        Change ip range of a peer
-        :param vrf: vrf name. Name is equal "default" for the global vrf
-        :param nbr: neighbor ip address (name for dynamic peer type)
-        :param data: associated data
-        :return: True if this adding was successful, False otherwise
-        """
-        if data['ip_range']:
-            log_info("Peer '(%s|%s)' ip range is going to be updated with range: %s" % (vrf, nbr, data['ip_range']))
-            new_ip_range = data["ip_range"].split(",")
-            ip_ranges_to_add = new_ip_range
-            ip_ranges_to_del = []
-            existing_ipv4_range, existing_ipv6_range = self.get_existing_ip_ranges(vrf, nbr)
-            if existing_ipv4_range:
-                for ipv4_range in existing_ipv4_range:
-                    if ipv4_range not in new_ip_range:
-                        ip_ranges_to_del.append(ipv4_range)
-                    else:
-                        ip_ranges_to_add.remove(ipv4_range)
-            if existing_ipv6_range:
-                for ipv6_range in existing_ipv6_range:
-                    if ipv6_range not in new_ip_range:
-                        ip_ranges_to_del.append(ipv6_range)
-                    else:
-                        ip_ranges_to_add.remove(ipv6_range)
-            if ip_ranges_to_del or ip_ranges_to_add:
-                log_info("Peer '(%s|%s)' ip range is going to be updated. Ranges to delete: %s Ranges to add: %s" % (vrf, nbr, ip_ranges_to_del, ip_ranges_to_add))
-                self.apply_range_changes(vrf, nbr, ip_ranges_to_add, ip_ranges_to_del, data)
-
-    def get_existing_ip_ranges(self, vrf, nbr):
-        """
-        Get existing ip range of a peer
-        :param vrf: vrf name. Name is equal "default" for the global vrf
-        :param nbr: neighbor ip address (name for dynamic peer type)
-        :return: existing ip range of a peer
-        """
-        ipv4_ranges = []
-        ipv6_ranges = []
-        if vrf == 'default':
-            command = ["vtysh", "-c", "show bgp peer-group %s json" % (nbr)]
-        else:
-            command = ["vtysh", "-c", "show bgp vrf %s peer-group %s json" % (vrf, nbr)]
-        try:
-            ret_code, out, err = run_command(command)
-            if ret_code == 0:
-                js_bgp = json.loads(out)
-                if nbr in js_bgp and 'dynamicRanges' in js_bgp[nbr] and 'IPv4' in js_bgp[nbr]['dynamicRanges'] and 'ranges' in js_bgp[nbr]['dynamicRanges']['IPv4']:
-                    ipv4_ranges= js_bgp[nbr]['dynamicRanges']['IPv4']['ranges']
-                    log_info("Peer '(%s|%s)' already has ipV4 range: %s" % (vrf, nbr, ipv4_ranges))
-                if nbr in js_bgp and 'dynamicRanges' in js_bgp[nbr] and 'IPv6' in js_bgp[nbr]['dynamicRanges'] and 'ranges' in js_bgp[nbr]['dynamicRanges']['IPv6']:
-                    ipv6_ranges= js_bgp[nbr]['dynamicRanges']['IPv6']['ranges']
-                    log_info("Peer '(%s|%s)' already has ipV6 range: %s" % (vrf, nbr, ipv6_ranges))
-                return ipv4_ranges, ipv6_ranges
-            else:
-                log_err("Can't read ip range of peer '%s|%s': %s" % (vrf, nbr, str(err)))
-                return ipv4_ranges, ipv6_ranges
-        except Exception as e:
-            log_err("Error in parsing ip range: %s" % str(e))
-            return ipv4_ranges, ipv6_ranges
-
-    def apply_range_changes(self, vrf, nbr, new_ip_range, ip_ranges_to_del, data):
-        """
-        Apply changes of ip range of a peer
-        :param vrf: vrf name. Name is equal "default" for the global vrf
-        :param nbr: neighbor ip address (name for dynamic peer type)
-        :param new_ip_range: new ip range
-        :param ip_ranges_to_del: ip ranges to delete
-        """
-        print_data = vrf, nbr, data
-        kwargs = {
-            'operation': 'update',
-            'vrf': vrf,
-            'neighbor_addr': nbr,
-            'bgp_session': data,
-            'delete_ranges': ip_ranges_to_del,
-            'add_ranges': new_ip_range
-        }
-        try:
-            cmd = self.templates["add"].render(**kwargs)
-        except jinja2.TemplateError as e:
-            msg = "Peer '(%s|%s)'. Error in rendering the template for 'SET' command '%s'" % print_data
-            log_err("%s: %s" % (msg, str(e)))
-            return True
-        if cmd is not None:
-            self.apply_op(cmd, vrf)
-            log_info("Peer '(%s|%s)' ip range has been scheduled to be updated with new range '%s'" % (vrf, nbr, new_ip_range))
 
     def del_handler(self, key):
         """

--- a/src/sonic-bgpcfgd/tests/test_bgp.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp.py
@@ -152,6 +152,18 @@ def test_add_peer_ipv6():
         res = m.set_handler("fc00:20::1", {'asn': '65200', 'holdtime': '180', 'keepalive': '60', 'local_addr': 'fc00:20::20', 'name': 'TOR', 'nhopself': '0', 'rrclient': '0'})
         assert res, "Expect True return value"
 
+def test_add_peer_in_vnet():
+    for constant in load_constant_files():
+        m = constructor(constant)
+        res = m.set_handler("Vnet-10|30.30.30.1", {'asn': '65200', 'holdtime': '180', 'keepalive': '60', 'local_addr': '30.30.30.30', 'name': 'TOR', 'nhopself': '0', 'rrclient': '0'})
+        assert res, "Expect True return value"
+
+def test_add_peer_ipv6_in_vnet():
+    for constant in load_constant_files():
+        m = constructor(constant)
+        res = m.set_handler("Vnet-10|fc00:20::1", {'asn': '65200', 'holdtime': '180', 'keepalive': '60', 'local_addr': 'fc00:20::20', 'name': 'TOR', 'nhopself': '0', 'rrclient': '0'})
+        assert res, "Expect True return value"
+
 @patch('bgpcfgd.managers_bgp.log_warn')
 def test_add_peer_no_local_addr(mocked_log_warn):
     for constant in load_constant_files():

--- a/src/sonic-bgpcfgd/tests/test_bgp.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp.py
@@ -164,30 +164,6 @@ def test_add_peer_ipv6_in_vnet():
         res = m.set_handler("Vnet-10|fc00:20::1", {'asn': '65200', 'holdtime': '180', 'keepalive': '60', 'local_addr': 'fc00:20::20', 'name': 'TOR', 'nhopself': '0', 'rrclient': '0'})
         assert res, "Expect True return value"
 
-def test_add_dynamic_peer():
-    for constant in load_constant_files():
-        m = constructor(constant, peer_type="dynamic")
-        res = m.set_handler("BGPSLBPassive", {"peer_asn": "65200", "ip_range": "10.250.0.0/27"})
-        assert res, "Expect True return value"
-
-def test_add_dynamic_peer_ipv6():
-    for constant in load_constant_files():
-        m = constructor(constant, peer_type="dynamic")
-        res = m.set_handler("BGPSLBPassive", {"peer_asn": "65200", "ip_range": "fc00:20::/64"})
-        assert res, "Expect True return value"
-
-def test_modify_dynamic_peer_range():
-    for constant in load_constant_files():
-        m = constructor(constant, peer_type="dynamic")
-        res = m.set_handler("BGPSLBPassive", {"peer_asn": "65200", "ip_range": "10.250.0.0/27"})
-        assert res, "Expect True return value"
-        res = m.set_handler("BGPSLBPassive", {"peer_asn": "65200", "ip_range": "10.250.0.0/27,10.251.0.0/27"})
-        assert res, "Expect True return value"
-        res = m.set_handler("BGPSLBPassive", {"peer_asn": "65200", "ip_range": "10.250.0.0/27,10.251.0.0/26"})
-        assert res, "Expect True return value"
-        res = m.set_handler("BGPSLBPassive", {"peer_asn": "65200", "ip_range": "10.251.0.0/27"})
-        assert res, "Expect True return value"
-
 @patch('bgpcfgd.managers_bgp.log_warn')
 def test_add_peer_no_local_addr(mocked_log_warn):
     for constant in load_constant_files():

--- a/src/sonic-bgpcfgd/tests/test_bgp.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp.py
@@ -164,6 +164,30 @@ def test_add_peer_ipv6_in_vnet():
         res = m.set_handler("Vnet-10|fc00:20::1", {'asn': '65200', 'holdtime': '180', 'keepalive': '60', 'local_addr': 'fc00:20::20', 'name': 'TOR', 'nhopself': '0', 'rrclient': '0'})
         assert res, "Expect True return value"
 
+def test_add_dynamic_peer():
+    for constant in load_constant_files():
+        m = constructor(constant, peer_type="dynamic")
+        res = m.set_handler("BGPSLBPassive", {"peer_asn": "65200", "ip_range": "10.250.0.0/27"})
+        assert res, "Expect True return value"
+
+def test_add_dynamic_peer_ipv6():
+    for constant in load_constant_files():
+        m = constructor(constant, peer_type="dynamic")
+        res = m.set_handler("BGPSLBPassive", {"peer_asn": "65200", "ip_range": "fc00:20::/64"})
+        assert res, "Expect True return value"
+
+def test_modify_dynamic_peer_range():
+    for constant in load_constant_files():
+        m = constructor(constant, peer_type="dynamic")
+        res = m.set_handler("BGPSLBPassive", {"peer_asn": "65200", "ip_range": "10.250.0.0/27"})
+        assert res, "Expect True return value"
+        res = m.set_handler("BGPSLBPassive", {"peer_asn": "65200", "ip_range": "10.250.0.0/27,10.251.0.0/27"})
+        assert res, "Expect True return value"
+        res = m.set_handler("BGPSLBPassive", {"peer_asn": "65200", "ip_range": "10.250.0.0/27,10.251.0.0/26"})
+        assert res, "Expect True return value"
+        res = m.set_handler("BGPSLBPassive", {"peer_asn": "65200", "ip_range": "10.251.0.0/27"})
+        assert res, "Expect True return value"
+
 @patch('bgpcfgd.managers_bgp.log_warn')
 def test_add_peer_no_local_addr(mocked_log_warn):
     for constant in load_constant_files():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This change allows BGP peer creation inside a VNET through bgpcfgd. The support already exists for peers to be created in VRF. Removing the check which blocks peers to be created inside a VNET. This can already be done directly through FRR configs. However, that method does not persist the configuration. Letting peer addition inside vnet go through via bgpcfgd ensures that the configurations persists after reload or reboot.

We have proper support for handling VNETs and VRFs in sonic now. Hence it is safe to remove the check and allow peers to be created inside a VNET. We are already able to create peers in side VRFs since the support for VRF was added. From FRR perspective, both VNET and VRF translate to a VRF.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Removed check to allow BGP peer in a vnet.

#### How to verify it
Create a peer inside a VNET through bgpcfgd to verify that the peer gets added. Also used FRR CLI commands to validate details about the peer.

#### Sample configuration
Adding the following configuration to config_db.json results in creation of peer and dynamic peer in the Vnet.
"BGP_NEIGHBOR": {
        "Vnet1|10.0.0.57": {
            "admin_status": "up",
            "asn": "64600",
            "holdtime": "10",
            "keepalive": "3",
            "local_addr": "10.0.0.56",
            "name": "ARISTA01T1",
            "nhopself": "0",
            "rrclient": "0"
        },
        "Vnet2|fc00::7e": {
            "admin_status": "up",
            "asn": "64600",
            "holdtime": "10",
            "keepalive": "3",
            "local_addr": "fc00::7d",
            "name": "ARISTA04T1",
            "nhopself": "0",
            "rrclient": "0"
        }
    },
    "BGP_PEER_RANGE": {
        "Vnet2|BGPSLBPassive": {
            "ip_range": [
                "10.0.0.60/30"
            ],
            "peer_asn": "64600",
            "src_address": "10.0.0.60",
            "name": "BGPSLBPassive"
        }
    }
"VNET": {
        "Vnet1": {
            "vni": "799999",
            "vxlan_tunnel": "vtep_v4"
        },
        "Vnet2": {
            "vni": "799999",
            "vxlan_tunnel": "vtep_v4"
        }
    },
    "VXLAN_TUNNEL": {
        "vtep_v4": {
            "src_ip": "10.1.0.32"
        }
    }
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Removed check to allow BGP peer in a vnet
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

