### PR TITLE
[dhcp_relay] Clear all DHCPV4 counter data in DB when dhcp_relay container startup 

### DIFF
--- a/dockers/docker-dhcp-relay/start.sh
+++ b/dockers/docker-dhcp-relay/start.sh
@@ -10,6 +10,11 @@ then
     ${CTR_SCRIPT} -f dhcp_relay -o ${RUNTIME_OWNER} -v ${IMAGE_VERSION}
 fi
 
+keys=$(sonic-db-cli COUNTERS_DB keys "DHCPV4_COUNTER_TABLE*")
+for key in $keys; do
+    sonic-db-cli COUNTERS_DB del "$key"
+done
+
 # If our supervisor config has entries in the "dhcp-relay" group...
 if [ $(supervisorctl status | grep -c "^dhcp-relay:") -gt 0 ]; then
     # Wait for all interfaces to come up and be assigned IPv4 addresses before

--- a/dockers/docker-dhcp-relay/start.sh
+++ b/dockers/docker-dhcp-relay/start.sh
@@ -10,7 +10,7 @@ then
     ${CTR_SCRIPT} -f dhcp_relay -o ${RUNTIME_OWNER} -v ${IMAGE_VERSION}
 fi
 
-keys=$(sonic-db-cli COUNTERS_DB keys "DHCPV4_COUNTER_TABLE*")
+keys=$(sonic-db-cli COUNTERS_DB keys "DHCPV4_COUNTER_TABLE|*")
 for key in $keys; do
     sonic-db-cli COUNTERS_DB del "$key"
 done


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
DHCPV4 per-interface counter is added by https://github.com/sonic-net/sonic-dhcpmon/pull/36, it would store data in counters db and initialize data for interested interface when process start. But it wouldn’t clear outdated data which it doesn’t interested data it doesn’t interested 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Clear all counter data when container start.

#### How to verify it
Manually verify and pr check 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

