### PR TITLE
Add fix for building libnl3 on Ubuntu 24.04

### DIFF
--- a/src/libnl3/patch/series
+++ b/src/libnl3/patch/series
@@ -2,3 +2,4 @@
 switch-to-debhelper.patch
 keep-symbol-versions-in-libraries.patch
 update-changelog.patch
+skip-tests-when-having-no-private-netns.patch

--- a/src/libnl3/patch/skip-tests-when-having-no-private-netns.patch
+++ b/src/libnl3/patch/skip-tests-when-having-no-private-netns.patch
@@ -1,0 +1,163 @@
+From b3822aa3b605b2dc5f01f9aee8ee224fc23e23a0 Mon Sep 17 00:00:00 2001
+From: Thomas Haller <thaller@redhat.com>
+Date: Sun, 12 Jan 2025 10:54:59 +0100
+Subject: [PATCH] test: skip tests when having no private netns
+
+In github CI we seem now unable to create the netns. This worked
+previously, now it no longer does.
+
+Handle that by skipping the tests that require a netns.
+---
+ tests/cksuite-all-netns.c | 13 +++++++++-
+ tests/nl-test-util.c      | 50 +++++++++++++++++++++++++++++++++++++--
+ tests/nl-test-util.h      |  3 +++
+ 3 files changed, 63 insertions(+), 3 deletions(-)
+
+diff --git a/tests/cksuite-all-netns.c b/tests/cksuite-all-netns.c
+index 1948c3e8..04e0f6df 100644
+--- a/tests/cksuite-all-netns.c
++++ b/tests/cksuite-all-netns.c
+@@ -73,6 +73,9 @@ START_TEST(cache_and_clone)
+ 	int i;
+ 	int r;
+ 
++	if (_nltst_skip_no_netns())
++		return;
++
+ 	for (i = 0; i < _NL_N_ELEMENTS(links); i++) {
+ 		if (links[i].add)
+ 			_nltst_add_link(NULL, links[i].ifname, links[i].kind,
+@@ -132,11 +135,16 @@ START_TEST(test_create_iface)
+ 	_nl_auto_rtnl_link struct rtnl_link *link2 = NULL;
+ 	_nl_auto_rtnl_link struct rtnl_link *peer = NULL;
+ 	_nltst_auto_delete_link const char *IFNAME_DUMMY = NULL;
+-	_nltst_auto_delete_link const char *IFNAME = "ifname";
++	_nltst_auto_delete_link const char *IFNAME = NULL;
+ 	int ifindex_dummy;
+ 	uint32_t u32;
+ 	int r;
+ 
++	if (_nltst_skip_no_netns())
++		return;
++
++	IFNAME = "ifname";
++
+ 	switch (TEST_IDX) {
+ 	case 0:
+ 		link = _nltst_assert(rtnl_link_bridge_alloc());
+diff --git a/tests/nl-test-util.c b/tests/nl-test-util.c
+index dc8dc5ad..d1a8f3f1 100644
+--- a/tests/nl-test-util.c
++++ b/tests/nl-test-util.c
+@@ -84,6 +84,7 @@ uint32_t _nltst_rand_u32(void)
+ 
+ struct nltst_netns {
+ 	int canary;
++	bool is_unshared;
+ };
+ 
+ /*****************************************************************************/
+@@ -114,6 +115,23 @@ void nltst_netns_fixture_teardown(void)
+ 	_nl_clear_pointer(&_netns_fixture_global.nsdata, nltst_netns_leave);
+ }
+ 
++bool nltst_netns_fixture_is_unshared(void)
++{
++	_assert_nltst_netns(_netns_fixture_global.nsdata);
++	return _netns_fixture_global.nsdata->is_unshared;
++}
++
++/*****************************************************************************/
++
++bool _nltst_skip_no_netns(void)
++{
++	if (nltst_netns_fixture_is_unshared())
++		return false;
++
++	printf("skip test due to having no private netns\n");
++	return true;
++}
++
+ /*****************************************************************************/
+ 
+ static void unshare_user(void)
+@@ -125,6 +143,10 @@ static void unshare_user(void)
+ 
+ 	/* Become a root in new user NS. */
+ 	r = unshare(CLONE_NEWUSER);
++	if (r != 0 && errno == EPERM) {
++		/* No permissions? Ignore. Will be handled later. */
++		return;
++	}
+ 	_nltst_assert_errno(r == 0);
+ 
+ 	/* Since Linux 3.19 we have to disable setgroups() in order to map users.
+@@ -149,14 +171,28 @@ static void unshare_user(void)
+ 	}
+ 	r = fprintf(f, "0 %d 1", uid);
+ 	_nltst_assert_errno(r > 0);
+-	_nltst_fclose(f);
++	r = fclose(f);
++	if (r != 0 && errno == EPERM) {
++		/* Oddly, it seems close() can fail at this point. Ignore it,
++		 * but we probably will be unable to unshare (which we handle
++		 * later).
++		 */
++	} else
++		_nltst_assert_errno(r == 0);
+ 
+ 	/* Map current GID to root in NS to be created. */
+ 	f = fopen("/proc/self/gid_map", "we");
+ 	_nltst_assert_errno(f);
+ 	r = fprintf(f, "0 %d 1", gid);
+ 	_nltst_assert_errno(r > 0);
+-	_nltst_fclose(f);
++	r = fclose(f);
++	if (r != 0 && errno == EPERM) {
++		/* Oddly, it seems close() can fail at this point. Ignore it, but
++		 * we probably will be unable to unshare (which we handle
++		 * later).
++		 */
++	} else
++		_nltst_assert_errno(r == 0);
+ }
+ 
+ struct nltst_netns *nltst_netns_enter(void)
+@@ -172,6 +208,15 @@ struct nltst_netns *nltst_netns_enter(void)
+ 	unshare_user();
+ 
+ 	r = unshare(CLONE_NEWNET | CLONE_NEWNS);
++	if (r != 0 && errno == EPERM) {
++		/* The system is probably sandboxed somehow and we are unable
++		 * to create a private netns. That seems questionable, because
++		 * a point of a private netns is to sandbox an application.
++		 * Not having permissions to sandbox sounds bad.
++		 *
++		 * Anyway. We accept this and will later skip some tests. */
++		return nsdata;
++	}
+ 	_nltst_assert_errno(r == 0);
+ 
+ 	/* We need a read-only /sys so that the platform knows there's no udev. */
+@@ -179,6 +224,7 @@ struct nltst_netns *nltst_netns_enter(void)
+ 	r = mount("sys", "/sys", "sysfs", MS_RDONLY, NULL);
+ 	_nltst_assert_errno(r == 0);
+ 
++	nsdata->is_unshared = true;
+ 	return nsdata;
+ }
+ 
+diff --git a/tests/nl-test-util.h b/tests/nl-test-util.h
+index 981228b4..d840a4ab 100644
+--- a/tests/nl-test-util.h
++++ b/tests/nl-test-util.h
+@@ -429,6 +429,9 @@ char **_nltst_strtokv(const char *str);
+ 
+ void nltst_netns_fixture_setup(void);
+ void nltst_netns_fixture_teardown(void);
++bool nltst_netns_fixture_is_unshared(void);
++
++bool _nltst_skip_no_netns(void);
+ 
+ struct nltst_netns;
+ 


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When building libnl3 inside a container with a newer kernel (such as what is used on Ubuntu 24.04), some commands to create a private network namespace may fail due to restrictions. This was seen in libnl3's own Github Actions CI, and is now seen on build machines running Ubuntu 24.04 as the host with kernel 6.8.

##### Work item tracking
- Microsoft ADO **(number only)**: 31902668

#### How I did it

Backport a patch from libnl3 to handle such cases.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

