### PR TITLE
DASH HA Yang model updates

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -94,6 +94,10 @@
   * [Static DNS](#static-dns)
   * [ASIC_SENSORS](#asic_sensors)  
   * [SRv6](#srv6)
+  * [DPU](#dpu-configuration)
+  * [REMOTE_DPU](#remote_dpu-configuration)
+  * [VDPU](#vdpu-configuration)
+  * [DASH HA Global Configuration](#dash-ha-global-configuration)
   * [Prefix List](#prefix-list)
 * [For Developers](#for-developers)
   * [Generating Application Config by Jinja2 Template](#generating-application-config-by-jinja2-template)
@@ -3041,7 +3045,7 @@ The ASIC_SENSORS table introduces the asic sensors polling configuration when th
 
 ### DPU Configuration
 
-The **DPU** table introduces the configuration for the DPUs(Data Processing Unit) information available on the platform.
+The **DPU** table introduces the configuration for the DPUs (Data Processing Unit) information available on the platform.
 
 ```json
 {
@@ -3075,15 +3079,142 @@ The **DPU** table introduces the configuration for the DPUs(Data Processing Unit
 ```
 
 **state**: Administrative status of the DPU (`up` or `down`).
+
 **local_port**: local port mapped to DPU port on the switch.
+
 **vip_ipv4**: VIP IPv4 address from minigraph.
+
 **vip_ipv6**: VIP IPv6 address from minigraph.
+
 **pa_ipv4**: PA IPv4 address from minigraph.
+
 **pa_ipv6**: PA IPv6 address from minigraph.
+
 **dpu_id**: Id of the DPU from minigraph.
+
 **vdpu_id**: ID of VDPUs from minigraph.
+
 **gnmi_port**: TCP listening port for gnmi service on DPU.
+
 **orchagent_zmq_port**: TCP listening port for ZMQ service on DPU orchagent.
+
+### REMOTE_DPU Configuration
+
+The **REMOTE_DPU** table introduces the configuration for the remote DPUs (Data Processing Unit) accessible on other machines.
+
+```json
+{
+    "REMOTE_DPU": {
+        "str-8103-t1-dpu0": {
+            "type": "typeA",
+            "pa_ipv4": "192.168.2.1",
+            "pa_ipv6": "2001:db8::30",
+            "npu_ipv4": "192.168.2.10",
+            "npu_ipv6": "2001:db8::40",
+            "dpu_id": "0",
+            "swbus_port": "23606"
+        },
+        "str-8103-t1-dpu1": {
+            "type": "typeB",
+            "pa_ipv4": "192.168.2.2",
+            "pa_ipv6": "2001:db8::50",
+            "npu_ipv4": "192.168.2.20",
+            "npu_ipv6": "2001:db8::60",
+            "dpu_id": "1",
+            "swbus_port": "23607"
+        }
+    }
+}
+```
+
+**type**: Type of the DPU.
+
+**pa_ipv4**: DPU IPv4 physical address.
+
+**pa_ipv6**: DPU IPv6 physical address.
+
+**npu_ipv4**: Loopback IPv4 address of remote NPU.
+
+**npu_ipv6**: Loopback IPv6 address of remote NPU.
+
+**dpu_id**: ID of the DPU from minigraph.
+
+**swbus_port**: TCP listening port for swbus service for this DPU. Must be 23606 + dpu_id.
+
+### VDPU Configuration
+
+The **VDPU** table introduces the configuration for the VDPUs (Virtual Data Processing Unit) information available on the platform.
+
+```json
+{
+    "VDPU": {
+        "vdpu0": {
+            "profile": "",
+            "tier": "",
+            "main_dpu_ids": ["dpu0"]
+        },
+        "vdpu1": {
+            "profile": "",
+            "tier": "",
+            "main_dpu_ids": ["dpu1"]
+        },
+        "vdpu2": {
+            "profile": "",
+            "tier": "",
+            "main_dpu_ids": ["dpu2"]
+        },
+        "vdpu3": {
+            "profile": "",
+            "tier": "",
+            "main_dpu_ids": ["dpu3"]
+        }
+    }
+}
+```
+
+**profile**: VDPU profile. Currently unused, reserved for future use.
+
+**tier**: VDPU tier. Currently unused, reserved for future use.
+
+**main_dpu_ids**: Main DPUs involved in this VDPU.
+
+### DASH HA Global Configuration
+
+The **DASH_HA_GLOBAL_CONFIG** table introduces the configuration for the DASH High Availability global settings available on the platform.
+Like NTP global configuration, DASH HA global configuration must have one entry with the key "global".
+
+```json
+{
+    "DASH_HA_GLOBAL_CONFIG": {
+        "global": {
+            "cp_data_channel_port": "11362",
+            "dp_channel_port": "11368",
+            "dp_channel_src_port_min": "49152",
+            "dp_channel_src_port_max": "53247",
+            "dp_channel_probe_interval_ms": "100",
+            "dp_channel_probe_fail_threshold": "3",
+            "dpu_bfd_probe_interval_in_ms": "100",
+            "dpu_bfd_probe_multiplier": "3"
+        }
+    }
+}
+```
+
+**cp_data_channel_port**: Control plane data channel port, used for bulk sync.
+
+**dp_channel_port**: Destination port when tunneling packets via DPU-to-DPU data plane channel.
+
+**dp_channel_src_port_min**: Minimum source port used when tunneling packets via DPU-to-DPU data plane channel.
+
+**dp_channel_src_port_max**: Maximum source port used when tunneling packets via DPU-to-DPU data plane channel.
+
+**dp_channel_probe_interval_ms**: Interval in milliseconds for sending each DPU-to-DPU data path probe.
+
+**dp_channel_probe_fail_threshold**: Number of probe failures needed to consider data plane channel as dead.
+
+**dpu_bfd_probe_interval_in_ms**: Interval in milliseconds for DPU BFD probe.
+
+**dpu_bfd_probe_multiplier**: Number of DPU BFD probe failures before considering the probe as down.
 
 # For Developers
 

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2817,6 +2817,60 @@
                 "orchagent_zmq_port": "50"
             }
         },
+        "REMOTE_DPU": {
+            "str-8103-t1-dpu0": {
+                "type": "typeA",
+                "pa_ipv4": "192.168.2.1",
+                "pa_ipv6": "2001:db8::30",
+                "npu_ipv4": "192.168.2.10",
+                "npu_ipv6": "2001:db8::40",
+                "dpu_id": "0",
+                "swbus_port": "23606"
+            },
+            "str-8103-t1-dpu1": {
+                "type": "typeB",
+                "pa_ipv4": "192.168.2.2",
+                "pa_ipv6": "2001:db8::50",
+                "npu_ipv4": "192.168.2.20",
+                "npu_ipv6": "2001:db8::60",
+                "dpu_id": "1",
+                "swbus_port": "23607"
+            }
+        },
+        "VDPU": {
+            "vdpu0": {
+                "profile": "",
+                "tier": "",
+                "main_dpu_ids": ["dpu0"]
+            },
+            "vdpu1": {
+                "profile": "",
+                "tier": "",
+                "main_dpu_ids": ["dpu1"]
+            },
+            "vdpu2": {
+                "profile": "",
+                "tier": "",
+                "main_dpu_ids": ["dpu2"]
+            },
+            "vdpu3": {
+                "profile": "",
+                "tier": "",
+                "main_dpu_ids": ["dpu3"]
+            }
+        },
+        "DASH_HA_GLOBAL_CONFIG": {
+            "global": {
+                "cp_data_channel_port": "11362",
+                "dp_channel_port": "11368",
+                "dp_channel_src_port_min": "49152",
+                "dp_channel_src_port_max": "53247",
+                "dp_channel_probe_interval_ms": "100",
+                "dp_channel_probe_fail_threshold": "3",
+                "dpu_bfd_probe_interval_in_ms": "100",
+                "dpu_bfd_probe_multiplier": "3"
+            }
+        },
 	"XCVRD_LOG": {
 	    "Y_CABLE": {
 		"log_verbosity": "notice"

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2802,7 +2802,8 @@
                 "dpu_id": "0",
                 "vdpu_id": "vdpu0",
                 "gnmi_port": "50052",
-                "orchagent_zmq_port": "50"
+                "orchagent_zmq_port": "50",
+                "swbus_port": "23607"
             },
             "str-8102-t1-dpu1": {
                 "state": "down",
@@ -2814,7 +2815,8 @@
                 "dpu_id": "1",
                 "vdpu_id": "vdpu1",
                 "gnmi_port": "50052",
-                "orchagent_zmq_port": "50"
+                "orchagent_zmq_port": "50",
+                "swbus_port": "23607"
             }
         },
         "REMOTE_DPU": {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2841,23 +2841,23 @@
         },
         "VDPU": {
             "vdpu0": {
-                "profile": "",
-                "tier": "",
+                "profile": "none",
+                "tier": "none",
                 "main_dpu_ids": ["dpu0"]
             },
             "vdpu1": {
-                "profile": "",
-                "tier": "",
+                "profile": "none",
+                "tier": "none",
                 "main_dpu_ids": ["dpu1"]
             },
             "vdpu2": {
-                "profile": "",
-                "tier": "",
+                "profile": "none",
+                "tier": "none",
                 "main_dpu_ids": ["dpu2"]
             },
             "vdpu3": {
-                "profile": "",
-                "tier": "",
+                "profile": "none",
+                "tier": "none",
                 "main_dpu_ids": ["dpu3"]
             }
         },

--- a/src/sonic-yang-models/tests/yang_model_pytests/test_smart_switch.py
+++ b/src/sonic-yang-models/tests/yang_model_pytests/test_smart_switch.py
@@ -420,7 +420,7 @@ class TestSmartSwitch:
         data = {
             "sonic-smart-switch:sonic-smart-switch": {
                 "sonic-smart-switch:DASH_HA_GLOBAL_CONFIG": {
-                    "DASH_HA_GLOBAL_CONFIG_LIST": [
+                    "global": [
                         {
                             "key": "global",
                             "cp_data_channel_port": 11234,

--- a/src/sonic-yang-models/tests/yang_model_pytests/test_smart_switch.py
+++ b/src/sonic-yang-models/tests/yang_model_pytests/test_smart_switch.py
@@ -369,3 +369,71 @@ class TestSmartSwitch:
             }
         }
         yang_model.load_data(data, error_message)
+
+    @pytest.mark.parametrize(
+        "dpu_id, swbus_port, error_message", [
+            (0, 23606, None),
+            (1, 23607, None),
+            (7, 23613, None),
+            (0, 23607, 'Must condition "current() = 23606 + number(current()/../dpu_id)" not satisfied.'),
+            (7, 23606, 'Must condition "current() = 23606 + number(current()/../dpu_id)" not satisfied.')]
+        )
+    def test_remote_dpu_swbus_port(self, yang_model, dpu_id, swbus_port, error_message):
+        data = {
+            "sonic-smart-switch:sonic-smart-switch": {
+                "sonic-smart-switch:REMOTE_DPU": {
+                    "REMOTE_DPU_LIST": [
+                        {
+                            "dpu_name": f"str-8102-t1-dpu{dpu_id}",
+                            "type": "xyz",
+                            "pa_ipv4": "192.168.1.4",
+                            "pa_ipv6": "2001:db8::4",
+                            "npu_ipv4": "192.168.1.5",
+                            "npu_ipv6": "2001:db8::5",
+                            "dpu_id": dpu_id,
+                            "swbus_port": swbus_port,
+                        }
+                    ]
+                }
+            }
+        }
+        yang_model.load_data(data, error_message)
+
+    def test_vdpu(self, yang_model):
+        data = {
+            "sonic-smart-switch:sonic-smart-switch": {
+                "sonic-smart-switch:VDPU": {
+                    "VDPU_LIST": [
+                        {
+                            "vdpu_id": "vdpu0",
+                            "profile": "none",
+                            "tier": "none",
+                            "main_dpu_ids": ["str-8102-t1-dpu0"]
+                        }
+                    ]
+                }
+            }
+        }
+        yang_model.load_data(data)
+
+    def test_dash_ha_global_config(self, yang_model):
+        data = {
+            "sonic-smart-switch:sonic-smart-switch": {
+                "sonic-smart-switch:DASH_HA_GLOBAL_CONFIG": {
+                    "DASH_HA_GLOBAL_CONFIG_LIST": [
+                        {
+                            "key": "global",
+                            "cp_data_channel_port": 11234,
+                            "dp_channel_port": 11235,
+                            "dp_channel_src_port_min": 11236,
+                            "dp_channel_src_port_max": 11237,
+                            "dp_channel_probe_interval_ms": 500,
+                            "dp_channel_probe_fail_threshold": 3,
+                            "dpu_bfd_probe_interval_in_ms": 500,
+                            "dpu_bfd_probe_multiplier": 3
+                        }
+                    ]
+                }
+            }
+        }
+        yang_model.load_data(data)

--- a/src/sonic-yang-models/tests/yang_model_pytests/test_smart_switch.py
+++ b/src/sonic-yang-models/tests/yang_model_pytests/test_smart_switch.py
@@ -374,9 +374,7 @@ class TestSmartSwitch:
         "dpu_id, swbus_port, error_message", [
             (0, 23606, None),
             (1, 23607, None),
-            (7, 23613, None),
-            (0, 23607, 'Must condition "current() = 23606 + number(current()/../dpu_id)" not satisfied.'),
-            (7, 23606, 'Must condition "current() = 23606 + number(current()/../dpu_id)" not satisfied.')]
+            (7, 23613, None)]
         )
     def test_remote_dpu_swbus_port(self, yang_model, dpu_id, swbus_port, error_message):
         data = {
@@ -420,19 +418,16 @@ class TestSmartSwitch:
         data = {
             "sonic-smart-switch:sonic-smart-switch": {
                 "sonic-smart-switch:DASH_HA_GLOBAL_CONFIG": {
-                    "global": [
-                        {
-                            "key": "global",
-                            "cp_data_channel_port": 11234,
-                            "dp_channel_port": 11235,
-                            "dp_channel_src_port_min": 11236,
-                            "dp_channel_src_port_max": 11237,
-                            "dp_channel_probe_interval_ms": 500,
-                            "dp_channel_probe_fail_threshold": 3,
-                            "dpu_bfd_probe_interval_in_ms": 500,
-                            "dpu_bfd_probe_multiplier": 3
-                        }
-                    ]
+                    "global": {
+                        "cp_data_channel_port": 11234,
+                        "dp_channel_port": 11235,
+                        "dp_channel_src_port_min": 11236,
+                        "dp_channel_src_port_max": 11237,
+                        "dp_channel_probe_interval_ms": 500,
+                        "dp_channel_probe_fail_threshold": 3,
+                        "dpu_bfd_probe_interval_in_ms": 500,
+                        "dpu_bfd_probe_multiplier": 3
+                    }
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
+++ b/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
@@ -1,6 +1,6 @@
 module sonic-smart-switch {
 
-    yang-version 1.1;
+	yang-version 1.1;
 
 	namespace "http://github.com/sonic-net/sonic-smart-switch";
 	prefix smart-switch;
@@ -35,6 +35,10 @@ module sonic-smart-switch {
 
 	revision 2025-03-19 {
 		description "Modify DPU_PORT to DPU and add new fields";
+	}
+
+	revision 2025-03-31 {
+		description "Add REMOTE_DPU, VDPU, and DASH_HA_GLOBAL_CONFIG containers";
 	}
 
 	container sonic-smart-switch {
@@ -93,7 +97,6 @@ module sonic-smart-switch {
 			description "DPUs part of config_db.json";
 
 			list DPU_LIST {
-				description "Name of the DPU";
 				key "dpu_name";
 
 				leaf dpu_name {
@@ -157,6 +160,149 @@ module sonic-smart-switch {
 			}
 		}
 		/* end of container DPU */
+
+		container REMOTE_DPU {
+			description "REMOTE_DPU part of config_db.json";
+
+			list REMOTE_DPU_LIST {
+				key "dpu_name";
+
+				leaf dpu_name {
+					description "Name of the dpu";
+					type string {
+						pattern "[a-zA-Z0-9-]+[0-9]+";
+					}
+				}
+
+				leaf type {
+					description "Type of dpu";
+					type string;
+				}
+
+				leaf pa_ipv4 {
+					description "DPU ipv4 physical address";
+					type inet:ipv4-address;
+				}
+
+				leaf pa_ipv6 {
+					description "DPU ipv6 physical address";
+					type inet:ipv6-address;
+				}
+
+				leaf npu_ipv4 {
+					description "Loopback ipv4 of remote NPU";
+					type inet:ipv4-address;
+				}
+
+				leaf npu_ipv6 {
+					description "Loopback ipv6 of remote NPU";
+					type inet:ipv6-address;
+				}
+
+				leaf dpu_id {
+					description "ID of the DPU from minigraph";
+					type string {
+						pattern [0-7];
+					}
+				}
+
+				leaf swbus_port {
+					description "TCP listening port for swbus service for this DPU. Must be 23606 + dpu_id";
+					type inet:port-number;
+					must "current() = 23606 + number(current()/../dpu_id)";
+				}
+			}
+		}
+		/* end of container REMOTE_DPU */
+
+		container VDPU {
+			description "VDPU part of config_db.json";
+
+			list VDPU_LIST {
+				key vdpu_id;
+
+				leaf vdpu_id {
+					description "ID of the VDPU";
+					type string {
+						pattern "vdpu[0-9]+";
+					}
+				}
+
+				leaf profile {
+					description "VDPU profile. Currently unused, reserved for future use.";
+					type string;
+				}
+
+				leaf tier {
+					description "VDPU tier. Currently unused, reserved for future use.";
+					type string;
+				}
+
+				leaf-list main_dpu_ids {
+					description "Main DPUs involved in this VDPU";
+					type string {
+						pattern "[a-zA-Z0-9-]+[0-9]+";
+					}
+				}
+			}
+		}
+		/* end of container VDPU */
+
+		container DASH_HA_GLOBAL_CONFIG {
+			description "DASH_HA_GLOBAL_CONFIG part of config_db.json";
+
+			list DASH_HA_GLOBAL_CONFIG_LIST {
+				key key;
+
+				leaf key {
+					description "Key, must be 'global'";
+					type string {
+						pattern "global";
+					}
+				}
+
+				leaf cp_data_channel_port {
+					description "Control plane data channel port, used for bulk sync";
+					type inet:port-number;
+				}
+
+				leaf dp_channel_port {
+					description "Destination port when tunneling packets via DPU-to-DPU data plane channel";
+					type inet:port-number;
+				}
+
+				leaf dp_channel_src_port_min {
+					description "Minimum source port used when tunneling packets via DPU-to-DPU data plane channel";
+					type inet:port-number;
+				}
+
+				leaf dp_channel_src_port_max {
+					description "Maximum source port used when tunneling packets via DPU-to-DPU data plane channel";
+					type inet:port-number;
+				}
+
+				leaf dp_channel_probe_interval_ms {
+					description "Interval in milliseconds for sending each DPU-to-DPU data path probe";
+					type uint32;
+				}
+
+				leaf dp_channel_probe_fail_threshold {
+					description "Number of probe failures needed to consider data plane channel as dead";
+					type uint32;
+				}
+
+				leaf dpu_bfd_probe_interval_in_ms {
+					description "Interval in milliseconds for DPU BFD probe";
+					type uint32;
+				}
+
+				leaf dpu_bfd_probe_multiplier {
+					description "Number of DPU BFD probe failures before considering the probe as down";
+					type uint32;
+				}
+			}
+		}
+		/* end of container DASH_HA_GLOBAL_CONFIG */
 	}
 	/* end of container sonic-smart-switch */
 }

--- a/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
+++ b/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
@@ -160,6 +160,11 @@ module sonic-smart-switch {
 					description "TCP listening port for ZMQ service on DPU orchagent";
 					type inet:port-number;
 				}
+
+				leaf swbus_port {
+					description "TCP listening port for swbus service for this DPU.";
+					type inet:port-number;
+				}
 			}
 		}
 		/* end of container DPU */
@@ -213,9 +218,8 @@ module sonic-smart-switch {
 				}
 
 				leaf swbus_port {
-					description "TCP listening port for swbus service for this DPU. Must be 23606 + dpu_id. This magic port number is defined in the NGS minigraph spec for smart switch.";
+					description "TCP listening port for swbus service for this DPU.";
 					type inet:port-number;
-					must "current() = 23606 + number(current()/../dpu_id)";
 				}
 			}
 		}

--- a/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
+++ b/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
@@ -103,6 +103,7 @@ module sonic-smart-switch {
 					description "Name of the DPU";
 					type string {
 						pattern "[a-zA-Z0-9-]+[0-9]";
+						length 1..255;
 					}
 				}
 
@@ -144,8 +145,10 @@ module sonic-smart-switch {
 				}
 
 				leaf vdpu_id {
-					description "ID of VDPUs from minigraph";
-					type string;
+					description "guid of VDPU from minigraph";
+					type string {
+						length 1..255;
+					}
 				}
 
 				leaf gnmi_port {
@@ -171,12 +174,15 @@ module sonic-smart-switch {
 					description "Name of the dpu";
 					type string {
 						pattern "[a-zA-Z0-9-]+[0-9]+";
+						length 1..255;
 					}
 				}
 
 				leaf type {
 					description "Type of dpu";
-					type string;
+					type string {
+						length 1..255;
+					}
 				}
 
 				leaf pa_ipv4 {
@@ -207,7 +213,7 @@ module sonic-smart-switch {
 				}
 
 				leaf swbus_port {
-					description "TCP listening port for swbus service for this DPU. Must be 23606 + dpu_id";
+					description "TCP listening port for swbus service for this DPU. Must be 23606 + dpu_id. This magic port number is defined in the NGS minigraph spec for smart switch.";
 					type inet:port-number;
 					must "current() = 23606 + number(current()/../dpu_id)";
 				}
@@ -222,26 +228,31 @@ module sonic-smart-switch {
 				key vdpu_id;
 
 				leaf vdpu_id {
-					description "ID of the VDPU";
+					description "guid of the VDPU";
 					type string {
-						pattern "vdpu[0-9]+";
+						length 1..255;
 					}
 				}
 
 				leaf profile {
 					description "VDPU profile. Currently unused, reserved for future use.";
-					type string;
+					type string {
+						length 1..255;
+					}
 				}
 
 				leaf tier {
 					description "VDPU tier. Currently unused, reserved for future use.";
-					type string;
+					type string {
+						length 1..255;
+					}
 				}
 
 				leaf-list main_dpu_ids {
 					description "Main DPUs involved in this VDPU";
 					type string {
 						pattern "[a-zA-Z0-9-]+[0-9]+";
+						length 1..255;
 					}
 				}
 			}
@@ -249,17 +260,10 @@ module sonic-smart-switch {
 		/* end of container VDPU */
 
 		container DASH_HA_GLOBAL_CONFIG {
-			description "DASH_HA_GLOBAL_CONFIG part of config_db.json";
 
-			list DASH_HA_GLOBAL_CONFIG_LIST {
-				key key;
+			container global {
 
-				leaf key {
-					description "Key, must be 'global'";
-					type string {
-						pattern "global";
-					}
-				}
+				description "DASH_HA_GLOBAL_CONFIG part of config_db.json";
 
 				leaf cp_data_channel_port {
 					description "Control plane data channel port, used for bulk sync";


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
These tables are described in the NGS minigraph requirements doc to support DASH HA.

##### Work item tracking
- Microsoft ADO **(number only)**: None

#### How I did it
Added definitions from minigraph doc to sonic-yang-models.

#### How to verify it
sonic-yang-model pytests

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

master

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added REMOTE_DPU, VDPU, and DASH_HA_GLOBAL_CONFIG tables to sonic-yang-models. 

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

https://github.com/erer1243/sonic-buildimage/blob/dash-ha-yang-model/src/sonic-yang-models/doc/Configuration.md#remote_dpu-configuration
