### PR TITLE
[BGPCFGD] Optimize bgpcfgd directory dependencies design

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
@@ -25,6 +25,7 @@ class SRv6Mgr(Manager):
             set(),
             db,
             table,
+            wait_for_all_deps=False
         )
 
     def set_handler(self, key, data):

--- a/src/sonic-bgpcfgd/tests/test_srv6.py
+++ b/src/sonic-bgpcfgd/tests/test_srv6.py
@@ -170,16 +170,20 @@ def test_out_of_order_add():
     loc_mgr.cfg_mgr.push_list = MagicMock()
     sid_mgr.cfg_mgr.push_list = MagicMock()
 
-    # add the sid first
+    # add two sids first
+    sid_mgr.handler(op='SET', key="loc1|FCBB:BBBB:20::/48", data={'action': 'uN'})
     sid_mgr.handler(op='SET', key="loc2|FCBB:BBBB:21::/48", data={'action': 'uN'})
 
     # verify that the sid is not added
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:20::\\48")
     assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21::\\48")
 
-    # add the locator
+    # add the locator loc2
     loc_mgr.handler(op='SET', key="loc2", data={'prefix': 'fcbb:bbbb:21::'})
 
     time.sleep(3)
 
-    # verify that the sid is added after locator config was there
+    # verify that the sid of loc2 is programmed and the sid of loc1 is not prrogrammed
+    # after locator config was added
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:20::\\48")
     assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21::\\48")

--- a/src/sonic-bgpcfgd/tests/test_srv6.py
+++ b/src/sonic-bgpcfgd/tests/test_srv6.py
@@ -181,9 +181,35 @@ def test_out_of_order_add():
     # add the locator loc2
     loc_mgr.handler(op='SET', key="loc2", data={'prefix': 'fcbb:bbbb:21::'})
 
-    time.sleep(3)
-
     # verify that the sid of loc2 is programmed and the sid of loc1 is not prrogrammed
     # after locator config was added
     assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:20::\\48")
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21::\\48")
+
+def test_out_of_order_add_wait_for_all_deps():
+    loc_mgr, sid_mgr = constructor()
+    sid_mgr.wait_for_all_deps = True
+    loc_mgr.cfg_mgr.push_list = MagicMock()
+    sid_mgr.cfg_mgr.push_list = MagicMock()
+
+    # add two sids first
+    sid_mgr.handler(op='SET', key="loc1|FCBB:BBBB:20::/48", data={'action': 'uN'})
+    sid_mgr.handler(op='SET', key="loc2|FCBB:BBBB:21::/48", data={'action': 'uN'})
+
+    # verify that the sid is not added
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:20::\\48")
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21::\\48")
+
+    # add the locator loc2
+    loc_mgr.handler(op='SET', key="loc2", data={'prefix': 'fcbb:bbbb:21::'})
+
+    # verify that neither of the sids are programmed because the manager is waiting for all dependencies
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:20::\\48")
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21::\\48")
+
+    # add the locator loc1
+    loc_mgr.handler(op='SET', key="loc1", data={'prefix': 'fcbb:bbbb:20::'})
+
+    # verify that both of the sids are programmed because all dependencies are satisfied
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:20::\\48")
     assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21::\\48")


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Preivously, every bgpcfgd manager need to wait on all of its dependencies to be ready before it can start processing next SET command. It was very inflexible and hurts performance particularly for SRv6 manager.

To reproduce the issue, a user can try the following config sequence:
```
 sonic-db-cli CONFIG_DB HSET 'SRV6_MY_SIDS|loc1|fcbb:bbbb:1::/48' action 'uN'
 sonic-db-cli CONFIG_DB HSET 'SRV6_MY_SIDS|loc2|fcbb:bbbb:2::/48' action 'uN'
 sonic-db-cli CONFIG_DB HSET 'SRV6_MY_SIDS|loc3|fcbb:bbbb:3::/48' action 'uN'
 sonic-db-cli CONFIG_DB HSET 'SRV6_MY_SIDS|loc4|fcbb:bbbb:4::/48' action 'uN'
sonic-db-cli CONFIG_DB HSET 'SRV6_MY_LOCATORS|loc1' prefix "fcbb:bbbb:1::"
sonic-db-cli CONFIG_DB HSET 'SRV6_MY_LOCATORS|loc2' prefix "fcbb:bbbb:2::"
sonic-db-cli CONFIG_DB HSET 'SRV6_MY_LOCATORS|loc3' prefix "fcbb:bbbb:3::"
sonic-db-cli CONFIG_DB HSET 'SRV6_MY_LOCATORS|loc4' prefix "fcbb:bbbb:4::"
```
Without this optimization, all 4 SIDs won't be programmed until the last locator is set.
With the optimization, the first SID will be programmed at the time the first locator is set and the second SID will be programmed at the time the second locator is set, vice versa.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

I added a knob to allow developers to control whether a manager needs to wait on all dependencies.

#### How to verify it
Run UT and test it out on virtual or physical platforms.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

