### PR TITLE
For armhf, allow using only manylinux python wheels

### DIFF
--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -401,7 +401,7 @@ RUN pip3 install wheel==0.38.1
 {%- if CONFIGURED_ARCH == "armhf" %}
 # Allow only manylinux wheels on armhf, to ensure that binaries/libraries work correctly on armhf
 COPY ["disable-non-manylinux.patch", "/"]
-{%- if CROSS_BUILD_ENVIRON == "y" %}
+{%- if CROSS_BUILD_ENVIRON | default("n") == "y" %}
 RUN patch -p1 -i /disable-non-manylinux.patch /python_virtualenv/env3/lib/python3.9/site-packages/pip/_vendor/packaging/tags.py
 {%- else %}
 RUN patch -p1 -i /disable-non-manylinux.patch /usr/local/lib/python3.9/dist-packages/pip/_vendor/packaging/tags.py

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -398,6 +398,16 @@ RUN apt-get purge -y python3-pip python3-yaml
 RUN pip3 install setuptools==49.6.00
 RUN pip3 install wheel==0.38.1
 
+{%- if CONFIGURED_ARCH == "armhf" %}
+# Allow only manylinux wheels on armhf, to ensure that binaries/libraries work correctly on armhf
+COPY ["disable-non-manylinux.patch", "/"]
+{%- if CROSS_BUILD_ENVIRON == "y" %}
+RUN patch -p1 -i /disable-non-manylinux.patch /python_virtualenv/env3/lib/python3.9/site-packages/pip/_vendor/packaging/tags.py
+{%- else %}
+RUN patch -p1 -i /disable-non-manylinux.patch /usr/local/lib/python3.9/dist-packages/pip/_vendor/packaging/tags.py
+{%- endif %}
+{%- endif %}
+
 # For building sonic-utilities
 RUN pip3 install fastentrypoints mock
 

--- a/sonic-slave-bullseye/disable-non-manylinux.patch
+++ b/sonic-slave-bullseye/disable-non-manylinux.patch
@@ -1,0 +1,10 @@
+--- a/tags.py	2022-07-12 00:07:22.710207780 +0000
++++ b/tags.py	2022-07-12 00:07:13.185890659 +0000
+@@ -424,7 +424,6 @@
+     _, arch = linux.split("_", 1)
+     yield from _manylinux.platform_tags(linux, arch)
+     yield from _musllinux.platform_tags(arch)
+-    yield linux
+ 
+ 
+ def _generic_platforms() -> Iterator[str]:


### PR DESCRIPTION
For amd64 and i386 (and, if available, arm64), Python provides manylinux wheels, which are wheels with binary packages compiled against some "baseline" glibc version. This is guaranteed to run across a wide number of distro versions, and if the distro version being used isn't new enough for the manylinux build environment that was used, pip will fall back to compiling locally.

For armhf, however, this doesn't appear to be the case; there are some wheels compiled for linux_armv7l, but there's no guarantee that such a wheel will successfully run on Debian Bullseye. For grpcio-tools, this is the issue. There is a linux_armv7l wheel available, but there is a shared library _protoc in the package that requires a newer version of glibc and libstdc++ than what is in Debian Bullseye. Our official builds are fine because the underlying build machines are arm64 build machines with armv8l architecture, and because there's no linux_armv8l wheel, python will locally compile it.

Therefore, for armhf, allow installing only manylinux wheels, or, if one doesn't exist, compile from source locally.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

