### PR TITLE
[T2-packet-chassis]: Add route-map entry to deny local_anchor_route_entries over iBGP

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/internal/policies.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/internal/policies.conf.j2
@@ -26,6 +26,7 @@ route-map FROM_BGP_INTERNAL_PEER_V6 permit 2
 {% elif CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
 bgp community-list standard DEVICE_INTERNAL_COMMUNITY permit {{ constants.bgp.internal_community }}
 bgp community-list standard DEVICE_INTERNAL_FALLBACK_COMMUNITY permit {{ constants.bgp.internal_fallback_community }}
+bgp community-list standard LOCAL_ANCHOR_ROUTE_COMMUNITY permit {{ constants.bgp.local_anchor_route_community }}
 bgp community-list standard NO_EXPORT permit no-export
 !
 route-map FROM_BGP_INTERNAL_PEER_V4 permit 1
@@ -78,9 +79,15 @@ route-map TO_BGP_INTERNAL_PEER_V4 permit 1
   match ip address prefix-list PL_LoopbackV4
   set community {{ constants.bgp.internal_community }}
 !
+route-map TO_BGP_INTERNAL_PEER_V4 deny 15
+  match community LOCAL_ANCHOR_ROUTE_COMMUNITY
+!
 route-map TO_BGP_INTERNAL_PEER_V6 permit 2
   match ipv6 address prefix-list PL_LoopbackV6
   set community {{ constants.bgp.internal_community }}
+!
+route-map TO_BGP_INTERNAL_PEER_V6 deny 15
+  match community LOCAL_ANCHOR_ROUTE_COMMUNITY
 !
 {% else %}
 route-map FROM_BGP_INTERNAL_PEER_V6 permit 1

--- a/src/sonic-bgpcfgd/tests/data/internal/policies.conf/param_chasiss_packet.json
+++ b/src/sonic-bgpcfgd/tests/data/internal/policies.conf/param_chasiss_packet.json
@@ -10,9 +10,10 @@
     "constants": {
         "bgp": {
             "internal_community": "12345:556",
-	    "internal_community_match_tag": "101",
-	    "route_eligible_for_fallback_to_default_tag": "203",
-	    "internal_fallback_community": "1111:2222"
+	        "internal_community_match_tag": "101",
+	        "route_eligible_for_fallback_to_default_tag": "203",
+	        "internal_fallback_community": "1111:2222",
+            "local_anchor_route_community": "12345:555"
         }
     },
     "loopback0_ipv4": "10.10.10.10/32"

--- a/src/sonic-bgpcfgd/tests/data/internal/policies.conf/result_chasiss_packet.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/policies.conf/result_chasiss_packet.conf
@@ -3,6 +3,7 @@
 !
 bgp community-list standard DEVICE_INTERNAL_COMMUNITY permit 12345:556
 bgp community-list standard DEVICE_INTERNAL_FALLBACK_COMMUNITY permit 1111:2222
+bgp community-list standard LOCAL_ANCHOR_ROUTE_COMMUNITY permit 12345:555
 bgp community-list standard NO_EXPORT permit no-export
 !
 route-map FROM_BGP_INTERNAL_PEER_V4 permit 1
@@ -41,9 +42,15 @@ route-map TO_BGP_INTERNAL_PEER_V4 permit 1
   match ip address prefix-list PL_LoopbackV4
   set community 12345:556
 !
+route-map TO_BGP_INTERNAL_PEER_V4 deny 15
+  match community LOCAL_ANCHOR_ROUTE_COMMUNITY
+!
 route-map TO_BGP_INTERNAL_PEER_V6 permit 2
   match ipv6 address prefix-list PL_LoopbackV6
   set community 12345:556
+!
+route-map TO_BGP_INTERNAL_PEER_V6 deny 15
+  match community LOCAL_ANCHOR_ROUTE_COMMUNITY
 !
 route-map FROM_BGP_INTERNAL_PEER_V4 permit 100
 !


### PR DESCRIPTION
…iBGP

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add route-map entry to deny local_anchor_route_entries over iBGP
##### Work item tracking
- Microsoft ADO **31998753**:

#### How I did it
Add route-map entry in internal template under packet-chassis
#### How to verify it
Verify that route-map is available on packet-chassis
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
202405-chassis
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

