### PR TITLE
[nvidia-bluefield] Fix the issue with the SDK compilation caused by missing dependencies.

### DIFF
--- a/platform/nvidia-bluefield/recipes/sdk.mk
+++ b/platform/nvidia-bluefield/recipes/sdk.mk
@@ -122,8 +122,9 @@ $(IB_VERBS_PROV)_DEPENDS = $(LIBNL3_DEV) $(LIBNL_ROUTE3_DEV)
 
 IB_VERBS = libibverbs1_${RDMA_CORE_VER}_${CONFIGURED_ARCH}.deb
 $(IB_VERBS)_DEPENDS = $(LIBNL3_DEV) $(LIBNL_ROUTE3_DEV)
+$(IB_VERBS)_RDEPENDS = $(LIBNL3_DEV) $(LIBNL_ROUTE3_DEV)
 IB_VERBS_DEV = libibverbs-dev_${RDMA_CORE_VER}_${CONFIGURED_ARCH}.deb
-$(IB_VERBS_DEV)_DEPENDS = $(IB_VERBS) $(IB_VERBS_PROV)
+$(IB_VERBS_DEV)_DEPENDS = $(LIBNL3_DEV) $(LIBNL_ROUTE3_DEV) $(IB_VERBS) $(IB_VERBS_PROV)
 
 IB_UMAD = libibumad3_${RDMA_CORE_VER}_${CONFIGURED_ARCH}.deb
 IB_UMAD_DEV = libibumad-dev_${RDMA_CORE_VER}_${CONFIGURED_ARCH}.deb
@@ -131,14 +132,6 @@ IB_UMAD_DEV = libibumad-dev_${RDMA_CORE_VER}_${CONFIGURED_ARCH}.deb
 RDMACM = librdmacm1_${RDMA_CORE_VER}_${CONFIGURED_ARCH}.deb
 RDMACM_DEV = librdmacm-dev_${RDMA_CORE_VER}_${CONFIGURED_ARCH}.deb
 $(RDMACM_DEV)_DEPENDS = $(RDMACM) $(IB_VERBS_DEV)
-
-$(eval $(call add_derived_package,$(RDMA_CORE),$(IB_VERBS_PROV)))
-$(eval $(call add_derived_package,$(RDMA_CORE),$(IB_VERBS)))
-$(eval $(call add_derived_package,$(RDMA_CORE),$(IB_VERBS_DEV)))
-$(eval $(call add_derived_package,$(RDMA_CORE),$(IB_UMAD)))
-$(eval $(call add_derived_package,$(RDMA_CORE),$(IB_UMAD_DEV)))
-$(eval $(call add_derived_package,$(RDMA_CORE),$(RDMACM)))
-$(eval $(call add_derived_package,$(RDMA_CORE),$(RDMACM_DEV)))
 
 export RDMA_CORE
 export IB_VERBS IB_VERBS_DEV
@@ -157,8 +150,19 @@ RDMA_CORE_DERIVED_DEBS = \
 
 export RDMA_CORE_DERIVED_DEBS
 
-SDK_DEBS += $(RDMA_CORE) $(RDMA_CORE_DERIVED_DEBS)
 SDK_SRC_TARGETS += $(RDMA_CORE)
+
+ifeq ($(SDK_FROM_SRC), y)
+$(eval $(call add_derived_package,$(RDMA_CORE),$(IB_VERBS_PROV)))
+$(eval $(call add_derived_package,$(RDMA_CORE),$(IB_VERBS)))
+$(eval $(call add_derived_package,$(RDMA_CORE),$(IB_VERBS_DEV)))
+$(eval $(call add_derived_package,$(RDMA_CORE),$(IB_UMAD)))
+$(eval $(call add_derived_package,$(RDMA_CORE),$(IB_UMAD_DEV)))
+$(eval $(call add_derived_package,$(RDMA_CORE),$(RDMACM)))
+$(eval $(call add_derived_package,$(RDMA_CORE),$(RDMACM_DEV)))
+else
+SDK_ONLINE_TARGETS += $(RDMA_CORE_DERIVED_DEBS)
+endif
 
 # DPDK and derived packages
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the issue with the SDK compilation caused by missing dependencies.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update package dependencies.

#### How to verify it
Compile the nvidia-bluefield image.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

