### PR TITLE
Fix max ECMP group members for Arista-7060X6-64PE

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-256x200G/sai.profile
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-256x200G/sai.profile
@@ -1,1 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-64pe.config.bcm
+SAI_NUM_ECMP_MEMBERS=320

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-64x400G/sai.profile
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-64x400G/sai.profile
@@ -1,1 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-64pe.config.bcm
+SAI_NUM_ECMP_MEMBERS=320

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C224O8/sai.profile
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C224O8/sai.profile
@@ -1,1 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-64pe.config.bcm
+SAI_NUM_ECMP_MEMBERS=320

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C256S2/sai.profile
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C256S2/sai.profile
@@ -1,1 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-64pe.config.bcm
+SAI_NUM_ECMP_MEMBERS=320

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-O128S2/sai.profile
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-O128S2/sai.profile
@@ -1,1 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-64pe.config.bcm
+SAI_NUM_ECMP_MEMBERS=320

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE/sai.profile
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE/sai.profile
@@ -1,1 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-64pe.config.bcm
+SAI_NUM_ECMP_MEMBERS=320


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This fixes the error: "Failed on nexthop group member creation due to max ecmp paths 64 reached

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

