### PR TITLE
[vs]: Add script to build individual boost libraries

### DIFF
--- a/platform/vs/docker-sonic-vs/scripts/build_boost_lib.sh
+++ b/platform/vs/docker-sonic-vs/scripts/build_boost_lib.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Run script with desired library and version, e.g. to get libboost-serialization1.71.0, run:
+# build_boost_lib.sh serialization 1.71.0
+
+script=$(basename "$0")
+if [[ -z "$1" || -z "$2" || "$1" == "-h" || "$1" == "--help" ]]; then
+    echo "Usage:"
+    echo "  ${script} <boost library name> <boost version>"
+    echo
+    echo "Example:"
+    echo "  ${script} serialization 1.71.0"
+    echo
+    echo "Parameters:"
+    echo "  -h,--help   Print this help message"
+    exit
+fi
+
+libname="$1"
+boost_ver="$2"
+boost_underscore=$(echo "${boost_ver}" | sed 's/\./_/g')
+boostdir="boost_${boost_underscore}"
+
+export DEBVERSION=${boost_ver}
+export PACKAGE_NAME="libboost-${libname}"
+
+if [ ! -d ${boostdir}  ]; then
+    boost_zip_file="boost_${boost_underscore}.zip" 
+    rm -f ${boost_zip_file}
+    wget "https://archives.boost.io/release/${boost_ver}/source/${boost_zip_file}"
+    unzip ${boost_zip_file}
+fi
+
+cd ${boostdir}
+rm -rf debian
+mkdir -p debian
+dch --create -v $DEBVERSION --package $PACKAGE_NAME ""
+touch debian
+
+cat > debian/control <<EOF
+Source: ${PACKAGE_NAME}
+Maintainer: None <none@example.com>
+Section: misc
+Priority: optional
+Standards-Version: 3.9.2
+Build-Depends: debhelper (>= 8), cdbs, zlib1g-dev
+
+Package: ${PACKAGE_NAME}
+Architecture: amd64
+Depends: \${shlibs:Depends}, \${misc:Depends}, ${PACKAGE_NAME}  (= ${DEBVERSION})
+Description: ${libname} library for C++
+
+Package: ${PACKAGE_NAME}-dev
+Architecture: amd64
+Depends: ${PACKAGE_NAME} (= $DEBVERSION)
+Description: ${libname} development files
+EOF
+
+cat > debian/rules <<EOF
+#!/usr/bin/make -f
+%:
+	dh \$@
+override_dh_auto_configure:
+	./bootstrap.sh
+override_dh_auto_build:
+	./b2 --no-cmake-config --with-${libname} link=static,shared -j 1 --prefix=$(pwd)/debian/${PACKAGE_NAME}/usr/
+override_dh_auto_install:
+	mkdir -p debian/${PACKAGE_NAME}/usr debian/${PACKAGE_NAME}-dev/usr
+	./b2 --no-cmake-config --with-${libname} link=static,shared --prefix=$(pwd)/debian/${PACKAGE_NAME}/usr/ install
+	mv debian/${PACKAGE_NAME}/usr/include debian/${PACKAGE_NAME}-dev/usr
+EOF
+echo "9" > debian/compat
+debuild -b


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When running Docker VS tests in sonic-swss, the host machine needs to have libswsscommon installed which requires the Boost serialization library. If the machine where libswsscommon was built has a different OS from the host machine, the required Boost version may not be available from package repositories.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add a script to build individual boost libraries from source.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

