### PR TITLE
Add ./cvlyang-models/sonic-vnet.yang to data_files

### DIFF
--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -272,6 +272,7 @@ setup(
                          './cvlyang-models/sonic-gnmi.yang',
                          './cvlyang-models/sonic-types.yang',
                          './cvlyang-models/sonic-versions.yang',
+                         './cvlyang-models/sonic-vnet.yang',
                          './cvlyang-models/sonic-vlan.yang',
                          './cvlyang-models/sonic-vrf.yang',
                          './cvlyang-models/sonic-warm-restart.yang',


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The pipeline for `sonic-gnmi` failed. An example failure is shown as below:
https://dev.azure.com/mssonic/build/_build/results?buildId=816337&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=335d3395-6d29-5762-4daa-c188603f3eb8
```
sonic-interface.yang sonic-port.yang sonic-portchannel.yang sonic-sflow.yang
error: sonic-interface:29: module "sonic-vnet" not found in search path
make[2]: *** [Makefile:187: ../../build/yang/.sync_sonic_yangs] Error 1
make[1]: *** [Makefile:70: models] Error 2
make[2]: Leaving directory '/__w/1/s/sonic-mgmt-common/models/yang'
make[1]: Leaving directory '/__w/1/s/sonic-mgmt-common'
dh_auto_build: error: make -j2 returned exit code 2
make: *** [debian/rules:3: build] Error 25
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
```

Discussion about the failures of the pipeline and possible solutions suggested by Sachin Holla [sachin.holla@broadcom.com](mailto:sachin.holla@broadcom.com) @sachinholla 

> Root cause -- sonic-yang-models's [setup.py](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fsonic-net%2Fsonic-buildimage%2Fblob%2Fmaster%2Fsrc%2Fsonic-yang-models%2Fsetup.py%23L85&data=05%7C02%7Cmiatao%40microsoft.com%7C164e7989dd7f49a78a4c08dd77f9b7f0%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638798636640887649%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=xX25NW8mfPZQSoDKnidT98wWgfDD9H63RQhpDmhJP3Q%3D&reserved=0) does not package all yangs of "./cvlyang-models" directory into the wheel. This is because it maintains two separate source file lists (one for ./yang-models directory and another for ./cvlyang-models directory) and developers tend to miss adding to the latter list. Current issue was present from the day sonic-vnet.yang was introduced; but so far it was not referred to by any of the yangs consumed by sonic-mgmt-common. [PR #21956](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fsonic-net%2Fsonic-buildimage%2Fpull%2F21956&data=05%7C02%7Cmiatao%40microsoft.com%7C164e7989dd7f49a78a4c08dd77f9b7f0%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638798636640907098%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=vhrCLUq%2FwxhsAb6%2BcTm%2BHrnR3ap19RUSpbTjBSByPNU%3D&reserved=0) exposed it now.

> Not sure who maintains the sonic-yang-models setup.py infra now. IMO best is to automatically package all sonic yang files from ./yang-models & ./cvlyang-models directories into the sonic-yang-models.wheel (without asking developers to list each file in setup.py). Alternatively, you can also try explicitly adding ./cvlyang-models/sonic-vnet.yang to the data_files list.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
I added `./cvlyang-models/sonic-vnet.yang` to the `data_files` list as suggested.

[Updated 04/10] As suggested by Sachin, sonic-mgmt-common can detect the dependent yangs automatically as long as the sonic-vnet.yang is packaged under cvlyang-models directory.
[Resolved] Question: But I am not sure whether it is also necessary to update the `sonic-interface.yang` in submodules as this pr did:  #21729.


#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

