### PR TITLE
Adding  to  yang model to enable support for YANG validation when using FRR mgmt framework to configure EVPN / VXLAN

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
@@ -445,6 +445,11 @@ module sonic-bgp-global {
                     }
                     description "Maximum duration to suppress a stable route";
                 }
+
+                leaf advertise-all-vni {
+                    type boolean;
+                    description "L2VPN advertise all VNIs";
+                }
             }
         }
 


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
closes #22167 

#### Why I did it

Identified issue when deploying VXLAN/EVPN, verified by locally updating `/usr/local/yang-models/sonic-bgp-global.yang` and attempting config replace.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Manually verify by adding missing key to `/usr/local/yang-models/sonic-bgp-global.yang`  on a live device, attempt config replace.

#### How to verify it

1. Manually updated file
2. performed config replace
3. vtysh
4. show run
    * check for advertise-all-vni for the l2vpn address family in running config
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update BGP_GLOBALS_AF yang model to support missing advertise-all-vni field used in FRR mgmt framework.
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

