### PR TITLE
Move software_bfd to system_defaults and enable for DPU.

### DIFF
--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -206,7 +206,7 @@ dependent_startup_wait_for=bgpd:running
 
 {% endif %}
 
-{% if FEATURE is defined and FEATURE.software_bfd is defined and FEATURE.software_bfd.state is defined and FEATURE.software_bfd.state == "enabled" %}
+{% if SYSTEM_DEFAULTS is defined and SYSTEM_DEFAULTS.software_bfd is defined and SYSTEM_DEFAULTS.software_bfd.status is defined and SYSTEM_DEFAULTS.software_bfd.status == "enabled" %}
 [program:bfdmon]
 command=/usr/local/bin/bfdmon
 priority=6

--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -91,8 +91,8 @@ def do_work():
 
     config_db = ConfigDBConnector()
     config_db.connect()
-    features = config_db.get_table('FEATURE')
-    if 'software_bfd' in features and 'state' in features['software_bfd'] and features['software_bfd']['state'] == 'enabled':
+    sys_defaults = config_db.get_table('SYSTEM_DEFAULTS')
+    if 'software_bfd' in sys_defaults and 'status' in sys_defaults['software_bfd'] and sys_defaults['software_bfd']['status'] == 'enabled':
         log_notice("software_bfd feature is enabled, starting bfd manager")
         managers.append(BfdMgr(common_objs, "STATE_DB", swsscommon.STATE_BFD_SOFTWARE_SESSION_TABLE_NAME))
 

--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -151,6 +151,12 @@ def generate_t1_smartswitch_dpu_sample_config(data, ss_config):
     data['DEVICE_METADATA']['localhost']['subtype'] = 'SmartSwitch'
     data['DEVICE_METADATA']['localhost']['bgp_asn'] = '65100'
 
+    data['SYSTEM_DEFAULTS'] = {
+        "software_bfd": {
+            "status": "enabled"
+        }
+    }
+
     for port in natsorted(data['PORT']):
         data['PORT'][port]['admin_status'] = 'up'
         data['PORT'][port]['mtu'] = '9100'

--- a/src/sonic-config-engine/tests/sample_output/t1-smartswitch-dpu.json
+++ b/src/sonic-config-engine/tests/sample_output/t1-smartswitch-dpu.json
@@ -9,6 +9,11 @@
             "bgp_asn": "65100"
         }
     },
+    "SYSTEM_DEFAULTS": {
+        "software_bfd": {
+            "status": "enabled"
+        }
+    },
     "PORT": {
         "Ethernet0": {
             "lanes": "0,1,2,3,4,5,6,7",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The software_bfd flag is currently under FEATURE; it is more appropriate to put it under SYSTEM_DEFAULTS as it is a simple enabled/disabled flag. Additionally, enabling it by default on t1-smartswitch DPU.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Moved software bfd checks from FEATURE to SYSTEM_DEFAULTS, and enabled it by default in src/sonic-config-engine/config_samples.py. 


#### How to verify it
Build and install DPU image (following https://github.com/sonic-net/sonic-buildimage/pull/22058), check that software_bfd flag is set in config_db.json and runningconfig by default. Unit tests during build also check this using src/sonic-config-engine/tests/sample_output/t1-smartswitch-dpu.json


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
- [x] master (953af37)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Move software_bfd to system_defaults and enable for DPU.
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

