### PR TITLE
[Mellanox] Update SN5640 ports 65,66 speed to 25G

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C448O16/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C448O16/hwsku.json
@@ -2321,10 +2321,10 @@
             "autoneg": "off"
         },
         "Ethernet512": {
-            "default_brkout_mode": "1x10G[25G]"
+            "default_brkout_mode": "1x25G[10G]"
         },
         "Ethernet520": {
-            "default_brkout_mode": "1x10G[25G]"
+            "default_brkout_mode": "1x25G[10G]"
         }
     }
 }

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C448O16/port_config.ini
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C448O16/port_config.ini
@@ -481,5 +481,5 @@ Ethernet508     508                                  etp64e     64       100000
 Ethernet509     509                                  etp64f     64       100000
 Ethernet510     510                                  etp64g     64       100000
 Ethernet511     511                                  etp64h     64       100000
-Ethernet512     512                                  etp65      65       10000
-Ethernet520     520                                  etp66      66       10000
+Ethernet512     512                                  etp65      65       25000
+Ethernet520     520                                  etp66      66       25000

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/hwsku.json
@@ -2561,10 +2561,10 @@
             "autoneg": "off"
         },
         "Ethernet512": {
-            "default_brkout_mode": "1x10G[25G]"
+            "default_brkout_mode": "1x25G[10G]"
         },
         "Ethernet520": {
-            "default_brkout_mode": "1x10G[25G]"
+            "default_brkout_mode": "1x25G[10G]"
         }
     }
 }

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/port_config.ini
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/port_config.ini
@@ -529,5 +529,5 @@ Ethernet508     508                                  etp64e     64       100000
 Ethernet509     509                                  etp64f     64       100000
 Ethernet510     510                                  etp64g     64       100000
 Ethernet511     511                                  etp64h     64       100000
-Ethernet512     512                                  etp65      65       10000
-Ethernet520     520                                  etp66      66       10000
+Ethernet512     512                                  etp65      65       25000
+Ethernet520     520                                  etp66      66       25000


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To align speed to 25G
#### How I did it
Update hwsku.json and port_config.ini of relevant SKUs of SN5640 to have 25G speed to ports 65,66
#### How to verify it
deploy image on SN5640 Mellanox switch and check speed.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

