### PR TITLE
Change the default IPinIP tunnel DSCP mode to pipe

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -88,7 +88,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"uniform",
+            "dscp_mode":"pipe",
 {% if "mlnx" in DEVICE_METADATA.localhost.platform %}
             "ecn_mode":"standard",
 {% else %}
@@ -141,7 +141,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"uniform",
+            "dscp_mode":"pipe",
 {% if "mlnx" in DEVICE_METADATA.localhost.platform %}
             "ecn_mode":"standard",
 {% else %}

--- a/src/sonic-config-engine/tests/multi_npu_data/py2/ipinip.json
+++ b/src/sonic-config-engine/tests/multi_npu_data/py2/ipinip.json
@@ -2,7 +2,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"uniform",
+            "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -41,7 +41,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"uniform",
+            "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },

--- a/src/sonic-config-engine/tests/multi_npu_data/py3/ipinip.json
+++ b/src/sonic-config-engine/tests/multi_npu_data/py3/ipinip.json
@@ -2,7 +2,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"uniform",
+            "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -41,7 +41,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"uniform",
+            "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },

--- a/src/sonic-config-engine/tests/sample_output/py2/ipinip.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/ipinip.json
@@ -2,7 +2,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"uniform",
+            "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -65,7 +65,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"uniform",
+            "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },

--- a/src/sonic-config-engine/tests/sample_output/py2/ipinip_subnet_decap_enable.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/ipinip_subnet_decap_enable.json
@@ -25,7 +25,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"uniform",
+            "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -97,7 +97,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"uniform",
+            "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },

--- a/src/sonic-config-engine/tests/sample_output/py3/ipinip.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/ipinip.json
@@ -2,7 +2,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"uniform",
+            "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -65,7 +65,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"uniform",
+            "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },

--- a/src/sonic-config-engine/tests/sample_output/py3/ipinip_subnet_decap_enable.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/ipinip_subnet_decap_enable.json
@@ -25,7 +25,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"uniform",
+            "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
@@ -97,7 +97,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dscp_mode":"uniform",
+            "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },


### PR DESCRIPTION
#### Why I did it
To change the default tunnel's DSCP decap mode to pipe

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated _ipinip.json.j2_ and sonic-confg-engine's tests

#### How to verify it
Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

