### PR TITLE
device_config_mode to make it as unified

### DIFF
--- a/dockers/docker-fpm-frr/docker_init.sh
+++ b/dockers/docker-fpm-frr/docker_init.sh
@@ -56,7 +56,7 @@ if [[ ! -z "$NAMESPACE_ID" ]]; then
    update_default_gw 6
 fi
 
-if [ -z "$CONFIG_TYPE" ] || [ "$CONFIG_TYPE" == "separated" ]; then
+if  [ "$CONFIG_TYPE" == "separated" ]; then
     CFGGEN_PARAMS=" \
         -d \
         -y /etc/sonic/constants.yml \
@@ -84,7 +84,7 @@ elif [ "$CONFIG_TYPE" == "split-unified" ]; then
     echo "service integrated-vtysh-config" > /etc/frr/vtysh.conf
     rm -f /etc/frr/bgpd.conf /etc/frr/zebra.conf /etc/frr/staticd.conf
     write_default_zebra_config /etc/frr/frr.conf
-elif [ "$CONFIG_TYPE" == "unified" ]; then
+elif [ -z "$CONFIG_TYPE" ] || [ "$CONFIG_TYPE" == "unified" ]; then
     CFGGEN_PARAMS=" \
         -d \
         -y /etc/sonic/constants.yml \


### PR DESCRIPTION
#### Why I did it
The docker_routing_config_mode value which is set to default of separated is not working properly with the latest FRR.

#### How I did it
The changes are done in the docker_init.sh to modify the default behavior of considering the docker_routing_config_mode value as 'separated' when it is not seen in the config_db to modifying the value to 'unified'.

#### How to verify it
These values are significant to restore the values in FRR. When the value is separated, each process in FRR will have its own config file from where the configs are played back after save and restore, with the value of 'unified' there will be only one file frr.conf from where all the configs will be played back. 

After doing this change, I manually verified the presence of frr.conf after save and restore and all the configs are restored properly.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
master

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->
-  20250407.145357

-### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Modified the default value of docker_routing_config_mode to unified.

UT Logs
----------

[UT_Logs.txt](https://github.com/user-attachments/files/19688979/UT_Logs.txt)
