### PR TITLE
Upgrade pygobject for armhf

### DIFF
--- a/files/build/versions/host-image/versions-py3-all-armhf
+++ b/files/build/versions/host-image/versions-py3-all-armhf
@@ -1,2 +1,2 @@
 protobuf==5.29.3
-pygobject==3.42.2
+pygobject==3.50.0


### PR DESCRIPTION
Update the version of pygobject to 3.50.0 to match the version wanted by sonic-host-services.

#### Why I did it

This is a speculative fix for build failures for marvell_armhf that started after the automated sonic-host-services bump.

#### How I did it

Update the version of pygobject in files/build/versions/host-image/versions-py3-all-armhf. I've been unable to build the armhf target locally so I'm not sure if this will actually fix the build errors being seen.

#### How to verify it

Should just be a build-time thing.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202411

#### Tested branch (Please provide the tested image version)
Unable to test locally

#### Description for the changelog
Update the version of pygobject used

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
                           .888888:.
                           88888.888.
                          .8888888888
                          8' `88' `888
                          8 8 88 8 888
                          8:.,::,.:888
                         .8`::::::'888
                         88  `::'  888
                        .88        `888.
                      .88'   .::.  .:8888.
                      888.'   :'    `'88:88.
                    .8888'    '        88:88.
                   .8888'     .        88:888
                   `88888     :        8:888'
                    `.:.88    .       .::888'
                   .:::::88   `      .:::::::.
                  .::::::.8         .:::::::::
                  :::::::::..     .:::::::::'
                   `:::::::::88888:::::::'
                      rs`:::'       `:'
```

