### PR TITLE
Change the sysctl fib_multipath_hash_policy default value

### DIFF
--- a/files/image_config/sysctl/sysctl-net.conf
+++ b/files/image_config/sysctl/sysctl-net.conf
@@ -39,3 +39,5 @@ net.core.rmem_max=16777216
 net.core.wmem_max=16777216
 net.core.somaxconn=512
 net.ipv4.fib_multipath_use_neigh=1
+net.ipv4.fib_multipath_hash_policy=1
+net.ipv6.fib_multipath_hash_policy=1


### PR DESCRIPTION
What I did:
Change hash policy to use for multipath routes
https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt


How I verify:
This configuration ensures that traffic, including flows between the same source and destination, is effectively balanced across available paths. This is useful in chassis scenario where there is ECMP route on LC to reach other LC's. After this fix working as expected.