### PR TITLE
Add delete template for dynamic BGP peers

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/dynamic/delete.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/dynamic/delete.conf.j2
@@ -1,0 +1,7 @@
+!
+! template: bgpd/templates/dynamic/delete.conf.j2
+!
+no neighbor {{ neighbor_addr }}
+!
+! end of template: bgpd/templates/dynamic/delete.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/test_bgp.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp.py
@@ -244,10 +244,27 @@ def test_del_handler(mocked_log_info):
         m = constructor(constant)
         m.del_handler("10.10.10.1")
         mocked_log_info.assert_called_with("Peer '(default|10.10.10.1)' has been removed")
+    
+@patch('bgpcfgd.managers_bgp.log_info')
+def test_del_handler_dynamic_template_exists(mocked_log_info):
+    for constant in load_constant_files():
+        m = constructor(constant, peer_type="dynamic")
+        mocked_log_info.assert_called_with("Using delete template found at %s" % "bgpd/templates/dynamic/delete.conf.j2")
+        m.del_handler("10.10.10.1")
+        mocked_log_info.assert_called_with("Peer '(default|10.10.10.1)' has been removed")
 
 @patch('bgpcfgd.managers_bgp.log_warn')
 def test_del_handler_nonexist_peer(mocked_log_warn):
     for constant in load_constant_files():
         m = constructor(constant)
+        m.del_handler("40.40.40.1")
+        mocked_log_warn.assert_called_with("Peer '(default|40.40.40.1)' has not been found")
+
+@patch('bgpcfgd.managers_bgp.log_info')
+@patch('bgpcfgd.managers_bgp.log_warn')
+def test_del_handler_dynamic_nonexist_peer_template_exists(mocked_log_warn, mocked_log_info):
+    for constant in load_constant_files():
+        m = constructor(constant, peer_type="dynamic")
+        mocked_log_info.assert_called_with("Using delete template found at %s" % "bgpd/templates/dynamic/delete.conf.j2")
         m.del_handler("40.40.40.1")
         mocked_log_warn.assert_called_with("Peer '(default|40.40.40.1)' has not been found")

