### PR TITLE
[sonic-mgmt-docker-image] Add packet mask counters in ptf dataplane

### DIFF
--- a/dockers/docker-sonic-mgmt/0003-add-dataplane-mask-counters-to-avoid-dataplane-noise.patch
+++ b/dockers/docker-sonic-mgmt/0003-add-dataplane-mask-counters-to-avoid-dataplane-noise.patch
@@ -1,0 +1,57 @@
+From a1e0c25218b5bac0adeebcbd95b29618b4cadf3d Mon Sep 17 00:00:00 2001
+From: wenda <wendachu@microsoft.com>
+Date: Fri, 11 Apr 2025 09:57:23 +0000
+Subject: [PATCH] 0003-add-dataplane-mask-counters-to-avoid-dataplane-noise
+
+---
+ src/ptf/dataplane.py | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/src/ptf/dataplane.py b/src/ptf/dataplane.py
+index a5d4664..0aee7ab 100644
+--- a/src/ptf/dataplane.py
++++ b/src/ptf/dataplane.py
+@@ -574,6 +574,12 @@ class DataPlane(Thread):
+         # counters of transmited packets
+         self.tx_counters = defaultdict(int)
+ 
++        # rx/tx counters of packets that matching the packet mask
++        # the key of dict is mask
++        # the value is a dict of device number, port number to count
++        self.mask_rx_cnt = {}
++        self.mask_tx_cnt = {}
++
+         # cvar serves double duty as a regular top level lock and
+         # as a condition variable
+         self.cvar = Condition()
+@@ -665,6 +671,9 @@ class DataPlane(Thread):
+                             self.logger.debug("Discarding oldest packet to make room")
+                         queue.append((pkt, timestamp))
+                         self.rx_counters[(device_number, port_number)] += 1
++                        for mask, cnt in self.mask_rx_cnt.items():
++                            if match_exp_pkt(mask, pkt):
++                                cnt[(device_number, port_number)] += 1
+                 self.cvar.notify_all()
+ 
+         self.logger.info("Thread exit")
+@@ -731,6 +740,9 @@ class DataPlane(Thread):
+             self.pcap_writer.write(packet, time.time(), device_number, port_number)
+         bytes = self.ports[(device_number, port_number)].send(packet)
+         self.tx_counters[(device_number, port_number)] += 1
++        for mask, cnt in self.mask_tx_cnt.items():
++            if match_exp_pkt(mask, packet):
++                cnt[(device_number, port_number)] += 1
+         if bytes != len(packet):
+             self.logger.error(
+                 "Unhandled send error, length mismatch %d != %d" % (bytes, len(packet))
+@@ -1038,3 +1050,8 @@ class DataPlane(Thread):
+                 self.pcap_writer.close()
+                 self.pcap_writer = None
+                 self.cvar.notify_all()
++
++    def create_mask_counters(self, mask):
++        """Create a new mask counters"""
++        self.mask_rx_cnt[mask] = defaultdict(int)
++        self.mask_tx_cnt[mask] = defaultdict(int)
+-- 
+2.49.0

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -279,12 +279,14 @@ WORKDIR /azp
 COPY start.sh \
      0001-Fix-getattr-AttributeError-in-multi-thread-scenario.patch \
      0002-extend-dataplane-poll-method-to-support-multi-ptf-nn.patch \
+     0003-add-dataplane-mask-counters-to-avoid-dataplane-noise.patch \
      ./
 RUN chmod +x start.sh \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && ln -sf `which pip3` /usr/bin/pip \
     && ln -sf `which pip3` /usr/local/sbin/pip \
     && patch -u -b /usr/local/lib/python3.8/dist-packages/ptf/dataplane.py  -i /azp/0002-extend-dataplane-poll-method-to-support-multi-ptf-nn.patch \
+    && patch -u -b /usr/local/lib/python3.8/dist-packages/ptf/dataplane.py  -i /azp/0003-extend-dataplane-poll-method-to-support-multi-ptf-nn.patch \
     && patch -u -b /usr/local/lib/python3.8/dist-packages/ansible/plugins/loader.py -i /azp/0001-Fix-getattr-AttributeError-in-multi-thread-scenario.patch
 
 USER $user


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
We need to count packets we care about on ptf dataplane.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add a specific counter in ptf datplane, user can create counter with packet mask, so ptf dataplane can count packets that matching specific mask.

#### How to verify it
Tested on testbed
Sent 5 packets for each 100 ports and read counters.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

