### PR TITLE
add bmp into feature table

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -68,6 +68,7 @@
                    ("snmp", "enabled", true, "enabled"),
                    ("swss", "enabled", false, "enabled"),
                    ("syncd", "enabled", false, "enabled")] %}
+{%- if include_system_bmp == "y" %}{% do features.append(("bmp", "disabled", false, "enabled")) %}{% endif %}
 {%- if include_router_advertiser == "y" %}{% do features.append(("radv", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_teamd == "y" %}{% do features.append(("teamd", "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] %}disabled{% else %}enabled{% endif %}", false, "enabled")) %}{% endif %}
 {% do features.append(("dhcp_relay", "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] is not in ['ToRRouter', 'EPMS', 'MgmtTsToR', 'MgmtToRRouter', 'BmcMgmtToRRouter']) %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}


### PR DESCRIPTION
#### Why I did it

Currently bmp can't be enabled via “sudo config feature state bmp enabled"

#### How I did it

Conditionally add bmp into FEATURE table of /etc/sonic/init_cfg.json
if the feature is enabled in build system.

#### How to verify it

Execute “sudo config feature state bmp enabled"

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202411

#### Tested branch (Please provide the tested image version)

- [x] 202411

#### A picture of a cute animal (not mandatory but encouraged)

sonic:~$ grep -A 8 bmp /etc/sonic/init_cfg.json  | more
        "bmp": {
            "state": "disabled",
            "delayed": "False",
            "has_global_scope": true,
            "has_per_asic_scope": "False",
            "auto_restart": "enabled",
            "support_syslog_rate_limit": "true",
            "high_mem_alert": "disabled"
        },

sonic:~$ show feature status 
Feature         State            AutoRestart     SetOwner
--------------  ---------------  --------------  ----------
bgp             enabled          enabled
bmp             disabled         enabled
...
...

sonic:~$ sudo config feature state bmp enabled

sonic:~$ show feature status 
Feature         State            AutoRestart     SetOwner
--------------  ---------------  --------------  ----------
bgp             enabled          enabled
bmp             enabled          enabled
...
...

sonic:~$ docker ps
CONTAINER ID   IMAGE                                COMMAND                  CREATED          STATUS          PORTS     NAMES
1d09ba5dbe11   docker-sonic-bmp:latest              "/usr/local/bin/supe…"   43 seconds ago   Up 42 seconds             bmp

