### PR TITLE
Add patch for gnmi client to support extensive configurations

### DIFF
--- a/dockers/docker-ptf/gnxi-patches/0006-Add-support-for-extensive-configurations.patch
+++ b/dockers/docker-ptf/gnxi-patches/0006-Add-support-for-extensive-configurations.patch
@@ -34,12 +34,12 @@ index 0ea6f3d..00549e3 100644
  def main():
    argparser = _create_parser()
    args = vars(argparser.parse_args())
-+  # Replace input args with args from arg_file if specified
++  # Merge input args with args from arg_file if specified
 +  if args['arg_file']:
 +      with open(args['arg_file'], 'r') as file:
 +          file_content = file.read()
 +          simulated_args = shlex.split(file_content)
-+          args = vars(argparser.parse_args(simulated_args))
++          args.update(vars(argparser.parse_args(simulated_args)))
    if args['version']:
      print(__version__)
      sys.exit()

--- a/dockers/docker-ptf/gnxi-patches/0006-Add-support-for-extensive-configurations.patch
+++ b/dockers/docker-ptf/gnxi-patches/0006-Add-support-for-extensive-configurations.patch
@@ -1,0 +1,48 @@
+From 5c8bc9e0142952748b327375ea2a45813dfe297f Mon Sep 17 00:00:00 2001
+From: ganglyu <ganglv@microsoft.com>
+Date: Wed, 9 Apr 2025 16:04:04 +0800
+Subject: [PATCH] Add args file to support huge configurations
+
+The command line has a length limitation, which restricts the number of configurations it can support. To overcome this limitation, introduce a new argument: arg_file. Users can place extensive configurations within the arg_file, enabling the GNMI client to handle a larger and more complex set of configurations.
+
+---
+ gnmi_cli_py/py_gnmicli.py | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/gnmi_cli_py/py_gnmicli.py b/gnmi_cli_py/py_gnmicli.py
+index 0ea6f3d..00549e3 100644
+--- a/gnmi_cli_py/py_gnmicli.py
++++ b/gnmi_cli_py/py_gnmicli.py
+@@ -35,6 +35,7 @@ import json
+ import logging
+ import os
+ import re
++import shlex
+ import ssl
+ import sys
+ import string
+@@ -94,6 +95,8 @@ def _create_parser():
+       '\npython py_gnmicli.py -t 127.0.0.1 -p 8080 -x \'/access-points/'
+       'access-point[hostname=test-ap]/\' -rcert ~/certs/target-cert.crt -o '
+       'openconfig.example.com')
++  parser.add_argument('--arg_file', type=str, help='The args file',
++                      required=False)
+   parser.add_argument('-t', '--target', type=str, help='The gNMI Target',
+                       required=True)
+   parser.add_argument('-p', '--port', type=str, help='The port the gNMI Target '
+@@ -533,6 +536,12 @@ def subscribe_start(stub, options, req_iterator):
+ def main():
+   argparser = _create_parser()
+   args = vars(argparser.parse_args())
++  # Replace input args with args from arg_file if specified
++  if args['arg_file']:
++      with open(args['arg_file'], 'r') as file:
++          file_content = file.read()
++          simulated_args = shlex.split(file_content)
++          args = vars(argparser.parse_args(simulated_args))
+   if args['version']:
+     print(__version__)
+     sys.exit()
+-- 
+2.48.1.windows.1
+

--- a/dockers/docker-ptf/gnxi-patches/series
+++ b/dockers/docker-ptf/gnxi-patches/series
@@ -3,3 +3,4 @@
 0003-gNMI_client-Add-an-option-to-trigger-memory-spike-on.patch
 0004-Add-support-for-streaming-structured-events-in-night.patch
 0005-Enhance-gnmi_cli_py-4.patch
+0006-Add-support-for-extensive-configurations.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The command line has a length limitation, which restricts the number of configurations it can support.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
To overcome this limitation, introduce a new argument: arg_file. Users can place extensive configurations within the arg_file, enabling the GNMI client to handle a larger and more complex set of configurations.

#### How to verify it
Run gnmi end to end test

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

