### PR TITLE
YANG: Add ZTP models

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2924,5 +2924,16 @@
             "daemon_polling_interval" : "3600",
             "fsstats_sync_interval"   : "86400"
         }
-    }
+    },
+    "ZTP" : {
+        "mode" : {
+            "profile" : "active",
+            "inband" : "true",
+            "out-of-band" : "true",
+            "ipv4" : "true",
+            "ipv6" : "true",
+            "product-name" : "product name",
+            "serial-no" : "1234-5678-91A"
+        }
+   }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/ztp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/ztp.json
@@ -1,0 +1,25 @@
+{
+    "ZTP_VALID": {
+        "desc": "ZTP All Valid"
+    },
+    "ZTP_PROFILE_INVALID": {
+        "desc": "ZTP profile invalid",
+        "eStrKey" : "InvalidValue"
+    },
+    "ZTP_INBAND_INVALID": {
+        "desc": "ZTP inband invalid",
+        "eStrKey" : "InvalidValue"
+    },
+    "ZTP_OUTOFBAND_INVALID": {
+        "desc": "ZTP out-of-band invalid",
+        "eStrKey" : "InvalidValue"
+    },
+    "ZTP_IPV4_INVALID": {
+        "desc": "ZTP ipv4 invalid",
+        "eStrKey" : "InvalidValue"
+    },
+    "ZTP_IPV6_INVALID": {
+        "desc": "ZTP ipv6 invalid",
+        "eStrKey" : "InvalidValue"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/ztp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/ztp.json
@@ -1,0 +1,66 @@
+{
+    "ZTP_VALID": {
+        "sonic-ztp:sonic-ztp": {
+            "sonic-ztp:ZTP": {
+                "sonic-ztp:mode": {
+                    "profile" : "active",
+                    "inband" : "true",
+                    "out-of-band" : "true",
+                    "ipv4" : "true",
+                    "ipv6" : "true",
+                    "product-name" : "product name",
+                    "serial-no" : "1234-5678-9A1"
+                }
+            }
+        }
+    },
+    "ZTP_PROFILE_INVALID": {
+        "sonic-ztp:sonic-ztp": {
+            "sonic-ztp:ZTP": {
+                "sonic-ztp:mode": {
+                    "profile" : "invalid"
+                }
+            }
+        }
+    },
+    "ZTP_INBAND_INVALID": {
+         "sonic-ztp:sonic-ztp": {
+            "sonic-ztp:ZTP": {
+                "sonic-ztp:mode": {
+                    "profile" : "active",
+                    "inband": "invalid"
+                }
+            }
+        }
+    },
+    "ZTP_OUTOFBAND_INVALID": {
+         "sonic-ztp:sonic-ztp": {
+            "sonic-ztp:ZTP": {
+                "sonic-ztp:mode": {
+                    "profile" : "active",
+                    "out-of-band": "invalid"
+                }
+            }
+        }
+    },
+    "ZTP_IPV4_INVALID": {
+         "sonic-ztp:sonic-ztp": {
+            "sonic-ztp:ZTP": {
+                "sonic-ztp:mode": {
+                    "profile" : "active",
+                    "ipv4": "invalid"
+                }
+            }
+        }
+    },
+    "ZTP_IPV6_INVALID": {
+         "sonic-ztp:sonic-ztp": {
+            "sonic-ztp:ZTP": {
+                "sonic-ztp:mode": {
+                    "profile" : "active",
+                    "ipv6": "invalid"
+                }
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-ztp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-ztp.yang
@@ -1,0 +1,70 @@
+module sonic-ztp {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/sonic-net/sonic-ztp";
+    prefix ztp;
+
+    description "ZTP YANG Module for SONiC OS";
+
+    revision 2025-04-03 {
+        description "First Revision";
+    }
+
+    container sonic-ztp {
+
+        container ZTP {
+
+            description "ZTP part of config_db.json used only temporarily during ZTP provisioning";
+
+            container mode {
+
+                leaf profile {
+                    type enumeration {
+                        enum active;
+                    }
+                    description "Whether or not ZTP is active";
+                }
+
+                leaf inband {
+                    type boolean;
+                    default true;
+                    description "If in-band ports are allowed to be used for ZTP";
+                }
+
+                leaf out-of-band {
+                    type boolean;
+                    default true;
+                    description "If out-of-band ports are allowed to be used for ZTP";
+                }
+
+                leaf ipv4 {
+                    type boolean;
+                    default true;
+                    description "If ipv4 is allowed to be used for ZTP";
+                }
+
+                leaf ipv6 {
+                    type boolean;
+                    default true;
+                    description "If ipv6 is allowed to be used for ZTP";
+                }
+
+                leaf product-name {
+                    type string;
+                    description "Product string as returned from decode-syseeprom -p";
+                }
+
+                leaf serial-no {
+                    type string;
+                    description "Serial number as returned from decode-syseeprom -s";
+                }
+
+            }
+            /* end of container mode */
+        }
+        /* end of container ZTP */
+    }
+    /* end of top level container */
+}
+/* end of module sonic-ztp */


### PR DESCRIPTION
#### Why I did it
During ZTP, the process creates temporary CONFIG_DB settings and if yang validation is enabled, these settings can cause failures. 

Failure might look like the below...
```
[342113.096731] sonic-ztp[789615]: main()
[342113.096785] sonic-ztp[789615]: File "/usr/local/bin/config_validator.py", line 40, in main
2025 Mar 11 15:43:01.942688 ztp-dut2 INFO sonic-ztp[789615]: main()
[342113.096855] sonic-ztp[789615]: raise Exception("Tables without yang models: " + str(yang_parser.tablesWithOutYang))
2025 Mar 11 15:43:01.942742 ztp-dut2 INFO sonic-ztp[789615]: File "/usr/local/bin/config_validator.py", line 40, in main
[342113.096926] sonic-ztp[789615]: Exception: Tables without yang models: {'ZTP': {'mode': {'inband': 'true', 'ipv4': 'true', 'ipv6': 'true', 'out-of-band': 'true', 'product-name': '9716-32D-O-AC-AB-F-US', 'profile': 'active', 'serial-no': '971632D2451040'}}}
2025 Mar 11 15:43:01.942811 ztp-dut2 INFO sonic-ztp[789615]: raise Exception("Tables without yang models: " + str(yang_parser.tablesWithOutYang))
2025 Mar 11 15:43:01.942882 ztp-dut2 INFO sonic-ztp[789615]: Exception: Tables without yang models: {'ZTP': {'mode': {'inband': 'true', 'ipv4': 'true', 'ipv6': 'true', 'out-of-band': 'true', 'product-name': '9716-32D-O-AC-AB-F-US', 'profile': 'active', 'serial-no': '971632D2451040'}}}
2025 Mar 11 15:43:01.967529 ztp-dut2 INFO sonic-ztp[788029]: sonic_yang(6):Note: Below table(s) have no YANG models: ZTP
```

##### Work item tracking

#### How I did it

Add a YANG model and tests so these won't fail even though these are temporary settings.

#### How to verify it

Test cases are added to sonic-yang-models and run automatically during build.  This can also be tested via ZTP to ensure there are no failures.


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202411

#### Tested branch (Please provide the tested image version)

Master as of 20250403

#### Description for the changelog

YANG: Add ZTP models

#### Link to config_db schema for YANG module changes

N/A, pre-existing functionality

#### A picture of a cute animal (not mandatory but encouraged)

Signed-off-by: Brad House <bhouse@nexthop.ai>
