### PR TITLE
change VNI to TUNNEL_VNI

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -348,7 +348,7 @@
                 "PRIORITY": "960",
                 "INNER_SRC_MAC_REWRITE_ACTION": "22:33:44:55:66:11",                     
                 "INNER_SRC_IP": "1.1.1.1/32",
-                "VNI": "45"
+                "TUNNEL_VNI": "45"
             }
         },
         "SWITCH_HASH": {
@@ -2645,7 +2645,7 @@
                 ],
                 "MATCHES": [
                     "INNER_SRC_IP",
-                    "VNI"
+                    "TUNNEL_VNI"
                 ],
                 "BIND_POINTS": [
                     "PORT",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -193,11 +193,11 @@
         "desc": "Configure INNERSRCMACREWRITE ACL TABLE with invalid MAC address format",
         "eStrKey": "Pattern"
     },
-    "ACL_INNERSRCMACREWRITE_INVALID_VNI": {
+    "ACL_INNERSRCMACREWRITE_INVALID_TUNNEL_VNI": {
         "desc": "Configure INNERSRCMACREWRITE ACL with invalid VNI ID",
         "eStrKey": "Pattern"
     },
-    "ACL_RULE_WITH_VNI":{
+    "ACL_RULE_WITH_TUNNEL_VNI":{
         "desc": "Configure a ACL rule with VNI ID"
     },
     "ACL_INNERSRCMACREWRITE_NO_INNERSRCIP": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -197,7 +197,11 @@
     "DEVICE_METADATA_VALID_SLICE_TYPE": {
         "desc": "Verifying valid slice_type configuration."
     },
-    "DEVICE_METADATA_VALID_NEXTHOP_GROUP": {
-        "desc": "Verifying nexthop_group configuration."
-     }
+    "DEVICE_METADATA_VALID_T2_GROUP_ASNS": {
+        "desc": "Verifying valid t2_group_asns."
+     },
+     "DEVICE_METADATA_VALID_T2_GROUP_ASNS_INVALID": {
+         "desc": "Verifying invalid t2_group_asns.",
+         "eStrKey": "InvalidValue"
+      }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -1756,18 +1756,18 @@
                     {
                         "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE",
                         "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
-                        "PRIORITY": 999960,
+                        "PRIORITY": "999960",
                         "RULE_NAME": "Rule_10",
                         "INNER_SRC_IP": "10.176.0.0/15",
-                        "VNI": 45
+                        "TUNNEL_VNI": "45"
                     },
                     {
                         "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE",
-                        "PRIORITY": 999960,
+                        "PRIORITY": "999960",
                         "RULE_NAME": "Rule_9",
                         "INNER_SRC_IP": "10.166.0.0/15",
                         "INNER_SRC_MAC_REWRITE_ACTION": "60:46:BD:08:19:68",
-                        "VNI": 47
+                        "TUNNEL_VNI": "47"
                     }
                 ]
             },
@@ -1794,7 +1794,7 @@
                         ],
                         "MATCHES": [
                             "INNER_SRC_IP",
-                            "VNI"
+                            "TUNNEL_VNI"
                         ],
                         "BIND_POINTS": [
                             "PORT",
@@ -1836,10 +1836,10 @@
                     {
                         "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-INVALID-REWRITE-ACTION",
                         "INNER_SRC_MAC_REWRITE_ACTION": "",
-                        "PRIORITY": 999963,
+                        "PRIORITY": "999963",
                         "RULE_NAME": "Rule_13",
                         "INNER_SRC_IP": "10.176.0.0/15",
-                        "VNI": "45"
+                        "TUNNEL_VNI": "45"
                     }
                 ]
             },
@@ -1866,7 +1866,7 @@
                         ],
                         "MATCHES": [
                             "INNER_SRC_IP",
-                            "VNI"
+                            "TUNNEL_VNI"
                         ],
                         "BIND_POINTS": [
                             "PORT",
@@ -1908,10 +1908,10 @@
                     {
                         "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-INVALID-MAC",
                         "INNER_SRC_MAC_REWRITE_ACTION": "60.45.BD.08:19:68",
-                        "PRIORITY": 999964,
+                        "PRIORITY": "999964",
                         "RULE_NAME": "Rule_14",
                         "INNER_SRC_IP": "10.176.0.0/15",
-                        "VNI": 45
+                        "TUNNEL_VNI": "45"
                     }
                 ]
             },
