### PR TITLE
Restart `XCVRD` when `SWSS` flushes APPL_DB on all SKUs that use `media_settings.json`

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -341,10 +341,14 @@ start() {
         rm -rf /tmp/cache
         MEDIA_SETTINGS="/usr/share/sonic/device/$PLATFORM/media_settings.json"
         if [ -f $MEDIA_SETTINGS ]; then
-            # Need to restart XCVRD on media_settings.json skus due to
-            # https://github.com/sonic-net/sonic-buildimage/issues/21902
-            debug "Restarting xcvrd service..."
-            /usr/bin/docker exec pmon supervisorctl restart xcvrd
+            if [ "$( docker inspect -f '{{.State.Running}}' pmon )" != "true" ]; then
+                debug "pmon not running so skip restarting xcvrd"
+            else
+                # Need to restart XCVRD on media_settings.json skus due to
+                # https://github.com/sonic-net/sonic-buildimage/issues/21902
+                debug "Restarting xcvrd service..."
+                /usr/bin/docker exec pmon supervisorctl restart xcvrd
+            fi
         fi
     fi
 

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -339,23 +339,13 @@ start() {
         $SONIC_DB_CLI APPL_STATE_DB FLUSHDB
         clean_up_chassis_db_tables
         rm -rf /tmp/cache
-        if [[ x"$sonic_asic_platform" == x"broadcom" ]]; then
-            . /host/machine.conf
-            if [ -n "$aboot_platform" ]; then
-                platform=$aboot_platform
-            elif [ -n "$onie_platform" ]; then
-                platform=$onie_platform
-            else
-                platform="unknown"
-            fi
+        MEDIA_SETTINGS="/usr/share/sonic/device/$PLATFORM/media_settings.json"
+        if [ -f $MEDIA_SETTINGS ]; then
             # Need to restart PMON on media_settings.json skus due to
             # https://github.com/sonic-net/sonic-buildimage/issues/21902
-            if [[ x"$platform" == x"x86_64-arista_7800r3a"* ]]; then
-                debug "Restarting pmon service..."
-                /bin/systemctl restart pmon
-            fi
+            debug "Restarting pmon service..."
+            /bin/systemctl restart pmon
         fi
-
     fi
 
     # On supervisor card, skip starting asic related services here. In wait(),

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -339,6 +339,23 @@ start() {
         $SONIC_DB_CLI APPL_STATE_DB FLUSHDB
         clean_up_chassis_db_tables
         rm -rf /tmp/cache
+        if [[ x"$sonic_asic_platform" == x"broadcom" ]]; then
+            . /host/machine.conf
+            if [ -n "$aboot_platform" ]; then
+                platform=$aboot_platform
+            elif [ -n "$onie_platform" ]; then
+                platform=$onie_platform
+            else
+                platform="unknown"
+            fi
+            # Need to restart PMON on media_settings.json skus due to
+            # https://github.com/sonic-net/sonic-buildimage/issues/21902
+            if [[ x"$platform" == x"x86_64-arista_7800r3a"* ]]; then
+                debug "Restarting pmon service..."
+                /bin/systemctl restart pmon
+            fi
+        fi
+
     fi
 
     # On supervisor card, skip starting asic related services here. In wait(),

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -341,10 +341,10 @@ start() {
         rm -rf /tmp/cache
         MEDIA_SETTINGS="/usr/share/sonic/device/$PLATFORM/media_settings.json"
         if [ -f $MEDIA_SETTINGS ]; then
-            # Need to restart PMON on media_settings.json skus due to
+            # Need to restart XCVRD on media_settings.json skus due to
             # https://github.com/sonic-net/sonic-buildimage/issues/21902
-            debug "Restarting pmon service..."
-            /bin/systemctl restart pmon
+            debug "Restarting xcvrd service..."
+            /usr/bin/docker exec pmon supervisorctl restart xcvrd
         fi
     fi
 


### PR DESCRIPTION
Workaround for https://github.com/sonic-net/sonic-buildimage/issues/21902

SWSS startup causes APPL_DB to be flushed.
This results in `PORT_TABLE:Ethernet#` losing it's media_settings tunings populated by XCVRD.


Without this change (tuning lost):
```
sonic-db-cli -n asic0 APPL_DB hgetall "PORT_TABLE:Ethernet96"
{'alias': 'Ethernet13/1', 'asic_port_name': 'Eth96', 'core_id': '0', 'core_port_id': '13', 'index': '13', 'lanes': '40,41,42,43', 'num_voq': '8', 'role': 'Ext', 'speed': '100000', 'admin_status': 'up', 'description': 'ARISTA13T3:Ethernet1', 'fec': 'none', 'mtu': '9100', 'pfc_asym': 'off', 'tpid': '0x8100', 'oper_stat
us': 'up', 'flap_count': '1', 'main': '0x4e,0x4e,0x53,0x4b', 'post1': '0xffffffea,0xffffffea,0xffffffea,0xffffffec', 'post2': '0x0,0x0,0x0,0x0', 'post3': '0x0,0x0,0x0,0x0', 'pre1': '0xfffffffb,0xfffffffb,0xfffffffb,0xfffffffb', 'pre2': '0x0,0x0,0x0,0x0', 'last_up_time': 'Thu Apr 03 16:32:03 2025'}

systemctl restart swss@0.service

sonic-db-cli -n asic0 APPL_DB hgetall "PORT_TABLE:Ethernet96"
{'alias': 'Ethernet13/1', 'asic_port_name': 'Eth96', 'core_id': '0', 'core_port_id': '13', 'index': '13', 'lanes': '40,41,42,43', 'num_voq': '8', 'role': 'Ext', 'speed': '100000', 'admin_status': 'up', 'description': 'ARISTA13T3:Ethernet1', 'fec': 'none', 'mtu': '9100', 'pfc_asym': 'off', 'tpid': '0x8100', 'oper_stat
us': 'up', 'flap_count': '1', 'last_up_time': 'Thu Apr 03 17:41:08 2025'}
```

With this change (tuning preserved):
```
sonic-db-cli -n asic0 APPL_DB hgetall "PORT_TABLE:Ethernet96"
{'alias': 'Ethernet13/1', 'asic_port_name': 'Eth96', 'core_id': '0', 'core_port_id': '13', 'index': '13', 'lanes': '40,41,42,43', 'num_voq': '8', 'role': 'Ext', 'speed': '100000', 'admin_status': 'up', 'description': 'ARISTA13T3:Ethernet1', 'fec': 'none', 'mtu': '9100', 'pfc_asym': 'off', 'tpid': '0x8100', 'oper_stat
us': 'up', 'flap_count': '1', 'main': '0x4e,0x4e,0x53,0x4b', 'post1': '0xffffffea,0xffffffea,0xffffffea,0xffffffec', 'post2': '0x0,0x0,0x0,0x0', 'post3': '0x0,0x0,0x0,0x0', 'pre1': '0xfffffffb,0xfffffffb,0xfffffffb,0xfffffffb', 'pre2': '0x0,0x0,0x0,0x0', 'last_up_time': 'Thu Apr 03 16:32:03 2025'}

systemctl restart swss@0.service

sonic-db-cli -n asic0 APPL_DB hgetall "PORT_TABLE:Ethernet96"
{'alias': 'Ethernet13/1', 'asic_port_name': 'Eth96', 'core_id': '0', 'core_port_id': '13', 'index': '13', 'lanes': '40,41,42,43', 'num_voq': '8', 'role': 'Ext', 'speed': '100000', 'admin_status': 'up', 'description': 'ARISTA13T3:Ethernet1', 'fec': 'none', 'mtu': '9100', 'pfc_asym': 'off', 'tpid': '0x8100', 'oper_stat
us': 'up', 'flap_count': '1', 'main': '0x4e,0x4e,0x53,0x4b', 'post1': '0xffffffea,0xffffffea,0xffffffea,0xffffffec', 'post2': '0x0,0x0,0x0,0x0', 'post3': '0x0,0x0,0x0,0x0', 'pre1': '0xfffffffb,0xfffffffb,0xfffffffb,0xfffffffb', 'pre2': '0x0,0x0,0x0,0x0', 'last_up_time': 'Fri Apr 04 17:12:59 2025'}
```

I also see the message in syslog that xcvrd is restarted right after the dbs are flushed:
```
NOTICE root: Chassis db clean up for swss0. Number of SYSTEM_LAG_TABLE entries deleted: 2
NOTICE root: Restarting pmon service...
NOTICE pmon#xcvrd[5016]: Stop daemon main loop
INFO pmon#supervisord 2025-07-11 20:27:09,608 INFO waiting for xcvrd to stop
NOTICE pmon#xcvrd[5016]: CMIS: Stopped
NOTICE pmon#DomInfoUpdateTask[5016]: Stop event generated during DOM monitoring loop
NOTICE pmon#DomInfoUpdateTask[5016]: Stop DOM monitoring loop
NOTICE pmon#python3: :- ~RedisPipeline: RedisPipeline dtor is called from another thread, possibly due to exit(), Database: STATE_DB
NOTICE pmon#python3: message repeated 7 times: [ :- ~RedisPipeline: RedisPipeline dtor is called from another thread, possibly due to exit(), Database: STATE_DB]
NOTICE pmon#python3: :- ~RedisPipeline: RedisPipeline dtor is called from another thread, possibly due to exit(), Database: APPL_DB
NOTICE pmon#python3: :- ~RedisPipeline: RedisPipeline dtor is called from another thread, possibly due to exit(), Database: APPL_DB
NOTICE pmon#python3: :- ~RedisPipeline: RedisPipeline dtor is called from another thread, possibly due to exit(), Database: CONFIG_DB
NOTICE pmon#python3: :- ~RedisPipeline: RedisPipeline dtor is called from another thread, possibly due to exit(), Database: CONFIG_DB
NOTICE pmon#python3: :- ~RedisPipeline: RedisPipeline dtor is called from another thread, possibly due to exit(), Database: STATE_DB
NOTICE pmon#python3: message repeated 65 times: [ :- ~RedisPipeline: RedisPipeline dtor is called from another thread, possibly due to exit(), Database: STATE_DB]
NOTICE pmon#python3: :- ~RedisPipeline: RedisPipeline dtor is called from another thread, possibly due to exit(), Database: CONFIG_DB
NOTICE pmon#python3: :- ~RedisPipeline: RedisPipeline dtor is called from another thread, possibly due to exit(), Database: STATE_DB
INFO pmon#supervisord 2025-07-11 20:27:11,572 INFO stopped: xcvrd (exit status 0)
INFO pmon#supervisord 2025-07-11 20:27:11,575 INFO spawned: 'xcvrd' with pid 5069
NOTICE pmon#xcvrd[5069]: Starting up...
NOTICE pmon#xcvrd[5069]: XCVRD INIT: Start daemon init...
NOTICE pmon#xcvrd[5069]: XCVRD INIT: Wait for port config is done
INFO pmon#supervisord 2025-07-11 20:27:21,590 INFO success: xcvrd entered RUNNING state, process has stayed up for > than 10 seconds (startsecs)
INFO swss.sh[747370]: xcvrd: stopped
INFO swss.sh[747370]: xcvrd: started
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] msft-202503

