### PR TITLE
[smartswitch][YANG] Add new fields to the DPU_LIST container in the sonic-smart-switch YANG module

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -3037,42 +3037,51 @@ The ASIC_SENSORS table introduces the asic sensors polling configuration when th
 }
 ```
 
-### DPU PORT Configuration^M
+### DPU Configuration
 
-The **DPU_PORT** table introduces the configuration for the DPUs(Data Processing Unit) PORT information available on the platform.
+The **DPU** table introduces the configuration for the DPUs(Data Processing Unit) information available on the platform.
 
 ```json
 {
-    "DPU_PORT": {
-        "dpu0": {
+    "DPU": {
+        "str-8102-t1-dpu0": {
             "state": "up",
+            "local_port": "Ethernet228",
             "vip_ipv4": "192.168.1.1",
             "vip_ipv6": "2001:db8::10",
             "pa_ipv4": "192.168.1.10",
             "pa_ipv6": "2001:db8::10",
+            "dpu_id": "0",
             "vdpu_id": "vdpu0",
-            "gnmi_port": "50052"
+            "gnmi_port": "50052",
+            "orchagent_zmq_port": "50"
         },
-        "dpu1": {
+        "str-8102-t1-dpu1": {
             "state": "down",
+            "local_port": "Ethernet232",
             "vip_ipv4": "192.168.1.2",
             "vip_ipv6": "2001:db8::20",
             "pa_ipv4": "192.168.1.20",
             "pa_ipv6": "2001:db8::20",
+            "dpu_id": "1",
             "vdpu_id": "vdpu1",
-            "gnmi_port": "50052"
+            "gnmi_port": "50052",
+            "orchagent_zmq_port": "50"
         }
     }
 }
 ```
 
 **state**: Administrative status of the DPU (`up` or `down`).
+**local_port**: local port mapped to DPU port on the switch.
 **vip_ipv4**: VIP IPv4 address from minigraph.
 **vip_ipv6**: VIP IPv6 address from minigraph.
 **pa_ipv4**: PA IPv4 address from minigraph.
 **pa_ipv6**: PA IPv6 address from minigraph.
+**dpu_id**: Id of the DPU from minigraph.
 **vdpu_id**: ID of VDPUs from minigraph.
-**gnmi_port**: Port gNMI runs on.
+**gnmi_port**: TCP listening port for gnmi service on DPU.
+**orchagent_zmq_port**: TCP listening port for ZMQ service on DPU orchagent.
 
 # For Developers
 

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2791,24 +2791,30 @@
                 "midplane_interface": "dpu1"
             }
         },
-        "DPU_PORT": {
-            "dpu0": {
+        "DPU": {
+            "str-8102-t1-dpu0": {
                 "state": "up",
+                "local_port": "Ethernet228",
                 "vip_ipv4": "192.168.1.1",
                 "vip_ipv6": "2001:db8::10",
                 "pa_ipv4": "192.168.1.10",
                 "pa_ipv6": "2001:db8::10",
+                "dpu_id": "0",
                 "vdpu_id": "vdpu0",
-                "gnmi_port": "50052"
+                "gnmi_port": "50052",
+                "orchagent_zmq_port": "50"
             },
-            "dpu1": {
+            "str-8102-t1-dpu1": {
                 "state": "down",
+                "local_port": "Ethernet232",
                 "vip_ipv4": "192.168.1.2",
                 "vip_ipv6": "2001:db8::20",
                 "pa_ipv4": "192.168.1.20",
                 "pa_ipv6": "2001:db8::20",
+                "dpu_id": "1",
                 "vdpu_id": "vdpu1",
-                "gnmi_port": "50052"
+                "gnmi_port": "50052",
+                "orchagent_zmq_port": "50"
             }
         },
 	"XCVRD_LOG": {

--- a/src/sonic-yang-models/tests/yang_model_pytests/test_smart_switch.py
+++ b/src/sonic-yang-models/tests/yang_model_pytests/test_smart_switch.py
@@ -110,30 +110,61 @@ class TestSmartSwitch:
         yang_model.load_data(data, error_message)
 
     @pytest.mark.parametrize(
-        "port_name, error_message", [
-            ("dpu0", None),
-            ("dp0rt0", 'Value "dp0rt0" does not satisfy the constraint "[a-zA-Z]+[0-9]+"')]
+        "dpu_name, error_message", [
+            ("str-8102-t1-dpu0", None),
+            ("str-8102-t1-dpu0a", 'Value "str-8102-t1-dpu0a" does not satisfy the constraint "[a-zA-Z0-9-]+[0-9]"')]
         )
-    def test_dpu_port_name(self, yang_model, port_name, error_message):
+    def test_dpu_name(self, yang_model, dpu_name, error_message):
         data = {
             "sonic-smart-switch:sonic-smart-switch": {
-                "sonic-smart-switch:DPU_PORT": {
-                    "DPU_PORT_LIST": [
+                "sonic-smart-switch:DPU": {
+                    "DPU_LIST": [
                         {
-                            "PORT_NAME": port_name,
+                            "dpu_name": dpu_name,
                             "state": "up",
+                            "local_port": "Ethernet0",
                             "vip_ipv4": "192.168.1.1",
                             "vip_ipv6": "2001:db8::1",
                             "pa_ipv4": "192.168.1.2",
                             "pa_ipv6": "2001:db8::2",
+                            "dpu_id": "0",
                             "vdpu_id": "vdpu0",
-                            "gnmi_port": 8080
+                            "gnmi_port": 8080,
+                            "orchagent_zmq_port": 50
                         }
                     ]
                 }
             }
         }
+        yang_model.load_data(data, error_message)
 
+    @pytest.mark.parametrize(
+        "local_port, error_message", [
+            ("Ethernet0", None),
+            ("EthernetXYZ284099", 'Invalid interface name length, it must not exceed 16 characters.')]
+        )
+    def test_dpu_local_port(self, yang_model, local_port, error_message):
+        data = {
+            "sonic-smart-switch:sonic-smart-switch": {
+                "sonic-smart-switch:DPU": {
+                    "DPU_LIST": [
+                        {
+                            "dpu_name": "str-8102-t1-dpu0",
+                            "state": "up",
+                            "local_port": local_port,
+                            "vip_ipv4": "192.168.1.1",
+                            "vip_ipv6": "2001:db8::1",
+                            "pa_ipv4": "192.168.1.2",
+                            "pa_ipv6": "2001:db8::2",
+                            "dpu_id": "0",
+                            "vdpu_id": "vdpu0",
+                            "gnmi_port": 8080,
+                            "orchagent_zmq_port": 50
+                        }
+                    ]
+                }
+            }
+        }
         yang_model.load_data(data, error_message)
 
     @pytest.mark.parametrize(
@@ -141,26 +172,28 @@ class TestSmartSwitch:
             ("192.168.1.1", None),
             ("192.168.1.xyz", 'Value "192.168.1.xyz" does not satisfy the constraint')]
         )
-    def test_dpu_port_vip_ipv4(self, yang_model, vip_ipv4, error_message):
+    def test_dpu_vip_ipv4(self, yang_model, vip_ipv4, error_message):
         data = {
             "sonic-smart-switch:sonic-smart-switch": {
-                "sonic-smart-switch:DPU_PORT": {
-                    "DPU_PORT_LIST": [
+                "sonic-smart-switch:DPU": {
+                    "DPU_LIST": [
                         {
-                            "PORT_NAME": "dpu0",
+                            "dpu_name": "str-8102-t1-dpu0",
                             "state": "up",
+                            "local_port": "Ethernet0",
                             "vip_ipv4": vip_ipv4,
                             "vip_ipv6": "2001:db8::1",
                             "pa_ipv4": "192.168.1.2",
                             "pa_ipv6": "2001:db8::2",
+                            "dpu_id": "0",
                             "vdpu_id": "vdpu0",
-                            "gnmi_port": 8080
+                            "gnmi_port": 8080,
+                            "orchagent_zmq_port": 50
                         }
                     ]
                 }
             }
         }
-
         yang_model.load_data(data, error_message)
 
     @pytest.mark.parametrize(
@@ -168,26 +201,28 @@ class TestSmartSwitch:
             ("2001:db8::1", None),
             ("2001:db8::xyz", 'Value "2001:db8::xyz" does not satisfy the constraint')]
         )
-    def test_dpu_port_vip_ipv6(self, yang_model, vip_ipv6, error_message):
+    def test_dpu_vip_ipv6(self, yang_model, vip_ipv6, error_message):
         data = {
             "sonic-smart-switch:sonic-smart-switch": {
-                "sonic-smart-switch:DPU_PORT": {
-                    "DPU_PORT_LIST": [
+                "sonic-smart-switch:DPU": {
+                    "DPU_LIST": [
                         {
-                            "PORT_NAME": "dpu0",
+                            "dpu_name": "str-8102-t1-dpu0",
                             "state": "up",
+                            "local_port": "Ethernet0",
                             "vip_ipv4": "192.168.1.1",
                             "vip_ipv6": vip_ipv6,
                             "pa_ipv4": "192.168.1.2",
                             "pa_ipv6": "2001:db8::2",
+                            "dpu_id": "0",
                             "vdpu_id": "vdpu0",
-                            "gnmi_port": 8080
+                            "gnmi_port": 8080,
+                            "orchagent_zmq_port": 50
                         }
                     ]
                 }
             }
         }
-
         yang_model.load_data(data, error_message)
 
     @pytest.mark.parametrize(
@@ -195,26 +230,28 @@ class TestSmartSwitch:
             ("192.168.1.2", None),
             ("192.168.1.xyz", 'Value "192.168.1.xyz" does not satisfy the constraint')]
         )
-    def test_dpu_port_pa_ipv4(self, yang_model, pa_ipv4, error_message):
+    def test_dpu_pa_ipv4(self, yang_model, pa_ipv4, error_message):
         data = {
             "sonic-smart-switch:sonic-smart-switch": {
-                "sonic-smart-switch:DPU_PORT": {
-                    "DPU_PORT_LIST": [
+                "sonic-smart-switch:DPU": {
+                    "DPU_LIST": [
                         {
-                            "PORT_NAME": "dpu0",
+                            "dpu_name": "str-8102-t1-dpu0",
                             "state": "up",
+                            "local_port": "Ethernet0",
                             "vip_ipv4": "192.168.1.1",
                             "vip_ipv6": "2001:db8::1",
                             "pa_ipv4": pa_ipv4,
                             "pa_ipv6": "2001:db8::2",
+                            "dpu_id": "0",
                             "vdpu_id": "vdpu0",
-                            "gnmi_port": 8080
+                            "gnmi_port": 8080,
+                            "orchagent_zmq_port": 50
                         }
                     ]
                 }
             }
         }
-
         yang_model.load_data(data, error_message)
 
     @pytest.mark.parametrize(
@@ -222,26 +259,57 @@ class TestSmartSwitch:
             ("2001:db8::2", None),
             ("2001:db8::xyz", 'Value "2001:db8::xyz" does not satisfy the constraint')]
         )
-    def test_dpu_port_pa_ipv6(self, yang_model, pa_ipv6, error_message):
+    def test_dpu_pa_ipv6(self, yang_model, pa_ipv6, error_message):
         data = {
             "sonic-smart-switch:sonic-smart-switch": {
-                "sonic-smart-switch:DPU_PORT": {
-                    "DPU_PORT_LIST": [
+                "sonic-smart-switch:DPU": {
+                    "DPU_LIST": [
                         {
-                            "PORT_NAME": "dpu0",
+                            "dpu_name": "str-8102-t1-dpu0",
                             "state": "up",
+                            "local_port": "Ethernet0",
                             "vip_ipv4": "192.168.1.1",
                             "vip_ipv6": "2001:db8::1",
                             "pa_ipv4": "192.168.1.2",
                             "pa_ipv6": pa_ipv6,
+                            "dpu_id": "0",
                             "vdpu_id": "vdpu0",
-                            "gnmi_port": 8080
+                            "gnmi_port": 8080,
+                            "orchagent_zmq_port": 50
                         }
                     ]
                 }
             }
         }
+        yang_model.load_data(data, error_message)
 
+    @pytest.mark.parametrize(
+        "dpu_id, error_message", [
+            ("0", None),
+            ("xyz", 'Value "xyz" does not satisfy the constraint')]
+        )
+    def test_dpu_id(self, yang_model, dpu_id, error_message):
+        data = {
+            "sonic-smart-switch:sonic-smart-switch": {
+                "sonic-smart-switch:DPU": {
+                    "DPU_LIST": [
+                        {
+                            "dpu_name": "str-8102-t1-dpu0",
+                            "state": "up",
+                            "local_port": "Ethernet0",
+                            "vip_ipv4": "192.168.1.1",
+                            "vip_ipv6": "2001:db8::1",
+                            "pa_ipv4": "192.168.1.2",
+                            "pa_ipv6": "2001:db8::2",
+                            "dpu_id": dpu_id,
+                            "vdpu_id": "vdpu0",
+                            "gnmi_port": 8080,
+                            "orchagent_zmq_port": 50
+                        }
+                    ]
+                }
+            }
+        }
         yang_model.load_data(data, error_message)
 
     @pytest.mark.parametrize(
@@ -249,24 +317,55 @@ class TestSmartSwitch:
             (8080, None),
             (99999, 'Invalid value "99999" in "gnmi_port" element.')]
         )
-    def test_dpu_port_gnmi(self, yang_model, gnmi_port, error_message):
+    def test_dpu_gnmi_port(self, yang_model, gnmi_port, error_message):
         data = {
             "sonic-smart-switch:sonic-smart-switch": {
-                "sonic-smart-switch:DPU_PORT": {
-                    "DPU_PORT_LIST": [
+                "sonic-smart-switch:DPU": {
+                    "DPU_LIST": [
                         {
-                            "PORT_NAME": "dpu0",
+                            "dpu_name": "str-8102-t1-dpu0",
                             "state": "up",
+                            "local_port": "Ethernet0",
                             "vip_ipv4": "192.168.1.1",
                             "vip_ipv6": "2001:db8::1",
                             "pa_ipv4": "192.168.1.2",
                             "pa_ipv6": "2001:db8::2",
+                            "dpu_id": "0",
                             "vdpu_id": "vdpu0",
-                            "gnmi_port": gnmi_port
+                            "gnmi_port": gnmi_port,
+                            "orchagent_zmq_port": 50
                         }
                     ]
                 }
             }
         }
+        yang_model.load_data(data, error_message)
 
+    @pytest.mark.parametrize(
+        "orchagent_zmq_port, error_message", [
+            (50, None),
+            (99999, 'Invalid value "99999" in "orchagent_zmq_port" element.')]
+        )
+    def test_dpu_orchagent_zmq_port(self, yang_model, orchagent_zmq_port, error_message):
+        data = {
+            "sonic-smart-switch:sonic-smart-switch": {
+                "sonic-smart-switch:DPU": {
+                    "DPU_LIST": [
+                        {
+                            "dpu_name": "str-8102-t1-dpu0",
+                            "state": "up",
+                            "local_port": "Ethernet0",
+                            "vip_ipv4": "192.168.1.1",
+                            "vip_ipv6": "2001:db8::1",
+                            "pa_ipv4": "192.168.1.2",
+                            "pa_ipv6": "2001:db8::2",
+                            "dpu_id": "0",
+                            "vdpu_id": "vdpu0",
+                            "gnmi_port": 8080,
+                            "orchagent_zmq_port": orchagent_zmq_port
+                        }
+                    ]
+                }
+            }
+        }
         yang_model.load_data(data, error_message)

--- a/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
+++ b/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
@@ -33,6 +33,10 @@ module sonic-smart-switch {
 		description "Add new container DPU_PORT";
 	}
 
+	revision 2025-03-19 {
+		description "Modify DPU_PORT to DPU and add new fields";
+	}
+
 	container sonic-smart-switch {
 
 		container MID_PLANE_BRIDGE {
@@ -85,23 +89,28 @@ module sonic-smart-switch {
 		}
 		/* end of container DPUS */
 
-		container DPU_PORT {
-			description "DPU_PORTs part of config_db.json";
+		container DPU {
+			description "DPUs part of config_db.json";
 
-			list DPU_PORT_LIST {
-				description "Name of the DPU port";
-				key "PORT_NAME";
+			list DPU_LIST {
+				description "Name of the DPU";
+				key "dpu_name";
 
-				leaf PORT_NAME {
-					description "Name of the DPU port";
+				leaf dpu_name {
+					description "Name of the DPU";
 					type string {
-						pattern "[a-zA-Z]+[0-9]+";
+						pattern "[a-zA-Z0-9-]+[0-9]";
 					}
 				}
 
 				leaf state {
 					description "Admin state of DPU device";
 					type stypes:admin_status;
+				}
+
+				leaf local_port {
+					description "DPU Physical port name on the switch";
+					type stypes:interface_name;
 				}
 
 				leaf vip_ipv4 {
@@ -124,18 +133,30 @@ module sonic-smart-switch {
 					type inet:ipv6-address;
 				}
 
+                leaf dpu_id {
+					description "ID of the DPU from minigraph";
+					type string {
+						pattern [0-7];
+					}
+				}
+
 				leaf vdpu_id {
 					description "ID of VDPUs from minigraph";
 					type string;
 				}
 
 				leaf gnmi_port {
-					description "Port gNMI runs on.";
+					description "TCP listening port for gnmi service on DPU";
+					type inet:port-number;
+				}
+
+				leaf orchagent_zmq_port {
+					description "TCP listening port for ZMQ service on DPU orchagent";
 					type inet:port-number;
 				}
 			}
 		}
-		/* end of container DPU_PORT */
+		/* end of container DPU */
 	}
 	/* end of container sonic-smart-switch */
 }

--- a/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
+++ b/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
@@ -132,8 +132,8 @@ module sonic-smart-switch {
 					description "PA IPv6 address from minigraph";
 					type inet:ipv6-address;
 				}
-
-                leaf dpu_id {
+				
+				leaf dpu_id {
 					description "ID of the DPU from minigraph";
 					type string {
 						pattern [0-7];


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Updated DPU_LIST table to follow:

DPU|<DPU_NAME>:                        ; Eg DPU name “str-8102-t1-dpu0” 
          - state: up|down	               ; admin state of DPU device  
          - local_port: port_name ; Physical port<Ethernet-BP0> 
          - vip_ipv4: ipv4 prefix    ; Optional  
          - vip_ipv6: ipv6 prefix    ; Optional  
          - pa_ipv4: ipv4 pa ip     ; from minigraph  
          - pa_ipv6: ipv6 pa ip     ; from minigraph  
          - dpu_id: id of dpu       ; <0-7> from minigraph 
          - vdpu_id: id of vdpu     ; <guid> from minigraph  
          - gnmi_port: TCP listening port for gnmi service on DPU 
          - orchagent_zmq_port: TCP listening port for ZMQ service on DPU orchagent 

##### Work item tracking
- Microsoft ADO **(number only)**: 31582203

#### How I did it
1. Container DPU_PORT renamed to DPU.
2. Added new fields to the DPU_LIST container:
          - dpu_id: ID of the DPU from minigraph.
          - vdpu_id: ID of VDPUs from minigraph.
          - gnmi_port: TCP listening port for gNMI service on DPU.
          - orchagent_zmq_port: TCP listening port for ZMQ service on DPU orchagent.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