@@ -1938,7 +1938,7 @@
                         ],
                         "MATCHES": [
                             "INNER_SRC_IP",
-                            "VNI"
+                            "TUNNEL_VNI"
                         ],
                         "BIND_POINTS": [
                             "PORT",
@@ -1973,24 +1973,24 @@
             }
         }
     },
-    "ACL_INNERSRCMACREWRITE_INVALID_VNI": {
+    "ACL_INNERSRCMACREWRITE_INVALID_TUNNEL_VNI": {
         "sonic-acl:sonic-acl": {
             "sonic-acl:ACL_RULE": {
                 "ACL_RULE_LIST": [
                     {
-                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-INVALID-VNI",
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-INVALID-TUNNEL_VNI",
                         "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
-                        "PRIORITY": 999960,
+                        "PRIORITY": "999960",
                         "RULE_NAME": "Rule_15",
                         "INNER_SRC_IP": "10.176.0.0/15",
-                        "VNI": 16777216
+                        "TUNNEL_VNI": "16777216"
                     }
                 ]
             },
             "sonic-acl:ACL_TABLE": {
                 "ACL_TABLE_LIST": [
                     {
-                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-INVALID-VNI",
+                        "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-INVALID-TUNNEL_VNI",
                         "policy_desc":"Replace src MAC with ENI MAC",
                         "ports": [
                             "Ethernet0",
@@ -2010,7 +2010,7 @@
                         ],
                         "MATCHES": [
                             "INNER_SRC_IP",
-                            "VNI"
+                            "TUNNEL_VNI"
                         ],
                         "BIND_POINTS": [
                             "PORT",
@@ -2045,7 +2045,7 @@
             }
         }
     },
-    "ACL_RULE_WITH_VNI": {
+    "ACL_RULE_WITH_TUNNEL_VNI": {
         "sonic-acl:sonic-acl": {
             "sonic-acl:ACL_RULE": {
                 "ACL_RULE_LIST": [
@@ -2055,8 +2055,8 @@
                         "IP_TYPE": "IPv4ANY",
                         "RULE_NAME": "Rule_20",
                         "INNER_SRC_IP": "10.176.0.0/15",
-                        "PRIORITY": 1222,
-                        "VNI": 16777213,
+                        "PRIORITY": "1222",
+                        "TUNNEL_VNI": "16777213",
                         "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68"
                     }
                 ]
@@ -2107,9 +2107,9 @@
                     {
                         "ACL_TABLE_NAME": "SRC-MAC-REWRITE-TABLE-NO-SRCIP",
                         "INNER_SRC_MAC_REWRITE_ACTION": "60:45:BD:08:19:68",
-                        "PRIORITY": 999960,
+                        "PRIORITY": "999960",
                         "RULE_NAME": "Rule_16",
-                        "VNI": 16777213
+                        "TUNNEL_VNI": "16777213"
                     }
                 ]
             },
@@ -2136,7 +2136,7 @@
                         ],
                         "MATCHES": [
                             "INNER_SRC_IP",
-                            "VNI"
+                            "TUNNEL_VNI"
                         ],
                         "BIND_POINTS": [
                             "PORT",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -563,5 +563,23 @@
                 }
             }
         }
+    },
+    "DEVICE_METADATA_VALID_T2_GROUP_ASNS": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "t2_group_asns": ["65000", "65001", "65002"]
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_VALID_T2_GROUP_ASNS_INVALID": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "t2_group_asns": ["str"]
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -290,6 +290,11 @@ module sonic-device_metadata {
                     default "false";
                 }
 
+                leaf-list t2_group_asns {
+                    type inet:as-number;
+                    description "ASNs inner same group";
+                }
+
             }
             /* end of container localhost */
         }

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -269,7 +269,7 @@ module sonic-acl {
 					}
 				}
 
-				leaf VNI {
+				leaf TUNNEL_VNI {
 					description "VXLAN Network Identifier";
 					type stypes:vnid_type;
 				}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
change the match type VNI to TUNNEL_VNI in ACL yang model

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
changed VNI to TUNNEL_VNI in acl-yang

#### How to verify it
changes in UTs

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

