### PR TITLE
[docker-ptf]: Fix to set /run/sshd permission affecting 202405

### DIFF
--- a/dockers/docker-ptf/conf.d/sshd.conf
+++ b/dockers/docker-ptf/conf.d/sshd.conf
@@ -1,5 +1,5 @@
 [program:sshd]
-command=/usr/sbin/sshd -D
+command=/bin/bash -c "mkdir -p /var/run/sshd && chmod 0755 /var/run/sshd && /usr/sbin/sshd -D"
 process_name=sshd
 stdout_logfile=/tmp/sshd.out.log
 stderr_logfile=/tmp/sshd.err.log


### PR DESCRIPTION
#### Why I did it

The docker-ptf image built on 202405 release branch is created with a wrong permission for `/run/sshd` (`/var/run/sshd`) with value `0775`. This fails to start `sshd` with the error below. Thus failing `add-topo`.

```
/run/sshd must be owned by root and not group or world-writable.
```

This PR fixes the permission to `0755` for `/run/sshd` (`/var/run/sshd`) in the docker-ptf image.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Set permissions in `sshd.conf` supervisor config.

#### How to verify it

Local environment

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

202405. This fix only applicable to 202405 and not required for other branches.

#### Description for the changelog

[docker-ptf]: Fix to set /run/sshd permission affecting 202405

The docker-ptf image built on 202405 release branch is created with a wrong permission for `/run/sshd` (`/var/run/sshd`) with value `0775`. This fails to start `sshd` with the error below. Thus failing `add-topo`.

```
/run/sshd must be owned by root and not group or world-writable.
```

This PR fixes the permission to `0755` for `/run/sshd` (`/var/run/sshd`) in the docker-ptf image.


#### Link to config_db schema for YANG module changes
NA

#### A picture of a cute animal (not mandatory but encouraged)

NA