### PR TITLE
Adding `custom_feature_start_tx_threshold=20` on Arista SKUs

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -865,3 +865,4 @@ sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=58
 appl_param_active_links_thr_low=1
+custom_feature_start_tx_threshold=20

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1019,3 +1019,4 @@ sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
+custom_feature_start_tx_threshold=20

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1019,3 +1019,4 @@ sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
+custom_feature_start_tx_threshold=20

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1036,3 +1036,4 @@ sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
+custom_feature_start_tx_threshold=20

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1036,3 +1036,4 @@ sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
+custom_feature_start_tx_threshold=20

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1056,3 +1056,4 @@ sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
+custom_feature_start_tx_threshold=20

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1056,3 +1056,4 @@ sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
+custom_feature_start_tx_threshold=20

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -355,3 +355,4 @@ sai_mmu_tc_to_pg_config
 sai_hostif_netif_iff_up_set
 appl_param_active_links_thr_high
 appl_param_active_links_thr_low
+custom_feature_start_tx_threshold


### PR DESCRIPTION
It's theorized that https://github.com/aristanetworks/sonic/issues/120 could be due to a FIFO underflow which is documented here https://brcmsemiconductor-csm.wolkenservicedesk.com/wolken-support/article?articleId=19817

In EOS we workaround this FIFO underflow issue by setting the `start_tx_threshold=20` for 100G and 400G ports.
Setting the same value via the soc properties in this change to match EOS values.

After the soc property change we can see the start_tx_threshold is 20 (0x14) on active lanes:
```
root@cmp227-4:~# bcmcmd -n 0 "getreg CDB_TX_MLF_CONFIG.CDB0"
getreg CDB_TX_MLF_CONFIG.CDB0
CDB_TX_MLF_CONFIG.CDB0[0x1b7]=0x120240480901202404814: <TX_START_TX_THRESHOLD_TMC_7=9,
   TX_START_TX_THRESHOLD_TMC_6=9,TX_START_TX_THRESHOLD_TMC_5=9,
   TX_START_TX_THRESHOLD_TMC_4=9,TX_START_TX_THRESHOLD_TMC_3=9,
   TX_START_TX_THRESHOLD_TMC_2=9,TX_START_TX_THRESHOLD_TMC_1=9,
   TX_START_TX_THRESHOLD_TMC_0=0x14>
```

#### Which release branch to backport (provide reason below if selected)

- [x] msft-202405


