### PR TITLE
[build] Fix docker dpkg_qpt removing target package in some scenario.

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -493,6 +493,7 @@ SONIC_SLAVE_USER_BUILD = \
 
 SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            -f slave.mk \
+                           TARGET=$@ \
                            PLATFORM=$(PLATFORM) \
                            PLATFORM_ARCH=$(PLATFORM_ARCH) \
                            MULTIARCH_QEMU_ENVIRON=$(MULTIARCH_QEMU_ENVIRON)  \

--- a/Makefile.work
+++ b/Makefile.work
@@ -493,7 +493,6 @@ SONIC_SLAVE_USER_BUILD = \
 
 SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            -f slave.mk \
-                           TARGET=$@ \
                            PLATFORM=$(PLATFORM) \
                            PLATFORM_ARCH=$(PLATFORM_ARCH) \
                            MULTIARCH_QEMU_ENVIRON=$(MULTIARCH_QEMU_ENVIRON)  \
@@ -615,7 +614,7 @@ endif
 
 	$(Q)$(DOCKER_RUN) \
 		$(SLAVE_IMAGE):$(SLAVE_TAG) \
-		bash -c "$(SONIC_BUILD_INSTRUCTION) $@; $(COLLECT_BUILD_VERSION); $(SLAVE_SHELL)" 
+		bash -c "$(SONIC_BUILD_INSTRUCTION) $@ TARGET=$@; $(COLLECT_BUILD_VERSION); $(SLAVE_SHELL)"
 	$(Q)$(docker-image-cleanup)
 
 docker-cleanup:

--- a/Makefile.work
+++ b/Makefile.work
@@ -614,7 +614,7 @@ endif
 
 	$(Q)$(DOCKER_RUN) \
 		$(SLAVE_IMAGE):$(SLAVE_TAG) \
-		bash -c "$(SONIC_BUILD_INSTRUCTION) $@ TARGET=$@; $(COLLECT_BUILD_VERSION); $(SLAVE_SHELL)"
+		bash -c "$(SONIC_BUILD_INSTRUCTION) $@ SONIC_BUILD_TARGET=$@; $(COLLECT_BUILD_VERSION); $(SLAVE_SHELL)"
 	$(Q)$(docker-image-cleanup)
 
 docker-cleanup:

--- a/dockers/dockerfile-macros.j2
+++ b/dockers/dockerfile-macros.j2
@@ -1,5 +1,5 @@
 {% macro install_debian_packages(packages) -%}
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; \
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f --no-remove; } || return 1; }; \
     {%- for deb in packages %}
         dpkg_apt /debs/{{ deb }} {%- if not loop.last %} && \ {%- endif %}
     {%- endfor %}

--- a/platform/vs/syncd-vs.mk
+++ b/platform/vs/syncd-vs.mk
@@ -4,9 +4,12 @@ SYNCD_VS = syncd-vs_1.0.0_$(CONFIGURED_ARCH).deb
 $(SYNCD_VS)_RDEPENDS += $(LIBSAIREDIS) $(LIBSAIMETADATA) $(LIBSAIVS)
 
 ifeq ($(BLDENV),bookworm)
+# dash-sai only support sonic-vs.img.gz. it don't support docker-sonic-vs.gz
+ifneq ($(TARGET), docker-sonic-vs.gz)
   $(LIBSAIREDIS)_DEB_BUILD_PROFILES += dashsai
   $(LIBSAIREDIS)_DEPENDS += $(DASH_SAI)
   $(SYNCD_VS)_RDEPENDS += $(DASH_SAI)
+endif
 else
   $(warning DASH_SAI cannot support this build environment $(BLDENV))
 endif

--- a/platform/vs/syncd-vs.mk
+++ b/platform/vs/syncd-vs.mk
@@ -5,7 +5,7 @@ $(SYNCD_VS)_RDEPENDS += $(LIBSAIREDIS) $(LIBSAIMETADATA) $(LIBSAIVS)
 
 ifeq ($(BLDENV),bookworm)
 # dash-sai only support sonic-vs.img.gz. it don't support docker-sonic-vs.gz
-ifeq ($(findstring docker-sonic-vs, $(TARGET)), )
+ifeq ($(findstring docker-sonic-vs, $(SONIC_BUILD_TARGET)), )
   $(LIBSAIREDIS)_DEB_BUILD_PROFILES += dashsai
   $(LIBSAIREDIS)_DEPENDS += $(DASH_SAI)
   $(SYNCD_VS)_RDEPENDS += $(DASH_SAI)

--- a/platform/vs/syncd-vs.mk
+++ b/platform/vs/syncd-vs.mk
@@ -5,7 +5,7 @@ $(SYNCD_VS)_RDEPENDS += $(LIBSAIREDIS) $(LIBSAIMETADATA) $(LIBSAIVS)
 
 ifeq ($(BLDENV),bookworm)
 # dash-sai only support sonic-vs.img.gz. it don't support docker-sonic-vs.gz
-ifneq ($(TARGET), docker-sonic-vs.gz)
+ifeq ($(findstring docker-sonic-vs, $(TARGET)), )
   $(LIBSAIREDIS)_DEB_BUILD_PROFILES += dashsai
   $(LIBSAIREDIS)_DEPENDS += $(DASH_SAI)
   $(SYNCD_VS)_RDEPENDS += $(DASH_SAI)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix docker dependency packages missing issue in specific scenario.
When run 'apt-get -y install -f', if dependency packages are not installed, it will remove the target package and it will not report error. It is not by design. Dependency missing is critical error.
With this PR, when dependency packages are not installed, it will report error and exit.
##### Work item tracking
- Microsoft ADO **(number only)**:  31996244

#### How I did it
Fix apt-get install command.
docker-sonic-vs has never installed DASH_SAI because dependency missing.
I have confirmed with peterosaur(Ze Gan) that docker-sonic-vs don't need DASH_SAI by design.
So when building docker-sonic-vs, don't add dependency for DASH_SAI.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

