### PR TITLE
Move `dsserve` and `bcmcmd` back to `/usr/bin/`

### DIFF
--- a/platform/broadcom/sswsyncd/Makefile
+++ b/platform/broadcom/sswsyncd/Makefile
@@ -28,9 +28,9 @@ $(BCMCMD): bcmcmd.cpp dsserve.h
 	$(CC) -o $@ $< $(CFLAGS) $(CFLAGS_COMMON) $(CPPFLAGS) $(LDFLAGS) $(LIBS)
 
 install:
-	install -d $(DESTDIR)/usr/sbin
-	install -D $(DSSERVE) $(DESTDIR)/usr/sbin/$(DSSERVE)
-	install -D $(BCMCMD) $(DESTDIR)/usr/sbin/$(BCMCMD)
+	install -d $(DESTDIR)/usr/bin
+	install -D $(DSSERVE) $(DESTDIR)/usr/bin/$(DSSERVE)
+	install -D $(BCMCMD) $(DESTDIR)/usr/bin/$(BCMCMD)
 
 clean:
 	rm -f $(DSSERVE) $(BCMCMD)


### PR DESCRIPTION
https://github.com/sonic-net/sonic-buildimage/pull/22153 moved dsserve and bcmcmd to /usr/sbin/ but there are a number of scripts that expect them to be at /usr/bin/.

More details issue: https://github.com/sonic-net/sonic-buildimage/issues/22287
