### PR TITLE
Add smbus2 library on host and pmon docker, and telnetlib3 library on host

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -61,6 +61,8 @@ RUN pip3 install psutil
 # Install blkinfo for block device information gathering operations
 RUN pip3 install blkinfo
 
+# Install smbus2 for SMBus/PMBus I2C transactions
+RUN pip3 install smbus2
 
 {% if docker_platform_monitor_debs.strip() -%}
 # Copy locally-built Debian package dependencies

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -150,6 +150,12 @@ if [[ $CONFIGURED_ARCH == amd64 || $CONFIGURED_ARCH == arm64 ]]; then
     sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio-tools==1.58.0"
 fi
 
+# Install Python module for smbus2
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install smbus2
+
+# Install Python module for telnetlib3
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install telnetlib3
+
 # Install sonic-py-common Python 3 package
 SONIC_PY_COMMON_PY3_WHEEL_NAME=$(basename {{sonic_py_common_py3_wheel_path}})
 sudo cp {{sonic_py_common_py3_wheel_path}} $FILESYSTEM_ROOT/$SONIC_PY_COMMON_PY3_WHEEL_NAME


### PR DESCRIPTION
#### Why I did it
- Add smbus2 python library to be used inside pmon docker and host for enhanced support while interacting with smbus devices through python.
- Add telnetlib3 python library on host as the default packaged library telnetlib is deprecated from 3.11 and slated for removal from 3.13 python version. (part of fix needed for https://migsonic.atlassian.net/browse/MIGSMSFT-574)

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added smbus2 module to host and pmon docker
Added telnetlib3 module to host

#### How to verify it
Install image with change, and check the following  
```
host:
root@sonic:/home/cisco# pip3 list | grep smbus2
smbus2                     0.5.0
root@sonic:/home/cisco# python3
Python 3.11.2 (main, Nov 30 2024, 21:22:50) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from smbus2 import SMBus
>>>
pmon:
root@sonic:/home/cisco# docker exec -it pmon bash
root@sonic:/# python3
Python 3.11.2 (main, Nov 30 2024, 21:22:50) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.                                                                                                                                                            
>>> from smbus2 import SMBus                                                                                                                                                              
>>>
```
```
root@sonic:/home/cisco# pip3 list | grep telnet
telnetlib3                 2.0.4
root@sonic:/home/cisco#
root@sonic:/home/cisco# python3
Python 3.11.2 (main, Nov 30 2024, 21:22:50) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import telnetlib3
>>>
```


#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

#### Description for the changelog

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

