### PR TITLE
Set default repo for buster-backports

### DIFF
--- a/files/apt/sources.list.j2
+++ b/files/apt/sources.list.j2
@@ -12,7 +12,12 @@ deb [arch={{ ARCHITECTURE }}] {{ mirror_url }} {{ DISTRIBUTION }} main contrib {
 deb-src [arch={{ ARCHITECTURE }}] {{ mirror_url }} {{ DISTRIBUTION }} main contrib {{ nonfree_component }}
 deb [arch={{ ARCHITECTURE }}] {{ mirror_url }} {{ DISTRIBUTION }}-updates main contrib {{ nonfree_component }}
 deb-src [arch={{ ARCHITECTURE }}] {{ mirror_url }} {{ DISTRIBUTION }}-updates main contrib {{ nonfree_component }}
+{% if DISTRIBUTION == 'buster' %}
+{% set mirror_url = 'http://archive.debian.org/debian/' %}
 deb [arch={{ ARCHITECTURE }}] {{ mirror_url }} {{ DISTRIBUTION }}-backports main contrib {{ nonfree_component }}
+{% else %}
+deb [arch={{ ARCHITECTURE }}] {{ mirror_url }} {{ DISTRIBUTION }}-backports main contrib {{ nonfree_component }}
+{% endif %}
 {% endfor %}
 {% for mirror_url in MIRROR_SECURITY_URLS.split(',') %}
 {% set dist_separator='/' %}{% if 'packages.trafficmanager.net/debian' in mirror_url %}{% set dist_separator='_' %}{% endif %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When setting MIRROR_URLS, the archive.debian.org repo which hosts buster-backports) gets removed from sources.list
`#13 5.459 E: The repository 'http://www.example.com/debian buster-backports Release' does not have a Release file. `
#### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modify the file "sources.list.j2" in the "files/apt" directory.
```
{% if DISTRIBUTION == 'buster' %}
{% set mirror_url = 'http://archive.debian.org/debian/' %}
deb [arch={{ ARCHITECTURE }}] {{ mirror_url }} {{ DISTRIBUTION }}-backports main contrib {{ nonfree_component }}
{% else %}
deb [arch={{ ARCHITECTURE }}] {{ mirror_url }} {{ DISTRIBUTION }}-backports main contrib {{ nonfree_component }}
{% endif %}
```

#### How to verify it

- #### When setting MIRROR_URLS

` export MIRROR_URLS=http://www.example.com/debian/;export  MIRROR_SECURITY_URLS=http://www.example.com/debian-security`
- **Build logs of buster**  
```
#74 [70/78] RUN apt-get update
#74 0.735 Hit:1 http://www.example.com/debian buster InRelease
#74 0.735 Hit:2 http://www.example.com/debian buster-updates InRelease
#74 0.735 Hit:3 http://www.example.com/debian-security buster/updates InRelease
#74 0.735 Hit:4 http://archive.debian.org/debian buster-backports InRelease
#74 0.787 Get:5 https://download.docker.com/linux/debian buster InRelease [53.9 kB]
#74 2.570 Get:6 https://download.docker.com/linux/debian buster/stable amd64 Packages [53.7 kB]
#74 2.599 Get:7 https://download.docker.com/linux/debian buster/stable amd64 Contents (deb) [2079 B]
#74 2.675 Fetched 110 kB in 2s (56.7 kB/s)
#74 2.675 Reading package lists...
#74 DONE 3.5s
...
...
#83 exporting to image
#83 exporting layers
#83 exporting layers 43.8s done
#83 writing image sha256:45d44b528eb49ef2c0450698e19d373f46138cfc8bad173a3907e1d1a5b70ef9 done
#83 naming to docker.io/library/sonic-slave-buster:119573a011b done
#83 DONE 43.8s
```
- **sources.list.amd64 of buster** 
```
# The configuration is generated by template
# Please add additional sources in /etc/apt/sources.list.d

deb [arch=amd64] http://www.example.com/debian/ buster main contrib non-free
deb-src [arch=amd64] http://www.example.com/debian/ buster main contrib non-free
deb [arch=amd64] http://www.example.com/debian/ buster-updates main contrib non-free
deb-src [arch=amd64] http://www.example.com/debian/ buster-updates main contrib non-free

deb [arch=amd64] http://archive.debian.org/debian/ buster-backports main contrib non-free

deb [arch=amd64] http://www.example.com/debian-security/ buster/updates main contrib non-free
deb-src [arch=amd64] http://www.example.com/debian-security/ buster/updates main contrib non-free
```
- **Build logs bullseye** 
```
#59 [55/64] RUN apt-get update
#59 0.673 Hit:1 http://www.example.com/debian bullseye InRelease
#59 0.673 Hit:2 http://www.example.com/debian bullseye-updates InRelease
#59 0.673 Hit:3 http://www.example.com/debian bullseye-backports InRelease
#59 0.673 Hit:4 http://www.example.com/debian-security bullseye-security InRelease
#59 0.699 Get:5 https://download.docker.com/linux/debian bullseye InRelease [43.3 kB]
#59 2.316 Get:6 https://download.docker.com/linux/debian bullseye/stable amd64 Packages [50.7 kB]
#59 2.345 Get:7 https://download.docker.com/linux/debian bullseye/stable amd64 Contents (deb) [1351 B]
#59 2.415 Fetched 95.4 kB in 2s (54.2 kB/s)
#59 2.415 Reading package lists...
#59 DONE 3.7s
....
....
#69 exporting to image
#69 exporting layers
#69 exporting layers 48.0s done
#69 writing image sha256:8d61ca92aea58fc18355d0951bc8783c3b3db3f307df2b15ae94bb2eaae899d7 done
#69 naming to docker.io/library/sonic-slave-bullseye:8ca6128fb40 done
#69 DONE 48.1s
```
- **sources.list.amd64 of bullseye** 

```
# The configuration is generated by template
# Please add additional sources in /etc/apt/sources.list.d

deb [arch=amd64] http://www.example.com/debian/ bullseye main contrib non-free
deb-src [arch=amd64] http://www.example.com/debian/ bullseye main contrib non-free
deb [arch=amd64] http://www.example.com/debian/ bullseye-updates main contrib non-free
deb-src [arch=amd64] http://www.example.com/debian/ bullseye-updates main contrib non-free

deb [arch=amd64] http://www.example.com/debian/ bullseye-backports main contrib non-free

deb [arch=amd64] http://www.example.com/debian-security/ bullseye-security main contrib non-free
deb-src [arch=amd64] http://www.example.com/debian-security/ bullseye-security main contrib non-free
```

- #### Without setting MIRROR_URLS

- **Build logs of buster**  
```
--
#65 [61/73] RUN apt-get update
#65 0.822 Hit:1 http://debian-archive.trafficmanager.net/debian-security buster/updates InRelease
#65 5.798 Hit:2 http://archive.debian.org/debian buster InRelease
#65 5.803 Hit:3 http://archive.debian.org/debian buster-updates InRelease
#65 5.806 Hit:4 http://archive.debian.org/debian buster-backports InRelease
#65 6.158 Get:5 http://archive.debian.org/debian buster/main amd64 Contents (deb) [37.8 MB]
#65 6.592 Get:6 http://archive.debian.org/debian buster/contrib amd64 Contents (deb) [103 kB]
#65 6.599 Get:7 http://archive.debian.org/debian buster/non-free amd64 Contents (deb) [861 kB]
#65 6.612 Get:8 http://archive.debian.org/debian buster-updates/main amd64 Contents (deb) [43.6 kB]
#65 6.905 Get:9 http://archive.debian.org/debian buster-backports/main amd64 Contents (deb) [5804 kB]
#65 7.006 Get:10 http://archive.debian.org/debian buster-backports/contrib amd64 Contents (deb) [27.7 kB]
#65 7.008 Get:11 http://archive.debian.org/debian buster-backports/non-free amd64 Contents (deb) [115 kB]
#65 12.87 Fetched 44.8 MB in 12s (3714 kB/s)
#65 12.87 Reading package lists...
#65 DONE 13.7s
...
...
#78 exporting to image
#78 exporting layers
#78 exporting layers 39.9s done
#78 writing image sha256:523b8ec3240a91a51b555f52bfc1488f5eb05df1038905a004efe7c23df76666 done
#78 naming to docker.io/library/sonic-slave-buster:e51fc77f3a7 done
#78 DONE 39.9s
```
- **sources.list.amd64 of buster** 
```
# The configuration is generated by template
# Please add additional sources in /etc/apt/sources.list.d

deb [arch=amd64] http://archive.debian.org/debian/ buster main contrib non-free
deb-src [arch=amd64] http://archive.debian.org/debian/ buster main contrib non-free
deb [arch=amd64] http://archive.debian.org/debian/ buster-updates main contrib non-free
deb-src [arch=amd64] http://archive.debian.org/debian/ buster-updates main contrib non-free

deb [arch=amd64] http://archive.debian.org/debian/ buster-backports main contrib non-free

deb [arch=amd64] http://debian-archive.trafficmanager.net/debian-security/ buster/updates main contrib non-free
deb-src [arch=amd64] http://debian-archive.trafficmanager.net/debian-security/ buster/updates main contrib non-free

```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
- [x] 202405
- [x] 202411
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Modify the file "sources.list.j2" in the "files/apt" directory.
```
{% if DISTRIBUTION == 'buster' %}
{% set mirror_url = 'http://archive.debian.org/debian/' %}
deb [arch={{ ARCHITECTURE }}] {{ mirror_url }} {{ DISTRIBUTION }}-backports main contrib {{ nonfree_component }}
{% else %}
deb [arch={{ ARCHITECTURE }}] {{ mirror_url }} {{ DISTRIBUTION }}-backports main contrib {{ nonfree_component }}
{% endif %}
```
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

