### PR TITLE
[ARP_UPDATE] Update arp_update tool suite to resolve static-route neighbors for BT0

### DIFF
--- a/files/build_templates/arp_update_vars.j2
+++ b/files/build_templates/arp_update_vars.j2
@@ -1,5 +1,6 @@
 {
     "switch_type": "{% if DEVICE_METADATA and 'localhost' in DEVICE_METADATA and 'switch_type' in DEVICE_METADATA['localhost'] %}{{ DEVICE_METADATA['localhost']['switch_type'] }}{%endif %}",
+    "type": "{% if DEVICE_METADATA and 'localhost' in DEVICE_METADATA and 'type' in DEVICE_METADATA['localhost'] %}{{ DEVICE_METADATA['localhost']['type'] }}{%endif %}",
     "interface": "{% for (name, prefix) in INTERFACE|pfx_filter %}{% if prefix|ipv6 %}{{ name }} {% endif %}{% endfor %}",
     "pc_interface" : "{% for (name, prefix) in PORTCHANNEL_INTERFACE|pfx_filter %}{% if prefix|ipv6 %}{{ name }} {% endif %}{% endfor %}",
     "vlan_sub_interface": "{% for (name, prefix) in VLAN_SUB_INTERFACE|pfx_filter %}{% if prefix|ipv6 %}{{ name }} {% endif %}{% endfor %}",

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -63,8 +63,8 @@ while /bin/true; do
               fi
           done
 
-          sleep 150
           if [[ "$SWITCH_TYPE" == "chassis-packet" ]]; then
+            sleep 150
             # skip the rest of the script if running on a packet chassis
             continue
           fi

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -18,49 +18,56 @@ while /bin/true; do
   # find L3 interfaces which are UP, send ipv6 multicast pings
   ARP_UPDATE_VARS=$(sonic-cfggen -d -t ${ARP_UPDATE_VARS_FILE})
   SWITCH_TYPE=$(echo $ARP_UPDATE_VARS | jq -r '.switch_type')
-  if [[ "$SWITCH_TYPE" == "chassis-packet" ]]; then
+  TYPE=$(echo $ARP_UPDATE_VARS | jq -r '.type')
+  if [[ "$SWITCH_TYPE" == "chassis-packet" ]] || [[ "$TYPE" == "BackEndToRRouter" ]]; then
       # Get array of Nexthops and ifnames. Nexthops and ifnames are mapped one to one
       STATIC_ROUTE_NEXTHOPS=($(echo $ARP_UPDATE_VARS | jq -r '.static_route_nexthops'))
       STATIC_ROUTE_IFNAMES=($(echo $ARP_UPDATE_VARS | jq -r '.static_route_ifnames'))
-      # on supervisor/rp exit the script gracefully
+
       if [[ -z "$STATIC_ROUTE_NEXTHOPS" ]] || [[ -z "$STATIC_ROUTE_IFNAMES" ]]; then
-          logger "exiting as no static route in packet based chassis"
-          exit 0
-      fi
-      for i in ${!STATIC_ROUTE_NEXTHOPS[@]}; do
-          nexthop="${STATIC_ROUTE_NEXTHOPS[i]}"
-          if [[ $nexthop == *"."* ]]; then
-              neigh_state=$(ip -4 neigh show | grep -w $nexthop | tr -s ' ')
-              ping_prefix=ping
-          elif [[ $nexthop == *":"* ]] ; then
-              neigh_state=$(ip -6 neigh show | grep -w $nexthop | tr -s ' ')
-              ping_prefix=ping6
+          if [[ "$SWITCH_TYPE" == "chassis-packet" ]]; then
+              # exit gracefully if running on supervisor/rp
+              logger "exiting as no static route in packet based chassis"
+              exit 0
           fi
-          # Check if there is an INCOMPLETE, FAILED, or STALE entry and try to resolve it again.
-          # STALE entries may be present if there is no traffic on a path. A far-end down event may not
-          # clear the STALE entry. Refresh the STALE entry to clear the table.
-          if [[ -z "${neigh_state}" ]] || [[ -n $(echo ${neigh_state} | grep 'INCOMPLETE\|FAILED\|STALE') ]]; then
-              interface="${STATIC_ROUTE_IFNAMES[i]}"
-              if [[ -z "$interface" ]]; then
-                  # should never be here, handling just in case
-                  logger -p error "missing interface entry for static route $nexthop"
-                  continue
+          # continue if running on BT0
+      else
+          for i in ${!STATIC_ROUTE_NEXTHOPS[@]}; do
+              nexthop="${STATIC_ROUTE_NEXTHOPS[i]}"
+              if [[ $nexthop == *"."* ]]; then
+                  neigh_state=$(ip -4 neigh show | grep -w $nexthop | tr -s ' ')
+                  ping_prefix=ping
+              elif [[ $nexthop == *":"* ]] ; then
+                  neigh_state=$(ip -6 neigh show | grep -w $nexthop | tr -s ' ')
+                  ping_prefix=ping6
               fi
-              intf_up=$(ip link show $interface | grep "state UP")
-              if [[ -n "$intf_up" ]]; then
-                  pingcmd="timeout 0.2 $ping_prefix -I ${interface} -n -q -i 0 -c 1 -W 1 $nexthop >/dev/null"
-                  eval $pingcmd
-                  # STALE entries may appear more often, not logging to prevent periodic syslogs
-                  if [[ -z $(echo ${neigh_state} | grep 'STALE') ]]; then
-                      logger "static route nexthop not resolved ($neigh_state), pinging $nexthop on $interface"
+              # Check if there is an INCOMPLETE, FAILED, or STALE entry and try to resolve it again.
+              # STALE entries may be present if there is no traffic on a path. A far-end down event may not
+              # clear the STALE entry. Refresh the STALE entry to clear the table.
+              if [[ -z "${neigh_state}" ]] || [[ -n $(echo ${neigh_state} | grep 'INCOMPLETE\|FAILED\|STALE') ]]; then
+                  interface="${STATIC_ROUTE_IFNAMES[i]}"
+                  if [[ -z "$interface" ]]; then
+                      # should never be here, handling just in case
+                      logger -p error "missing interface entry for static route $nexthop"
+                      continue
+                  fi
+                  intf_up=$(ip link show $interface | grep "state UP")
+                  if [[ -n "$intf_up" ]]; then
+                      pingcmd="timeout 0.2 $ping_prefix -I ${interface} -n -q -i 0 -c 1 -W 1 $nexthop >/dev/null"
+                      eval $pingcmd
+                      # STALE entries may appear more often, not logging to prevent periodic syslogs
+                      if [[ -z $(echo ${neigh_state} | grep 'STALE') ]]; then
+                          logger "static route nexthop not resolved ($neigh_state), pinging $nexthop on $interface"
+                      fi
                   fi
               fi
-          fi
-      done
+          done
 
-      sleep 150
-      continue
+          sleep 150
+          continue
+      fi
   fi
+
   # find L3 interfaces which are UP, send ipv6 multicast pings
   INTERFACE=$(echo $ARP_UPDATE_VARS | jq -r '.interface')
   PC_INTERFACE=$(echo $ARP_UPDATE_VARS | jq -r '.pc_interface')
@@ -122,7 +129,7 @@ while /bin/true; do
       ndisc6cmd="sed -e 's/^/ndisc6 -q -w 0 -1 /' -e 's/$/;/'"
       ip6cmd="ip -6 neigh show | grep -v fe80 | grep $vlan | cut -d ' ' -f 1,3 | $ndisc6cmd"
       eval `eval $ip6cmd`
- 
+
       if [[ $SUBTYPE == "dualtor" ]]; then
         # capture all current failed/incomplete IPv6 neighbors in the kernel to avoid situations where new neighbors are learned
         # in the middle of the below sequence of commands
@@ -161,13 +168,13 @@ while /bin/true; do
         # ip neigh replace <neighbor IPv6> dev <VLAN name> nud incomplete
         failed_kernel_neighbors=$(ip -6 neigh show | grep -v fe80 | grep $vlan | grep -E 'FAILED')
         if [[ ! -z "$failed_kernel_neighbors" ]]; then
-            neigh_replace_template="sed -e 's/^/ip neigh replace /' -e 's/,/ dev /' -e 's/$/ nud incomplete;/'" 
+            neigh_replace_template="sed -e 's/^/ip neigh replace /' -e 's/,/ dev /' -e 's/$/ nud incomplete;/'"
             ip_neigh_replace_cmd="echo \"$failed_kernel_neighbors\" | cut -d ' ' -f 1,3 --output-delimiter=',' | $neigh_replace_template"
             eval `eval "$ip_neigh_replace_cmd"`
         fi
       fi
   done
-  
+
 
   # sleep here before handling the mismatch as it is not required during startup
   sleep 300

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -64,7 +64,10 @@ while /bin/true; do
           done
 
           sleep 150
-          continue
+          if [[ "$SWITCH_TYPE" == "chassis-packet" ]]; then
+            # skip the rest of the script if running on a packet chassis
+            continue
+          fi
       fi
   fi
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

We need to proactively resolve static-route neighbors for BT0 to prevent VLAN flooding caused by MAC missing.

##### Work item tracking
- Microsoft ADO **(number only)**: 31751190

#### How I did it
Reuse the static-route neighbor probing mechanism (which was for packet-chassis) for BT0.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202412

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

