### PR TITLE
SSH hardening configuration options

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2797,6 +2797,11 @@ In this table, we allow configuring ssh server global settings. This will featur
 -   ports - Ssh port numbers - string of port numbers seperated by ','
 -   inactivity_timeout - Inactivity timeout for SSH session, allowed values: 0-35000 (min), default value: 15 (min)
 -   max_sessions - Max number of concurrent logins, allowed values: 0-100 (where 0 means no limit), default value: 0
+-   permit_root_login - Whether or not to allow root login.  Boolean.
+-   password_authentication - Whether or not to allow password authentication. Boolean.
+-   ciphers - Ciphers to allow.  See `ssh -Q ciphers`
+-   kex_algorithms - Key Exchange algorithms to allow.  See `ssh -Q kex_algorithms`
+-   macs - MAC algorithms to allow.  See `ssh -Q macs`
 ```
 {
     "SSH_SERVER": {
@@ -2805,7 +2810,12 @@ In this table, we allow configuring ssh server global settings. This will featur
             "login_timeout": "120",
             "ports": "22",
             "inactivity_timeout": "15",
-            "max_sessions": "0"
+            "max_sessions": "0",
+            "permit_root_login": "false",
+            "password_authentication": "true",
+            "ciphers": [ "chacha20-poly1305@openssh.com", "aes256-gcm@openssh.com" ],
+            "kex_algorithms": [ "sntrup761x25519-sha512", "curve25519-sha256", "ecdh-sha2-nistp521" ],
+            "macs": [ "hmac-sha2-512-etm@openssh.com", "hmac-sha2-512" ]
         }
     }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2564,7 +2564,12 @@
                 "login_timeout": "120",
                 "ports": "22",
                 "inactivity_timeout": "15",
-                "max_sessions": "0"
+                "max_sessions": "0",
+                "permit_root_login": "false",
+                "password_authentication": "true",
+                "ciphers": [ "chacha20-poly1305@openssh.com", "aes256-gcm@openssh.com" ],
+                "kex_algorithms": [ "sntrup761x25519-sha512", "curve25519-sha256", "ecdh-sha2-nistp521" ],
+                "macs": [ "hmac-sha2-512-etm@openssh.com", "hmac-sha2-512" ]
             }
         },
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/ssh-server.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/ssh-server.json
@@ -30,5 +30,25 @@
     "SSH_SERVER_INVALID_MAX_SESSIONS": {
         "desc": "Configure invalid max_sessions value in SSH_SERVER.",
         "eStr": "does not satisfy the constraint \"0..100\""
+    },
+    "SSH_SERVER_INVALID_PERMIT_ROOT_LOGIN": {
+        "desc": "Configure invalid permit_root_login value in SSH_SERVER.",
+        "eStrKey": "InvalidValue"
+    },
+    "SSH_SERVER_INVALID_PASSWORD_AUTHENTICATION": {
+        "desc": "Configure invalid password_authentication value in SSH_SERVER.",
+        "eStrKey": "InvalidValue"
+    },
+    "SSH_SERVER_INVALID_CIPHERS": {
+        "desc": "Configure invalid ciphers value in SSH_SERVER.",
+        "eStrKey": "InvalidValue"
+    },
+    "SSH_SERVER_INVALID_KEX_ALGORITHMS": {
+        "desc": "Configure invalid kex_algorithms value in SSH_SERVER.",
+        "eStrKey": "InvalidValue"
+    },
+    "SSH_SERVER_INVALID_MACS": {
+        "desc": "Configure invalid macs value in SSH_SERVER.",
+        "eStrKey": "InvalidValue"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/ssh-server.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/ssh-server.json
@@ -5,7 +5,14 @@
                 "POLICIES":{
                     "authentication_retries": "6",
                     "login_timeout": "120",
-                    "ports": "22"
+                    "ports": "22",
+                    "inactivity_timeout": "15",
+                    "max_sessions": "0",
+                    "permit_root_login": "false",
+                    "password_authentication": "true",
+                    "ciphers": [ "chacha20-poly1305@openssh.com", "aes256-gcm@openssh.com" ],
+                    "kex_algorithms": [ "sntrup761x25519-sha512", "curve25519-sha256", "ecdh-sha2-nistp521" ],
+                    "macs": [ "hmac-sha2-512-etm@openssh.com", "hmac-sha2-512" ]
                 }
             }
         }
@@ -71,6 +78,51 @@
             "sonic-ssh-server:SSH_SERVER": {
                 "POLICIES":{
                     "max_sessions": 222
+                }
+            }
+        }
+    },
+    "SSH_SERVER_INVALID_PERMIT_ROOT_LOGIN": {
+        "sonic-ssh-server:sonic-ssh-server": {
+            "sonic-ssh-server:SSH_SERVER": {
+                "POLICIES":{
+                    "permit_root_login": "invalid"
+                }
+            }
+        }
+    },
+    "SSH_SERVER_INVALID_PASSWORD_AUTHENTICATION": {
+        "sonic-ssh-server:sonic-ssh-server": {
+            "sonic-ssh-server:SSH_SERVER": {
+                "POLICIES":{
+                    "password_authentication": "invalid"
+                }
+            }
+        }
+    },
+    "SSH_SERVER_INVALID_CIPHERS": {
+        "sonic-ssh-server:sonic-ssh-server": {
+            "sonic-ssh-server:SSH_SERVER": {
+                "POLICIES":{
+                    "ciphers": [ "chacha20-poly1305@openssh.com", "invalid" ]
+                }
+            }
+        }
+    },
+    "SSH_SERVER_INVALID_KEX_ALGORITHMS": {
+        "sonic-ssh-server:sonic-ssh-server": {
+            "sonic-ssh-server:SSH_SERVER": {
+                "POLICIES":{
+                    "kex_algorithms": [ "sntrup761x25519-sha512", "invalid" ]
+                }
+            }
+        }
+    },
+    "SSH_SERVER_INVALID_MACS": {
+        "sonic-ssh-server:sonic-ssh-server": {
+            "sonic-ssh-server:SSH_SERVER": {
+                "POLICIES":{
+                    "macs": [ "hmac-sha2-512-etm@openssh.com", "invalid" ]
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-ssh-server.yang
+++ b/src/sonic-yang-models/yang-models/sonic-ssh-server.yang
@@ -59,6 +59,70 @@ module sonic-ssh-server {
                         range 0..100;
                     }
                 }
+                leaf permit_root_login {
+                    description "Specifies whether root can log in using ssh.";
+                    type boolean;
+                }
+                leaf password_authentication {
+                    description "Specifies whether password authentication is enabled.";
+                    type boolean;
+                    default true;
+                }
+                leaf-list ciphers {
+                    description "Specifies the ciphers allowed.";
+                    type enumeration {
+                        enum "3des-cbc";
+                        enum "aes128-cbc";
+                        enum "aes192-cbc";
+                        enum "aes256-cbc";
+                        enum "aes128-ctr";
+                        enum "aes192-ctr";
+                        enum "aes256-ctr";
+                        enum "aes128-gcm@openssh.com";
+                        enum "aes256-gcm@openssh.com";
+                        enum "chacha20-poly1305@openssh.com";
+                    }
+                }
+                leaf-list kex_algorithms {
+                    description "Specifies the available Key Exchange algorithms.";
+                    type enumeration {
+                        enum "diffie-hellman-group1-sha1";
+                        enum "diffie-hellman-group14-sha1";
+                        enum "diffie-hellman-group14-sha256";
+                        enum "diffie-hellman-group16-sha512";
+                        enum "diffie-hellman-group18-sha512";
+                        enum "diffie-hellman-group-exchange-sha1";
+                        enum "diffie-hellman-group-exchange-sha256";
+                        enum "ecdh-sha2-nistp256";
+                        enum "ecdh-sha2-nistp384";
+                        enum "ecdh-sha2-nistp521";
+                        enum "curve25519-sha256";
+                        enum "curve25519-sha256@libssh.org";
+                        enum "sntrup761x25519-sha512";
+                        enum "sntrup761x25519-sha512@openssh.com";
+                    }
+                }
+                leaf-list macs {
+                    description "Specifies the available MAC (message authentication code) algorithms.";
+                    type enumeration {
+                        enum "hmac-sha1";
+                        enum "hmac-sha1-96";
+                        enum "hmac-sha2-256";
+                        enum "hmac-sha2-512";
+                        enum "hmac-md5";
+                        enum "hmac-md5-96";
+                        enum "umac-64@openssh.com";
+                        enum "umac-128@openssh.com";
+                        enum "hmac-sha1-etm@openssh.com";
+                        enum "hmac-sha1-96-etm@openssh.com";
+                        enum "hmac-sha2-256-etm@openssh.com";
+                        enum "hmac-sha2-512-etm@openssh.com";
+                        enum "hmac-md5-etm@openssh.com";
+                        enum "hmac-md5-96-etm@openssh.com";
+                        enum "umac-64-etm@openssh.com";
+                        enum "umac-128-etm@openssh.com";
+                    }
+                }
             }/*container policies */
         } /* container SSH_SERVER  */
     }/* container sonic-ssh-server */


### PR DESCRIPTION
#### Why I did it
The SSH configuration does not contain many of the hardening requirements by the various standards bodies.

This PR depends on https://github.com/sonic-net/sonic-host-services/pull/XXX

#### How I did it

 This adds support for:
 * password_authentication - ability to disable password auth
 * permit_root_login - ability to prevent root logins
 * ciphers - ability to specify available ciphers
 * kex_algorithms - ability to specify key exchange algorithms
 * macs - ability to specify macs
 
#### How to verify it

sonic-yang-models runs tests during build, as does sonic-host-services which validates the behavior.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202411

#### Tested branch (Please provide the tested image version)

master as of 20250410

#### Description for the changelog

SSH hardening configuration options

#### Link to config_db schema for YANG module changes
https://github.com/bhouse-nexthop/sonic-buildimage/blob/bhouse-nexthop/ssh-config/src/sonic-yang-models/doc/Configuration.md#ssh_server

#### A picture of a cute animal (not mandatory but encouraged)

