### PR TITLE
[Smartswitch][Mellanox] Bug fix for module midplane ip address

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -265,8 +265,6 @@ class DpuModule(ModuleBase):
         self.fault_state = False
         self.dpu_vpd_parser = DpuVpdParser('/var/run/hw-management/eeprom/vpd_data', self.dpuctl_obj._name.upper())
         self.CONFIG_DB_NAME = "CONFIG_DB"
-        self.DHCP_SERVER_HASH = f"DHCP_SERVER_IPV4_PORT|bridge-midplane|{self._name.lower()}"
-        self.DHCP_IP_ADDRESS_KEY = "ips@"
         self.midplane_interface = None
         self.bus_info = None
         self.reboot_base_path = f"/var/run/hw-management/{self.dpuctl_obj._name}/system/"

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -269,7 +269,6 @@ class DpuModule(ModuleBase):
         self.DHCP_IP_ADDRESS_KEY = "ips@"
         self.config_db = ConfigDBConnector(use_unix_socket_path=False)
         self.config_db.connect()
-        self.midplane_ip = None
         self.midplane_interface = None
         self.bus_info = None
         self.reboot_base_path = f"/var/run/hw-management/{self.dpuctl_obj._name}/system/"
@@ -452,9 +451,7 @@ class DpuModule(ModuleBase):
         Returns:
             A string, the IP-address of the module reachable over the midplane
         """
-        if not self.midplane_ip:
-            self.midplane_ip = self.config_db.get(self.CONFIG_DB_NAME, self.DHCP_SERVER_HASH, self.DHCP_IP_ADDRESS_KEY)
-        return self.midplane_ip
+        return f"169.254.200.{int(self.dpu_id) + 1}"
 
     def is_midplane_reachable(self):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -267,8 +267,6 @@ class DpuModule(ModuleBase):
         self.CONFIG_DB_NAME = "CONFIG_DB"
         self.DHCP_SERVER_HASH = f"DHCP_SERVER_IPV4_PORT|bridge-midplane|{self._name.lower()}"
         self.DHCP_IP_ADDRESS_KEY = "ips@"
-        self.config_db = ConfigDBConnector(use_unix_socket_path=False)
-        self.config_db.connect()
         self.midplane_interface = None
         self.bus_info = None
         self.reboot_base_path = f"/var/run/hw-management/{self.dpuctl_obj._name}/system/"

--- a/platform/mellanox/mlnx-platform-api/tests/test_module.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_module.py
@@ -265,41 +265,14 @@ class TestModule:
             mock_method.assert_called_once_with("Failed to set the admin state for DPU3")
         m.dpuctl_obj.dpu_power_off = mock.MagicMock(return_value=True)
         assert m.set_admin_state(False)
-        midplane_ips = {
-            "dpu0": "169.254.200.1",
-            "dpu1": "169.254.200.2",
-            "dpu2": "169.254.200.3",
-            "dpu3": "169.254.200.4"
-        }
-        def get_midplane_ip(DB_NAME, _hash, key):
-            dpu_name = _hash.split("|")[-1]
-            return midplane_ips.get(dpu_name)
-        mock_get.side_effect = get_midplane_ip
-        assert m.get_midplane_ip() == "169.254.200.4"
-        assert m.midplane_ip == "169.254.200.4"
-        mock_get.assert_called_with('CONFIG_DB', 'DHCP_SERVER_IPV4_PORT|bridge-midplane|dpu3', 'ips@')
         m1 = DpuModule(2)
-        assert m1.get_midplane_ip() == "169.254.200.3"
-        assert m1.midplane_ip == "169.254.200.3"
-        mock_get.assert_called_with('CONFIG_DB', 'DHCP_SERVER_IPV4_PORT|bridge-midplane|dpu2', 'ips@')
-        mock_get.reset_mock()
-        mock_get.return_value = None
-        mock_get.side_effect = None
-        # We check for the IP only once in CONFIG_DB after initialization
         assert m.get_midplane_ip() == "169.254.200.4"
-        mock_get.assert_not_called()
-        m.midplane_ip = None
-        m1.midplane_ip = None
-        assert not m.get_midplane_ip()
-        assert not m1.get_midplane_ip()
-        mock_get.side_effect = get_midplane_ip
+        assert m1.get_midplane_ip() == "169.254.200.3"
         with patch.object(m, '_is_midplane_up', ) as mock_midplane_m, \
              patch.object(m1, '_is_midplane_up',) as mock_midplane_m1:
             mock_midplane_m.return_value = True
             mock_midplane_m1.return_value = True
-            m.midplane_ip = None
-            midplane_ips["dpu3"] = "169.254.200.244"
-            command = ['ping', '-c', '1', '-W', '1', "169.254.200.244"]
+            command = ['ping', '-c', '1', '-W', '1', "169.254.200.4"]
             mock_call.return_value = 0
             assert m.is_midplane_reachable()
             mock_call.assert_called_with(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The midplane interface IP address is currently part of the CONFIG_DB, but since the IP address for the DPUs will not change it is expected to be removed from the CONFIG_DB. The IP address for the DPUs will still be obtained from the dhcp servers, but it will be consistent . since the IP Prefix will not be present in CONFIG_DB, we are obtaining the IP address directly from the known prefix and the DPU ID
This also prevent the following log error if the config_db does not contain the IP address:
`Failed to check midplane reachability for DPU0! expected str, bytes or os.PathLike object, not NoneType`


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Changed `get_midplane_ip` to obtain IP address from known prefix + DPU ID instead of CONFIG_DB

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