--- a/src/sonic-bgpcfgd/tests/test_bgp.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp.py
@@ -56,6 +56,7 @@ def constructor(constants_path, bgp_router_id="", peer_type="general", with_lo0_
     m.directory.put("LOCAL", "local_addresses", "fc00:20::20", {"interface": "Ethernet8|fc00:20::20/96"})
     m.directory.put("LOCAL", "interfaces", "Ethernet4|30.30.30.30/24", {"anything": "anything"})
     m.directory.put("LOCAL", "interfaces", "Ethernet8|fc00:20::20/96", {"anything": "anything"})
+    m.directory.put("CONFIG_DB", swsscommon.CFG_BGP_NEIGHBOR_TABLE_NAME, "default|10.10.10.1", {"ip_range": None})
 
     if m.check_neig_meta:
         m.directory.put("CONFIG_DB", swsscommon.CFG_DEVICE_NEIGHBOR_METADATA_TABLE_NAME, "TOR", {})

--- a/src/sonic-bgpcfgd/tests/test_bgp.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp.py
@@ -249,7 +249,8 @@ def test_del_handler(mocked_log_info):
 def test_del_handler_dynamic_template_exists(mocked_log_info):
     for constant in load_constant_files():
         m = constructor(constant, peer_type="dynamic")
-        mocked_log_info.assert_called_with("Using delete template found at %s" % "bgpd/templates/dynamic/delete.conf.j2")
+        if os.path.exists(TEMPLATE_PATH + "/bgpd/templates/dynamic/delete.conf.j2"):
+            mocked_log_info.assert_called_with("Using delete template found at %s" % "bgpd/templates/dynamic/delete.conf.j2")
         m.del_handler("10.10.10.1")
         mocked_log_info.assert_called_with("Peer '(default|10.10.10.1)' has been removed")
 
@@ -265,6 +266,7 @@ def test_del_handler_nonexist_peer(mocked_log_warn):
 def test_del_handler_dynamic_nonexist_peer_template_exists(mocked_log_warn, mocked_log_info):
     for constant in load_constant_files():
         m = constructor(constant, peer_type="dynamic")
-        mocked_log_info.assert_called_with("Using delete template found at %s" % "bgpd/templates/dynamic/delete.conf.j2")
+        if os.path.exists(TEMPLATE_PATH + "/bgpd/templates/dynamic/delete.conf.j2"):
+            mocked_log_info.assert_called_with("Using delete template found at %s" % "bgpd/templates/dynamic/delete.conf.j2")
         m.del_handler("40.40.40.1")
         mocked_log_warn.assert_called_with("Peer '(default|40.40.40.1)' has not been found")

--- a/src/sonic-bgpcfgd/tests/test_bgp.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp.py
@@ -250,8 +250,9 @@ def test_del_handler(mocked_log_info):
 def test_del_handler_dynamic_template_exists(mocked_log_info):
     for constant in load_constant_files():
         m = constructor(constant, peer_type="dynamic")
-        if os.path.exists(TEMPLATE_PATH + "/bgpd/templates/dynamic/delete.conf.j2"):
-            mocked_log_info.assert_called_with("Using delete template found at %s" % "bgpd/templates/dynamic/delete.conf.j2")
+        base_template = "bgpd/templates/" + m.constants["bgp"]["peers"]["dynamic"]["template_dir"] + "/delete.conf.j2"
+        if os.path.exists(TEMPLATE_PATH + "/" + base_template):
+            mocked_log_info.assert_called_with("Using delete template found at %s" % base_template)
         m.del_handler("10.10.10.1")
         mocked_log_info.assert_called_with("Peer '(default|10.10.10.1)' has been removed")
 
@@ -267,7 +268,8 @@ def test_del_handler_nonexist_peer(mocked_log_warn):
 def test_del_handler_dynamic_nonexist_peer_template_exists(mocked_log_warn, mocked_log_info):
     for constant in load_constant_files():
         m = constructor(constant, peer_type="dynamic")
-        if os.path.exists(TEMPLATE_PATH + "/bgpd/templates/dynamic/delete.conf.j2"):
-            mocked_log_info.assert_called_with("Using delete template found at %s" % "bgpd/templates/dynamic/delete.conf.j2")
+        base_template = "bgpd/templates/" + m.constants["bgp"]["peers"]["dynamic"]["template_dir"] + "/delete.conf.j2"
+        if os.path.exists(TEMPLATE_PATH + "/" + base_template):
+            mocked_log_info.assert_called_with("Using delete template found at %s" % base_template)
         m.del_handler("40.40.40.1")
         mocked_log_warn.assert_called_with("Peer '(default|40.40.40.1)' has not been found")


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This change is to support enhanced CRUD operations on dynamic bgp peers  using a standard template-based mechanism. 
Here is the High level design document explaining this feature:
https://github.com/sonic-net/SONiC/pull/1963

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Upon a delete peer ocurring, we render the delete template(instead of executing the current behavior of ```no neighbor {{ neighbor addr}}```), on the other hand if a delete template is not defined then the default behavior of ```no neighbor {{ neighbor addr}}``` applies as usual, thereby making this change backward compatible.

#### How to verify it
Create a dynamic peer like so in config_db.json:

"BGP_NEIGHBOR": {
        "10.0.0.62": {
            "admin_status": "up",
            "asn": "65100",
            "holdtime": "10",
            "keepalive": "3",
            "local_addr": "10.0.0.63",
            "name": "vlab-01",
            "nhopself": "0",
            "rrclient": "0"
        }
}

Once the peer is up, delete the neighbor (eg. config bgp neighbor remove <neighbor name>). Verify that the neighbor is deleted. 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

