### PR TITLE
[Nokia 7250e] enable crashkernel

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/installer.conf
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/installer.conf
@@ -1,4 +1,4 @@
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
 CONSOLE_SPEED=115200
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="amd_iommu=off pci=resource_alignment=48@00:03.1 pci=noaer crashkernel=8G-:1G"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="amd_iommu=off pci=resource_alignment=48@00:03.1 crashkernel=8G-:1G"

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/installer.conf
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/installer.conf
@@ -1,4 +1,4 @@
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
 CONSOLE_SPEED=115200
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="amd_iommu=off pci=resource_alignment=48@00:03.1 pci=noaer"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="amd_iommu=off pci=resource_alignment=48@00:03.1 pci=noaer crashkernel=8G-:1G"

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/installer.conf
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/installer.conf
@@ -1,4 +1,4 @@
 CONSOLE_PORT=0x2f8
 CONSOLE_DEV=0
 CONSOLE_SPEED=115200
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="amd_iommu=off pci=resource_alignment=26@00:01.4 pci=noaer"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="amd_iommu=off pci=resource_alignment=26@00:01.4 pci=noaer crashkernel=8G-:1G"

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/installer.conf
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/installer.conf
@@ -1,4 +1,4 @@
 CONSOLE_PORT=0x2f8
 CONSOLE_DEV=0
 CONSOLE_SPEED=115200
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="amd_iommu=off pci=resource_alignment=26@00:01.4 pci=noaer crashkernel=8G-:1G"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="amd_iommu=off pci=resource_alignment=26@00:01.4 crashkernel=8G-:1G"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Enable support to gather vmcore in the event of kernel panic.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

Can be cherry-picked to 202405.

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

