### PR TITLE
[installer] Add CSTATE configuration for the AMD CPU.

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -484,6 +484,9 @@ bootloader_menu_config()
     if echo "$CPUVENDOR" | grep -i 'Intel' >/dev/null 2>&1; then
         echo "Switch CPU cstates are: disabled"
         CSTATES="processor.max_cstate=1 intel_idle.max_cstate=0"
+    elif echo "$CPUVENDOR" | grep -i 'AMD' >/dev/null 2>&1; then
+        echo "Switch CPU cstates are: disabled"
+        CSTATES="processor.max_cstate=1 amd_idle.max_cstate=0"
     else
         CSTATES=""
     fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add CSTATE configuration for the AMD CPU to disable CPU idling.
Related to: https://github.com/sonic-net/sonic-buildimage/pull/16339

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add `processor.max_cstate=1 amd_idle.max_cstate=0` to installer default grub config.

#### How to verify it
Boot the image. Verify the added option are present in `cat /proc/cmdline` command output.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

