### PR TITLE
[BGPCFGD] Eliminate the possibility of changing key size during iteration over notification dictionary

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/directory.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/directory.py
@@ -72,10 +72,14 @@ class Directory(object):
         slot = self.get_slot_name(db, table)
         self.data[slot][key] = value
         if slot in self.notify:
+            handlers_to_run = []
+
             for path in self.notify[slot].keys():
                 if self.path_exist(db, table, path):
-                    for handler in self.notify[slot][path]:
-                        handler()
+                    handlers_to_run += self.notify[slot][path]
+
+            for handler in handlers_to_run:
+                handler()
 
     def get(self, db, table, key):
         """

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
@@ -60,8 +60,11 @@ class SRv6Mgr(Manager):
 
         if not self.directory.path_exist(self.db_name, "SRV6_MY_LOCATORS", locator_name):
             log_warn("Found a SRv6 SID config entry with a locator that does not exist yet: {} | {}".format(key, data))
-            self.deps.add((self.db_name, "SRV6_MY_LOCATORS", locator_name))
-            self.directory.subscribe([(self.db_name, "SRV6_MY_LOCATORS", locator_name)], self.on_deps_change)
+            if (self.db_name, "SRV6_MY_LOCATORS", locator_name) not in self.deps:
+                # add the dependency to the deps set
+                # this will trigger a subscription to the locator table
+                self.deps.add((self.db_name, "SRV6_MY_LOCATORS", locator_name))
+                self.directory.subscribe([(self.db_name, "SRV6_MY_LOCATORS", locator_name)], self.on_deps_change)
             return False
 
         locator = self.directory.get(self.db_name, "SRV6_MY_LOCATORS", locator_name)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Previously, the bgpcfgd's directory invokes callbacks in the iteration over notification dictionary when it gets a new record. However, the callbacks may change the size of the notification dictionary, which will cause runtime errors.

Fix issue #22239 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

I changed the bgpcfgd directory to invoke callbacks after the whole iteration over the notification dictionary.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

