### PR TITLE
[neighbor] Preserve default lo neighbor to prevent the redis operation failure when arp cache overflow

### DIFF
--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -88,5 +88,7 @@ sysctl -p /etc/sysctl.d/90-dhcp6-systcl.conf
 
 systemctl restart networking
 
+ip neigh replace 0.0.0.0 dev lo lladdr 00:00:00:00:00:00 nud permanent
+
 # Clean-up created files
 rm -f /tmp/ztp_input.json /tmp/ztp_port_data.json


### PR DESCRIPTION
#### Why I did it
Fix the issue https://github.com/sonic-net/sonic-buildimage/issues/2189. 
The neighbor garbage collector was clearing the default neighbor (0.0.0.0) on the loopback interface, causing Redis operations to fail and the SONiC CLI to hang. Syslog entries showed errors like:

  `Mar 14 10:17:38.* INFO kernel: neighbour: arp_cache: neighbor table overflow!`

and netlink messages (by `ip -ts monitor`) confirmed the deletion:

  `[2025-03-14T10:11:14.214473] Deleted 0.0.0.0 dev lo lladdr 00:00:00:00:00:00 NOARP`

This commit fixes the issue by adding a persistent neighbor entry using:

  `ip neigh replace 0.0.0.0 dev lo lladdr 00:00:00:00:00:00 nud permanent`

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Continuously generating gratuitous ARP to trigger the neighbor table overflow

#### How to verify it
- Adjusting ARP settings via /proc/sys/net/ipv4/conf/*

```
echo 0 > /proc/sys/net/ipv4/conf/all/arp_ignore
echo 1 > /proc/sys/net/ipv4/conf/Ethernet16/arp_accept
```
- Continuously generating gratuitous ARP
- Ensuring proper SONiC CLI output (e.g., via "show vlan brief")

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

