### PR TITLE
T2: anchor prefix fixes

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/prefix_list
+++ b/dockers/docker-fpm-frr/base_image_files/prefix_list
@@ -35,10 +35,10 @@ check_root_privileges() {
 # Function to check if the device is supported device with type spine routers and subtype UpstreamLC
 check_spine_router() {
     type=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.type)
-    sub_type=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.sub_type)
-    
+    subtype=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype)
+
     # only supported on spine routers and UpstreamLC
-    if [[ "$type" != "SpineRouter" ||  "$sub_type" != "UpstreamLC" ]]; then
+    if [[ "$type" != "SpineRouter" ||  "$subtype" != "UpstreamLC" ]]; then
         echo "Operation is only supported on UpstreamLC of SpineRouter." >&2
         exit 1
     fi
@@ -46,7 +46,7 @@ check_spine_router() {
 
 # Function to skip operation on chassis supervisor
 skip_chassis_supervisor() {
-    if [ -f /etc/sonic/chassisdb.conf ]; then  
+    if [ -f /etc/sonic/chassisdb.conf ]; then
         echo "Skipping Operation on chassis supervisor"
         exit 0
     fi
@@ -72,12 +72,19 @@ validate_operation() {
     fi
 
     # Check if the prefix type is supported or not if the operation is not status
-    if [ $1 != "status" ]; then
-        for prefix_type in "${supported_prefix_types[@]}"; do
-        if [[ "$2" == "$prefix_type" ]]; then
-            valid_prefix_type=true
-            break
+    if [ "$1" == "status" ]; then
+        if [ -n "$2" ]; then
+            echo "No additional parameters required for status operation." >&2
+            echo ""
+            display_help
+            exit 1
         fi
+    else
+        for prefix_type in "${supported_prefix_types[@]}"; do
+            if [[ "$2" == "$prefix_type" ]]; then
+                valid_prefix_type=true
+                break
+            fi
         done
 
         if [ $valid_prefix_type == false ]; then
@@ -144,7 +151,9 @@ if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     display_help
 fi
 
-check_root_privileges
+if [ "$1" != "status" ]; then
+    check_root_privileges
+fi
 check_spine_router
 skip_chassis_supervisor
 
@@ -162,7 +171,7 @@ ASIC_CONF=/usr/share/sonic/device/$PLATFORM/asic.conf
 if [[ ($NUM_ASIC -gt 1) ]]; then
     asic=0
     while [ $asic -lt $NUM_ASIC ]
-    do        
+    do
         sub_role=`sonic-cfggen -d -v "DEVICE_METADATA['localhost']['sub_role']" -n asic$asic`
         if [ $sub_role == 'FrontEnd' ]; then
             handle_prefix_list_asic $asic $1 $2 $3

--- a/dockers/docker-fpm-frr/frr/bgpd/radian/add_radian.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/radian/add_radian.conf.j2
@@ -1,5 +1,4 @@
-{{ data.ipv }} prefix-list ANCHOR_CONTRIBUTING_ROUTES permit {{ data.prefix }} ge 48
-{# #}
+{{ data.ipv }} prefix-list ANCHOR_CONTRIBUTING_ROUTES permit {{ data.prefix }} ge {{ data.prefixlen }}
 router bgp {{ data.bgp_asn }}
 {% if data.ipv == 'ip' -%}
  address-family ipv4 unicast

--- a/dockers/docker-fpm-frr/frr/bgpd/radian/add_radian.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/radian/add_radian.conf.j2
@@ -1,4 +1,4 @@
-{{ data.ipv }} prefix-list ANCHOR_CONTRIBUTING_ROUTES permit {{ data.prefix }} ge {{ data.prefixlen }}
+{{ data.ipv }} prefix-list ANCHOR_CONTRIBUTING_ROUTES permit {{ data.prefix }} ge {{ data.prefixlen + 1 }}
 router bgp {{ data.bgp_asn }}
 {% if data.ipv == 'ip' -%}
  address-family ipv4 unicast

--- a/dockers/docker-fpm-frr/frr/bgpd/radian/del_radian.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/radian/del_radian.conf.j2
@@ -1,4 +1,4 @@
-no {{ data.ipv }} prefix-list ANCHOR_CONTRIBUTING_ROUTES permit {{ data.prefix }} ge 48 
+no {{ data.ipv }} prefix-list ANCHOR_CONTRIBUTING_ROUTES permit {{ data.prefix }} ge {{ data.prefixlen }}
 router bgp {{ data.bgp_asn }}
 {% if data.ipv == 'ip' -%}
  address-family ipv4 unicast

--- a/dockers/docker-fpm-frr/frr/bgpd/radian/del_radian.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/radian/del_radian.conf.j2
@@ -1,4 +1,4 @@
-no {{ data.ipv }} prefix-list ANCHOR_CONTRIBUTING_ROUTES permit {{ data.prefix }} ge {{ data.prefixlen }}
+no {{ data.ipv }} prefix-list ANCHOR_CONTRIBUTING_ROUTES permit {{ data.prefix }} ge {{ data.prefixlen + 1 }}
 router bgp {{ data.bgp_asn }}
 {% if data.ipv == 'ip' -%}
  address-family ipv4 unicast

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
@@ -75,6 +75,7 @@ class PrefixListMgr(Manager):
                 return True
             data["prefix_list_name"] = prefix_list_name
             data["prefix"] = str(prefix.cidr)
+            data["prefixlen"] = prefix.prefixlen
             data["ipv"] = self.get_ip_type(prefix)
             # Generate the prefix list configuration
             if self.generate_prefix_list_config(data, add=True):
@@ -96,6 +97,7 @@ class PrefixListMgr(Manager):
             data = {}
             data["prefix_list_name"] = prefix_list_name
             data["prefix"] = str(prefix.cidr)
+            data["prefixlen"] = prefix.prefixlen
             data["ipv"] = self.get_ip_type(prefix)
             # remove the prefix list configuration
             if self.generate_prefix_list_config(data, add=False):

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/radian/add_radian.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/radian/add_radian.conf
@@ -1,4 +1,4 @@
-ipv6 prefix-list ANCHOR_CONTRIBUTING_ROUTES permit ffff::/64 ge 64
+ipv6 prefix-list ANCHOR_CONTRIBUTING_ROUTES permit ffff::/64 ge 65
 router bgp 1234
 address-family ipv6 unicast
  aggregate-address ffff::/64 route-map TAG_ANCHOR_COMMUNITY

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/radian/add_radian.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/radian/add_radian.conf
@@ -1,4 +1,4 @@
-ipv6 prefix-list ANCHOR_CONTRIBUTING_ROUTES permit ffff::/64 ge 48
+ipv6 prefix-list ANCHOR_CONTRIBUTING_ROUTES permit ffff::/64 ge 64
 router bgp 1234
 address-family ipv6 unicast
  aggregate-address ffff::/64 route-map TAG_ANCHOR_COMMUNITY

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/radian/add_radian.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/radian/add_radian.json
@@ -2,6 +2,7 @@
     "data": {
         "ipv": "ipv6",
         "prefix": "ffff::/64",
+        "prefixlen": 64,
         "bgp_asn": 1234
     }
 }

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/radian/del_radian.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/radian/del_radian.conf
@@ -1,4 +1,4 @@
-no ipv6 prefix-list ANCHOR_CONTRIBUTING_ROUTES permit ffff::/64 ge 64
+no ipv6 prefix-list ANCHOR_CONTRIBUTING_ROUTES permit ffff::/64 ge 65
 router bgp 1234
  address-family ipv6 unicast
 no aggregate-address ffff::/64 route-map TAG_ANCHOR_COMMUNITY

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/radian/del_radian.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/radian/del_radian.conf
@@ -1,4 +1,4 @@
-no ipv6 prefix-list ANCHOR_CONTRIBUTING_ROUTES permit ffff::/64 ge 48 
+no ipv6 prefix-list ANCHOR_CONTRIBUTING_ROUTES permit ffff::/64 ge 64
 router bgp 1234
  address-family ipv6 unicast
 no aggregate-address ffff::/64 route-map TAG_ANCHOR_COMMUNITY

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/radian/del_radian.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/radian/del_radian.json
@@ -2,6 +2,7 @@
     "data": {
         "ipv": "ipv6",
         "prefix": "ffff::/64",
+        "prefixlen": 64,
         "bgp_asn": 1234
     }
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fixes in T2 Radian Resiliency feature support checked in as part of PR https://github.com/sonic-net/sonic-buildimage/pull/21732/

##### Work item tracking
- Microsoft ADO **31982579**:

#### How I did it
The changes take care of following
1. Fix a typo which fetching chassis subtype in prefix_list script
2. remove root permission validation during radian status check
3. Input argument parsing fix during status check
4. during add_radian/del_radian template rendering, prefix-list entry to have prefixlen passed as an argument, instead of hardcoding it 
#### How to verify it
1. Execute the prefix_list script, and make sure add/del radian entries go through as expected.
2. Ensure that status check doesnt require sudo
3. Ensure that status check fails when passed second argument
4. Ensure that backend code renders radian config as per expectation
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
202405-chassis
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

