### PR TITLE
Split frr_bmp feature switch for turn on FRR side bmp tunneling via Liquid

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -88,8 +88,10 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   bgp graceful-restart select-defer-time {{ constants.bgp.graceful_restart.select_defer_time | default(45) }}
 {% endif %}
 !
-{# set bmp info #}
-{% if (FEATURE is defined) and ('bmp' in FEATURE) and ('state' in FEATURE['bmp']) and (FEATURE['bmp']['state'] == 'enabled') %}
+{# set frr_bmp info #}
+{% if (FEATURE is defined) and
+      (('frr_bmp' in FEATURE and 'state' in FEATURE['frr_bmp'] and FEATURE['frr_bmp']['state'] == 'enabled') or
+      ('bmp' in FEATURE and 'state' in FEATURE['bmp'] and FEATURE['bmp']['state'] == 'enabled')) %}
 !
   bmp mirror buffer-limit 4294967214
 !

--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -98,7 +98,7 @@ dependent_startup_wait_for=zebra:running
 {% endif %}
 
 [program:bgpd]
-{% if FEATURE is defined and FEATURE.bmp is defined and FEATURE.bmp.state is defined and FEATURE.bmp.state == "enabled" %}
+{% if FEATURE is defined and FEATURE.frr_bmp is defined and FEATURE.frr_bmp.state is defined and FEATURE.frr_bmp.state == "enabled" %}
 command=/usr/lib/frr/bgpd -A 127.0.0.1 -P 0 -M snmp -M bmp
 {% else %}
 command=/usr/lib/frr/bgpd -A 127.0.0.1 -P 0 -M snmp

--- a/src/sonic-config-engine/tests/test_frr.py
+++ b/src/sonic-config-engine/tests/test_frr.py
@@ -80,5 +80,5 @@ class TestCfgGen(TestCase):
         self.assertTrue(*self.run_case('zebra/zebra.conf.j2', 'zebra_frr_dualtor.conf', extra_data=extra_data))
 
     def test_bgpd_frr_bmp(self):
-        extra_data = {"FEATURE": {"bmp": {"state": "enabled"}}}
+        extra_data = {"FEATURE": {"frr_bmp": {"state": "enabled"}}}
         self.assertTrue(*self.run_case('bgpd/bgpd.conf.j2', 'bgpd_frr_bmp.conf', extra_data=extra_data))


### PR DESCRIPTION
liquid.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Use new feature switch to turn on FRR side bmp tunneling, so that we can control FRR side feature switch in image first, and BMP container side feature will be controlled via kubeSonic rollout.

##### Work item tracking
- Microsoft ADO **(number only)**:30807821

#### How I did it
Create new feature switch for FRR side bmp tunneling

#### How to verify it
Unit test is covered.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

