### PR TITLE
Removing libswsscommon deb to fix a pipeline issue in libswsscommon

### DIFF
--- a/files/build/versions/dockers/docker-framework/versions-deb-bookworm
+++ b/files/build/versions/dockers/docker-framework/versions-deb-bookworm
@@ -158,7 +158,6 @@ libss2==1.46.2-2
 libssh2-1==1.9.0-2
 libssl1.1==1.1.1w-0+deb11u1
 libstdc++6==10.2.1-6
-libswsscommon==1.0.0
 libsystemd0==247.3-7+deb11u4
 libtasn1-6==4.16.0-2+deb11u1
 libtinfo6==6.2+20201114-2+deb11u2


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix pipeline issue in libswsscommon

#### How I did it
Removed libswsscommon deb in docker-framework/versions-deb-bookworm .

#### How to verify it
UT is verified on sonic-virtual switch triggering cold and warm reboots.


#### Description for the changelog
Removing libswsscommon deb from docker-framework/versions-deb-bookworm file to fix a pipeline issue in libswsscommon.



