### PR TITLE
[Mellanox][Nvidia-BF] Enable Watchdog support for Smartswitch DPU

### DIFF
--- a/platform/nvidia-bluefield/platform-api/sonic_platform/utils.py
+++ b/platform/nvidia-bluefield/platform-api/sonic_platform/utils.py
@@ -71,3 +71,64 @@ def default_return(return_value, log_func=logger.log_debug):
                 return return_value
         return _impl
     return wrapper
+
+def read_from_file(file_path, target_type, default='', raise_exception=False, log_func=logger.log_error):
+    """
+    Read content from file and convert to target type
+    :param file_path: File path
+    :param target_type: target type
+    :param default: Default return value if any exception occur
+    :param raise_exception: Raise exception to caller if True else just return default value
+    :param log_func: function to log the error
+    :return: String content of the file
+    """
+    try:
+        with open(file_path, 'r') as f:
+            value = f.read()
+            if value is None:
+                # None return value is not allowed in any case, so we log error here for further debug.
+                logger.log_error('Failed to read from {}, value is None, errno is {}'.format(file_path, ctypes.get_errno()))
+                # Raise ValueError for the except statement to handle this as a normal exception
+                raise ValueError('File content of {} is None'.format(file_path))
+            else:
+                value = target_type(value.strip())
+    except (ValueError, IOError) as e:
+        if log_func:
+            log_func('Failed to read from file {} - {}'.format(file_path, repr(e)))
+        if not raise_exception:
+            value = default
+        else:
+            raise e
+
+    return value
+
+def read_float_from_file(file_path, default=0.0, raise_exception=False, log_func=logger.log_error):
+    """
+    Read content from file and cast it to integer
+    :param file_path: File path
+    :param default: Default return value if any exception occur
+    :param raise_exception: Raise exception to caller if True else just return default value
+    :param log_func: function to log the error
+    :return: Integer value of the file content
+    """
+    return read_from_file(file_path=file_path, target_type=float, default=default, raise_exception=raise_exception, log_func=log_func)
+
+def write_file(file_path, content, raise_exception=False, log_func=logger.log_error):
+    """
+    Write the given value to a file
+    :param file_path: File path
+    :param content: Value to write to the file
+    :param raise_exception: Raise exception to caller if True
+    :return: True if write success else False
+    """
+    try:
+        with open(file_path, 'w') as f:
+            f.write(str(content))
+    except (ValueError, IOError) as e:
+        if log_func:
+            log_func('Failed to write {} to file {} - {}'.format(content, file_path, repr(e)))
+        if not raise_exception:
+            return False
+        else:
+            raise e
+    return True

--- a/platform/nvidia-bluefield/platform-api/sonic_platform/utils.py
+++ b/platform/nvidia-bluefield/platform-api/sonic_platform/utils.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import ctypes
 import functools
 import subprocess
 from sonic_py_common.logger import Logger
@@ -72,6 +74,7 @@ def default_return(return_value, log_func=logger.log_debug):
         return _impl
     return wrapper
 
+
 def read_from_file(file_path, target_type, default='', raise_exception=False, log_func=logger.log_error):
     """
     Read content from file and convert to target type
@@ -102,6 +105,7 @@ def read_from_file(file_path, target_type, default='', raise_exception=False, lo
 
     return value
 
+
 def read_float_from_file(file_path, default=0.0, raise_exception=False, log_func=logger.log_error):
     """
     Read content from file and cast it to integer
