### PR TITLE
[Bgpcfgd][YANG] Remove the prefix matching constraint in sonic-srv6.yang and add prefix match checking in bgpcfgd

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
@@ -1,6 +1,6 @@
 from .log import log_err, log_debug, log_warn
 from .manager import Manager
-from ipaddress import IPv6Address
+from ipaddress import IPv6Network
 from swsscommon import swsscommon
 
 supported_SRv6_behaviors = {
@@ -65,8 +65,10 @@ class SRv6Mgr(Manager):
             return False
 
         locator = self.directory.get(self.db_name, "SRV6_MY_LOCATORS", locator_name)
-        if locator.block_len + locator.node_len > prefix_len:
-            log_err("Found a SRv6 SID config entry with an invalid prefix length {} | {}".format(key, data))
+        locator_prefix = IPv6Network(locator.prefix)
+        sid_prefix = IPv6Network(ip_prefix)
+        if not locator_prefix.supernet_of(sid_prefix):
+            log_err("Found a SRv6 SID config entry that does not match the locator prefix: {} | {}; locator {}".format(key, data, locator))
             return False
 
         if 'action' not in data:

--- a/src/sonic-bgpcfgd/tests/test_srv6.py
+++ b/src/sonic-bgpcfgd/tests/test_srv6.py
@@ -165,6 +165,17 @@ def test_invalid_add():
 
     assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21:f1::\\64")
 
+def test_add_unmatched_sid():
+    loc_mgr, sid_mgr = constructor()
+    assert loc_mgr.set_handler("loc1", {'prefix': 'fcbb:bbbb:20::'})
+
+    # test the addition of a SID with a non-matching locator
+    op_test(sid_mgr, 'SET', ("loc1|FCBB:BBBB:21::/48", {
+        'action': 'uN'
+    }), expected_ret=False, expected_cmds=[])
+
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:21::\\48")
+
 def test_out_of_order_add():
     loc_mgr, sid_mgr = constructor()
     loc_mgr.cfg_mgr.push_list = MagicMock()

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/srv6.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/srv6.json
@@ -19,10 +19,6 @@
         "desc": "A SID configured with invalid IPv6 address",
         "eStrKey" : "Pattern"
     },
-    "SRV6_MY_SID_UNMATCHED_IP_PREFIX": {
-        "desc": "A SID configured with an IPv6 Address that does not match with the prefix of the locator",
-        "eStrKey" : "Must"
-    },
     "SRV6_MY_SID_INVALID_ACTION": {
         "desc": "A SID configured with invalid action",
         "eStrKey" : "InvalidValue",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/srv6.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/srv6.json
@@ -131,32 +131,6 @@
             }
         }
     },
-    "SRV6_MY_SID_UNMATCHED_IP_PREFIX": {
-        "sonic-srv6:sonic-srv6": {
-            "sonic-srv6:SRV6_MY_LOCATORS": {
-                "SRV6_MY_LOCATORS_LIST": [
-                    {
-                        "locator_name": "MAIN",
-                        "prefix": "FCBB:BBBB:20::"
-                    }
-                ]
-            },
-            "sonic-srv6:SRV6_MY_SIDS": {
-                "SRV6_MY_SIDS_LIST": [
-                    {
-                        "ip_prefix": "FCBB:BBBB:21::/48",
-                        "locator": "MAIN",
-                        "action": "uN"
-                    },
-                    {
-                        "ip_prefix": "FCBB:BBBB:20:F1::/64",
-                        "locator": "MAIN",
-                        "action": "uDT46"
-                    }
-                ]
-            }
-        }
-    },
     "SRV6_MY_SID_INVALID_ACTION": {
         "sonic-srv6:sonic-srv6": {
             "sonic-srv6:SRV6_MY_LOCATORS": {

--- a/src/sonic-yang-models/yang-models/sonic-srv6.yang
+++ b/src/sonic-yang-models/yang-models/sonic-srv6.yang
@@ -122,9 +122,6 @@ module sonic-srv6 {
                         enum pipe;
                     }
                 }
-
-                must 'starts-with(substring-before(./ip_prefix, "::"),
-                                  substring-before(/srv6:sonic-srv6/SRV6_MY_LOCATORS/SRV6_MY_LOCATORS_LIST[current()/locator]/prefix, "::"))';
             }
         }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The prefix matching constraint hit some unknown problem about libyang in testing and it prevents multiple MYSIDs being used.
fix issue: #[21876](https://github.com/sonic-net/sonic-buildimage/issues/21867)

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Remove the prefix matching constraint in sonic-srv6.yang and add prefix matching check in bgpcfgd/managers_srv6.py.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202412

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

