### PR TITLE
DNS configuration option enhancements

### DIFF
--- a/files/image_config/resolv-config/resolv.conf.j2
+++ b/files/image_config/resolv-config/resolv.conf.j2
@@ -1,3 +1,23 @@
 {% for ip in DNS_NAMESERVER|sort %}
 nameserver {{ ip }}
 {% endfor -%}
+
+{%- if DNS_OPTIONS is defined %}
+{%   set search = DNS_OPTIONS.get('search') %}
+{%   if search is not none %}
+search {{ search.split(",") | join(" ") }}
+{%   endif %}
+{%   set options="" %}
+{%   if DNS_OPTIONS["ndots"] is defined %}
+{%     set options = options ~ ' ndots:' ~ DNS_OPTIONS["ndots"] %}
+{%   endif %}
+{%   if DNS_OPTIONS["timeout"] is defined %}
+{%     set options = options ~ ' timeout:' ~ DNS_OPTIONS["timeout"] %}
+{%   endif %}
+{%   if DNS_OPTIONS["attempts"] is defined %}
+{%     set options = options ~ ' attempts:' ~ DNS_OPTIONS["attempts"] %}
+{%   endif %}
+{%   if options|length > 0 %}
+options{{ options }}
+{%   endif %}
+{% endif -%}

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2973,7 +2973,19 @@ The DNS_NAMESERVER table introduces static DNS nameservers configuration.
 	"DNS_NAMESERVER": {
 		"1.1.1.1": {},
 		"fe80:1000:2000:3000::1": {}
-	},
+	}
+}
+```
+
+DNS configuration options can also be set when nameservers are defined:
+```json
+{
+    "DNS_OPTIONS": {
+        "search": [ "d1.example.com", "d2.example.com", "d3.example.com" ],
+        "ndots": 0,
+        "timeout": 1,
+        "attempts": 2
+    }
 }
 ```
 

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -21,6 +21,12 @@
             "1.1.1.1": {},
             "fe80:1000:2000:3000::1": {}
         },
+        "DNS_OPTIONS": {
+            "search": [ "d1.example.com", "d2.example.com", "d3.example.com" ],
+            "ndots": "0",
+            "timeout": "1",
+            "attempts": "2"
+        },
         "BUFFER_POOL": {
             "ingress_lossy_pool": {
                "mode": "static",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/dns.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/dns.json
@@ -9,5 +9,25 @@
     "DNS_NAMESERVER_TEST_MAX_IP_NUMBER" : {
         "desc": "DNS nameserver configuration exceeds the maximum IPs in DNS_NAMESERVER table.",
         "eStr": "Too many elements."
+    },
+    "DNS_OPTIONS_NO_NAMESERVER" : {
+        "desc": "DNS options specified without nameserver.",
+        "eStrKey": "When"
+    },
+    "DNS_OPTIONS_INVALID_SEARCH" : {
+        "desc": "DNS nameserver search invalid.",
+        "eStrKey": "InvalidValue"
+    },
+    "DNS_OPTIONS_INVALID_NDOTS" : {
+        "desc": "DNS ndots invalid.",
+        "eStrKey": "Range"
+    },
+    "DNS_OPTIONS_INVALID_TIMEOUT" : {
+        "desc": "DNS timeout invalid.",
+        "eStrKey": "Range"
+    },
+    "DNS_OPTIONS_INVALID_ATTEMPTS" : {
+        "desc": "DNS attempts invalid.",
+        "eStrKey": "Range"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/dns.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/dns.json
@@ -10,6 +10,12 @@
                         "ip": "fe80:1000:2000:3000::1"
                     }
                 ]
+            },
+            "sonic-dns:DNS_OPTIONS": {
+                "search": [ "d1.example.com", "d2.example.com", "d3.example.com" ],
+                "ndots": 0,
+                "timeout": 1,
+                "attempts": 1
             }
         }
     },
@@ -41,6 +47,72 @@
                         "ip": "fe80:1000:2000:3000::4"
                     }
                 ]
+            }
+        }
+    },
+    "DNS_OPTIONS_NO_NAMESERVER": {
+        "sonic-dns:sonic-dns": {
+            "sonic-dns:DNS_OPTIONS": {
+                "search": [ "d1.example.com", "d2.example.com", "d3.example.com" ],
+                "ndots": 0,
+                "timeout": 1,
+                "attempts": 1
+            }
+        }
+    },
+    "DNS_OPTIONS_INVALID_SEARCH": {
+        "sonic-dns:sonic-dns": {
+            "sonic-dns:DNS_NAMESERVER": {
+                "DNS_NAMESERVER_LIST": [
+                    {
+                        "ip": "192.168.1.1"
+                    }
+                ]
+            },
+            "sonic-dns:DNS_OPTIONS": {
+                "search": [ "d1*.example.com" ]
+            }
+        }
+    },
+    "DNS_OPTIONS_INVALID_NDOTS": {
+        "sonic-dns:sonic-dns": {
+            "sonic-dns:DNS_NAMESERVER": {
+                "DNS_NAMESERVER_LIST": [
+                    {
+                        "ip": "192.168.1.1"
+                    }
+                ]
+            },
+            "sonic-dns:DNS_OPTIONS": {
+                "ndots": 100
+            }
+        }
+    },
+    "DNS_OPTIONS_INVALID_TIMEOUT": {
+        "sonic-dns:sonic-dns": {
+            "sonic-dns:DNS_NAMESERVER": {
+                "DNS_NAMESERVER_LIST": [
+                    {
+                        "ip": "192.168.1.1"
+                    }
+                ]
+            },
+            "sonic-dns:DNS_OPTIONS": {
+                "timeout": 0
+            }
+        }
+    },
+    "DNS_OPTIONS_INVALID_ATTEMPTS": {
+        "sonic-dns:sonic-dns": {
+            "sonic-dns:DNS_NAMESERVER": {
+                "DNS_NAMESERVER_LIST": [
+                    {
+                        "ip": "192.168.1.1"
+                    }
+                ]
+            },
+            "sonic-dns:DNS_OPTIONS": {
+                "attempts": 10
             }
         }
     }

--- a/src/sonic-yang-models/yang-models/sonic-dns.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dns.yang
@@ -40,6 +40,41 @@ module sonic-dns {
 
         } /* end of container DNS_NAMESERVER */
 
+        container DNS_OPTIONS {
+            description "DNS_OPTIONS requires at least one DNS_NAMESERVER to be set.";
+
+            leaf-list search {
+                description "Configure the DNS search suffix list";
+                type inet:host;
+            }
+
+            leaf ndots {
+                description "Sets a threshold for the number of dots which must appear in a name given before an initial absolute query will be made";
+                type uint8 {
+                    range "0..15";
+                }
+                default 1;
+            }
+
+            leaf timeout {
+                description "Sets the amount of time in seconds the resolver will wait for a response from a remote name server before retrying the query via a different name server.";
+                type uint8 {
+                    range "1..30";
+                }
+                default 5;
+            }
+
+            leaf attempts {
+                description "Sets the number of times the resolver will send a query to its name servers before giving up and returning an error to the calling application.";
+                type uint8 {
+                    range "1..5";
+                }
+                default 2;
+            }
+
+            when "count(../DNS_NAMESERVER/DNS_NAMESERVER_LIST/ip) > 0";
+        } /* end of container DNS_OPTIONS */
+
     } /* end of container sonic-dns */
 
 } /* end of module sonic-dns */


### PR DESCRIPTION
#### Why I did it

Some needed DNS configuration options are not available such as search suffixes, ndots, query timeout (s), and query attempts.

Also depends on https://github.com/sonic-net/sonic-host-services/pull/239
Fixes #22311

#### How I did it

Added yang models, tests, and documentation.

#### How to verify it

During build it will run through the test suite.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202411

#### Tested branch (Please provide the tested image version)

master as of 20250410

#### Description for the changelog
DNS configuration option enhancements

#### Link to config_db schema for YANG module changes

https://github.com/bhouse-nexthop/sonic-buildimage/blob/bhouse-nexthop/dns-config/src/sonic-yang-models/doc/Configuration.md#static-dns

#### A picture of a cute animal (not mandatory but encouraged)