@@ -112,6 +116,7 @@ def read_float_from_file(file_path, default=0.0, raise_exception=False, log_func
     :return: Integer value of the file content
     """
     return read_from_file(file_path=file_path, target_type=float, default=default, raise_exception=raise_exception, log_func=log_func)
+
 
 def write_file(file_path, content, raise_exception=False, log_func=logger.log_error):
     """

--- a/platform/nvidia-bluefield/platform-api/sonic_platform/watchdog.py
+++ b/platform/nvidia-bluefield/platform-api/sonic_platform/watchdog.py
@@ -56,7 +56,6 @@ class Watchdog(WatchdogBase):
         ret_time = 0
         try:
             stat_output_list = self.exec_cmd(status_cmd).split('\n')
-            print(stat_output_list)
             bootctl_stat_dict = {item.split(': ')[0]: item.split(': ')[1] for item in stat_output_list}
             ret_status = bootctl_stat_dict.get('boot watchdog mode', 'disabled')
             ret_time = int(bootctl_stat_dict.get('boot watchdog interval', 0))
@@ -123,7 +122,6 @@ class Watchdog(WatchdogBase):
         """
         conf_mode, conf_time = self.get_conf_time_and_mode()
         armed = conf_mode == 'standard'
-        print(f"Armed value {armed} and conf_mode = {conf_mode}")
         if not time_check:
             return armed
         return armed and (time_check == conf_time)

--- a/platform/nvidia-bluefield/platform-api/sonic_platform/watchdog.py
+++ b/platform/nvidia-bluefield/platform-api/sonic_platform/watchdog.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 try:
     from sonic_platform_base.watchdog_base import WatchdogBase
@@ -81,7 +81,7 @@ class Watchdog(WatchdogBase):
         if seconds < 45 or seconds > 4095:
             logger.log_error(f"Arm time provided {seconds} is outside the valid range 45-4095")
             return arm_time
-        arm_command = [self.MLXBF_DRIVER, "--watchdog-boot-mode", "standard", 
+        arm_command = [self.MLXBF_DRIVER, "--watchdog-boot-mode", "standard",
                        "--watchdog-boot-interval", str(seconds)]
         try:
             if self.is_armed_for_time(seconds):
@@ -114,7 +114,7 @@ class Watchdog(WatchdogBase):
 
     def is_armed_for_time(self, time_check=None):
         """
-        Retrieves the armed state of the hardware watchdog 
+        Retrieves the armed state of the hardware watchdog
         And it also checks if the time configured
         If the time_check parameter is not provided, we check
         if watchdog is just armed or not

--- a/platform/nvidia-bluefield/platform-api/sonic_platform/watchdog.py
+++ b/platform/nvidia-bluefield/platform-api/sonic_platform/watchdog.py
@@ -18,13 +18,51 @@
 
 try:
     from sonic_platform_base.watchdog_base import WatchdogBase
-    from sonic_py_common.logger import Logger
+    from sonic_py_common.syslogger import SysLogger
+    import time
+    from . import utils
+    import os
+    import subprocess
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
+
+logger = SysLogger(log_identifier='Watchdog')
+
+WD_COMMON_ERROR = -1
 
 
 class Watchdog(WatchdogBase):
     """Placeholder for watchdog implementation"""
+
+    def __init__(self):
+        self.MLXBF_DRIVER = "mlxbf-bootctl"
+        self.TIMESTAMP_FILE = '/tmp/nvidia/watchdog_timestamp'
+
+    def exec_cmd(self, cmd, raise_exception=True):
+        """Execute commands related to watchdog api"""
+        try:
+            return subprocess.check_output(cmd).decode().strip()
+        except Exception as err:
+            if raise_exception:
+                raise err
+            else:
+                logger.log_info(f"Failed to run cmd {' '.join(cmd)}")
+
+    def get_conf_time_and_mode(self):
+        """Obtain the mode in which the watchdog is configured and the time
+        Returns - A Tuple (Arm status, configured timeout)"""
+        status_cmd = {self.MLXBF_DRIVER}
+        ret_status = "disabled"
+        ret_time = 0
+        try:
+            stat_output_list = self.exec_cmd(status_cmd).split('\n')
+            print(stat_output_list)
+            bootctl_stat_dict = {item.split(': ')[0]: item.split(': ')[1] for item in stat_output_list}
+            ret_status = bootctl_stat_dict.get('boot watchdog mode', 'disabled')
+            ret_time = int(bootctl_stat_dict.get('boot watchdog interval', 0))
+        except Exception as err:
+            logger.log_error(f"Could not obtain status usind mlxbf-bootctl :{err}")
+        return ret_status, ret_time
 
     def arm(self, seconds):
         """
@@ -39,7 +77,24 @@ class Watchdog(WatchdogBase):
             An integer specifying the *actual* number of seconds the watchdog
             was armed with. On failure returns -1.
         """
-        return -1
+        arm_time = WD_COMMON_ERROR
+        if seconds < 45 or seconds > 4095:
+            logger.log_error(f"Arm time provided {seconds} is outside the valid range 45-4095")
+            return arm_time
+        arm_command = [self.MLXBF_DRIVER, "--watchdog-boot-mode", "standard", 
+                       "--watchdog-boot-interval", str(seconds)]
+        try:
+            if self.is_armed_for_time(seconds):
+                # Already armed for the time specified
+                return seconds
+            self.exec_cmd(arm_command)
+            arm_time = seconds
+            os.makedirs('/tmp/nvidia', exist_ok=True)
+            utils.write_file(self.TIMESTAMP_FILE, str(time.monotonic()))
+        except Exception as err:
+            # On an error return code check_output raises exception, return Fault
+            logger.log_error(f"Could not arm watchdog :{err}")
+        return arm_time
 
     def disarm(self):
         """
@@ -48,7 +103,30 @@ class Watchdog(WatchdogBase):
         Returns:
             A boolean, True if watchdog is disarmed successfully, False if not
         """
-        return False
+        disarm_command = [self.MLXBF_DRIVER, "--watchdog-boot-mode", "disabled"]
+        try:
+            self.exec_cmd(disarm_command)
+        except Exception as err:
+            logger.log_error(f"Could not disarm watchdog :{err}")
+            # On an error return code check_output raises exception, return Fault
+            return False
+        return True
+
+    def is_armed_for_time(self, time_check=None):
+        """
+        Retrieves the armed state of the hardware watchdog 
+        And it also checks if the time configured
+        If the time_check parameter is not provided, we check
+        if watchdog is just armed or not
+        Returns:
+            A boolean, True if watchdog is armed, False if not
+        """
+        conf_mode, conf_time = self.get_conf_time_and_mode()
+        armed = conf_mode == 'standard'
+        print(f"Armed value {armed} and conf_mode = {conf_mode}")
+        if not time_check:
+            return armed
+        return armed and (time_check == conf_time)
 
     def is_armed(self):
         """
@@ -57,7 +135,7 @@ class Watchdog(WatchdogBase):
         Returns:
             A boolean, True if watchdog is armed, False if not
         """
-        return False
+        return self.is_armed_for_time()
 
     def get_remaining_time(self):
         """
@@ -68,4 +146,9 @@ class Watchdog(WatchdogBase):
             An integer specifying the number of seconds remaining on thei
             watchdog timer. If the watchdog is not armed, returns -1.
         """
-        return -1
+        timeleft = WD_COMMON_ERROR
+        if self.is_armed():
+            arm_timestamp = utils.read_float_from_file(self.TIMESTAMP_FILE, raise_exception=True)
+            _, conf_time = self.get_conf_time_and_mode()
+            timeleft = int(conf_time - (time.monotonic() - arm_timestamp))
+        return timeleft

--- a/platform/nvidia-bluefield/platform-api/tests/test_utils.py
+++ b/platform/nvidia-bluefield/platform-api/tests/test_utils.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,22 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import os
 import pytest
 import sys
-import threading
-import time
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
+from sonic_platform import utils
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
-
-from sonic_platform import utils
 
 
 class TestUtils:

--- a/platform/nvidia-bluefield/platform-api/tests/test_utils.py
+++ b/platform/nvidia-bluefield/platform-api/tests/test_utils.py
@@ -1,0 +1,55 @@
+#
+# Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import pytest
+import sys
+import threading
+import time
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    import mock
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+sys.path.insert(0, modules_path)
+
+from sonic_platform import utils
+
+
+class TestUtils:
+    def test_read_file(self):
+        ret = utils.read_float_from_file('not exist', 3.14)
+        assert ret == 3.14
+
+        with pytest.raises(IOError):
+            ret = utils.read_float_from_file('not exist', 2.25, raise_exception=True)
+            assert ret == 2.25
+        file_path = '/tmp/test.txt'
+        utils.write_file(file_path, '3.09')
+        assert utils.read_float_from_file(file_path) == 3.09
+        utils.write_file(file_path, '3.00')
+        assert utils.read_float_from_file(file_path) == 3
+
+    def test_write_file(self):
+        file_path = '/tmp/test.txt'
+        utils.write_file(file_path, '3.14 ')
+        assert utils.read_float_from_file(file_path) == 3.14
+
+        with pytest.raises(IOError):
+            utils.write_file('/not/exist/file', '123', raise_exception=True)

--- a/platform/nvidia-bluefield/platform-api/tests/test_utils.py
+++ b/platform/nvidia-bluefield/platform-api/tests/test_utils.py
@@ -41,7 +41,7 @@ class TestUtils:
 
     def test_write_file(self):
         file_path = '/tmp/test.txt'
-        utils.write_file(file_path, '3.14 ')
+        utils.write_file(file_path, '3.14')
         assert utils.read_float_from_file(file_path) == 3.14
 
         with pytest.raises(IOError):

--- a/platform/nvidia-bluefield/platform-api/tests/test_watchdog.py
+++ b/platform/nvidia-bluefield/platform-api/tests/test_watchdog.py
@@ -1,0 +1,142 @@
+#
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import pytest
+import sys
+import subprocess
+from unittest import mock
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+sys.path.insert(0, modules_path)
+
+
+disarm_string = 'primary: /dev/mmcblk0boot0\n'\
+        'backup: /dev/mmcblk0boot1\n'\
+        'boot-bus-width: x8\n'\
+        'reset to x1 after reboot: FALSE\n'\
+        'boot watchdog interval: 0\n'\
+        'boot watchdog mode: disabled\n'\
+        'watchdog-swap: disabled\n'\
+        'lifecycle state: Secured (development)\n'\
+        'secure boot key free slots: 3'
+
+
+arm_string = 'primary: /dev/mmcblk0boot0\n'\
+        'backup: /dev/mmcblk0boot1\n'\
+        'boot-bus-width: x8\n'\
+        'reset to x1 after reboot: FALSE\n'\
+        'boot watchdog interval: 180\n'\
+        'boot watchdog mode: standard\n'\
+        'watchdog-swap: disabled\n'\
+        'lifecycle state: Secured (development)\n'\
+        'secure boot key free slots: 3'
+
+from sonic_platform.watchdog import Watchdog, WD_COMMON_ERROR
+
+
+class TestWatchdog:
+    @mock.patch('sonic_platform.watchdog.Watchdog.is_armed_for_time')
+    @mock.patch('sonic_platform.watchdog.Watchdog.exec_cmd')
+    def test_arm(self, mock_exec_cmd, mock_is_armed_for_time):
+        # Valid Arm time
+        test_wd = Watchdog()
+        assert test_wd.arm(0) == WD_COMMON_ERROR
+        assert test_wd.arm(-1) == WD_COMMON_ERROR
+        assert test_wd.arm(40000) == WD_COMMON_ERROR
+        # If watchdog is already armed we do not re-arm it
+        mock_exec_cmd.return_value = 'standard'
+        mock_is_armed_for_time.return_value = True
+        assert test_wd.arm(180)
+        mock_exec_cmd.assert_not_called()
+        mock_is_armed_for_time.return_value = False
+        assert test_wd.arm(180)
+        mock_exec_cmd.assert_called_once_with(['mlxbf-bootctl', 
+                                               '--watchdog-boot-mode',
+                                               'standard',
+                                               '--watchdog-boot-interval',
+                                               '180'])
+
+    @mock.patch('sonic_platform.watchdog.Watchdog.exec_cmd')
+    def test_disarm(self, mock_exec_cmd):
+        # Valid Arm time
+        test_wd = Watchdog()
+        assert test_wd.disarm()
+        mock_exec_cmd.side_effect = subprocess.CalledProcessError(returncode=1, cmd='mlxbf-bootctl')
+        assert not test_wd.disarm()
+
+    @mock.patch('sonic_platform.watchdog.Watchdog.is_armed_for_time')
+    @mock.patch('sonic_platform.watchdog.Watchdog.exec_cmd')
+    @mock.patch('sonic_platform.watchdog.Watchdog.get_conf_time_and_mode')
+    @mock.patch('sonic_platform.watchdog.Watchdog.is_armed')
+    def test_get_remaining_time_watchdog(self, mock_is_armed, mock_get_time, mock_exec_cmd, mock_is_armed_for_time):
+        watchdog = Watchdog()
+        mock_is_armed.return_value = False
+        assert watchdog.get_remaining_time() == WD_COMMON_ERROR
+        mock_exec_cmd.return_value = True
+        mock_is_armed_for_time.return_value = False
+        watchdog.arm(180)
+        mock_is_armed.return_value = True
+        mock_get_time.return_value = 'standard', 100
+        first_value = watchdog.get_remaining_time() 
+        assert first_value > 0
+        second_value = watchdog.get_remaining_time() 
+        assert second_value <= first_value
+
+    @mock.patch('sonic_platform.watchdog.Watchdog.exec_cmd')
+    def test_is_armed(self, mock_exec_cmd):
+        watchdog = Watchdog()
+        mock_exec_cmd.return_value = disarm_string
+        assert not watchdog.is_armed()
+        assert not watchdog.is_armed_for_time(100)
+        assert not watchdog.is_armed_for_time(50)
+        assert not watchdog.is_armed_for_time(180)
+        mock_exec_cmd.return_value = arm_string
+        assert watchdog.is_armed()
+        assert not watchdog.is_armed_for_time(100)
+        assert not watchdog.is_armed_for_time(50)
+        assert watchdog.is_armed_for_time(180)
+        change_time_str = arm_string.replace('180', '200')
+        mock_exec_cmd.return_value = change_time_str
+        assert watchdog.is_armed_for_time(200)
+
+    @mock.patch('sonic_platform.watchdog.Watchdog.exec_cmd')
+    def test_conf_time(self, mock_exec_cmd):
+        watchdog = Watchdog()
+        mock_exec_cmd.return_value = disarm_string
+        arm_str, arm_time = watchdog.get_conf_time_and_mode()
+        assert arm_str == "disabled"
+        assert arm_time == 0
+        mock_exec_cmd.return_value = arm_string
+        arm_str, arm_time = watchdog.get_conf_time_and_mode()
+        assert arm_str == "standard"
+        assert arm_time == 180
+        mock_exec_cmd.side_effect = subprocess.CalledProcessError(returncode=1, cmd='mlxbf-bootctl')
+        arm_str, arm_time = watchdog.get_conf_time_and_mode()
+        assert arm_str == "disabled"
+        assert arm_time == 0
+
+    def test_exec_cmd(self):
+        watchdog = Watchdog()
+        assert watchdog.exec_cmd(['echo', 'abc']) == "abc"
+        assert watchdog.exec_cmd(['echo', 't1']) == "t1"
+        with pytest.raises(subprocess.CalledProcessError):
+            watchdog.exec_cmd(['ls', 'non-existent-dir'])
+            watchdog.exec_cmd(['cat', 'non-existent-file.txt'])
+            watchdog.exec_cmd(['non-existent-cmd'])
+

--- a/platform/nvidia-bluefield/platform-api/tests/test_watchdog.py
+++ b/platform/nvidia-bluefield/platform-api/tests/test_watchdog.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +21,7 @@ import pytest
 import sys
 import subprocess
 from unittest import mock
+from sonic_platform.watchdog import Watchdog, WD_COMMON_ERROR
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -47,8 +49,6 @@ arm_string = 'primary: /dev/mmcblk0boot0\n'\
         'lifecycle state: Secured (development)\n'\
         'secure boot key free slots: 3'
 
-from sonic_platform.watchdog import Watchdog, WD_COMMON_ERROR
-
 
 class TestWatchdog:
     @mock.patch('sonic_platform.watchdog.Watchdog.is_armed_for_time')
@@ -66,7 +66,7 @@ class TestWatchdog:
         mock_exec_cmd.assert_not_called()
         mock_is_armed_for_time.return_value = False
         assert test_wd.arm(180)
-        mock_exec_cmd.assert_called_once_with(['mlxbf-bootctl', 
+        mock_exec_cmd.assert_called_once_with(['mlxbf-bootctl',
                                                '--watchdog-boot-mode',
                                                'standard',
                                                '--watchdog-boot-interval',
@@ -93,9 +93,9 @@ class TestWatchdog:
         watchdog.arm(180)
         mock_is_armed.return_value = True
         mock_get_time.return_value = 'standard', 100
-        first_value = watchdog.get_remaining_time() 
+        first_value = watchdog.get_remaining_time()
         assert first_value > 0
-        second_value = watchdog.get_remaining_time() 
+        second_value = watchdog.get_remaining_time()
         assert second_value <= first_value
 
     @mock.patch('sonic_platform.watchdog.Watchdog.exec_cmd')
@@ -139,4 +139,3 @@ class TestWatchdog:
             watchdog.exec_cmd(['ls', 'non-existent-dir'])
             watchdog.exec_cmd(['cat', 'non-existent-file.txt'])
             watchdog.exec_cmd(['non-existent-cmd'])
-


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Updated Platform code to enable watchdog for DPU. Changes to :
`watchdog.py` -> Added support for the new watchdog on DPU platforms with the `mlxbf-bootctl` command to enable/disable watchdog as required
`utils.py` -> Changes relevant to reading and writing to file taken over from switch implementation

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated watchdog.py file for nvidia-bluefied

#### How to verify it
Execute the following commands
`watchdogutil arm -s 180` -> Arms watchdog for 180 seconds
`watchdogutil disarm` -> Disarms wawtchdog 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

