### PR TITLE
update memory monit threshold for bmp container according to test.

### DIFF
--- a/dockers/docker-sonic-bmp/base_image_files/monit_bmp
+++ b/dockers/docker-sonic-bmp/base_image_files/monit_bmp
@@ -1,5 +1,5 @@
 ###############################################################################
 ## Monit configuration for bmp container
 ###############################################################################
-check program container_memory_bmp with path "/usr/bin/memory_checker bmp 419430400"
+check program container_memory_bmp with path "/usr/bin/memory_checker bmp 838860800"
     if status == 3 for 10 times within 20 cycles then exec "/usr/bin/docker exec bmp supervisorctl restart openbmpd"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
BMP feature is enabled by-default currently, but there's config cli to enable dataset dump into redis-bmp dynamically. Previously we added test https://github.com/sonic-net/sonic-mgmt/pull/16854, added memory checker and thought that's the extremely case which will hit peak usage for both bgp and bmp memory. By recent Nightly, there're other cases like nhop and test_pfc_counters which reports that bmp exceeds the pre-defined monit threshold 400MB from time to time, and usually unable to be reproduced stably. 
Thus we need to update the monit memory threshold for bmp container based on the recent Nightly test result, meanwhile will turn on bmp for cover all existing test cases so that we can measure whether the threshold value makes sense.

##### Work item tracking
- Microsoft ADO **(number only)**:32246488

#### How I did it
Updated the memory monit threshold based on kusto queries, and turn on bmp as pre-condition step https://github.com/sonic-net/sonic-mgmt/pull/17963

#### How to verify it
need observe some days via Nightly on master.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

