### PR TITLE
Port Fix from FRR community for issue https://github.com/FRRouting/frr/issues/18493 in sonic-frr(FRR 10.0.1)

### DIFF
--- a/src/sonic-frr/patch/0084-lib-Return-duplicate-prefix-list-entry-test.patch
+++ b/src/sonic-frr/patch/0084-lib-Return-duplicate-prefix-list-entry-test.patch
@@ -1,0 +1,61 @@
+From 8384d41144496019725c1e250abd0ceea854341f Mon Sep 17 00:00:00 2001
+From: Donatas Abraitis <donatas@opensourcerouting.org>
+Date: Tue, 25 Mar 2025 13:54:24 +0200
+Subject: [PATCH] lib: Return duplicate prefix-list entry test If we do e.g.:
+
+ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
+ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
+ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
+
+We end up, having duplicate records with a different sequence number only.
+Also ported the same changes for ipv6 also.
+---
+ lib/filter_cli.c | 25 ++++++++++++++++---------
+ 1 file changed, 16 insertions(+), 9 deletions(-)
+
+diff --git a/lib/filter_cli.c b/lib/filter_cli.c
+index c40c2a75f..2012fa987 100644
+--- a/lib/filter_cli.c
++++ b/lib/filter_cli.c
+@@ -1206,10 +1206,14 @@ DEFPY_YANG(
+ 	snprintf(xpath, sizeof(xpath),
+ 		 "/frr-filter:lib/prefix-list[type='ipv4'][name='%s']", name);
+ 	if (seq_str == NULL) {
+-		/* Use XPath to find the next sequence number. */
+-		sseq = acl_get_seq(vty, xpath, false);
+-		if (sseq < 0)
+-			return CMD_WARNING_CONFIG_FAILED;
++		if (plist_is_dup(vty->candidate_config->dnode, &pda))
++			sseq = pda.pda_seq;
++		else {
++			/* Use XPath to find the next sequence number. */
++			sseq = acl_get_seq(vty, xpath, false);
++			if (sseq < 0)
++				return CMD_WARNING_CONFIG_FAILED;
++		}
+ 
+ 		snprintfrr(xpath_entry, sizeof(xpath_entry),
+ 			   "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
+@@ -1396,11 +1400,14 @@ DEFPY_YANG(
+ 	snprintf(xpath, sizeof(xpath),
+ 		 "/frr-filter:lib/prefix-list[type='ipv6'][name='%s']", name);
+ 	if (seq_str == NULL) {
+-		/* Use XPath to find the next sequence number. */
+-		sseq = acl_get_seq(vty, xpath, false);
+-		if (sseq < 0)
+-			return CMD_WARNING_CONFIG_FAILED;
+-
++		if (plist_is_dup(vty->candidate_config->dnode, &pda))
++			sseq = pda.pda_seq;
++		else {
++			/* Use XPath to find the next sequence number. */
++			sseq = acl_get_seq(vty, xpath, false);
++			if (sseq < 0)
++				return CMD_WARNING_CONFIG_FAILED;
++		}
+ 		snprintfrr(xpath_entry, sizeof(xpath_entry),
+ 			   "%s/entry[sequence='%" PRId64 "']", xpath, sseq);
+ 	} else
+-- 
+2.39.4
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -64,3 +64,4 @@
 0081-bgpd-Optimize-evaluate-paths-for-a-peer-going-down.patch
 0082-Revert-bgpd-upon-if-event-evaluate-bnc-with-matching.patch
 0083-staticd-add-cli-to-support-steering-of-ipv4-traffic-over-srv6-sid-list.patch
+0084-lib-Return-duplicate-prefix-list-entry-test.patch


### PR DESCRIPTION

#### Why I did it
The fix from FRR (https://github.com/FRRouting/frr/issues/18493) is taken as a patch in sonic(FRR 10.0.1).
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

