### PR TITLE
[YANG] sonic-neigh.yang need support portchannel

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/neigh.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/neigh.json
@@ -11,5 +11,15 @@
     "NEIGH_INVALID_VLAN": {
         "desc": "Load NEIGH missing VLAN",
         "eStr": ["does not satisfy the constraint"]
+    },
+
+    "VALID_NEIGH_PORTCHANNEL": {
+        "desc": "Load valid PORTCHANNEL"
+    },
+
+    "NEIGH_INVALID_PORTCHANNEL": {
+        "desc": "Load NEIGH missing PORTCHANNEL",
+        "eStrKey": "InvalidValue",
+        "eStr": ["port"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/neigh.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/neigh.json
@@ -10,7 +10,8 @@
 
     "NEIGH_INVALID_VLAN": {
         "desc": "Load NEIGH missing VLAN",
-        "eStr": ["does not satisfy the constraint"]
+        "eStrKey": "InvalidValue",
+        "eStr": ["port"]
     },
 
     "VALID_NEIGH_PORTCHANNEL": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
@@ -76,13 +76,13 @@
             "sonic-neigh:NEIGH": {
                 "NEIGH_LIST": [
                     {
-                        "port": "PortChannel11",
+                        "port": "PortChannel1024",
                         "neighbor": "100.1.1.3",
                         "neigh": "00:02:02:03:04:05",
                         "family": "IPv4"
                     },
                     {
-                        "port": "PortChannel11",
+                        "port": "PortChannel1024",
                         "neighbor": "100.1.1.4",
                         "family": "IPv4"
                     }
@@ -94,7 +94,7 @@
                 "PORTCHANNEL_LIST": [
                     {
                         "admin_status": "up",
-                        "name": "PortChannel11"
+                        "name": "PortChannel1024"
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
@@ -13,13 +13,13 @@
             "sonic-neigh:NEIGH": {
                 "NEIGH_LIST": [
                     {
-                        "vlan": "Vlan1000",
+                        "port": "Vlan1000",
                         "neighbor": "100.1.1.3",
                         "neigh": "00:02:02:03:04:05",
                         "family": "IPv4"
                     },
                     {
-                        "vlan": "Vlan1000",
+                        "port": "Vlan1000",
                         "neighbor": "100.1.1.4",
                         "family": "IPv4"
                     }
@@ -42,7 +42,7 @@
             "sonic-neigh:NEIGH": {
                 "NEIGH_LIST": [
                     {
-                        "vlan": "Vlan1000",
+                        "port": "Vlan1000",
                         "neigh": "00:02:02:03:04:05",
                         "family": "IPv4"
                     }
@@ -56,13 +56,13 @@
             "sonic-neigh:NEIGH": {
                 "NEIGH_LIST": [
                     {
-                        "vlan": "INVALIDVlan",
+                        "port": "INVALIDVlan",
                         "neighbor": "100.1.1.3",
                         "neigh": "00:02:02:03:04:05",
                         "family": "IPv4"
                     },
                     {
-                        "vlan": "Vlan1000",
+                        "port": "Vlan1000",
                         "neighbor": "100.1.1.4",
                         "family": "IPv4"
                     }
@@ -74,11 +74,19 @@
     "VALID_NEIGH_PORTCHANNEL": {
         "sonic-neigh:sonic-neigh": {
             "sonic-neigh:NEIGH": {
-                "sonic-neigh:global": {
-                    "port": [
-                        "PortChannel11"
-                    ]
-                }
+                "NEIGH_LIST": [
+                    {
+                        "port": "PortChannel11",
+                        "neighbor": "100.1.1.3",
+                        "neigh": "00:02:02:03:04:05",
+                        "family": "IPv4"
+                    },
+                    {
+                        "port": "PortChannel11",
+                        "neighbor": "100.1.1.4",
+                        "family": "IPv4"
+                    }
+                ]
             }
         },
         "sonic-portchannel:sonic-portchannel": {
@@ -96,11 +104,14 @@
     "NEIGH_INVALID_PORTCHANNEL": {
         "sonic-neigh:sonic-neigh": {
             "sonic-neigh:NEIGH": {
-                "sonic-neigh:global": {
-                    "port": [
-                        "PortChannel10"
-                    ]
-                }
+                "NEIGH_LIST": [
+                    {
+                        "port": "PortChannel10",
+                        "neighbor": "100.1.1.3",
+                        "neigh": "00:02:02:03:04:05",
+                        "family": "IPv4"
+                    }
+                ]
             }
         },
         "sonic-portchannel:sonic-portchannel": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
@@ -76,8 +76,8 @@
             "sonic-neigh:NTP": {
                 "sonic-neigh:global": {
                     "port": [
-			            "PortChannel11"
-		            ]
+                        "PortChannel11"
+                    ]
                 }
             }
         },
@@ -98,8 +98,8 @@
             "sonic-neigh:NTP": {
                 "sonic-neigh:global": {
                     "port": [
-			            "PortChannel10"
-		            ]
+                        "PortChannel10"
+                    ]
                 }
             }
         },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
@@ -73,7 +73,7 @@
 
     "VALID_NEIGH_PORTCHANNEL": {
         "sonic-neigh:sonic-neigh": {
-            "sonic-neigh:NTP": {
+            "sonic-neigh:NEIGH": {
                 "sonic-neigh:global": {
                     "port": [
                         "PortChannel11"
@@ -95,7 +95,7 @@
 
     "NEIGH_INVALID_PORTCHANNEL": {
         "sonic-neigh:sonic-neigh": {
-            "sonic-neigh:NTP": {
+            "sonic-neigh:NEIGH": {
                 "sonic-neigh:global": {
                     "port": [
                         "PortChannel10"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
@@ -69,5 +69,49 @@
                 ]
             }
         }
+    },
+
+    "VALID_NEIGH_PORTCHANNEL": {
+        "sonic-neigh:sonic-neigh": {
+            "sonic-neigh:NTP": {
+                "sonic-neigh:global": {
+                    "port": [
+			            "PortChannel11"
+		            ]
+                }
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "name": "PortChannel11"
+                    }
+                ]
+            }
+        }
+    },
+
+    "NEIGH_INVALID_PORTCHANNEL": {
+        "sonic-neigh:sonic-neigh": {
+            "sonic-neigh:NTP": {
+                "sonic-neigh:global": {
+                    "port": [
+			            "PortChannel10"
+		            ]
+                }
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "name": "PortChannel11"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-neigh.yang
+++ b/src/sonic-yang-models/yang-models/sonic-neigh.yang
@@ -35,7 +35,7 @@ module sonic-neigh {
 				key "port neighbor";
 
 				leaf port {
-					description "Neighbor interface ex. Vlan1000";
+					description "Neighbor interface ex. Vlan1000, PortChannel1024";
 					type union {
 						type leafref {
 							path /lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name;

--- a/src/sonic-yang-models/yang-models/sonic-neigh.yang
+++ b/src/sonic-yang-models/yang-models/sonic-neigh.yang
@@ -11,6 +11,9 @@ module sonic-neigh {
 		prefix yang;
 	}
 
+	import sonic-portchannel {
+		prefix lag;
+	}
 	// TODO: Uncomment the following lines when sonic-vlan.yang is available
 	// import sonic-vlan {
 	// 	prefix svlan;
@@ -29,18 +32,22 @@ module sonic-neigh {
 		container NEIGH {
 			description "NEIGH configuration";
 			list NEIGH_LIST {
-				key "vlan neighbor";
+				key "port neighbor";
 
-				leaf vlan {
-					// TODO: Remove the following lines when sonic-vlan.yang is available
-					description "Neighbor Vlan interface ex. Vlan1000";
-					type string {
-						pattern "Vlan[0-9]+";
+				leaf port {
+					description "Neighbor interface ex. Vlan1000";
+					type union {
+						type leafref {
+							path /lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name;
+						}
+						type string {
+							pattern "Vlan[0-9]+";
+						}
+						// TODO: Uncomment the following lines when sonic-vlan.yang is available
+						// type leafref {
+						// 	path "/svlan:sonic-vlan/svlan:VLAN/svlan:VLAN_LIST/svlan:name";
+						// }
 					}
-					// TODO: Uncomment the following lines when sonic-vlan.yang is available
-					// type leafref {
-					// 	path "/svlan:sonic-vlan/svlan:VLAN/svlan:VLAN_LIST/svlan:name";
-					// }
 				}
 
 				leaf neighbor {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
NEIGH need to support PORTCHANNEL for t1 topology when VLAN is non-existent.
##### Work item tracking
- Microsoft ADO **(number only)**: 31872308


#### How I did it
Add portchannel to port as an alllowed leafref
#### How to verify it
unit test
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

