### PR TITLE
[Ufispace] Update platform device configruations and drivers

### DIFF
--- a/device/ufispace/x86_64-ufispace_s9300_32d-r0/pddf/pd-plugin.json
+++ b/device/ufispace/x86_64-ufispace_s9300_32d-r0/pddf/pd-plugin.json
@@ -24,10 +24,6 @@
             "i2c":
             {
                 "valmap": { "1":true, "0":false }
-            },
-            "bmc":
-            {
-                "valmap": { "Device Present":true, "Device Absent":false }
             }
         }, 
 		
@@ -36,11 +32,7 @@
             "i2c":
             {
                 "valmap": { "1": true, "0":false }
-            },
-            "bmc":
-            {
-                "valmap": { "State Asserted":true, "State Deasserted":false }
-            }        
+            }
         },
 
         "psu_fan_dir":

--- a/device/ufispace/x86_64-ufispace_s9300_32d-r0/pddf/pddf-device.json
+++ b/device/ufispace/x86_64-ufispace_s9300_32d-r0/pddf/pddf-device.json
@@ -185,7 +185,7 @@
                         "raw": "0",
                         "field_name": "TEMP_CPU_ENV",
                         "field_pos": "18"
-                    }               
+                    }
                 ]
             }
         }
@@ -407,6 +407,14 @@
                 {
                     "chn": "4",
                     "dev": "GPIO2"
+                },
+                {
+                    "chn": "1",
+                    "dev": "PSU1"
+                },
+                {
+                    "chn": "1",
+                    "dev": "PSU2"
                 }
             ]
         }
@@ -1060,34 +1068,20 @@
         "dev_info": {
             "device_type": "PSU",
             "device_name": "PSU1",
-            "device_parent": "SMBUS0"
+            "device_parent": "MUX1"
         },
         "dev_attr": {
             "dev_idx": "1",
             "num_psu_fans": "1"
         },
         "i2c": {
-            "interface": []
+            "interface": [
+                { "itf":"eeprom", "dev":"PSU1-EEPROM" }
+            ]
         },
         "bmc": {
             "ipmitool": {
                 "attr_list": [
-                    {
-                        "attr_name": "psu_present",
-                        "bmc_cmd": "ipmitool sdr -c get PSU0_PRSNT_L | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
-                        "raw": "0",
-                        "field_name": "PSU0_PRSNT_L",
-                        "field_pos": "5",
-                        "separator": ","
-                    },
-                    {
-                        "attr_name": "psu_power_good",
-                        "bmc_cmd": "ipmitool sdr -c get PSU0_PWROK_H | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
-                        "raw": "0",
-                        "field_name": "PSU0_PWROK_H",
-                        "field_pos": "5",
-                        "separator": ","
-                    },
                     {
                         "attr_name": "psu_v_out",
                         "bmc_cmd": "ipmitool sdr -c get PSU0_VOUT | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
@@ -1175,38 +1169,59 @@
             }
         }
     },
+    "PSU1-EEPROM": {
+        "dev_info": {
+            "device_type": "PSU-EEPROM",
+            "device_name": "PSU1-EEPROM",
+            "device_parent": "MUX1",
+            "virt_parent": "PSU1"
+        },
+        "i2c": {
+            "topo_info": {
+                "parent_bus": "0x2",
+                "dev_addr": "0x5a",
+                "dev_type": "psu_eeprom"
+            },
+            "attr_list": [
+                {
+                    "attr_name":"psu_present",
+                    "attr_devaddr":"0x30",
+                    "attr_devtype":"cpld",
+                    "attr_offset":"0x51",
+                    "attr_mask":"0x4",
+                    "attr_cmpval":"0x0",
+                    "attr_len":"1"
+                },
+                {
+                    "attr_name":"psu_power_good",
+                    "attr_devaddr":"0x30",
+                    "attr_devtype":"cpld",
+                    "attr_offset":"0x51",
+                    "attr_mask":"0x1",
+                    "attr_cmpval":"0x1",
+                    "attr_len":"1"
+                }
+            ]
+        }
+    },
     "PSU2": {
         "dev_info": {
             "device_type": "PSU",
             "device_name": "PSU2",
-            "device_parent": "SMBUS0"
+            "device_parent": "MUX1"
         },
         "dev_attr": {
             "dev_idx": "2",
             "num_psu_fans": "1"
         },
         "i2c": {
-            "interface": []
+            "interface": [
+                { "itf":"eeprom", "dev":"PSU2-EEPROM" }
+            ]
         },
         "bmc": {
             "ipmitool": {
                 "attr_list": [
-                    {
-                        "attr_name": "psu_present",
-                        "bmc_cmd": "ipmitool sdr -c get PSU1_PRSNT_L | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
-                        "raw": "0",
-                        "field_name": "PSU1_PRSNT_L",
-                        "field_pos": "5",
-                        "separator": ","
-                    },
-                    {
-                        "attr_name": "psu_power_good",
-                        "bmc_cmd": "ipmitool sdr -c get PSU1_PWROK_H | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
-                        "raw": "0",
-                        "field_name": "PSU1_PWROK_H",
-                        "field_pos": "5",
-                        "separator": ","
-                    },
                     {
                         "attr_name": "psu_v_out",
                         "bmc_cmd": "ipmitool sdr -c get PSU1_VOUT | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
@@ -1292,6 +1307,41 @@
                     }
                 ]
             }
+        }
+    },
+    "PSU2-EEPROM": {
+        "dev_info": {
+            "device_type": "PSU-EEPROM",
+            "device_name": "PSU2-EEPROM",
+            "device_parent": "MUX1",
+            "virt_parent": "PSU2"
+        },
+        "i2c": {
+            "topo_info": {
+                "parent_bus": "0x2",
+                "dev_addr": "0x5b",
+                "dev_type": "psu_eeprom"
+            },
+            "attr_list": [
+                {
+                    "attr_name":"psu_present",
+                    "attr_devaddr":"0x30",
+                    "attr_devtype":"cpld",
+                    "attr_offset":"0x51",
+                    "attr_mask":"0x8",
+                    "attr_cmpval":"0x0",
+                    "attr_len":"1"
+                },
+                {
+                    "attr_name":"psu_power_good",
+                    "attr_devaddr":"0x30",
+                    "attr_devtype":"cpld",
+                    "attr_offset":"0x51",
+                    "attr_mask":"0x2",
+                    "attr_cmpval":"0x2",
+                    "attr_len":"1"
+                }
+            ]
         }
     },
     "FAN-CTRL": {
@@ -1722,7 +1772,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT1": {
         "dev_info": {
             "device_type": "QSFP-DD",

--- a/device/ufispace/x86_64-ufispace_s9300_32d-r0/platform.json
+++ b/device/ufispace/x86_64-ufispace_s9300_32d-r0/platform.json
@@ -292,9 +292,22 @@
             "lanes": "1,2,3,4,5,6,7,8",
             "breakout_modes": {
                 "1x400G": ["Eth0(Port0)"],
+                "1x200G(4)": ["Eth0(Port0)"],
+                "1x100G(2)": ["Eth0(Port0)"],
+                "1x100G(4)": ["Eth0(Port0)"],
+                "1x50G(2)": ["Eth0(Port0)"],
+                "1x40G(4)": ["Eth0(Port0)"],
+                "1x25G(1)": ["Eth0(Port0)"],
                 "2x200G": ["Eth0/1(Port0)", "Eth0/2(Port0)"],
+                "2x100G": ["Eth0/1(Port0)", "Eth0/2(Port0)"],
+                "2x50G(2)": ["Eth0/1(Port0)", "Eth0/2(Port0)"],
+                "2x50G(4)": ["Eth0/1(Port0)", "Eth0/2(Port0)"],
+                "2x40G": ["Eth0/1(Port0)", "Eth0/2(Port0)"],
                 "4x100G": ["Eth0/1(Port0)", "Eth0/2(Port0)", "Eth0/3(Port0)", "Eth0/4(Port0)"],
-                "8x50G": ["Eth0/1(Port0)", "Eth0/2(Port0)", "Eth0/3(Port0)", "Eth0/4(Port0)", "Eth0/5(Port0)", "Eth0/6(Port0)", "Eth0/7(Port0)", "Eth0/8(Port0)"]
+                "4x25G(4)": ["Eth0/1(Port0)", "Eth0/2(Port0)", "Eth0/3(Port0)", "Eth0/4(Port0)"],
+                "4x10G(4)": ["Eth0/1(Port0)", "Eth0/2(Port0)", "Eth0/3(Port0)", "Eth0/4(Port0)"],
+                "8x50G": ["Eth0/1(Port0)", "Eth0/2(Port0)", "Eth0/3(Port0)", "Eth0/4(Port0)", "Eth0/5(Port0)", "Eth0/6(Port0)", "Eth0/7(Port0)", "Eth0/8(Port0)"],
+                "8x25G": ["Eth0/1(Port0)", "Eth0/2(Port0)", "Eth0/3(Port0)", "Eth0/4(Port0)", "Eth0/5(Port0)", "Eth0/6(Port0)", "Eth0/7(Port0)", "Eth0/8(Port0)"]
             }
         },
 
@@ -303,9 +316,22 @@
             "lanes": "9,10,11,12,13,14,15,16",
             "breakout_modes": {
                 "1x400G": ["Eth1(Port1)"],
+                "1x200G(4)": ["Eth1(Port1)"],
+                "1x100G(2)": ["Eth1(Port1)"],
+                "1x100G(4)": ["Eth1(Port1)"],
+                "1x50G(2)": ["Eth1(Port1)"],
+                "1x40G(4)": ["Eth1(Port1)"],
+                "1x25G(1)": ["Eth1(Port1)"],
                 "2x200G": ["Eth1/1(Port1)", "Eth1/2(Port1)"],
+                "2x100G": ["Eth1/1(Port1)", "Eth1/2(Port1)"],
+                "2x50G(2)": ["Eth1/1(Port1)", "Eth1/2(Port1)"],
+                "2x50G(4)": ["Eth1/1(Port1)", "Eth1/2(Port1)"],
+                "2x40G": ["Eth1/1(Port1)", "Eth1/2(Port1)"],
                 "4x100G": ["Eth1/1(Port1)", "Eth1/2(Port1)", "Eth1/3(Port1)", "Eth1/4(Port1)"],
-                "8x50G": ["Eth1/1(Port1)", "Eth1/2(Port1)", "Eth1/3(Port1)", "Eth1/4(Port1)", "Eth1/5(Port1)", "Eth1/6(Port1)", "Eth1/7(Port1)", "Eth1/8(Port1)"]
+                "4x25G(4)": ["Eth1/1(Port1)", "Eth1/2(Port1)", "Eth1/3(Port1)", "Eth1/4(Port1)"],
+                "4x10G(4)": ["Eth1/1(Port1)", "Eth1/2(Port1)", "Eth1/3(Port1)", "Eth1/4(Port1)"],
+                "8x50G": ["Eth1/1(Port1)", "Eth1/2(Port1)", "Eth1/3(Port1)", "Eth1/4(Port1)", "Eth1/5(Port1)", "Eth1/6(Port1)", "Eth1/7(Port1)", "Eth1/8(Port1)"],
+                "8x25G": ["Eth1/1(Port1)", "Eth1/2(Port1)", "Eth1/3(Port1)", "Eth1/4(Port1)", "Eth1/5(Port1)", "Eth1/6(Port1)", "Eth1/7(Port1)", "Eth1/8(Port1)"]
             }
        },
 
@@ -314,9 +340,22 @@
             "lanes": "17,18,19,20,21,22,23,24",
             "breakout_modes": {
                 "1x400G": ["Eth2(Port2)"],
+                "1x200G(4)": ["Eth2(Port2)"],
+                "1x100G(2)": ["Eth2(Port2)"],
+                "1x100G(4)": ["Eth2(Port2)"],
+                "1x50G(2)": ["Eth2(Port2)"],
+                "1x40G(4)": ["Eth2(Port2)"],
+                "1x25G(1)": ["Eth2(Port2)"],
                 "2x200G": ["Eth2/1(Port2)", "Eth2/2(Port2)"],
+                "2x100G": ["Eth2/1(Port2)", "Eth2/2(Port2)"],
+                "2x50G(2)": ["Eth2/1(Port2)", "Eth2/2(Port2)"],
+                "2x50G(4)": ["Eth2/1(Port2)", "Eth2/2(Port2)"],
+                "2x40G": ["Eth2/1(Port2)", "Eth2/2(Port2)"],
                 "4x100G": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)"],
-                "8x50G": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)", "Eth2/5(Port2)", "Eth2/6(Port2)", "Eth2/7(Port2)", "Eth2/8(Port2)"]
+                "4x25G(4)": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)"],
+                "4x10G(4)": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)"],
+                "8x50G": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)", "Eth2/5(Port2)", "Eth2/6(Port2)", "Eth2/7(Port2)", "Eth2/8(Port2)"],
+                "8x25G": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)", "Eth2/5(Port2)", "Eth2/6(Port2)", "Eth2/7(Port2)", "Eth2/8(Port2)"]
             }
         },
 
@@ -325,9 +364,22 @@
             "lanes": "25,26,27,28,29,30,31,32",
             "breakout_modes": {
                 "1x400G": ["Eth3(Port3)"],
+                "1x200G(4)": ["Eth3(Port3)"],
+                "1x100G(2)": ["Eth3(Port3)"],
+                "1x100G(4)": ["Eth3(Port3)"],
+                "1x50G(2)": ["Eth3(Port3)"],
+                "1x40G(4)": ["Eth3(Port3)"],
+                "1x25G(1)": ["Eth3(Port3)"],
                 "2x200G": ["Eth3/1(Port3)", "Eth3/2(Port3)"],
+                "2x100G": ["Eth3/1(Port3)", "Eth3/2(Port3)"],
+                "2x50G(2)": ["Eth3/1(Port3)", "Eth3/2(Port3)"],
+                "2x50G(4)": ["Eth3/1(Port3)", "Eth3/2(Port3)"],
+                "2x40G": ["Eth3/1(Port3)", "Eth3/2(Port3)"],
                 "4x100G": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)"],
-                "8x50G": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)", "Eth3/5(Port3)", "Eth3/6(Port3)", "Eth3/7(Port3)", "Eth3/8(Port3)"]
+                "4x25G(4)": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)"],
+                "4x10G(4)": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)"],
+                "8x50G": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)", "Eth3/5(Port3)", "Eth3/6(Port3)", "Eth3/7(Port3)", "Eth3/8(Port3)"],
+                "8x25G": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)", "Eth3/5(Port3)", "Eth3/6(Port3)", "Eth3/7(Port3)", "Eth3/8(Port3)"]
             }
         },
 
@@ -336,9 +388,22 @@
             "lanes": "33,34,35,36,37,38,39,40",
             "breakout_modes": {
                 "1x400G": ["Eth4(Port4)"],
+                "1x200G(4)": ["Eth4(Port4)"],
+                "1x100G(2)": ["Eth4(Port4)"],
+                "1x100G(4)": ["Eth4(Port4)"],
+                "1x50G(2)": ["Eth4(Port4)"],
+                "1x40G(4)": ["Eth4(Port4)"],
+                "1x25G(1)": ["Eth4(Port4)"],
                 "2x200G": ["Eth4/1(Port4)", "Eth4/2(Port4)"],
+                "2x100G": ["Eth4/1(Port4)", "Eth4/2(Port4)"],
+                "2x50G(2)": ["Eth4/1(Port4)", "Eth4/2(Port4)"],
+                "2x50G(4)": ["Eth4/1(Port4)", "Eth4/2(Port4)"],
+                "2x40G": ["Eth4/1(Port4)", "Eth4/2(Port4)"],
                 "4x100G": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)"],
-                "8x50G": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)", "Eth4/5(Port4)", "Eth4/6(Port4)", "Eth4/7(Port4)", "Eth4/8(Port4)"]
+                "4x25G(4)": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)"],
+                "4x10G(4)": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)"],
+                "8x50G": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)", "Eth4/5(Port4)", "Eth4/6(Port4)", "Eth4/7(Port4)", "Eth4/8(Port4)"],
+                "8x25G": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)", "Eth4/5(Port4)", "Eth4/6(Port4)", "Eth4/7(Port4)", "Eth4/8(Port4)"]
             }
         },
 
@@ -347,9 +412,22 @@
             "lanes": "41,42,43,44,45,46,47,48",
             "breakout_modes": {
                 "1x400G": ["Eth5(Port5)"],
+                "1x200G(4)": ["Eth5(Port5)"],
+                "1x100G(2)": ["Eth5(Port5)"],
+                "1x100G(4)": ["Eth5(Port5)"],
+                "1x50G(2)": ["Eth5(Port5)"],
+                "1x40G(4)": ["Eth5(Port5)"],
+                "1x25G(1)": ["Eth5(Port5)"],
                 "2x200G": ["Eth5/1(Port5)", "Eth5/2(Port5)"],
+                "2x100G": ["Eth5/1(Port5)", "Eth5/2(Port5)"],
+                "2x50G(2)": ["Eth5/1(Port5)", "Eth5/2(Port5)"],
+                "2x50G(4)": ["Eth5/1(Port5)", "Eth5/2(Port5)"],
+                "2x40G": ["Eth5/1(Port5)", "Eth5/2(Port5)"],
                 "4x100G": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)"],
-                "8x50G": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)", "Eth5/5(Port5)", "Eth5/6(Port5)", "Eth5/7(Port5)", "Eth5/8(Port5)"]
+                "4x25G(4)": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)"],
+                "4x10G(4)": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)"],
+                "8x50G": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)", "Eth5/5(Port5)", "Eth5/6(Port5)", "Eth5/7(Port5)", "Eth5/8(Port5)"],
+                "8x25G": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)", "Eth5/5(Port5)", "Eth5/6(Port5)", "Eth5/7(Port5)", "Eth5/8(Port5)"]
             }
         },
 
@@ -358,9 +436,22 @@
             "lanes": "49,50,51,52,53,54,55,56",
             "breakout_modes": {
                 "1x400G": ["Eth6(Port6)"],
+                "1x200G(4)": ["Eth6(Port6)"],
+                "1x100G(2)": ["Eth6(Port6)"],
+                "1x100G(4)": ["Eth6(Port6)"],
+                "1x50G(2)": ["Eth6(Port6)"],
+                "1x40G(4)": ["Eth6(Port6)"],
+                "1x25G(1)": ["Eth6(Port6)"],
                 "2x200G": ["Eth6/1(Port6)", "Eth6/2(Port6)"],
+                "2x100G": ["Eth6/1(Port6)", "Eth6/2(Port6)"],
+                "2x50G(2)": ["Eth6/1(Port6)", "Eth6/2(Port6)"],
+                "2x50G(4)": ["Eth6/1(Port6)", "Eth6/2(Port6)"],
+                "2x40G": ["Eth6/1(Port6)", "Eth6/2(Port6)"],
                 "4x100G": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)"],
-                "8x50G": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)", "Eth6/5(Port6)", "Eth6/6(Port6)", "Eth6/7(Port6)", "Eth6/8(Port6)"]
+                "4x25G(4)": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)"],
+                "4x10G(4)": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)"],
+                "8x50G": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)", "Eth6/5(Port6)", "Eth6/6(Port6)", "Eth6/7(Port6)", "Eth6/8(Port6)"],
+                "8x25G": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)", "Eth6/5(Port6)", "Eth6/6(Port6)", "Eth6/7(Port6)", "Eth6/8(Port6)"]
             }
         },
 
@@ -369,9 +460,22 @@
             "lanes": "57,58,59,60,61,62,63,64",
             "breakout_modes": {
                 "1x400G": ["Eth7(Port7)"],
+                "1x200G(4)": ["Eth7(Port7)"],
+                "1x100G(2)": ["Eth7(Port7)"],
+                "1x100G(4)": ["Eth7(Port7)"],
+                "1x50G(2)": ["Eth7(Port7)"],
+                "1x40G(4)": ["Eth7(Port7)"],
+                "1x25G(1)": ["Eth7(Port7)"],
                 "2x200G": ["Eth7/1(Port7)", "Eth7/2(Port7)"],
+                "2x100G": ["Eth7/1(Port7)", "Eth7/2(Port7)"],
+                "2x50G(2)": ["Eth7/1(Port7)", "Eth7/2(Port7)"],
+                "2x50G(4)": ["Eth7/1(Port7)", "Eth7/2(Port7)"],
+                "2x40G": ["Eth7/1(Port7)", "Eth7/2(Port7)"],
                 "4x100G": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)"],
-                "8x50G": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)", "Eth7/5(Port7)", "Eth7/6(Port7)", "Eth7/7(Port7)", "Eth7/8(Port7)"]
+                "4x25G(4)": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)"],
+                "4x10G(4)": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)"],
+                "8x50G": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)", "Eth7/5(Port7)", "Eth7/6(Port7)", "Eth7/7(Port7)", "Eth7/8(Port7)"],
+                "8x25G": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)", "Eth7/5(Port7)", "Eth7/6(Port7)", "Eth7/7(Port7)", "Eth7/8(Port7)"]
             }
         },
 
@@ -380,9 +484,22 @@
             "lanes": "65,66,67,68,69,70,71,72",
             "breakout_modes": {
                 "1x400G": ["Eth8(Port8)"],
+                "1x200G(4)": ["Eth8(Port8)"],
+                "1x100G(2)": ["Eth8(Port8)"],
+                "1x100G(4)": ["Eth8(Port8)"],
+                "1x50G(2)": ["Eth8(Port8)"],
+                "1x40G(4)": ["Eth8(Port8)"],
+                "1x25G(1)": ["Eth8(Port8)"],
                 "2x200G": ["Eth8/1(Port8)", "Eth8/2(Port8)"],
+                "2x100G": ["Eth8/1(Port8)", "Eth8/2(Port8)"],
+                "2x50G(2)": ["Eth8/1(Port8)", "Eth8/2(Port8)"],
+                "2x50G(4)": ["Eth8/1(Port8)", "Eth8/2(Port8)"],
+                "2x40G": ["Eth8/1(Port8)", "Eth8/2(Port8)"],
                 "4x100G": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)"],
-                "8x50G": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)", "Eth8/5(Port8)", "Eth8/6(Port8)", "Eth8/7(Port8)", "Eth8/8(Port8)"]
+                "4x25G(4)": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)"],
+                "4x10G(4)": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)"],
+                "8x50G": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)", "Eth8/5(Port8)", "Eth8/6(Port8)", "Eth8/7(Port8)", "Eth8/8(Port8)"],
+                "8x25G": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)", "Eth8/5(Port8)", "Eth8/6(Port8)", "Eth8/7(Port8)", "Eth8/8(Port8)"]
             }
         },
 
@@ -391,9 +508,22 @@
             "lanes": "73,74,75,76,77,78,79,80",
             "breakout_modes": {
                 "1x400G": ["Eth9(Port9)"],
+                "1x200G(4)": ["Eth9(Port9)"],
+                "1x100G(2)": ["Eth9(Port9)"],
+                "1x100G(4)": ["Eth9(Port9)"],
+                "1x50G(2)": ["Eth9(Port9)"],
+                "1x40G(4)": ["Eth9(Port9)"],
+                "1x25G(1)": ["Eth9(Port9)"],
                 "2x200G": ["Eth9/1(Port9)", "Eth9/2(Port9)"],
+                "2x100G": ["Eth9/1(Port9)", "Eth9/2(Port9)"],
+                "2x50G(2)": ["Eth9/1(Port9)", "Eth9/2(Port9)"],
+                "2x50G(4)": ["Eth9/1(Port9)", "Eth9/2(Port9)"],
+                "2x40G": ["Eth9/1(Port9)", "Eth9/2(Port9)"],
                 "4x100G": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)"],
-                "8x50G": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)", "Eth9/5(Port9)", "Eth9/6(Port9)", "Eth9/7(Port9)", "Eth9/8(Port9)"]
+                "4x25G(4)": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)"],
+                "4x10G(4)": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)"],
+                "8x50G": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)", "Eth9/5(Port9)", "Eth9/6(Port9)", "Eth9/7(Port9)", "Eth9/8(Port9)"],
+                "8x25G": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)", "Eth9/5(Port9)", "Eth9/6(Port9)", "Eth9/7(Port9)", "Eth9/8(Port9)"]
             }
         },
 
@@ -402,9 +532,22 @@
             "lanes": "81,82,83,84,85,86,87,88",
             "breakout_modes": {
                 "1x400G": ["Eth10(Port10)"],
+                "1x200G(4)": ["Eth10(Port10)"],
+                "1x100G(2)": ["Eth10(Port10)"],
+                "1x100G(4)": ["Eth10(Port10)"],
+                "1x50G(2)": ["Eth10(Port10)"],
+                "1x40G(4)": ["Eth10(Port10)"],
+                "1x25G(1)": ["Eth10(Port10)"],
                 "2x200G": ["Eth10/1(Port10)", "Eth10/2(Port10)"],
+                "2x100G": ["Eth10/1(Port10)", "Eth10/2(Port10)"],
+                "2x50G(2)": ["Eth10/1(Port10)", "Eth10/2(Port10)"],
+                "2x50G(4)": ["Eth10/1(Port10)", "Eth10/2(Port10)"],
+                "2x40G": ["Eth10/1(Port10)", "Eth10/2(Port10)"],
                 "4x100G": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)"],
-                "8x50G": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)", "Eth10/5(Port10)", "Eth10/6(Port10)", "Eth10/7(Port10)", "Eth10/8(Port10)"]
+                "4x25G(4)": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)"],
+                "4x10G(4)": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)"],
+                "8x50G": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)", "Eth10/5(Port10)", "Eth10/6(Port10)", "Eth10/7(Port10)", "Eth10/8(Port10)"],
+                "8x25G": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)", "Eth10/5(Port10)", "Eth10/6(Port10)", "Eth10/7(Port10)", "Eth10/8(Port10)"]
             }
         },
         
@@ -413,9 +556,22 @@
             "lanes": "89,90,91,92,93,94,95,96",
             "breakout_modes": {
                 "1x400G": ["Eth11(Port11)"],
+                "1x200G(4)": ["Eth11(Port11)"],
+                "1x100G(2)": ["Eth11(Port11)"],
+                "1x100G(4)": ["Eth11(Port11)"],
+                "1x50G(2)": ["Eth11(Port11)"],
+                "1x40G(4)": ["Eth11(Port11)"],
+                "1x25G(1)": ["Eth11(Port11)"],
                 "2x200G": ["Eth11/1(Port11)", "Eth11/2(Port11)"],
+                "2x100G": ["Eth11/1(Port11)", "Eth11/2(Port11)"],
+                "2x50G(2)": ["Eth11/1(Port11)", "Eth11/2(Port11)"],
+                "2x50G(4)": ["Eth11/1(Port11)", "Eth11/2(Port11)"],
+                "2x40G": ["Eth11/1(Port11)", "Eth11/2(Port11)"],
                 "4x100G": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)"],
-                "8x50G": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)", "Eth11/5(Port11)", "Eth11/6(Port11)", "Eth11/7(Port11)", "Eth11/8(Port11)"]
+                "4x25G(4)": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)"],
+                "4x10G(4)": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)"],
+                "8x50G": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)", "Eth11/5(Port11)", "Eth11/6(Port11)", "Eth11/7(Port11)", "Eth11/8(Port11)"],
+                "8x25G": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)", "Eth11/5(Port11)", "Eth11/6(Port11)", "Eth11/7(Port11)", "Eth11/8(Port11)"]
             }
         },
         
@@ -424,9 +580,22 @@
             "lanes": "97,98,99,100,101,102,103,104",
             "breakout_modes": {
                 "1x400G": ["Eth12(Port12)"],
+                "1x200G(4)": ["Eth12(Port12)"],
+                "1x100G(2)": ["Eth12(Port12)"],
+                "1x100G(4)": ["Eth12(Port12)"],
+                "1x50G(2)": ["Eth12(Port12)"],
+                "1x40G(4)": ["Eth12(Port12)"],
+                "1x25G(1)": ["Eth12(Port12)"],
                 "2x200G": ["Eth12/1(Port12)", "Eth12/2(Port12)"],
+                "2x100G": ["Eth12/1(Port12)", "Eth12/2(Port12)"],
+                "2x50G(2)": ["Eth12/1(Port12)", "Eth12/2(Port12)"],
+                "2x50G(4)": ["Eth12/1(Port12)", "Eth12/2(Port12)"],
+                "2x40G": ["Eth12/1(Port12)", "Eth12/2(Port12)"],
                 "4x100G": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)"],
-                "8x50G": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)", "Eth12/5(Port12)", "Eth12/6(Port12)", "Eth12/7(Port12)", "Eth12/8(Port12)"]
+                "4x25G(4)": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)"],
+                "4x10G(4)": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)"],
+                "8x50G": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)", "Eth12/5(Port12)", "Eth12/6(Port12)", "Eth12/7(Port12)", "Eth12/8(Port12)"],
+                "8x25G": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)", "Eth12/5(Port12)", "Eth12/6(Port12)", "Eth12/7(Port12)", "Eth12/8(Port12)"]
             }
         },
 
@@ -435,9 +604,22 @@
             "lanes": "105,106,107,108,109,110,111,112",
             "breakout_modes": {
                 "1x400G": ["Eth13(Port13)"],
+                "1x200G(4)": ["Eth13(Port13)"],
+                "1x100G(2)": ["Eth13(Port13)"],
+                "1x100G(4)": ["Eth13(Port13)"],
+                "1x50G(2)": ["Eth13(Port13)"],
+                "1x40G(4)": ["Eth13(Port13)"],
+                "1x25G(1)": ["Eth13(Port13)"],
                 "2x200G": ["Eth13/1(Port13)", "Eth13/2(Port13)"],
+                "2x100G": ["Eth13/1(Port13)", "Eth13/2(Port13)"],
+                "2x50G(2)": ["Eth13/1(Port13)", "Eth13/2(Port13)"],
+                "2x50G(4)": ["Eth13/1(Port13)", "Eth13/2(Port13)"],
+                "2x40G": ["Eth13/1(Port13)", "Eth13/2(Port13)"],
                 "4x100G": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)"],
-                "8x50G": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)", "Eth13/5(Port13)", "Eth13/6(Port13)", "Eth13/7(Port13)", "Eth13/8(Port13)"]
+                "4x25G(4)": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)"],
+                "4x10G(4)": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)"],
+                "8x50G": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)", "Eth13/5(Port13)", "Eth13/6(Port13)", "Eth13/7(Port13)", "Eth13/8(Port13)"],
+                "8x25G": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)", "Eth13/5(Port13)", "Eth13/6(Port13)", "Eth13/7(Port13)", "Eth13/8(Port13)"]
             }
         },
 
@@ -446,9 +628,22 @@
             "lanes": "113,114,115,116,117,118,119,120",
             "breakout_modes": {
                 "1x400G": ["Eth14(Port14)"],
+                "1x200G(4)": ["Eth14(Port14)"],
+                "1x100G(2)": ["Eth14(Port14)"],
+                "1x100G(4)": ["Eth14(Port14)"],
+                "1x50G(2)": ["Eth14(Port14)"],
+                "1x40G(4)": ["Eth14(Port14)"],
+                "1x25G(1)": ["Eth14(Port14)"],
                 "2x200G": ["Eth14/1(Port14)", "Eth14/2(Port14)"],
+                "2x100G": ["Eth14/1(Port14)", "Eth14/2(Port14)"],
+                "2x50G(2)": ["Eth14/1(Port14)", "Eth14/2(Port14)"],
+                "2x50G(4)": ["Eth14/1(Port14)", "Eth14/2(Port14)"],
+                "2x40G": ["Eth14/1(Port14)", "Eth14/2(Port14)"],
                 "4x100G": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)"],
-                "8x50G": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)", "Eth14/5(Port14)", "Eth14/6(Port14)", "Eth14/7(Port14)", "Eth14/8(Port14)"]
+                "4x25G(4)": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)"],
+                "4x10G(4)": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)"],
+                "8x50G": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)", "Eth14/5(Port14)", "Eth14/6(Port14)", "Eth14/7(Port14)", "Eth14/8(Port14)"],
+                "8x25G": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)", "Eth14/5(Port14)", "Eth14/6(Port14)", "Eth14/7(Port14)", "Eth14/8(Port14)"]
             }
         },
 
@@ -457,9 +652,22 @@
             "lanes": "121,122,123,124,125,126,127,128",
             "breakout_modes": {
                 "1x400G": ["Eth15(Port15)"],
+                "1x200G(4)": ["Eth15(Port15)"],
+                "1x100G(2)": ["Eth15(Port15)"],
+                "1x100G(4)": ["Eth15(Port15)"],
+                "1x50G(2)": ["Eth15(Port15)"],
+                "1x40G(4)": ["Eth15(Port15)"],
+                "1x25G(1)": ["Eth15(Port15)"],
                 "2x200G": ["Eth15/1(Port15)", "Eth15/2(Port15)"],
+                "2x100G": ["Eth15/1(Port15)", "Eth15/2(Port15)"],
+                "2x50G(2)": ["Eth15/1(Port15)", "Eth15/2(Port15)"],
+                "2x50G(4)": ["Eth15/1(Port15)", "Eth15/2(Port15)"],
+                "2x40G": ["Eth15/1(Port15)", "Eth15/2(Port15)"],
                 "4x100G": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)"],
-                "8x50G": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)", "Eth15/5(Port15)", "Eth15/6(Port15)", "Eth15/7(Port15)", "Eth15/8(Port15)"]
+                "4x25G(4)": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)"],
+                "4x10G(4)": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)"],
+                "8x50G": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)", "Eth15/5(Port15)", "Eth15/6(Port15)", "Eth15/7(Port15)", "Eth15/8(Port15)"],
+                "8x25G": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)", "Eth15/5(Port15)", "Eth15/6(Port15)", "Eth15/7(Port15)", "Eth15/8(Port15)"]
             }
         },
 
@@ -468,9 +676,22 @@
             "lanes": "129,130,131,132,133,134,135,136",
             "breakout_modes": {
                 "1x400G": ["Eth16(Port16)"],
+                "1x200G(4)": ["Eth16(Port16)"],
+                "1x100G(2)": ["Eth16(Port16)"],
+                "1x100G(4)": ["Eth16(Port16)"],
+                "1x50G(2)": ["Eth16(Port16)"],
+                "1x40G(4)": ["Eth16(Port16)"],
+                "1x25G(1)": ["Eth16(Port16)"],
                 "2x200G": ["Eth16/1(Port16)", "Eth16/2(Port16)"],
+                "2x100G": ["Eth16/1(Port16)", "Eth16/2(Port16)"],
+                "2x50G(2)": ["Eth16/1(Port16)", "Eth16/2(Port16)"],
+                "2x50G(4)": ["Eth16/1(Port16)", "Eth16/2(Port16)"],
+                "2x40G": ["Eth16/1(Port16)", "Eth16/2(Port16)"],
                 "4x100G": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)"],
-                "8x50G": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)", "Eth16/5(Port16)", "Eth16/6(Port16)", "Eth16/7(Port16)", "Eth16/8(Port16)"]
+                "4x25G(4)": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)"],
+                "4x10G(4)": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)"],
+                "8x50G": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)", "Eth16/5(Port16)", "Eth16/6(Port16)", "Eth16/7(Port16)", "Eth16/8(Port16)"],
+                "8x25G": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)", "Eth16/5(Port16)", "Eth16/6(Port16)", "Eth16/7(Port16)", "Eth16/8(Port16)"]
             }
         },
 
@@ -479,9 +700,22 @@
             "lanes": "137,138,139,140,141,142,143,144",
             "breakout_modes": {
                 "1x400G": ["Eth17(Port17)"],
+                "1x200G(4)": ["Eth17(Port17)"],
+                "1x100G(2)": ["Eth17(Port17)"],
+                "1x100G(4)": ["Eth17(Port17)"],
+                "1x50G(2)": ["Eth17(Port17)"],
+                "1x40G(4)": ["Eth17(Port17)"],
+                "1x25G(1)": ["Eth17(Port17)"],
                 "2x200G": ["Eth17/1(Port17)", "Eth17/2(Port17)"],
+                "2x100G": ["Eth17/1(Port17)", "Eth17/2(Port17)"],
+                "2x50G(2)": ["Eth17/1(Port17)", "Eth17/2(Port17)"],
+                "2x50G(4)": ["Eth17/1(Port17)", "Eth17/2(Port17)"],
+                "2x40G": ["Eth17/1(Port17)", "Eth17/2(Port17)"],
                 "4x100G": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)"],
-                "8x50G": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)", "Eth17/5(Port17)", "Eth17/6(Port17)", "Eth17/7(Port17)", "Eth17/8(Port17)"]
+                "4x25G(4)": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)"],
+                "4x10G(4)": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)"],
+                "8x50G": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)", "Eth17/5(Port17)", "Eth17/6(Port17)", "Eth17/7(Port17)", "Eth17/8(Port17)"],
+                "8x25G": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)", "Eth17/5(Port17)", "Eth17/6(Port17)", "Eth17/7(Port17)", "Eth17/8(Port17)"]
             }
         },
 
@@ -490,9 +724,22 @@
             "lanes": "145,146,147,148,149,150,151,152",
             "breakout_modes": {
                 "1x400G": ["Eth18(Port18)"],
+                "1x200G(4)": ["Eth18(Port18)"],
+                "1x100G(2)": ["Eth18(Port18)"],
+                "1x100G(4)": ["Eth18(Port18)"],
+                "1x50G(2)": ["Eth18(Port18)"],
+                "1x40G(4)": ["Eth18(Port18)"],
+                "1x25G(1)": ["Eth18(Port18)"],
                 "2x200G": ["Eth18/1(Port18)", "Eth18/2(Port18)"],
+                "2x100G": ["Eth18/1(Port18)", "Eth18/2(Port18)"],
+                "2x50G(2)": ["Eth18/1(Port18)", "Eth18/2(Port18)"],
+                "2x50G(4)": ["Eth18/1(Port18)", "Eth18/2(Port18)"],
+                "2x40G": ["Eth18/1(Port18)", "Eth18/2(Port18)"],
                 "4x100G": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)"],
-                "8x50G": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)", "Eth18/5(Port18)", "Eth18/6(Port18)", "Eth18/7(Port18)", "Eth18/8(Port18)"]
+                "4x25G(4)": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)"],
+                "4x10G(4)": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)"],
+                "8x50G": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)", "Eth18/5(Port18)", "Eth18/6(Port18)", "Eth18/7(Port18)", "Eth18/8(Port18)"],
+                "8x25G": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)", "Eth18/5(Port18)", "Eth18/6(Port18)", "Eth18/7(Port18)", "Eth18/8(Port18)"]
             }
         },
 
@@ -501,9 +748,22 @@
             "lanes": "153,154,155,156,157,158,159,160",
             "breakout_modes": {
                 "1x400G": ["Eth19(Port19)"],
+                "1x200G(4)": ["Eth19(Port19)"],
+                "1x100G(2)": ["Eth19(Port19)"],
+                "1x100G(4)": ["Eth19(Port19)"],
+                "1x50G(2)": ["Eth19(Port19)"],
+                "1x40G(4)": ["Eth19(Port19)"],
+                "1x25G(1)": ["Eth19(Port19)"],
                 "2x200G": ["Eth19/1(Port19)", "Eth19/2(Port19)"],
+                "2x100G": ["Eth19/1(Port19)", "Eth19/2(Port19)"],
+                "2x50G(2)": ["Eth19/1(Port19)", "Eth19/2(Port19)"],
+                "2x50G(4)": ["Eth19/1(Port19)", "Eth19/2(Port19)"],
+                "2x40G": ["Eth19/1(Port19)", "Eth19/2(Port19)"],
                 "4x100G": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)"],
-                "8x50G": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)", "Eth19/5(Port19)", "Eth19/6(Port19)", "Eth19/7(Port19)", "Eth19/8(Port19)"]
+                "4x25G(4)": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)"],
+                "4x10G(4)": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)"],
+                "8x50G": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)", "Eth19/5(Port19)", "Eth19/6(Port19)", "Eth19/7(Port19)", "Eth19/8(Port19)"],
+                "8x25G": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)", "Eth19/5(Port19)", "Eth19/6(Port19)", "Eth19/7(Port19)", "Eth19/8(Port19)"]
             }
         },
 
@@ -512,9 +772,22 @@
             "lanes": "161,162,163,164,165,166,167,168",
             "breakout_modes": {
                 "1x400G": ["Eth20(Port20)"],
+                "1x200G(4)": ["Eth20(Port20)"],
+                "1x100G(2)": ["Eth20(Port20)"],
+                "1x100G(4)": ["Eth20(Port20)"],
+                "1x50G(2)": ["Eth20(Port20)"],
+                "1x40G(4)": ["Eth20(Port20)"],
+                "1x25G(1)": ["Eth20(Port20)"],
                 "2x200G": ["Eth20/1(Port20)", "Eth20/2(Port20)"],
+                "2x100G": ["Eth20/1(Port20)", "Eth20/2(Port20)"],
+                "2x50G(2)": ["Eth20/1(Port20)", "Eth20/2(Port20)"],
+                "2x50G(4)": ["Eth20/1(Port20)", "Eth20/2(Port20)"],
+                "2x40G": ["Eth20/1(Port20)", "Eth20/2(Port20)"],
                 "4x100G": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)"],
-                "8x50G": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)", "Eth20/5(Port20)", "Eth20/6(Port20)", "Eth20/7(Port20)", "Eth20/8(Port20)"]
+                "4x25G(4)": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)"],
+                "4x10G(4)": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)"],
+                "8x50G": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)", "Eth20/5(Port20)", "Eth20/6(Port20)", "Eth20/7(Port20)", "Eth20/8(Port20)"],
+                "8x25G": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)", "Eth20/5(Port20)", "Eth20/6(Port20)", "Eth20/7(Port20)", "Eth20/8(Port20)"]
             }
         },
 
@@ -523,9 +796,22 @@
             "lanes": "169,170,171,172,173,174,175,176",
             "breakout_modes": {
                 "1x400G": ["Eth21(Port21)"],
+                "1x200G(4)": ["Eth21(Port21)"],
+                "1x100G(2)": ["Eth21(Port21)"],
+                "1x100G(4)": ["Eth21(Port21)"],
+                "1x50G(2)": ["Eth21(Port21)"],
+                "1x40G(4)": ["Eth21(Port21)"],
+                "1x25G(1)": ["Eth21(Port21)"],
                 "2x200G": ["Eth21/1(Port21)", "Eth21/2(Port21)"],
+                "2x100G": ["Eth21/1(Port21)", "Eth21/2(Port21)"],
+                "2x50G(2)": ["Eth21/1(Port21)", "Eth21/2(Port21)"],
+                "2x50G(4)": ["Eth21/1(Port21)", "Eth21/2(Port21)"],
+                "2x40G": ["Eth21/1(Port21)", "Eth21/2(Port21)"],
                 "4x100G": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)"],
-                "8x50G": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)", "Eth21/5(Port21)", "Eth21/6(Port21)", "Eth21/7(Port21)", "Eth21/8(Port21)"]
+                "4x25G(4)": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)"],
+                "4x10G(4)": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)"],
+                "8x50G": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)", "Eth21/5(Port21)", "Eth21/6(Port21)", "Eth21/7(Port21)", "Eth21/8(Port21)"],
+                "8x25G": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)", "Eth21/5(Port21)", "Eth21/6(Port21)", "Eth21/7(Port21)", "Eth21/8(Port21)"]
             }
         },                        
 
@@ -534,9 +820,22 @@
             "lanes": "177,178,179,180,181,182,183,184",
             "breakout_modes": {
                 "1x400G": ["Eth22(Port22)"],
+                "1x200G(4)": ["Eth22(Port22)"],
+                "1x100G(2)": ["Eth22(Port22)"],
+                "1x100G(4)": ["Eth22(Port22)"],
+                "1x50G(2)": ["Eth22(Port22)"],
+                "1x40G(4)": ["Eth22(Port22)"],
+                "1x25G(1)": ["Eth22(Port22)"],
                 "2x200G": ["Eth22/1(Port22)", "Eth22/2(Port22)"],
+                "2x100G": ["Eth22/1(Port22)", "Eth22/2(Port22)"],
+                "2x50G(2)": ["Eth22/1(Port22)", "Eth22/2(Port22)"],
+                "2x50G(4)": ["Eth22/1(Port22)", "Eth22/2(Port22)"],
+                "2x40G": ["Eth22/1(Port22)", "Eth22/2(Port22)"],
                 "4x100G": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)"],
-                "8x50G": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)", "Eth22/5(Port22)", "Eth22/6(Port22)", "Eth22/7(Port22)", "Eth22/8(Port22)"]
+                "4x25G(4)": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)"],
+                "4x10G(4)": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)"],
+                "8x50G": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)", "Eth22/5(Port22)", "Eth22/6(Port22)", "Eth22/7(Port22)", "Eth22/8(Port22)"],
+                "8x25G": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)", "Eth22/5(Port22)", "Eth22/6(Port22)", "Eth22/7(Port22)", "Eth22/8(Port22)"]
             }
         },
       
@@ -545,9 +844,22 @@
             "lanes": "185,186,187,188,189,190,191,192",
             "breakout_modes": {
                 "1x400G": ["Eth23(Port23)"],
+                "1x200G(4)": ["Eth23(Port23)"],
+                "1x100G(2)": ["Eth23(Port23)"],
+                "1x100G(4)": ["Eth23(Port23)"],
+                "1x50G(2)": ["Eth23(Port23)"],
+                "1x40G(4)": ["Eth23(Port23)"],
+                "1x25G(1)": ["Eth23(Port23)"],
                 "2x200G": ["Eth23/1(Port23)", "Eth23/2(Port23)"],
+                "2x100G": ["Eth23/1(Port23)", "Eth23/2(Port23)"],
+                "2x50G(2)": ["Eth23/1(Port23)", "Eth23/2(Port23)"],
+                "2x50G(4)": ["Eth23/1(Port23)", "Eth23/2(Port23)"],
+                "2x40G": ["Eth23/1(Port23)", "Eth23/2(Port23)"],
                 "4x100G": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)"],
-                "8x50G": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)", "Eth23/5(Port23)", "Eth23/6(Port23)", "Eth23/7(Port23)", "Eth23/8(Port23)"]
+                "4x25G(4)": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)"],
+                "4x10G(4)": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)"],
+                "8x50G": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)", "Eth23/5(Port23)", "Eth23/6(Port23)", "Eth23/7(Port23)", "Eth23/8(Port23)"],
+                "8x25G": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)", "Eth23/5(Port23)", "Eth23/6(Port23)", "Eth23/7(Port23)", "Eth23/8(Port23)"]
             }
         },
 
@@ -556,9 +868,22 @@
             "lanes": "193,194,195,196,197,198,199,200",
             "breakout_modes": {
                 "1x400G": ["Eth24(Port24)"],
+                "1x200G(4)": ["Eth24(Port24)"],
+                "1x100G(2)": ["Eth24(Port24)"],
+                "1x100G(4)": ["Eth24(Port24)"],
+                "1x50G(2)": ["Eth24(Port24)"],
+                "1x40G(4)": ["Eth24(Port24)"],
+                "1x25G(1)": ["Eth24(Port24)"],
                 "2x200G": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
+                "2x100G": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
+                "2x50G(2)": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
+                "2x50G(4)": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
+                "2x40G": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
                 "4x100G": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)"],
-                "8x50G": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)", "Eth24/5(Port24)", "Eth24/6(Port24)", "Eth24/7(Port24)", "Eth24/8(Port24)"]
+                "4x25G(4)": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)"],
+                "4x10G(4)": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)"],
+                "8x50G": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)", "Eth24/5(Port24)", "Eth24/6(Port24)", "Eth24/7(Port24)", "Eth24/8(Port24)"],
+                "8x25G": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)", "Eth24/5(Port24)", "Eth24/6(Port24)", "Eth24/7(Port24)", "Eth24/8(Port24)"]
             }
         },
 
@@ -567,9 +892,22 @@
             "lanes": "201,202,203,204,205,206,207,208",
             "breakout_modes": {
                 "1x400G": ["Eth25(Port25)"],
+                "1x200G(4)": ["Eth25(Port25)"],
+                "1x100G(2)": ["Eth25(Port25)"],
+                "1x100G(4)": ["Eth25(Port25)"],
+                "1x50G(2)": ["Eth25(Port25)"],
+                "1x40G(4)": ["Eth25(Port25)"],
+                "1x25G(1)": ["Eth25(Port25)"],
                 "2x200G": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
+                "2x100G": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
+                "2x50G(2)": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
+                "2x50G(4)": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
+                "2x40G": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
                 "4x100G": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)"],
-                "8x50G": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)", "Eth25/5(Port25)", "Eth25/6(Port25)", "Eth25/7(Port25)", "Eth25/8(Port25)"]
+                "4x25G(4)": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)"],
+                "4x10G(4)": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)"],
+                "8x50G": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)", "Eth25/5(Port25)", "Eth25/6(Port25)", "Eth25/7(Port25)", "Eth25/8(Port25)"],
+                "8x25G": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)", "Eth25/5(Port25)", "Eth25/6(Port25)", "Eth25/7(Port25)", "Eth25/8(Port25)"]
             }
         },
 
@@ -578,9 +916,22 @@
             "lanes": "209,210,211,212,213,214,215,216",
             "breakout_modes": {
                 "1x400G": ["Eth26(Port26)"],
+                "1x200G(4)": ["Eth26(Port26)"],
+                "1x100G(2)": ["Eth26(Port26)"],
+                "1x100G(4)": ["Eth26(Port26)"],
+                "1x50G(2)": ["Eth26(Port26)"],
+                "1x40G(4)": ["Eth26(Port26)"],
+                "1x25G(1)": ["Eth26(Port26)"],
                 "2x200G": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
+                "2x100G": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
+                "2x50G(2)": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
+                "2x50G(4)": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
+                "2x40G": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
                 "4x100G": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)"],
-                "8x50G": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)", "Eth26/5(Port26)", "Eth26/6(Port26)", "Eth26/7(Port26)", "Eth26/8(Port26)"]
+                "4x25G(4)": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)"],
+                "4x10G(4)": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)"],
+                "8x50G": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)", "Eth26/5(Port26)", "Eth26/6(Port26)", "Eth26/7(Port26)", "Eth26/8(Port26)"],
+                "8x25G": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)", "Eth26/5(Port26)", "Eth26/6(Port26)", "Eth26/7(Port26)", "Eth26/8(Port26)"]
             }
         },
         
@@ -589,9 +940,22 @@
             "lanes": "217,218,219,220,221,222,223,224",
             "breakout_modes": {
                 "1x400G": ["Eth27(Port27)"],
+                "1x200G(4)": ["Eth27(Port27)"],
+                "1x100G(2)": ["Eth27(Port27)"],
+                "1x100G(4)": ["Eth27(Port27)"],
+                "1x50G(2)": ["Eth27(Port27)"],
+                "1x40G(4)": ["Eth27(Port27)"],
+                "1x25G(1)": ["Eth27(Port27)"],
                 "2x200G": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
+                "2x100G": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
+                "2x50G(2)": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
+                "2x50G(4)": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
+                "2x40G": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
                 "4x100G": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)"],
-                "8x50G": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)", "Eth27/5(Port27)", "Eth27/6(Port27)", "Eth27/7(Port27)", "Eth27/8(Port27)"]
+                "4x25G(4)": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)"],
+                "4x10G(4)": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)"],
+                "8x50G": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)", "Eth27/5(Port27)", "Eth27/6(Port27)", "Eth27/7(Port27)", "Eth27/8(Port27)"],
+                "8x25G": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)", "Eth27/5(Port27)", "Eth27/6(Port27)", "Eth27/7(Port27)", "Eth27/8(Port27)"]
             }
         },
 
@@ -600,9 +964,22 @@
             "lanes": "225,226,227,228,229,230,231,232",
             "breakout_modes": {
                 "1x400G": ["Eth28(Port28)"],
+                "1x200G(4)": ["Eth28(Port28)"],
+                "1x100G(2)": ["Eth28(Port28)"],
+                "1x100G(4)": ["Eth28(Port28)"],
+                "1x50G(2)": ["Eth28(Port28)"],
+                "1x40G(4)": ["Eth28(Port28)"],
+                "1x25G(1)": ["Eth28(Port28)"],
                 "2x200G": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
+                "2x100G": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
+                "2x50G(2)": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
+                "2x50G(4)": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
+                "2x40G": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
                 "4x100G": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)"],
-                "8x50G": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)", "Eth28/5(Port28)", "Eth28/6(Port28)", "Eth28/7(Port28)", "Eth28/8(Port28)"]
+                "4x25G(4)": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)"],
+                "4x10G(4)": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)"],
+                "8x50G": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)", "Eth28/5(Port28)", "Eth28/6(Port28)", "Eth28/7(Port28)", "Eth28/8(Port28)"],
+                "8x25G": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)", "Eth28/5(Port28)", "Eth28/6(Port28)", "Eth28/7(Port28)", "Eth28/8(Port28)"]
             }
         },
 
@@ -611,9 +988,22 @@
             "lanes": "233,234,235,236,237,238,239,240",
             "breakout_modes": {
                 "1x400G": ["Eth29(Port29)"],
+                "1x200G(4)": ["Eth29(Port29)"],
+                "1x100G(2)": ["Eth29(Port29)"],
+                "1x100G(4)": ["Eth29(Port29)"],
+                "1x50G(2)": ["Eth29(Port29)"],
+                "1x40G(4)": ["Eth29(Port29)"],
+                "1x25G(1)": ["Eth29(Port29)"],
                 "2x200G": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
+                "2x100G": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
+                "2x50G(2)": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
+                "2x50G(4)": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
+                "2x40G": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
                 "4x100G": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)"],
-                "8x50G": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)", "Eth29/5(Port29)", "Eth29/6(Port29)", "Eth29/7(Port29)", "Eth29/8(Port29)"]
+                "4x25G(4)": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)"],
+                "4x10G(4)": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)"],
+                "8x50G": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)", "Eth29/5(Port29)", "Eth29/6(Port29)", "Eth29/7(Port29)", "Eth29/8(Port29)"],
+                "8x25G": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)", "Eth29/5(Port29)", "Eth29/6(Port29)", "Eth29/7(Port29)", "Eth29/8(Port29)"]
             }
         },
 
@@ -622,9 +1012,22 @@
             "lanes": "241,242,243,244,245,246,247,248",
             "breakout_modes": {
                 "1x400G": ["Eth30(Port30)"],
+                "1x200G(4)": ["Eth30(Port30)"],
+                "1x100G(2)": ["Eth30(Port30)"],
+                "1x100G(4)": ["Eth30(Port30)"],
+                "1x50G(2)": ["Eth30(Port30)"],
+                "1x40G(4)": ["Eth30(Port30)"],
+                "1x25G(1)": ["Eth30(Port30)"],
                 "2x200G": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
+                "2x100G": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
+                "2x50G(2)": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
+                "2x50G(4)": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
+                "2x40G": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
                 "4x100G": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)"],
-                "8x50G": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)", "Eth30/5(Port30)", "Eth30/6(Port30)", "Eth30/7(Port30)", "Eth30/8(Port30)"]
+                "4x25G(4)": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)"],
+                "4x10G(4)": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)"],
+                "8x50G": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)", "Eth30/5(Port30)", "Eth30/6(Port30)", "Eth30/7(Port30)", "Eth30/8(Port30)"],
+                "8x25G": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)", "Eth30/5(Port30)", "Eth30/6(Port30)", "Eth30/7(Port30)", "Eth30/8(Port30)"]
             }
         },
 
@@ -633,9 +1036,22 @@
             "lanes": "249,250,251,252,253,254,255,256",
             "breakout_modes": {
                 "1x400G": ["Eth31(Port31)"],
+                "1x200G(4)": ["Eth31(Port31)"],
+                "1x100G(2)": ["Eth31(Port31)"],
+                "1x100G(4)": ["Eth31(Port31)"],
+                "1x50G(2)": ["Eth31(Port31)"],
+                "1x40G(4)": ["Eth31(Port31)"],
+                "1x25G(1)": ["Eth31(Port31)"],
                 "2x200G": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
+                "2x100G": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
+                "2x50G(2)": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
+                "2x50G(4)": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
+                "2x40G": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
                 "4x100G": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)"],
-                "8x50G": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)", "Eth31/5(Port31)", "Eth31/6(Port31)", "Eth31/7(Port31)", "Eth31/8(Port31)"]
+                "4x25G(4)": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)"],
+                "4x10G(4)": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)"],
+                "8x50G": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)", "Eth31/5(Port31)", "Eth31/6(Port31)", "Eth31/7(Port31)", "Eth31/8(Port31)"],
+                "8x25G": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)", "Eth31/5(Port31)", "Eth31/6(Port31)", "Eth31/7(Port31)", "Eth31/8(Port31)"]
             }
         },
 
@@ -643,7 +1059,7 @@
             "index": "32",
             "lanes": "257",
             "breakout_modes": {
-                "1x10G": ["Eth32(Port32)"]
+                "1x10G": ["Eth312(Port32)"]
             }
         },
         
@@ -651,7 +1067,7 @@
             "index": "33",
             "lanes": "259",
             "breakout_modes": {
-                "1x10G": ["Eth33(Port33)"]
+                "1x10G": ["Eth313(Port33)"]
             }
         }
     }

--- a/device/ufispace/x86_64-ufispace_s9301_32d-r0/pddf/pd-plugin.json
+++ b/device/ufispace/x86_64-ufispace_s9301_32d-r0/pddf/pd-plugin.json
@@ -24,10 +24,6 @@
             "i2c":
             {
                 "valmap": { "1":true, "0":false }
-            },
-            "bmc":
-            {
-                "valmap": { "Device Present":true, "Device Absent":false }
             }
         }, 
 		
@@ -36,11 +32,7 @@
             "i2c":
             {
                 "valmap": { "1": true, "0":false }
-            },
-            "bmc":
-            {
-                "valmap": { "State Asserted":true, "State Deasserted":false }
-            }        
+            }
         },
 
         "psu_fan_dir":

--- a/device/ufispace/x86_64-ufispace_s9301_32d-r0/pddf/pddf-device.json
+++ b/device/ufispace/x86_64-ufispace_s9301_32d-r0/pddf/pddf-device.json
@@ -148,7 +148,7 @@
                         "raw": "0",
                         "field_name": "TEMP_CPU_PECI",
                         "field_pos": "18"
-                    }              
+                    }
                 ]
             }
         }
@@ -185,7 +185,7 @@
                         "raw": "0",
                         "field_name": "TEMP_CPU_ENV",
                         "field_pos": "18"
-                    }               
+                    }
                 ]
             }
         }
@@ -222,7 +222,7 @@
                         "raw": "0",
                         "field_name": "TEMP_CPU_ENV_2",
                         "field_pos": "18"
-                    }              
+                    }
                 ]
             }
         }
@@ -259,7 +259,7 @@
                         "raw": "0",
                         "field_name": "TEMP_MAC_ENV",
                         "field_pos": "18"
-                    }               
+                    }
                 ]
             }
         }
@@ -296,7 +296,7 @@
                         "raw": "0",
                         "field_name": "TEMP_MAC_DIE",
                         "field_pos": "18"
-                    }              
+                    }
                 ]
             }
         }
@@ -333,7 +333,7 @@
                         "raw": "0",
                         "field_name": "TEMP_CAGE",
                         "field_pos": "18"
-                    }              
+                    }
                 ]
             }
         }
@@ -370,7 +370,7 @@
                         "raw": "0",
                         "field_name": "TEMP_PSU_CONN",
                         "field_pos": "18"
-                    }              
+                    }
                 ]
             }
         }
@@ -407,6 +407,14 @@
                 {
                     "chn": "4",
                     "dev": "GPIO2"
+                },
+                {
+                    "chn": "1",
+                    "dev": "PSU1"
+                },
+                {
+                    "chn": "1",
+                    "dev": "PSU2"
                 }
             ]
         }
@@ -1060,34 +1068,20 @@
         "dev_info": {
             "device_type": "PSU",
             "device_name": "PSU1",
-            "device_parent": "SMBUS0"
+            "device_parent": "MUX1"
         },
         "dev_attr": {
             "dev_idx": "1",
             "num_psu_fans": "1"
         },
         "i2c": {
-            "interface": []
+            "interface": [
+                { "itf":"eeprom", "dev":"PSU1-EEPROM" }
+            ]
         },
         "bmc": {
             "ipmitool": {
                 "attr_list": [
-                    {
-                        "attr_name": "psu_present",
-                        "bmc_cmd": "ipmitool sdr -c get PSU0_PRSNT_L | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
-                        "raw": "0",
-                        "field_name": "PSU0_PRSNT_L",
-                        "field_pos": "5",
-                        "separator": ","
-                    },
-                    {
-                        "attr_name": "psu_power_good",
-                        "bmc_cmd": "ipmitool sdr -c get PSU0_PWROK_H | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
-                        "raw": "0",
-                        "field_name": "PSU0_PWROK_H",
-                        "field_pos": "5",
-                        "separator": ","
-                    },
                     {
                         "attr_name": "psu_v_out",
                         "bmc_cmd": "ipmitool sdr -c get PSU0_VOUT | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
@@ -1175,38 +1169,59 @@
             }
         }
     },
+    "PSU1-EEPROM": {
+        "dev_info": {
+            "device_type": "PSU-EEPROM",
+            "device_name": "PSU1-EEPROM",
+            "device_parent": "MUX1",
+            "virt_parent": "PSU1"
+        },
+        "i2c": {
+            "topo_info": {
+                "parent_bus": "0x2",
+                "dev_addr": "0x5a",
+                "dev_type": "psu_eeprom"
+            },
+            "attr_list": [
+                {
+                    "attr_name":"psu_present",
+                    "attr_devaddr":"0x30",
+                    "attr_devtype":"cpld",
+                    "attr_offset":"0x51",
+                    "attr_mask":"0x4",
+                    "attr_cmpval":"0x0",
+                    "attr_len":"1"
+                },
+                {
+                    "attr_name":"psu_power_good",
+                    "attr_devaddr":"0x30",
+                    "attr_devtype":"cpld",
+                    "attr_offset":"0x51",
+                    "attr_mask":"0x1",
+                    "attr_cmpval":"0x1",
+                    "attr_len":"1"
+                }
+            ]
+        }
+    },
     "PSU2": {
         "dev_info": {
             "device_type": "PSU",
             "device_name": "PSU2",
-            "device_parent": "SMBUS0"
+            "device_parent": "MUX1"
         },
         "dev_attr": {
             "dev_idx": "2",
             "num_psu_fans": "1"
         },
         "i2c": {
-            "interface": []
+            "interface": [
+                { "itf":"eeprom", "dev":"PSU2-EEPROM" }
+            ]
         },
         "bmc": {
             "ipmitool": {
                 "attr_list": [
-                    {
-                        "attr_name": "psu_present",
-                        "bmc_cmd": "ipmitool sdr -c get PSU1_PRSNT_L | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
-                        "raw": "0",
-                        "field_name": "PSU1_PRSNT_L",
-                        "field_pos": "5",
-                        "separator": ","
-                    },
-                    {
-                        "attr_name": "psu_power_good",
-                        "bmc_cmd": "ipmitool sdr -c get PSU1_PWROK_H | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
-                        "raw": "0",
-                        "field_name": "PSU1_PWROK_H",
-                        "field_pos": "5",
-                        "separator": ","
-                    },
                     {
                         "attr_name": "psu_v_out",
                         "bmc_cmd": "ipmitool sdr -c get PSU1_VOUT | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
@@ -1292,6 +1307,41 @@
                     }
                 ]
             }
+        }
+    },
+    "PSU2-EEPROM": {
+        "dev_info": {
+            "device_type": "PSU-EEPROM",
+            "device_name": "PSU2-EEPROM",
+            "device_parent": "MUX1",
+            "virt_parent": "PSU2"
+        },
+        "i2c": {
+            "topo_info": {
+                "parent_bus": "0x2",
+                "dev_addr": "0x5b",
+                "dev_type": "psu_eeprom"
+            },
+            "attr_list": [
+                {
+                    "attr_name":"psu_present",
+                    "attr_devaddr":"0x30",
+                    "attr_devtype":"cpld",
+                    "attr_offset":"0x51",
+                    "attr_mask":"0x8",
+                    "attr_cmpval":"0x0",
+                    "attr_len":"1"
+                },
+                {
+                    "attr_name":"psu_power_good",
+                    "attr_devaddr":"0x30",
+                    "attr_devtype":"cpld",
+                    "attr_offset":"0x51",
+                    "attr_mask":"0x2",
+                    "attr_cmpval":"0x2",
+                    "attr_len":"1"
+                }
+            ]
         }
     },
     "FAN-CTRL": {
@@ -1722,7 +1772,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT1": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -2019,7 +2069,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT4": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -2118,7 +2168,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT5": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -2217,7 +2267,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT6": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -2316,7 +2366,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT7": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -2415,7 +2465,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT8": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -2514,7 +2564,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT9": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -2613,7 +2663,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT10": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -2811,7 +2861,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT12": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -2910,7 +2960,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT13": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -3009,7 +3059,7 @@
                 }
             ]
         }
-    },        
+    },
     "PORT14": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -3207,7 +3257,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT16": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -3306,7 +3356,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT17": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -3504,7 +3554,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT19": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -3603,7 +3653,7 @@
                 }
             ]
         }
-    },            
+    },
     "PORT20": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -3999,7 +4049,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT24": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -4098,7 +4148,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT25": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -4296,7 +4346,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT27": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -4395,7 +4445,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT28": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -4494,7 +4544,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT29": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -4593,7 +4643,7 @@
                 }
             ]
         }
-    },        
+    },
     "PORT30": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -4692,7 +4742,7 @@
                 }
             ]
         }
-    },        
+    },
     "PORT31": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -4890,7 +4940,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT33": {
         "dev_info": {
             "device_type": "SFP",
@@ -5088,5 +5138,5 @@
                 }
             ]
         }
-    }    
+    }
 }

--- a/device/ufispace/x86_64-ufispace_s9301_32db-r0/pddf/pd-plugin.json
+++ b/device/ufispace/x86_64-ufispace_s9301_32db-r0/pddf/pd-plugin.json
@@ -24,10 +24,6 @@
             "i2c":
             {
                 "valmap": { "1":true, "0":false }
-            },
-            "bmc":
-            {
-                "valmap": { "Device Present":true, "Device Absent":false }
             }
         }, 
 		
@@ -36,11 +32,7 @@
             "i2c":
             {
                 "valmap": { "1": true, "0":false }
-            },
-            "bmc":
-            {
-                "valmap": { "State Asserted":true, "State Deasserted":false }
-            }        
+            }
         },
 
         "psu_fan_dir":

--- a/device/ufispace/x86_64-ufispace_s9301_32db-r0/pddf/pddf-device.json
+++ b/device/ufispace/x86_64-ufispace_s9301_32db-r0/pddf/pddf-device.json
@@ -148,7 +148,7 @@
                         "raw": "0",
                         "field_name": "TEMP_CPU_PECI",
                         "field_pos": "18"
-                    }              
+                    }
                 ]
             }
         }
@@ -185,7 +185,7 @@
                         "raw": "0",
                         "field_name": "TEMP_CPU_ENV",
                         "field_pos": "18"
-                    }               
+                    }
                 ]
             }
         }
@@ -222,7 +222,7 @@
                         "raw": "0",
                         "field_name": "TEMP_CPU_ENV_2",
                         "field_pos": "18"
-                    }               
+                    }
                 ]
             }
         }
@@ -259,7 +259,7 @@
                         "raw": "0",
                         "field_name": "TEMP_MAC_ENV",
                         "field_pos": "18"
-                    }               
+                    }
                 ]
             }
         }
@@ -296,7 +296,7 @@
                         "raw": "0",
                         "field_name": "TEMP_MAC_DIE",
                         "field_pos": "18"
-                    }               
+                    }
                 ]
             }
         }
@@ -333,7 +333,7 @@
                         "raw": "0",
                         "field_name": "TEMP_CAGE",
                         "field_pos": "18"
-                    }               
+                    }
                 ]
             }
         }
@@ -370,7 +370,7 @@
                         "raw": "0",
                         "field_name": "TEMP_PSU_CONN",
                         "field_pos": "18"
-                    }              
+                    }
                 ]
             }
         }
@@ -407,6 +407,14 @@
                 {
                     "chn": "4",
                     "dev": "GPIO2"
+                },
+                {
+                    "chn": "1",
+                    "dev": "PSU1"
+                },
+                {
+                    "chn": "1",
+                    "dev": "PSU2"
                 }
             ]
         }
@@ -1052,34 +1060,20 @@
         "dev_info": {
             "device_type": "PSU",
             "device_name": "PSU1",
-            "device_parent": "SMBUS0"
+            "device_parent": "MUX1"
         },
         "dev_attr": {
             "dev_idx": "1",
             "num_psu_fans": "1"
         },
         "i2c": {
-            "interface": []
+            "interface": [
+                { "itf":"eeprom", "dev":"PSU1-EEPROM" }
+            ]
         },
         "bmc": {
             "ipmitool": {
                 "attr_list": [
-                    {
-                        "attr_name": "psu_present",
-                        "bmc_cmd": "ipmitool sdr -c get PSU0_PRSNT_L | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
-                        "raw": "0",
-                        "field_name": "PSU0_PRSNT_L",
-                        "field_pos": "5",
-                        "separator": ","
-                    },
-                    {
-                        "attr_name": "psu_power_good",
-                        "bmc_cmd": "ipmitool sdr -c get PSU0_PWROK_H | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
-                        "raw": "0",
-                        "field_name": "PSU0_PWROK_H",
-                        "field_pos": "5",
-                        "separator": ","
-                    },
                     {
                         "attr_name": "psu_v_out",
                         "bmc_cmd": "ipmitool sdr -c get PSU0_VOUT | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
@@ -1162,43 +1156,64 @@
                         "bmc_cmd": "ipmitool raw 0x3c 0x30 0x0 | xargs | cut -d' ' -f1",
                         "raw": "1",
                         "type": "raw"
-                    }                 
+                    }
                 ]
             }
+        }
+    },
+    "PSU1-EEPROM": {
+        "dev_info": {
+            "device_type": "PSU-EEPROM",
+            "device_name": "PSU1-EEPROM",
+            "device_parent": "MUX1",
+            "virt_parent": "PSU1"
+        },
+        "i2c": {
+            "topo_info": {
+                "parent_bus": "0x2",
+                "dev_addr": "0x5a",
+                "dev_type": "psu_eeprom"
+            },
+            "attr_list": [
+                {
+                    "attr_name":"psu_present",
+                    "attr_devaddr":"0x30",
+                    "attr_devtype":"cpld",
+                    "attr_offset":"0x51",
+                    "attr_mask":"0x4",
+                    "attr_cmpval":"0x0",
+                    "attr_len":"1"
+                },
+                {
+                    "attr_name":"psu_power_good",
+                    "attr_devaddr":"0x30",
+                    "attr_devtype":"cpld",
+                    "attr_offset":"0x51",
+                    "attr_mask":"0x1",
+                    "attr_cmpval":"0x1",
+                    "attr_len":"1"
+                }
+            ]
         }
     },
     "PSU2": {
         "dev_info": {
             "device_type": "PSU",
             "device_name": "PSU2",
-            "device_parent": "SMBUS0"
+            "device_parent": "MUX1"
         },
         "dev_attr": {
             "dev_idx": "2",
             "num_psu_fans": "1"
         },
         "i2c": {
-            "interface": []
+            "interface": [
+                { "itf":"eeprom", "dev":"PSU2-EEPROM" }
+            ]
         },
         "bmc": {
             "ipmitool": {
                 "attr_list": [
-                    {
-                        "attr_name": "psu_present",
-                        "bmc_cmd": "ipmitool sdr -c get PSU1_PRSNT_L | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
-                        "raw": "0",
-                        "field_name": "PSU1_PRSNT_L",
-                        "field_pos": "5",
-                        "separator": ","
-                    },
-                    {
-                        "attr_name": "psu_power_good",
-                        "bmc_cmd": "ipmitool sdr -c get PSU1_PWROK_H | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
-                        "raw": "0",
-                        "field_name": "PSU1_PWROK_H",
-                        "field_pos": "5",
-                        "separator": ","
-                    },
                     {
                         "attr_name": "psu_v_out",
                         "bmc_cmd": "ipmitool sdr -c get PSU1_VOUT | sed -e 's/,,/,N\\/A,/g' -e 's/,,/,N\\/A,/g'",
@@ -1284,6 +1299,41 @@
                     }
                 ]
             }
+        }
+    },
+    "PSU2-EEPROM": {
+        "dev_info": {
+            "device_type": "PSU-EEPROM",
+            "device_name": "PSU2-EEPROM",
+            "device_parent": "MUX1",
+            "virt_parent": "PSU2"
+        },
+        "i2c": {
+            "topo_info": {
+                "parent_bus": "0x2",
+                "dev_addr": "0x5b",
+                "dev_type": "psu_eeprom"
+            },
+            "attr_list": [
+                {
+                    "attr_name":"psu_present",
+                    "attr_devaddr":"0x30",
+                    "attr_devtype":"cpld",
+                    "attr_offset":"0x51",
+                    "attr_mask":"0x8",
+                    "attr_cmpval":"0x0",
+                    "attr_len":"1"
+                },
+                {
+                    "attr_name":"psu_power_good",
+                    "attr_devaddr":"0x30",
+                    "attr_devtype":"cpld",
+                    "attr_offset":"0x51",
+                    "attr_mask":"0x2",
+                    "attr_cmpval":"0x2",
+                    "attr_len":"1"
+                }
+            ]
         }
     },
     "FAN-CTRL": {
@@ -1714,7 +1764,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT1": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -2011,7 +2061,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT4": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -2110,7 +2160,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT5": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -2209,7 +2259,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT6": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -2308,7 +2358,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT7": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -2407,7 +2457,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT8": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -2506,7 +2556,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT9": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -2605,7 +2655,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT10": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -2803,7 +2853,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT12": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -2902,7 +2952,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT13": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -3001,7 +3051,7 @@
                 }
             ]
         }
-    },        
+    },
     "PORT14": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -3199,7 +3249,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT16": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -3298,7 +3348,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT17": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -3496,7 +3546,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT19": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -3595,7 +3645,7 @@
                 }
             ]
         }
-    },            
+    },
     "PORT20": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -3991,7 +4041,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT24": {
         "dev_info": {
             "device_type": "QSFP28",
@@ -4090,7 +4140,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT25": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -4288,7 +4338,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT27": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -4387,7 +4437,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT28": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -4486,7 +4536,7 @@
                 }
             ]
         }
-    },    
+    },
     "PORT29": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -4585,7 +4635,7 @@
                 }
             ]
         }
-    },        
+    },
     "PORT30": {
         "dev_info": {
             "device_type": "QSFP-DD",
@@ -4684,7 +4734,7 @@
                 }
             ]
         }
-    },        
+    },
     "PORT31": {
         "dev_info": {
             "device_type": "QSFP-DD",

--- a/device/ufispace/x86_64-ufispace_s9301_32db-r0/platform.json
+++ b/device/ufispace/x86_64-ufispace_s9301_32db-r0/platform.json
@@ -286,8 +286,17 @@
             "lanes": "1,2,3,4",
             "breakout_modes": {
                 "1x200G": ["Eth0(Port0)"],
-                "2x100G": ["Eth0/1(Port0)", "Eth0/2(Port0)"],
-                "4x50G": ["Eth0/1(Port0)", "Eth0/2(Port0)", "Eth0/3(Port0)", "Eth0/4(Port0)"]
+                "1x100G(2)": ["Eth0(Port0)"],
+                "1x100G(4)": ["Eth0(Port0)"],
+                "1x50G(2)": ["Eth0(Port0)"],
+                "1x40G(4)": ["Eth0(Port0)"],
+                "1x25G(1)": ["Eth0(Port0)"],
+                "2x100G(4)": ["Eth0/1(Port0)", "Eth0/2(Port0)"],
+                "2x50G(2)": ["Eth0/1(Port0)", "Eth0/2(Port0)"],
+                "2x25G(2)": ["Eth0/1(Port0)", "Eth0/2(Port0)"],
+                "4x50G(4)": ["Eth0/1(Port0)", "Eth0/2(Port0)", "Eth0/3(Port0)", "Eth0/4(Port0)"],
+                "4x25G(4)": ["Eth0/1(Port0)", "Eth0/2(Port0)", "Eth0/3(Port0)", "Eth0/4(Port0)"],
+                "4x10G(4)": ["Eth0/1(Port0)", "Eth0/2(Port0)", "Eth0/3(Port0)", "Eth0/4(Port0)"]
             }
         },
 
@@ -296,8 +305,17 @@
             "lanes": "5,6,7,8",
             "breakout_modes": {
                 "1x200G": ["Eth1(Port1)"],
-                "2x100G": ["Eth1/1(Port1)", "Eth1/2(Port1)"],
-                "4x50G": ["Eth1/1(Port1)", "Eth1/2(Port1)", "Eth1/3(Port1)", "Eth1/4(Port1)"]
+                "1x100G(2)": ["Eth1(Port1)"],
+                "1x100G(4)": ["Eth1(Port1)"],
+                "1x50G(2)": ["Eth1(Port1)"],
+                "1x40G(4)": ["Eth1(Port1)"],
+                "1x25G(1)": ["Eth1(Port1)"],
+                "2x100G(4)": ["Eth1/1(Port1)", "Eth1/2(Port1)"],
+                "2x50G(2)": ["Eth1/1(Port1)", "Eth1/2(Port1)"],
+                "2x25G(2)": ["Eth1/1(Port1)", "Eth1/2(Port1)"],
+                "4x50G(4)": ["Eth1/1(Port1)", "Eth1/2(Port1)", "Eth1/3(Port1)", "Eth1/4(Port1)"],
+                "4x25G(4)": ["Eth1/1(Port1)", "Eth1/2(Port1)", "Eth1/3(Port1)", "Eth1/4(Port1)"],
+                "4x10G(4)": ["Eth1/1(Port1)", "Eth1/2(Port1)", "Eth1/3(Port1)", "Eth1/4(Port1)"]
             }
         },
 
@@ -306,8 +324,17 @@
             "lanes": "9,10,11,12",
             "breakout_modes": {
                 "1x200G": ["Eth2(Port2)"],
-                "2x100G": ["Eth2/1(Port2)", "Eth2/2(Port2)"],
-                "4x50G": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)"]
+                "1x100G(2)": ["Eth2(Port2)"],
+                "1x100G(4)": ["Eth2(Port2)"],
+                "1x50G(2)": ["Eth2(Port2)"],
+                "1x40G(4)": ["Eth2(Port2)"],
+                "1x25G(1)": ["Eth2(Port2)"],
+                "2x100G(4)": ["Eth2/1(Port2)", "Eth2/2(Port2)"],
+                "2x50G(2)": ["Eth2/1(Port2)", "Eth2/2(Port2)"],
+                "2x25G(2)": ["Eth2/1(Port2)", "Eth2/2(Port2)"],
+                "4x50G(4)": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)"],
+                "4x25G(4)": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)"],
+                "4x10G(4)": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)"]
             }
         },
 
@@ -316,8 +343,17 @@
             "lanes": "13,14,15,16",
             "breakout_modes": {
                 "1x200G": ["Eth3(Port3)"],
-                "2x100G": ["Eth3/1(Port3)", "Eth3/2(Port3)"],
-                "4x50G": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)"]
+                "1x100G(2)": ["Eth3(Port3)"],
+                "1x100G(4)": ["Eth3(Port3)"],
+                "1x50G(2)": ["Eth3(Port3)"],
+                "1x40G(4)": ["Eth3(Port3)"],
+                "1x25G(1)": ["Eth3(Port3)"],
+                "2x100G(4)": ["Eth3/1(Port3)", "Eth3/2(Port3)"],
+                "2x50G(2)": ["Eth3/1(Port3)", "Eth3/2(Port3)"],
+                "2x25G(2)": ["Eth3/1(Port3)", "Eth3/2(Port3)"],
+                "4x50G(4)": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)"],
+                "4x25G(4)": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)"],
+                "4x10G(4)": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)"]
             }
         },
 
@@ -326,8 +362,17 @@
             "lanes": "17,18,19,20",
             "breakout_modes": {
                 "1x200G": ["Eth4(Port4)"],
-                "2x100G": ["Eth4/1(Port4)", "Eth4/2(Port4)"],
-                "4x50G": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)"]
+                "1x100G(2)": ["Eth4(Port4)"],
+                "1x100G(4)": ["Eth4(Port4)"],
+                "1x50G(2)": ["Eth4(Port4)"],
+                "1x40G(4)": ["Eth4(Port4)"],
+                "1x25G(1)": ["Eth4(Port4)"],
+                "2x100G(4)": ["Eth4/1(Port4)", "Eth4/2(Port4)"],
+                "2x50G(2)": ["Eth4/1(Port4)", "Eth4/2(Port4)"],
+                "2x25G(2)": ["Eth4/1(Port4)", "Eth4/2(Port4)"],
+                "4x50G(4)": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)"],
+                "4x25G(4)": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)"],
+                "4x10G(4)": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)"]
             }
         },
 
@@ -336,8 +381,17 @@
             "lanes": "21,22,23,24",
             "breakout_modes": {
                 "1x200G": ["Eth5(Port5)"],
-                "2x100G": ["Eth5/1(Port5)", "Eth5/2(Port5)"],
-                "4x50G": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)"]
+                "1x100G(2)": ["Eth5(Port5)"],
+                "1x100G(4)": ["Eth5(Port5)"],
+                "1x50G(2)": ["Eth5(Port5)"],
+                "1x40G(4)": ["Eth5(Port5)"],
+                "1x25G(1)": ["Eth5(Port5)"],
+                "2x100G(4)": ["Eth5/1(Port5)", "Eth5/2(Port5)"],
+                "2x50G(2)": ["Eth5/1(Port5)", "Eth5/2(Port5)"],
+                "2x25G(2)": ["Eth5/1(Port5)", "Eth5/2(Port5)"],
+                "4x50G(4)": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)"],
+                "4x25G(4)": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)"],
+                "4x10G(4)": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)"]
             }
         },
 
@@ -346,8 +400,17 @@
             "lanes": "25,26,27,28",
             "breakout_modes": {
                 "1x200G": ["Eth6(Port6)"],
-                "2x100G": ["Eth6/1(Port6)", "Eth6/2(Port6)"],
-                "4x50G": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)"]
+                "1x100G(2)": ["Eth6(Port6)"],
+                "1x100G(4)": ["Eth6(Port6)"],
+                "1x50G(2)": ["Eth6(Port6)"],
+                "1x40G(4)": ["Eth6(Port6)"],
+                "1x25G(1)": ["Eth6(Port6)"],
+                "2x100G(4)": ["Eth6/1(Port6)", "Eth6/2(Port6)"],
+                "2x50G(2)": ["Eth6/1(Port6)", "Eth6/2(Port6)"],
+                "2x25G(2)": ["Eth6/1(Port6)", "Eth6/2(Port6)"],
+                "4x50G(4)": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)"],
+                "4x25G(4)": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)"],
+                "4x10G(4)": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)"]
             }
         },
 
@@ -356,8 +419,17 @@
             "lanes": "29,30,31,32",
             "breakout_modes": {
                 "1x200G": ["Eth7(Port7)"],
-                "2x100G": ["Eth7/1(Port7)", "Eth7/2(Port7)"],
-                "4x50G": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)"]
+                "1x100G(2)": ["Eth7(Port7)"],
+                "1x100G(4)": ["Eth7(Port7)"],
+                "1x50G(2)": ["Eth7(Port7)"],
+                "1x40G(4)": ["Eth7(Port7)"],
+                "1x25G(1)": ["Eth7(Port7)"],
+                "2x100G(4)": ["Eth7/1(Port7)", "Eth7/2(Port7)"],
+                "2x50G(2)": ["Eth7/1(Port7)", "Eth7/2(Port7)"],
+                "2x25G(2)": ["Eth7/1(Port7)", "Eth7/2(Port7)"],
+                "4x50G(4)": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)"],
+                "4x25G(4)": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)"],
+                "4x10G(4)": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)"]
             }
         },
 
@@ -366,8 +438,17 @@
             "lanes": "33,34,35,36",
             "breakout_modes": {
                 "1x200G": ["Eth8(Port8)"],
-                "2x100G": ["Eth8/1(Port8)", "Eth8/2(Port8)"],
-                "4x50G": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)"]
+                "1x100G(2)": ["Eth8(Port8)"],
+                "1x100G(4)": ["Eth8(Port8)"],
+                "1x50G(2)": ["Eth8(Port8)"],
+                "1x40G(4)": ["Eth8(Port8)"],
+                "1x25G(1)": ["Eth8(Port8)"],
+                "2x100G(4)": ["Eth8/1(Port8)", "Eth8/2(Port8)"],
+                "2x50G(2)": ["Eth8/1(Port8)", "Eth8/2(Port8)"],
+                "2x25G(2)": ["Eth8/1(Port8)", "Eth8/2(Port8)"],
+                "4x50G(4)": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)"],
+                "4x25G(4)": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)"],
+                "4x10G(4)": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)"]
             }
         },
 
@@ -376,8 +457,17 @@
             "lanes": "37,38,39,40",
             "breakout_modes": {
                 "1x200G": ["Eth9(Port9)"],
-                "2x100G": ["Eth9/1(Port9)", "Eth9/2(Port9)"],
-                "4x50G": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)"]
+                "1x100G(2)": ["Eth9(Port9)"],
+                "1x100G(4)": ["Eth9(Port9)"],
+                "1x50G(2)": ["Eth9(Port9)"],
+                "1x40G(4)": ["Eth9(Port9)"],
+                "1x25G(1)": ["Eth9(Port9)"],
+                "2x100G(4)": ["Eth9/1(Port9)", "Eth9/2(Port9)"],
+                "2x50G(2)": ["Eth9/1(Port9)", "Eth9/2(Port9)"],
+                "2x25G(2)": ["Eth9/1(Port9)", "Eth9/2(Port9)"],
+                "4x50G(4)": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)"],
+                "4x25G(4)": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)"],
+                "4x10G(4)": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)"]
             }
         },
 
@@ -386,8 +476,17 @@
             "lanes": "41,42,43,44",
             "breakout_modes": {
                 "1x200G": ["Eth10(Port10)"],
-                "2x100G": ["Eth10/1(Port10)", "Eth10/2(Port10)"],
-                "4x50G": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)"]
+                "1x100G(2)": ["Eth10(Port10)"],
+                "1x100G(4)": ["Eth10(Port10)"],
+                "1x50G(2)": ["Eth10(Port10)"],
+                "1x40G(4)": ["Eth10(Port10)"],
+                "1x25G(1)": ["Eth10(Port10)"],
+                "2x100G(4)": ["Eth10/1(Port10)", "Eth10/2(Port10)"],
+                "2x50G(2)": ["Eth10/1(Port10)", "Eth10/2(Port10)"],
+                "2x25G(2)": ["Eth10/1(Port10)", "Eth10/2(Port10)"],
+                "4x50G(4)": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)"],
+                "4x25G(4)": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)"],
+                "4x10G(4)": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)"]
             }
         },
 
@@ -396,8 +495,17 @@
             "lanes": "45,46,47,48",
             "breakout_modes": {
                 "1x200G": ["Eth11(Port11)"],
-                "2x100G": ["Eth11/1(Port11)", "Eth11/2(Port11)"],
-                "4x50G": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)"]
+                "1x100G(2)": ["Eth11(Port11)"],
+                "1x100G(4)": ["Eth11(Port11)"],
+                "1x50G(2)": ["Eth11(Port11)"],
+                "1x40G(4)": ["Eth11(Port11)"],
+                "1x25G(1)": ["Eth11(Port11)"],
+                "2x100G(4)": ["Eth11/1(Port11)", "Eth11/2(Port11)"],
+                "2x50G(2)": ["Eth11/1(Port11)", "Eth11/2(Port11)"],
+                "2x25G(2)": ["Eth11/1(Port11)", "Eth11/2(Port11)"],
+                "4x50G(4)": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)"],
+                "4x25G(4)": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)"],
+                "4x10G(4)": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)"]
             }
         },
 
@@ -406,8 +514,17 @@
             "lanes": "49,50,51,52",
             "breakout_modes": {
                 "1x200G": ["Eth12(Port12)"],
-                "2x100G": ["Eth12/1(Port12)", "Eth12/2(Port12)"],
-                "4x50G": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)"]
+                "1x100G(2)": ["Eth12(Port12)"],
+                "1x100G(4)": ["Eth12(Port12)"],
+                "1x50G(2)": ["Eth12(Port12)"],
+                "1x40G(4)": ["Eth12(Port12)"],
+                "1x25G(1)": ["Eth12(Port12)"],
+                "2x100G(4)": ["Eth12/1(Port12)", "Eth12/2(Port12)"],
+                "2x50G(2)": ["Eth12/1(Port12)", "Eth12/2(Port12)"],
+                "2x25G(2)": ["Eth12/1(Port12)", "Eth12/2(Port12)"],
+                "4x50G(4)": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)"],
+                "4x25G(4)": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)"],
+                "4x10G(4)": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)"]
             }
         },
 
@@ -416,8 +533,17 @@
             "lanes": "53,54,55,56",
             "breakout_modes": {
                 "1x200G": ["Eth13(Port13)"],
-                "2x100G": ["Eth13/1(Port13)", "Eth13/2(Port13)"],
-                "4x50G": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)"]
+                "1x100G(2)": ["Eth13(Port13)"],
+                "1x100G(4)": ["Eth13(Port13)"],
+                "1x50G(2)": ["Eth13(Port13)"],
+                "1x40G(4)": ["Eth13(Port13)"],
+                "1x25G(1)": ["Eth13(Port13)"],
+                "2x100G(4)": ["Eth13/1(Port13)", "Eth13/2(Port13)"],
+                "2x50G(2)": ["Eth13/1(Port13)", "Eth13/2(Port13)"],
+                "2x25G(2)": ["Eth13/1(Port13)", "Eth13/2(Port13)"],
+                "4x50G(4)": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)"],
+                "4x25G(4)": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)"],
+                "4x10G(4)": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)"]
             }
         },
 
@@ -426,8 +552,17 @@
             "lanes": "57,58,59,60",
             "breakout_modes": {
                 "1x200G": ["Eth14(Port14)"],
-                "2x100G": ["Eth14/1(Port14)", "Eth14/2(Port14)"],
-                "4x50G": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)"]
+                "1x100G(2)": ["Eth14(Port14)"],
+                "1x100G(4)": ["Eth14(Port14)"],
+                "1x50G(2)": ["Eth14(Port14)"],
+                "1x40G(4)": ["Eth14(Port14)"],
+                "1x25G(1)": ["Eth14(Port14)"],
+                "2x100G(4)": ["Eth14/1(Port14)", "Eth14/2(Port14)"],
+                "2x50G(2)": ["Eth14/1(Port14)", "Eth14/2(Port14)"],
+                "2x25G(2)": ["Eth14/1(Port14)", "Eth14/2(Port14)"],
+                "4x50G(4)": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)"],
+                "4x25G(4)": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)"],
+                "4x10G(4)": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)"]
             }
         },
 
@@ -436,8 +571,17 @@
             "lanes": "61,62,63,64",
             "breakout_modes": {
                 "1x200G": ["Eth15(Port15)"],
-                "2x100G": ["Eth15/1(Port15)", "Eth15/2(Port15)"],
-                "4x50G": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)"]
+                "1x100G(2)": ["Eth15(Port15)"],
+                "1x100G(4)": ["Eth15(Port15)"],
+                "1x50G(2)": ["Eth15(Port15)"],
+                "1x40G(4)": ["Eth15(Port15)"],
+                "1x25G(1)": ["Eth15(Port15)"],
+                "2x100G(4)": ["Eth15/1(Port15)", "Eth15/2(Port15)"],
+                "2x50G(2)": ["Eth15/1(Port15)", "Eth15/2(Port15)"],
+                "2x25G(2)": ["Eth15/1(Port15)", "Eth15/2(Port15)"],
+                "4x50G(4)": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)"],
+                "4x25G(4)": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)"],
+                "4x10G(4)": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)"]
             }
         },
 
@@ -446,8 +590,17 @@
             "lanes": "65,66,67,68",
             "breakout_modes": {
                 "1x200G": ["Eth16(Port16)"],
-                "2x100G": ["Eth16/1(Port16)", "Eth16/2(Port16)"],
-                "4x50G": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)"]
+                "1x100G(2)": ["Eth16(Port16)"],
+                "1x100G(4)": ["Eth16(Port16)"],
+                "1x50G(2)": ["Eth16(Port16)"],
+                "1x40G(4)": ["Eth16(Port16)"],
+                "1x25G(1)": ["Eth16(Port16)"],
+                "2x100G(4)": ["Eth16/1(Port16)", "Eth16/2(Port16)"],
+                "2x50G(2)": ["Eth16/1(Port16)", "Eth16/2(Port16)"],
+                "2x25G(2)": ["Eth16/1(Port16)", "Eth16/2(Port16)"],
+                "4x50G(4)": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)"],
+                "4x25G(4)": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)"],
+                "4x10G(4)": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)"]
             }
         },
 
@@ -456,8 +609,17 @@
             "lanes": "69,70,71,72",
             "breakout_modes": {
                 "1x200G": ["Eth17(Port17)"],
-                "2x100G": ["Eth17/1(Port17)", "Eth17/2(Port17)"],
-                "4x50G": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)"]
+                "1x100G(2)": ["Eth17(Port17)"],
+                "1x100G(4)": ["Eth17(Port17)"],
+                "1x50G(2)": ["Eth17(Port17)"],
+                "1x40G(4)": ["Eth17(Port17)"],
+                "1x25G(1)": ["Eth17(Port17)"],
+                "2x100G(4)": ["Eth17/1(Port17)", "Eth17/2(Port17)"],
+                "2x50G(2)": ["Eth17/1(Port17)", "Eth17/2(Port17)"],
+                "2x25G(2)": ["Eth17/1(Port17)", "Eth17/2(Port17)"],
+                "4x50G(4)": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)"],
+                "4x25G(4)": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)"],
+                "4x10G(4)": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)"]
             }
         },
 
@@ -466,8 +628,17 @@
             "lanes": "73,74,75,76",
             "breakout_modes": {
                 "1x200G": ["Eth18(Port18)"],
-                "2x100G": ["Eth18/1(Port18)", "Eth18/2(Port18)"],
-                "4x50G": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)"]
+                "1x100G(2)": ["Eth18(Port18)"],
+                "1x100G(4)": ["Eth18(Port18)"],
+                "1x50G(2)": ["Eth18(Port18)"],
+                "1x40G(4)": ["Eth18(Port18)"],
+                "1x25G(1)": ["Eth18(Port18)"],
+                "2x100G(4)": ["Eth18/1(Port18)", "Eth18/2(Port18)"],
+                "2x50G(2)": ["Eth18/1(Port18)", "Eth18/2(Port18)"],
+                "2x25G(2)": ["Eth18/1(Port18)", "Eth18/2(Port18)"],
+                "4x50G(4)": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)"],
+                "4x25G(4)": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)"],
+                "4x10G(4)": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)"]
             }
         },
 
@@ -476,8 +647,17 @@
             "lanes": "77,78,79,80",
             "breakout_modes": {
                 "1x200G": ["Eth19(Port19)"],
-                "2x100G": ["Eth19/1(Port19)", "Eth19/2(Port19)"],
-                "4x50G": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)"]
+                "1x100G(2)": ["Eth19(Port19)"],
+                "1x100G(4)": ["Eth19(Port19)"],
+                "1x50G(2)": ["Eth19(Port19)"],
+                "1x40G(4)": ["Eth19(Port19)"],
+                "1x25G(1)": ["Eth19(Port19)"],
+                "2x100G(4)": ["Eth19/1(Port19)", "Eth19/2(Port19)"],
+                "2x50G(2)": ["Eth19/1(Port19)", "Eth19/2(Port19)"],
+                "2x25G(2)": ["Eth19/1(Port19)", "Eth19/2(Port19)"],
+                "4x50G(4)": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)"],
+                "4x25G(4)": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)"],
+                "4x10G(4)": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)"]
             }
         },
 
@@ -486,8 +666,17 @@
             "lanes": "81,82,83,84",
             "breakout_modes": {
                 "1x200G": ["Eth20(Port20)"],
-                "2x100G": ["Eth20/1(Port20)", "Eth20/2(Port20)"],
-                "4x50G": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)"]
+                "1x100G(2)": ["Eth20(Port20)"],
+                "1x100G(4)": ["Eth20(Port20)"],
+                "1x50G(2)": ["Eth20(Port20)"],
+                "1x40G(4)": ["Eth20(Port20)"],
+                "1x25G(1)": ["Eth20(Port20)"],
+                "2x100G(4)": ["Eth20/1(Port20)", "Eth20/2(Port20)"],
+                "2x50G(2)": ["Eth20/1(Port20)", "Eth20/2(Port20)"],
+                "2x25G(2)": ["Eth20/1(Port20)", "Eth20/2(Port20)"],
+                "4x50G(4)": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)"],
+                "4x25G(4)": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)"],
+                "4x10G(4)": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)"]
             }
         },
 
@@ -496,8 +685,17 @@
             "lanes": "85,86,87,88",
             "breakout_modes": {
                 "1x200G": ["Eth21(Port21)"],
-                "2x100G": ["Eth21/1(Port21)", "Eth21/2(Port21)"],
-                "4x50G": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)"]
+                "1x100G(2)": ["Eth21(Port21)"],
+                "1x100G(4)": ["Eth21(Port21)"],
+                "1x50G(2)": ["Eth21(Port21)"],
+                "1x40G(4)": ["Eth21(Port21)"],
+                "1x25G(1)": ["Eth21(Port21)"],
+                "2x100G(4)": ["Eth21/1(Port21)", "Eth21/2(Port21)"],
+                "2x50G(2)": ["Eth21/1(Port21)", "Eth21/2(Port21)"],
+                "2x25G(2)": ["Eth21/1(Port21)", "Eth21/2(Port21)"],
+                "4x50G(4)": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)"],
+                "4x25G(4)": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)"],
+                "4x10G(4)": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)"]
             }
         },
 
@@ -506,8 +704,17 @@
             "lanes": "89,90,91,92",
             "breakout_modes": {
                 "1x200G": ["Eth22(Port22)"],
-                "2x100G": ["Eth22/1(Port22)", "Eth22/2(Port22)"],
-                "4x50G": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)"]
+                "1x100G(2)": ["Eth22(Port22)"],
+                "1x100G(4)": ["Eth22(Port22)"],
+                "1x50G(2)": ["Eth22(Port22)"],
+                "1x40G(4)": ["Eth22(Port22)"],
+                "1x25G(1)": ["Eth22(Port22)"],
+                "2x100G(4)": ["Eth22/1(Port22)", "Eth22/2(Port22)"],
+                "2x50G(2)": ["Eth22/1(Port22)", "Eth22/2(Port22)"],
+                "2x25G(2)": ["Eth22/1(Port22)", "Eth22/2(Port22)"],
+                "4x50G(4)": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)"],
+                "4x25G(4)": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)"],
+                "4x10G(4)": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)"]
             }
         },
 
@@ -516,8 +723,17 @@
             "lanes": "93,94,95,96",
             "breakout_modes": {
                 "1x200G": ["Eth23(Port23)"],
-                "2x100G": ["Eth23/1(Port23)", "Eth23/2(Port23)"],
-                "4x50G": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)"]
+                "1x100G(2)": ["Eth23(Port23)"],
+                "1x100G(4)": ["Eth23(Port23)"],
+                "1x50G(2)": ["Eth23(Port23)"],
+                "1x40G(4)": ["Eth23(Port23)"],
+                "1x25G(1)": ["Eth23(Port23)"],
+                "2x100G(4)": ["Eth23/1(Port23)", "Eth23/2(Port23)"],
+                "2x50G(2)": ["Eth23/1(Port23)", "Eth23/2(Port23)"],
+                "2x25G(2)": ["Eth23/1(Port23)", "Eth23/2(Port23)"],
+                "4x50G(4)": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)"],
+                "4x25G(4)": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)"],
+                "4x10G(4)": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)"]
             }
         },
 
@@ -526,9 +742,22 @@
             "lanes": "97,98,99,100,101,102,103,104",
             "breakout_modes": {
                 "1x400G": ["Eth24(Port24)"],
+                "1x200G(4)": ["Eth24(Port24)"],
+                "1x100G(2)": ["Eth24(Port24)"],
+                "1x100G(4)": ["Eth24(Port24)"],
+                "1x50G(2)": ["Eth24(Port24)"],
+                "1x40G(4)": ["Eth24(Port24)"],
+                "1x25G(1)": ["Eth24(Port24)"],
                 "2x200G": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
+                "2x100G(8)": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
+                "2x50G(2)": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
+                "2x50G(4)": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
+                "2x40G": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
                 "4x100G": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)"],
-                "8x50G": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)", "Eth24/5(Port24)", "Eth24/6(Port24)", "Eth24/7(Port24)", "Eth24/8(Port24)"]
+                "4x25G(4)": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)"],
+                "4x10G(4)": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)"],
+                "8x50G": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)", "Eth24/5(Port24)", "Eth24/6(Port24)", "Eth24/7(Port24)", "Eth24/8(Port24)"],
+                "8x25G": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)", "Eth24/5(Port24)", "Eth24/6(Port24)", "Eth24/7(Port24)", "Eth24/8(Port24)"]
             }
         },
 
@@ -537,9 +766,22 @@
             "lanes": "105,106,107,108,109,110,111,112",
             "breakout_modes": {
                 "1x400G": ["Eth25(Port25)"],
+                "1x200G(4)": ["Eth25(Port25)"],
+                "1x100G(2)": ["Eth25(Port25)"],
+                "1x100G(4)": ["Eth25(Port25)"],
+                "1x50G(2)": ["Eth25(Port25)"],
+                "1x40G(4)": ["Eth25(Port25)"],
+                "1x25G(1)": ["Eth25(Port25)"],
                 "2x200G": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
+                "2x100G(8)": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
+                "2x50G(2)": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
+                "2x50G(4)": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
+                "2x40G": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
                 "4x100G": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)"],
-                "8x50G": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)", "Eth25/5(Port25)", "Eth25/6(Port25)", "Eth25/7(Port25)", "Eth25/8(Port25)"]
+                "4x25G(4)": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)"],
+                "4x10G(4)": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)"],
+                "8x50G": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)", "Eth25/5(Port25)", "Eth25/6(Port25)", "Eth25/7(Port25)", "Eth25/8(Port25)"],
+                "8x25G": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)", "Eth25/5(Port25)", "Eth25/6(Port25)", "Eth25/7(Port25)", "Eth25/8(Port25)"]
             }
         },
 
@@ -548,9 +790,22 @@
             "lanes": "113,114,115,116,117,118,119,120",
             "breakout_modes": {
                 "1x400G": ["Eth26(Port26)"],
+                "1x200G(4)": ["Eth26(Port26)"],
+                "1x100G(2)": ["Eth26(Port26)"],
+                "1x100G(4)": ["Eth26(Port26)"],
+                "1x50G(2)": ["Eth26(Port26)"],
+                "1x40G(4)": ["Eth26(Port26)"],
+                "1x25G(1)": ["Eth26(Port26)"],
                 "2x200G": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
+                "2x100G(8)": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
+                "2x50G(2)": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
+                "2x50G(4)": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
+                "2x40G": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
                 "4x100G": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)"],
-                "8x50G": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)", "Eth26/5(Port26)", "Eth26/6(Port26)", "Eth26/7(Port26)", "Eth26/8(Port26)"]
+                "4x25G(4)": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)"],
+                "4x10G(4)": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)"],
+                "8x50G": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)", "Eth26/5(Port26)", "Eth26/6(Port26)", "Eth26/7(Port26)", "Eth26/8(Port26)"],
+                "8x25G": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)", "Eth26/5(Port26)", "Eth26/6(Port26)", "Eth26/7(Port26)", "Eth26/8(Port26)"]
             }
         },
         
@@ -559,9 +814,22 @@
             "lanes": "121,122,123,124,125,126,127,128",
             "breakout_modes": {
                 "1x400G": ["Eth27(Port27)"],
+                "1x200G(4)": ["Eth27(Port27)"],
+                "1x100G(2)": ["Eth27(Port27)"],
+                "1x100G(4)": ["Eth27(Port27)"],
+                "1x50G(2)": ["Eth27(Port27)"],
+                "1x40G(4)": ["Eth27(Port27)"],
+                "1x25G(1)": ["Eth27(Port27)"],
                 "2x200G": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
+                "2x100G(8)": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
+                "2x50G(2)": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
+                "2x50G(4)": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
+                "2x40G": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
                 "4x100G": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)"],
-                "8x50G": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)", "Eth27/5(Port27)", "Eth27/6(Port27)", "Eth27/7(Port27)", "Eth27/8(Port27)"]
+                "4x25G(4)": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)"],
+                "4x10G(4)": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)"],
+                "8x50G": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)", "Eth27/5(Port27)", "Eth27/6(Port27)", "Eth27/7(Port27)", "Eth27/8(Port27)"],
+                "8x25G": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)", "Eth27/5(Port27)", "Eth27/6(Port27)", "Eth27/7(Port27)", "Eth27/8(Port27)"]
             }
         },
 
@@ -570,9 +838,22 @@
             "lanes": "129,130,131,132,133,134,135,136",
             "breakout_modes": {
                 "1x400G": ["Eth28(Port28)"],
+                "1x200G(4)": ["Eth28(Port28)"],
+                "1x100G(2)": ["Eth28(Port28)"],
+                "1x100G(4)": ["Eth28(Port28)"],
+                "1x50G(2)": ["Eth28(Port28)"],
+                "1x40G(4)": ["Eth28(Port28)"],
+                "1x25G(1)": ["Eth28(Port28)"],
                 "2x200G": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
+                "2x100G(8)": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
+                "2x50G(2)": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
+                "2x50G(4)": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
+                "2x40G": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
                 "4x100G": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)"],
-                "8x50G": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)", "Eth28/5(Port28)", "Eth28/6(Port28)", "Eth28/7(Port28)", "Eth28/8(Port28)"]
+                "4x25G(4)": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)"],
+                "4x10G(4)": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)"],
+                "8x50G": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)", "Eth28/5(Port28)", "Eth28/6(Port28)", "Eth28/7(Port28)", "Eth28/8(Port28)"],
+                "8x25G": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)", "Eth28/5(Port28)", "Eth28/6(Port28)", "Eth28/7(Port28)", "Eth28/8(Port28)"]
             }
         },
 
@@ -581,9 +862,22 @@
             "lanes": "137,138,139,140,141,142,143,144",
             "breakout_modes": {
                 "1x400G": ["Eth29(Port29)"],
+                "1x200G(4)": ["Eth29(Port29)"],
+                "1x100G(2)": ["Eth29(Port29)"],
+                "1x100G(4)": ["Eth29(Port29)"],
+                "1x50G(2)": ["Eth29(Port29)"],
+                "1x40G(4)": ["Eth29(Port29)"],
+                "1x25G(1)": ["Eth29(Port29)"],
                 "2x200G": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
+                "2x100G(8)": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
+                "2x50G(2)": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
+                "2x50G(4)": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
+                "2x40G": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
                 "4x100G": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)"],
-                "8x50G": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)", "Eth29/5(Port29)", "Eth29/6(Port29)", "Eth29/7(Port29)", "Eth29/8(Port29)"]
+                "4x25G(4)": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)"],
+                "4x10G(4)": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)"],
+                "8x50G": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)", "Eth29/5(Port29)", "Eth29/6(Port29)", "Eth29/7(Port29)", "Eth29/8(Port29)"],
+                "8x25G": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)", "Eth29/5(Port29)", "Eth29/6(Port29)", "Eth29/7(Port29)", "Eth29/8(Port29)"]
             }
         },
 
@@ -592,20 +886,45 @@
             "lanes": "145,146,147,148,149,150,151,152",
             "breakout_modes": {
                 "1x400G": ["Eth30(Port30)"],
+                "1x200G(4)": ["Eth30(Port30)"],
+                "1x100G(2)": ["Eth30(Port30)"],
+                "1x100G(4)": ["Eth30(Port30)"],
+                "1x50G(2)": ["Eth30(Port30)"],
+                "1x40G(4)": ["Eth30(Port30)"],
+                "1x25G(1)": ["Eth30(Port30)"],
                 "2x200G": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
+                "2x100G(8)": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
+                "2x50G(2)": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
+                "2x50G(4)": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
+                "2x40G": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
                 "4x100G": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)"],
-                "8x50G": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)", "Eth30/5(Port30)", "Eth30/6(Port30)", "Eth30/7(Port30)", "Eth30/8(Port30)"]
+                "4x25G(4)": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)"],
+                "4x10G(4)": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)"],
+                "8x50G": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)", "Eth30/5(Port30)", "Eth30/6(Port30)", "Eth30/7(Port30)", "Eth30/8(Port30)"],
+                "8x25G": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)", "Eth30/5(Port30)", "Eth30/6(Port30)", "Eth30/7(Port30)", "Eth30/8(Port30)"]
             }
         },
-
         "Ethernet152": {
             "index": "31,31,31,31,31,31,31,31",
             "lanes": "153,154,155,156,157,158,159,160",
             "breakout_modes": {
                 "1x400G": ["Eth31(Port31)"],
+                "1x200G(4)": ["Eth31(Port31)"],
+                "1x100G(2)": ["Eth31(Port31)"],
+                "1x100G(4)": ["Eth31(Port31)"],
+                "1x50G(2)": ["Eth31(Port31)"],
+                "1x40G(4)": ["Eth31(Port31)"],
+                "1x25G(1)": ["Eth31(Port31)"],
                 "2x200G": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
+                "2x100G(8)": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
+                "2x50G(2)": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
+                "2x50G(4)": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
+                "2x40G": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
                 "4x100G": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)"],
-                "8x50G": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)", "Eth31/5(Port31)", "Eth31/6(Port31)", "Eth31/7(Port31)", "Eth31/8(Port31)"]
+                "4x25G(4)": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)"],
+                "4x10G(4)": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)"],
+                "8x50G": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)", "Eth31/5(Port31)", "Eth31/6(Port31)", "Eth31/7(Port31)", "Eth31/8(Port31)"],
+                "8x25G": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)", "Eth31/5(Port31)", "Eth31/6(Port31)", "Eth31/7(Port31)", "Eth31/8(Port31)"]
             }
         }
     }

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9300-32d/modules/x86-64-ufispace-s9300-32d-lpc.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9300-32d/modules/x86-64-ufispace-s9300-32d-lpc.c
@@ -26,15 +26,16 @@
 #include <linux/io.h>
 #include <linux/platform_device.h>
 #include <linux/hwmon-sysfs.h>
+#include <linux/gpio.h>
 
-#define BSP_LOG_R(fmt, args...) \
-    _bsp_log (LOG_READ, KERN_INFO "%s:%s[%d]: " fmt "\r\n", \
-            __FILE__, __func__, __LINE__, ##args)
-#define BSP_LOG_W(fmt, args...) \
-    _bsp_log (LOG_WRITE, KERN_INFO "%s:%s[%d]: " fmt "\r\n", \
-            __FILE__, __func__, __LINE__, ##args)
+#define BSP_LOG_R(fmt, args...)                            \
+    _bsp_log(LOG_READ, KERN_INFO "%s:%s[%d]: " fmt "\r\n", \
+             __FILE__, __func__, __LINE__, ##args)
+#define BSP_LOG_W(fmt, args...)                             \
+    _bsp_log(LOG_WRITE, KERN_INFO "%s:%s[%d]: " fmt "\r\n", \
+             __FILE__, __func__, __LINE__, ##args)
 
-#define BSP_PR(level, fmt, args...) _bsp_log (LOG_SYS, level "[BSP]" fmt "\r\n", ##args)
+#define BSP_PR(level, fmt, args...) _bsp_log(LOG_SYS, level "[BSP]" fmt "\r\n", ##args)
 
 #define DRIVER_NAME "x86_64_ufispace_s9300_32d_lpc"
 #define CPU_BDE 0
@@ -43,53 +44,54 @@
 
 /* LPC registers */
 
-#define REG_BASE_CPU                      0x600
+#define REG_BASE_CPU 0x600
 
 #if CPU_TYPE == CPU_SKY
-#define REG_BASE_MB                       0xE00
-#define REG_BASE_I2C_ALERT                0x700
+#define REG_BASE_MB 0xE00
+#define REG_BASE_I2C_ALERT 0x700
 #else
-#define REG_BASE_MB                       0x700
-#define REG_BASE_I2C_ALERT                0xF000
+#define REG_BASE_MB 0x700
+#define REG_BASE_I2C_ALERT 0xF000
 #endif
 
-//CPU CPLD
-#define REG_CPU_CPLD_VERSION              (REG_BASE_CPU + 0x00)
-#define REG_CPU_STATUS_0                  (REG_BASE_CPU + 0x01)
-#define REG_CPU_STATUS_1                  (REG_BASE_CPU + 0x02)
-#define REG_CPU_CTRL_0                    (REG_BASE_CPU + 0x03)
-#define REG_CPU_CTRL_1                    (REG_BASE_CPU + 0x04)
-#define REG_CPU_CPLD_BUILD                (REG_BASE_CPU + 0xE0)
+// CPU CPLD
+#define REG_CPU_CPLD_VERSION (REG_BASE_CPU + 0x00)
+#define REG_CPU_STATUS_0 (REG_BASE_CPU + 0x01)
+#define REG_CPU_STATUS_1 (REG_BASE_CPU + 0x02)
+#define REG_CPU_CTRL_0 (REG_BASE_CPU + 0x03)
+#define REG_CPU_CTRL_1 (REG_BASE_CPU + 0x04)
+#define REG_CPU_CPLD_BUILD (REG_BASE_CPU + 0xE0)
 
-//MB CPLD
-//TBD, need to change after CPLD spec release
-#define REG_MB_BRD_ID_0                   (REG_BASE_MB + 0x00)
-#define REG_MB_BRD_ID_1                   (REG_BASE_MB + 0x01)
-#define REG_MB_CPLD_VERSION               (REG_BASE_MB + 0x02)
-#define REG_MB_CPLD_BUILD                 (REG_BASE_MB + 0x04)
-#define REG_MB_MUX_RESET                  (REG_BASE_MB + 0x46)
-#define REG_MB_MUX_CTRL                   (REG_BASE_MB + 0x5c)
+// MB CPLD
+// TBD, need to change after CPLD spec release
+#define REG_MB_BRD_ID_0 (REG_BASE_MB + 0x00)
+#define REG_MB_BRD_ID_1 (REG_BASE_MB + 0x01)
+#define REG_MB_CPLD_VERSION (REG_BASE_MB + 0x02)
+#define REG_MB_CPLD_BUILD (REG_BASE_MB + 0x04)
+#define REG_MB_MUX_RESET (REG_BASE_MB + 0x46)
+#define REG_MB_MUX_CTRL (REG_BASE_MB + 0x5c)
 
-//I2C Alert
+// I2C Alert
 #if CPU_TYPE == CPU_SKY
-#define REG_ALERT_STATUS                  (REG_BASE_I2C_ALERT + 0x80)
+#define REG_ALERT_STATUS (REG_BASE_I2C_ALERT + 0x80)
 #else
-#define REG_ALERT_STATUS                  (REG_BASE_I2C_ALERT + 0x00)
-#define REG_ALERT_DISABLE                 (REG_BASE_I2C_ALERT + 0x11)
+#define REG_ALERT_STATUS (REG_BASE_I2C_ALERT + 0x00)
+#define REG_ALERT_DISABLE (REG_BASE_I2C_ALERT + 0x11)
 #endif
 
-#define MASK_ALL                          (0xFF)
-#define LPC_MDELAY                        (5)
+#define MASK_ALL (0xFF)
+#define LPC_MDELAY (5)
 
 /* LPC sysfs attributes index  */
-enum lpc_sysfs_attributes {
-    //CPU CPLD
+enum lpc_sysfs_attributes
+{
+    // CPU CPLD
     ATT_CPU_CPLD_VERSION,
     ATT_CPU_CPLD_VERSION_H,
     ATT_CPU_BIOS_BOOT_ROM,
     ATT_CPU_BIOS_BOOT_CFG,
     ATT_CPU_CPLD_BUILD,
-    //MB CPLD
+    // MB CPLD
     ATT_MB_BRD_ID_0,
     ATT_MB_BRD_ID_1,
     ATT_MB_CPLD_1_VERSION,
@@ -102,21 +104,23 @@ enum lpc_sysfs_attributes {
     ATT_MB_BRD_ID_TYPE,
     ATT_MB_BRD_BUILD_ID,
     ATT_MB_BRD_DEPH_ID,
-    //I2C Alert
+    // I2C Alert
     ATT_ALERT_STATUS,
 #if CPU_TYPE == CPU_BDE
     ATT_ALERT_DISABLE,
 #endif
-    //BSP
+    // BSP
     ATT_BSP_VERSION,
     ATT_BSP_DEBUG,
     ATT_BSP_PR_INFO,
     ATT_BSP_PR_ERR,
     ATT_BSP_REG,
+    ATT_BSP_GPIO_MAX,
     ATT_MAX
 };
 
-enum bsp_log_types {
+enum bsp_log_types
+{
     LOG_NONE,
     LOG_RW,
     LOG_READ,
@@ -124,29 +128,32 @@ enum bsp_log_types {
     LOG_SYS
 };
 
-enum bsp_log_ctrl {
+enum bsp_log_ctrl
+{
     LOG_DISABLE,
     LOG_ENABLE
 };
 
-struct lpc_data_s {
-    struct mutex    access_lock;
+struct lpc_data_s
+{
+    struct mutex access_lock;
 };
 
 struct lpc_data_s *lpc_data;
-char bsp_version[16]="";
-char bsp_debug[2]="0";
-char bsp_reg[8]="0x0";
-u8 enable_log_read=LOG_DISABLE;
-u8 enable_log_write=LOG_DISABLE;
-u8 enable_log_sys=LOG_ENABLE;
+char bsp_version[16] = "";
+char bsp_debug[2] = "0";
+char bsp_reg[8] = "0x0";
+u8 enable_log_read = LOG_DISABLE;
+u8 enable_log_write = LOG_DISABLE;
+u8 enable_log_sys = LOG_ENABLE;
 
 /* reg shift */
 static u8 _shift(u8 mask)
 {
-    int i=0, mask_one=1;
+    int i = 0, mask_one = 1;
 
-    for(i=0; i<8; ++i) {
+    for (i = 0; i < 8; ++i)
+    {
         if ((mask & mask_one) == 1)
             return i;
         else
@@ -159,7 +166,7 @@ static u8 _shift(u8 mask)
 /* reg mask and shift */
 static u8 _mask_shift(u8 val, u8 mask)
 {
-    int shift=0;
+    int shift = 0;
 
     shift = _shift(mask);
 
@@ -177,9 +184,10 @@ static u8 _bit_operation(u8 reg_val, u8 bit, u8 bit_val)
 
 static int _bsp_log(u8 log_type, char *fmt, ...)
 {
-    if ((log_type==LOG_READ  && enable_log_read) ||
-        (log_type==LOG_WRITE && enable_log_write) ||
-        (log_type==LOG_SYS && enable_log_sys) ) {
+    if ((log_type == LOG_READ && enable_log_read) ||
+        (log_type == LOG_WRITE && enable_log_write) ||
+        (log_type == LOG_SYS && enable_log_sys))
+    {
         va_list args;
         int r;
 
@@ -188,32 +196,35 @@ static int _bsp_log(u8 log_type, char *fmt, ...)
         va_end(args);
 
         return r;
-    } else {
+    }
+    else
+    {
         return 0;
     }
 }
 
 static int _config_bsp_log(u8 log_type)
 {
-    switch(log_type) {
-        case LOG_NONE:
-            enable_log_read = LOG_DISABLE;
-            enable_log_write = LOG_DISABLE;
-            break;
-        case LOG_RW:
-            enable_log_read = LOG_ENABLE;
-            enable_log_write = LOG_ENABLE;
-            break;
-        case LOG_READ:
-            enable_log_read = LOG_ENABLE;
-            enable_log_write = LOG_DISABLE;
-            break;
-        case LOG_WRITE:
-            enable_log_read = LOG_DISABLE;
-            enable_log_write = LOG_ENABLE;
-            break;
-        default:
-            return -EINVAL;
+    switch (log_type)
+    {
+    case LOG_NONE:
+        enable_log_read = LOG_DISABLE;
+        enable_log_write = LOG_DISABLE;
+        break;
+    case LOG_RW:
+        enable_log_read = LOG_ENABLE;
+        enable_log_write = LOG_ENABLE;
+        break;
+    case LOG_READ:
+        enable_log_read = LOG_ENABLE;
+        enable_log_write = LOG_DISABLE;
+        break;
+    case LOG_WRITE:
+        enable_log_read = LOG_DISABLE;
+        enable_log_write = LOG_ENABLE;
+        break;
+    default:
+        return -EINVAL;
     }
     return 0;
 }
@@ -224,7 +235,7 @@ static u8 _read_lpc_reg(u16 reg, u8 mask)
     u8 reg_val;
 
     mutex_lock(&lpc_data->access_lock);
-    reg_val=_mask_shift(inb(reg), mask);
+    reg_val = _mask_shift(inb(reg), mask);
     mutex_unlock(&lpc_data->access_lock);
 
     BSP_LOG_R("reg=0x%03x, reg_val=0x%02x", reg, reg_val);
@@ -236,10 +247,10 @@ static u8 _read_lpc_reg(u16 reg, u8 mask)
 static ssize_t read_lpc_reg(u16 reg, u8 mask, char *buf)
 {
     u8 reg_val;
-    int len=0;
+    int len = 0;
 
     reg_val = _read_lpc_reg(reg, mask);
-    len=sprintf(buf,"0x%x\n", reg_val);
+    len = sprintf(buf, "0x%x\n", reg_val);
 
     return len;
 }
@@ -252,8 +263,9 @@ static ssize_t write_lpc_reg(u16 reg, u8 mask, const char *buf, size_t count)
     if (kstrtou8(buf, 0, &reg_val) < 0)
         return -EINVAL;
 
-    //apply SINGLE BIT operation if mask is specified, multiple bits are not supported
-    if (mask != MASK_ALL) {
+    // apply SINGLE BIT operation if mask is specified, multiple bits are not supported
+    if (mask != MASK_ALL)
+    {
         reg_val_now = _read_lpc_reg(reg, 0x0);
         shift = _shift(mask);
         reg_val = _bit_operation(reg_val_now, shift, reg_val);
@@ -274,10 +286,10 @@ static ssize_t write_lpc_reg(u16 reg, u8 mask, const char *buf, size_t count)
 /* get bsp value */
 static ssize_t read_bsp(char *buf, char *str)
 {
-    ssize_t len=0;
+    ssize_t len = 0;
 
     mutex_lock(&lpc_data->access_lock);
-    len=sprintf(buf, "%s", str);
+    len = sprintf(buf, "%s", str);
     mutex_unlock(&lpc_data->access_lock);
 
     BSP_LOG_R("reg_val=%s", str);
@@ -299,9 +311,9 @@ static ssize_t write_bsp(const char *buf, char *str, size_t str_len, size_t coun
 
 /* get cpu cpld version in human readable format */
 static ssize_t read_cpu_cpld_version_h(struct device *dev,
-        struct device_attribute *da, char *buf)
+                                       struct device_attribute *da, char *buf)
 {
-    ssize_t len=0;
+    ssize_t len = 0;
     u16 reg = REG_CPU_CPLD_VERSION;
     u8 mask = MASK_ALL;
     u8 mask_major = 0b11000000;
@@ -325,9 +337,9 @@ static ssize_t read_cpu_cpld_version_h(struct device *dev,
 
 /* get mb cpld version in human readable format */
 static ssize_t read_mb_cpld_1_version_h(struct device *dev,
-        struct device_attribute *da, char *buf)
+                                        struct device_attribute *da, char *buf)
 {
-    ssize_t len=0;
+    ssize_t len = 0;
     u16 reg = REG_MB_CPLD_VERSION;
     u8 mask = MASK_ALL;
     u8 mask_major = 0b11000000;
@@ -351,7 +363,7 @@ static ssize_t read_mb_cpld_1_version_h(struct device *dev,
 
 /* get mux_reset register value */
 static ssize_t read_mux_reset_callback(struct device *dev,
-        struct device_attribute *da, char *buf)
+                                       struct device_attribute *da, char *buf)
 {
     int len = 0;
     u16 reg = REG_MB_MUX_RESET;
@@ -359,9 +371,9 @@ static ssize_t read_mux_reset_callback(struct device *dev,
     u8 reg_val;
 
     mutex_lock(&lpc_data->access_lock);
-    reg_val=_mask_shift(inb(reg), mask);
+    reg_val = _mask_shift(inb(reg), mask);
     BSP_LOG_R("reg=0x%03x, reg_val=0x%02x", reg, reg_val);
-    len=sprintf(buf, "%d\n", reg_val);
+    len = sprintf(buf, "%d\n", reg_val);
     mutex_unlock(&lpc_data->access_lock);
 
     return len;
@@ -369,7 +381,7 @@ static ssize_t read_mux_reset_callback(struct device *dev,
 
 /* set mux_reset register value */
 static ssize_t write_mux_reset_callback(struct device *dev,
-        struct device_attribute *da, const char *buf, size_t count)
+                                        struct device_attribute *da, const char *buf, size_t count)
 {
     u8 val = 0;
     u16 reg = REG_MB_MUX_RESET;
@@ -380,8 +392,10 @@ static ssize_t write_mux_reset_callback(struct device *dev,
     if (kstrtou8(buf, 0, &val) < 0)
         return -EINVAL;
 
-    if (mux_reset_flag == 0) {
-        if (val == 0) {
+    if (mux_reset_flag == 0)
+    {
+        if (val == 0)
+        {
             mutex_lock(&lpc_data->access_lock);
             mux_reset_flag = 1;
             BSP_LOG_W("i2c mux reset is triggered...");
@@ -397,10 +411,14 @@ static ssize_t write_mux_reset_callback(struct device *dev,
             mdelay(500);
             mux_reset_flag = 0;
             mutex_unlock(&lpc_data->access_lock);
-        } else {
+        }
+        else
+        {
             return -EINVAL;
         }
-    } else {
+    }
+    else
+    {
         BSP_LOG_W("i2c mux is resetting... (ignore)");
         mutex_lock(&lpc_data->access_lock);
         mutex_unlock(&lpc_data->access_lock);
@@ -411,165 +429,173 @@ static ssize_t write_mux_reset_callback(struct device *dev,
 
 /* get lpc register value */
 static ssize_t read_lpc_callback(struct device *dev,
-        struct device_attribute *da, char *buf)
+                                 struct device_attribute *da, char *buf)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
     u16 reg = 0;
     u8 mask = MASK_ALL;
 
-    switch (attr->index) {
-        //CPU CPLD
-        case ATT_CPU_CPLD_VERSION:
-            reg = REG_CPU_CPLD_VERSION;
-            break;
-        case ATT_CPU_BIOS_BOOT_ROM:
-            reg = REG_CPU_STATUS_1;
-            mask = 0x80;
-            break;
-        case ATT_CPU_BIOS_BOOT_CFG:
-            reg = REG_CPU_CTRL_1;
-            mask = 0x80;
-            break;
-        case ATT_CPU_CPLD_BUILD:
-            reg = REG_CPU_CPLD_BUILD;
-            break;
-        //MB CPLD
-        case ATT_MB_BRD_ID_0:
-            reg = REG_MB_BRD_ID_0;
-            break;
-        case ATT_MB_BRD_ID_1:
-            reg = REG_MB_BRD_ID_1;
-            break;
-        case ATT_MB_CPLD_1_VERSION:
-            reg = REG_MB_CPLD_VERSION;
-            break;
-        case ATT_MB_CPLD_1_BUILD:
-            reg = REG_MB_CPLD_BUILD;
-            break;
-        case ATT_MB_BRD_SKU_ID:
-            reg = REG_MB_BRD_ID_0;
-            mask = 0xFF;
-            break;
-        case ATT_MB_BRD_HW_ID:
-            reg = REG_MB_BRD_ID_1;
-            mask = 0x03;
-            break;
-        case ATT_MB_BRD_ID_TYPE:
-            reg = REG_MB_BRD_ID_1;
-            mask = 0x80;
-            break;
-        case ATT_MB_BRD_BUILD_ID:
-            reg = REG_MB_BRD_ID_1;
-            mask = 0x38;
-            break;
-        case ATT_MB_BRD_DEPH_ID:
-            reg = REG_MB_BRD_ID_1;
-            mask = 0x04;
-            break;
-        case ATT_MB_MUX_CTRL:
-            reg = REG_MB_MUX_CTRL;
-            break;
-        //I2C Alert
-        case ATT_ALERT_STATUS:
-            reg = REG_ALERT_STATUS;
-            mask = 0x20;
-            break;
+    switch (attr->index)
+    {
+    // CPU CPLD
+    case ATT_CPU_CPLD_VERSION:
+        reg = REG_CPU_CPLD_VERSION;
+        break;
+    case ATT_CPU_BIOS_BOOT_ROM:
+        reg = REG_CPU_STATUS_1;
+        mask = 0x80;
+        break;
+    case ATT_CPU_BIOS_BOOT_CFG:
+        reg = REG_CPU_CTRL_1;
+        mask = 0x80;
+        break;
+    case ATT_CPU_CPLD_BUILD:
+        reg = REG_CPU_CPLD_BUILD;
+        break;
+    // MB CPLD
+    case ATT_MB_BRD_ID_0:
+        reg = REG_MB_BRD_ID_0;
+        break;
+    case ATT_MB_BRD_ID_1:
+        reg = REG_MB_BRD_ID_1;
+        break;
+    case ATT_MB_CPLD_1_VERSION:
+        reg = REG_MB_CPLD_VERSION;
+        break;
+    case ATT_MB_CPLD_1_BUILD:
+        reg = REG_MB_CPLD_BUILD;
+        break;
+    case ATT_MB_BRD_SKU_ID:
+        reg = REG_MB_BRD_ID_0;
+        mask = 0xFF;
+        break;
+    case ATT_MB_BRD_HW_ID:
+        reg = REG_MB_BRD_ID_1;
+        mask = 0x03;
+        break;
+    case ATT_MB_BRD_ID_TYPE:
+        reg = REG_MB_BRD_ID_1;
+        mask = 0x80;
+        break;
+    case ATT_MB_BRD_BUILD_ID:
+        reg = REG_MB_BRD_ID_1;
+        mask = 0x38;
+        break;
+    case ATT_MB_BRD_DEPH_ID:
+        reg = REG_MB_BRD_ID_1;
+        mask = 0x04;
+        break;
+    case ATT_MB_MUX_CTRL:
+        reg = REG_MB_MUX_CTRL;
+        break;
+    // I2C Alert
+    case ATT_ALERT_STATUS:
+        reg = REG_ALERT_STATUS;
+        mask = 0x20;
+        break;
 #if CPU_TYPE == CPU_BDE
-        case ATT_ALERT_DISABLE:
-            reg = REG_ALERT_DISABLE;
-            mask = 0x04;
-            break;
+    case ATT_ALERT_DISABLE:
+        reg = REG_ALERT_DISABLE;
+        mask = 0x04;
+        break;
 #endif
-        //BSP
-        case ATT_BSP_REG:
-            if (kstrtou16(bsp_reg, 0, &reg) < 0)
-                return -EINVAL;
-            break;
-        default:
+    // BSP
+    case ATT_BSP_REG:
+        if (kstrtou16(bsp_reg, 0, &reg) < 0)
             return -EINVAL;
+        break;
+    default:
+        return -EINVAL;
     }
     return read_lpc_reg(reg, mask, buf);
 }
 
 /* set lpc register value */
 static ssize_t write_lpc_callback(struct device *dev,
-        struct device_attribute *da, const char *buf, size_t count)
+                                  struct device_attribute *da, const char *buf, size_t count)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
     u16 reg = 0;
     u8 mask = MASK_ALL;
 
-    switch (attr->index) {
-        case ATT_MB_MUX_CTRL:
-            reg = REG_MB_MUX_CTRL;
-            break;
-        default:
-            return -EINVAL;
+    switch (attr->index)
+    {
+    case ATT_MB_MUX_CTRL:
+        reg = REG_MB_MUX_CTRL;
+        break;
+    default:
+        return -EINVAL;
     }
     return write_lpc_reg(reg, mask, buf, count);
 }
 
 /* get bsp parameter value */
 static ssize_t read_bsp_callback(struct device *dev,
-        struct device_attribute *da, char *buf)
+                                 struct device_attribute *da, char *buf)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
-    int str_len=0;
-    char *str=NULL;
+    int str_len = 0;
+    char *str = NULL;
 
-    switch (attr->index) {
-        case ATT_BSP_VERSION:
-            str = bsp_version;
-            str_len = sizeof(bsp_version);
-            break;
-        case ATT_BSP_DEBUG:
-            str = bsp_debug;
-            str_len = sizeof(bsp_debug);
-            break;
-        case ATT_BSP_REG:
-            str = bsp_reg;
-            str_len = sizeof(bsp_reg);
-            break;
-        default:
-            return -EINVAL;
+    switch (attr->index)
+    {
+    case ATT_BSP_VERSION:
+        str = bsp_version;
+        str_len = sizeof(bsp_version);
+        break;
+    case ATT_BSP_DEBUG:
+        str = bsp_debug;
+        str_len = sizeof(bsp_debug);
+        break;
+    case ATT_BSP_REG:
+        str = bsp_reg;
+        str_len = sizeof(bsp_reg);
+        break;
+    default:
+        return -EINVAL;
     }
     return read_bsp(buf, str);
 }
 
 /* set bsp parameter value */
 static ssize_t write_bsp_callback(struct device *dev,
-        struct device_attribute *da, const char *buf, size_t count)
+                                  struct device_attribute *da, const char *buf, size_t count)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
-    int str_len=0;
-    char *str=NULL;
+    int str_len = 0;
+    char *str = NULL;
     u16 reg = 0;
     u8 bsp_debug_u8 = 0;
 
-    switch (attr->index) {
-        case ATT_BSP_VERSION:
-            str = bsp_version;
-            str_len = sizeof(bsp_version);
-            break;
-        case ATT_BSP_DEBUG:
-            str = bsp_debug;
-            str_len = sizeof(bsp_debug);
-            break;
-        case ATT_BSP_REG:
-            if (kstrtou16(buf, 0, &reg) < 0)
-                return -EINVAL;
-
-            str = bsp_reg;
-            str_len = sizeof(bsp_reg);
-            break;
-        default:
+    switch (attr->index)
+    {
+    case ATT_BSP_VERSION:
+        str = bsp_version;
+        str_len = sizeof(bsp_version);
+        break;
+    case ATT_BSP_DEBUG:
+        str = bsp_debug;
+        str_len = sizeof(bsp_debug);
+        break;
+    case ATT_BSP_REG:
+        if (kstrtou16(buf, 0, &reg) < 0)
             return -EINVAL;
+
+        str = bsp_reg;
+        str_len = sizeof(bsp_reg);
+        break;
+    default:
+        return -EINVAL;
     }
 
-    if (attr->index == ATT_BSP_DEBUG) {
-        if (kstrtou8(buf, 0, &bsp_debug_u8) < 0) {
+    if (attr->index == ATT_BSP_DEBUG)
+    {
+        if (kstrtou8(buf, 0, &bsp_debug_u8) < 0)
+        {
             return -EINVAL;
-        } else if (_config_bsp_log(bsp_debug_u8) < 0) {
+        }
+        else if (_config_bsp_log(bsp_debug_u8) < 0)
+        {
             return -EINVAL;
         }
     }
@@ -578,58 +604,74 @@ static ssize_t write_bsp_callback(struct device *dev,
 }
 
 static ssize_t write_bsp_pr_callback(struct device *dev,
-        struct device_attribute *da, const char *buf, size_t count)
+                                     struct device_attribute *da, const char *buf, size_t count)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
     int str_len = strlen(buf);
 
-    if(str_len <= 0)
+    if (str_len <= 0)
         return str_len;
 
-    switch (attr->index) {
-        case ATT_BSP_PR_INFO:
-            BSP_PR(KERN_INFO, "%s", buf);
-            break;
-        case ATT_BSP_PR_ERR:
-            BSP_PR(KERN_ERR, "%s", buf);
-            break;
-        default:
-            return -EINVAL;
+    switch (attr->index)
+    {
+    case ATT_BSP_PR_INFO:
+        BSP_PR(KERN_INFO, "%s", buf);
+        break;
+    case ATT_BSP_PR_ERR:
+        BSP_PR(KERN_ERR, "%s", buf);
+        break;
+    default:
+        return -EINVAL;
     }
 
     return str_len;
 }
 
-//SENSOR_DEVICE_ATTR - CPU
+/* get gpio max value */
+static ssize_t read_gpio_max(struct device *dev,
+                             struct device_attribute *da,
+                             char *buf)
+{
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+
+    if (attr->index == ATT_BSP_GPIO_MAX)
+    {
+        return sprintf(buf, "%d\n", ARCH_NR_GPIOS - 1);
+    }
+    return -1;
+}
+
+// SENSOR_DEVICE_ATTR - CPU
 static SENSOR_DEVICE_ATTR(cpu_cpld_version, S_IRUGO, read_lpc_callback, NULL, ATT_CPU_CPLD_VERSION);
 static SENSOR_DEVICE_ATTR(cpu_cpld_version_h, S_IRUGO, read_cpu_cpld_version_h, NULL, ATT_CPU_CPLD_VERSION_H);
-static SENSOR_DEVICE_ATTR(boot_rom,         S_IRUGO, read_lpc_callback, NULL, ATT_CPU_BIOS_BOOT_ROM);
-static SENSOR_DEVICE_ATTR(boot_cfg,         S_IRUGO, read_lpc_callback, NULL, ATT_CPU_BIOS_BOOT_CFG);
-static SENSOR_DEVICE_ATTR(cpu_cpld_build,   S_IRUGO, read_lpc_callback, NULL, ATT_CPU_CPLD_BUILD);
-//SENSOR_DEVICE_ATTR - MB
-static SENSOR_DEVICE_ATTR(board_id_0,       S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_0);
-static SENSOR_DEVICE_ATTR(board_id_1,       S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_1);
-static SENSOR_DEVICE_ATTR(mb_cpld_1_version,   S_IRUGO, read_lpc_callback, NULL, ATT_MB_CPLD_1_VERSION);
+static SENSOR_DEVICE_ATTR(boot_rom, S_IRUGO, read_lpc_callback, NULL, ATT_CPU_BIOS_BOOT_ROM);
+static SENSOR_DEVICE_ATTR(boot_cfg, S_IRUGO, read_lpc_callback, NULL, ATT_CPU_BIOS_BOOT_CFG);
+static SENSOR_DEVICE_ATTR(cpu_cpld_build, S_IRUGO, read_lpc_callback, NULL, ATT_CPU_CPLD_BUILD);
+// SENSOR_DEVICE_ATTR - MB
+static SENSOR_DEVICE_ATTR(board_id_0, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_0);
+static SENSOR_DEVICE_ATTR(board_id_1, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_1);
+static SENSOR_DEVICE_ATTR(mb_cpld_1_version, S_IRUGO, read_lpc_callback, NULL, ATT_MB_CPLD_1_VERSION);
 static SENSOR_DEVICE_ATTR(mb_cpld_1_version_h, S_IRUGO, read_mb_cpld_1_version_h, NULL, ATT_MB_CPLD_1_VERSION_H);
-static SENSOR_DEVICE_ATTR(mb_cpld_1_build,  S_IRUGO, read_lpc_callback, NULL, ATT_MB_CPLD_1_BUILD);
-static SENSOR_DEVICE_ATTR(mux_ctrl,         S_IRUGO | S_IWUSR, read_lpc_callback, write_lpc_callback, ATT_MB_MUX_CTRL);
-static SENSOR_DEVICE_ATTR(mux_reset,        S_IRUGO | S_IWUSR, read_mux_reset_callback, write_mux_reset_callback, ATT_MB_MUX_RESET);
-static SENSOR_DEVICE_ATTR(board_sku_id,     S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_SKU_ID);
-static SENSOR_DEVICE_ATTR(board_hw_id,      S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_HW_ID);
-static SENSOR_DEVICE_ATTR(board_id_type,    S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_TYPE);
-static SENSOR_DEVICE_ATTR(board_build_id,   S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_BUILD_ID);
-static SENSOR_DEVICE_ATTR(board_deph_id,    S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_DEPH_ID);
-//SENSOR_DEVICE_ATTR - I2C Alert
-static SENSOR_DEVICE_ATTR(alert_status,     S_IRUGO, read_lpc_callback, NULL, ATT_ALERT_STATUS);
+static SENSOR_DEVICE_ATTR(mb_cpld_1_build, S_IRUGO, read_lpc_callback, NULL, ATT_MB_CPLD_1_BUILD);
+static SENSOR_DEVICE_ATTR(mux_ctrl, S_IRUGO | S_IWUSR, read_lpc_callback, write_lpc_callback, ATT_MB_MUX_CTRL);
+static SENSOR_DEVICE_ATTR(mux_reset, S_IRUGO | S_IWUSR, read_mux_reset_callback, write_mux_reset_callback, ATT_MB_MUX_RESET);
+static SENSOR_DEVICE_ATTR(board_sku_id, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_SKU_ID);
+static SENSOR_DEVICE_ATTR(board_hw_id, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_HW_ID);
+static SENSOR_DEVICE_ATTR(board_id_type, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_TYPE);
+static SENSOR_DEVICE_ATTR(board_build_id, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_BUILD_ID);
+static SENSOR_DEVICE_ATTR(board_deph_id, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_DEPH_ID);
+// SENSOR_DEVICE_ATTR - I2C Alert
+static SENSOR_DEVICE_ATTR(alert_status, S_IRUGO, read_lpc_callback, NULL, ATT_ALERT_STATUS);
 #if CPU_TYPE == CPU_BDE
-static SENSOR_DEVICE_ATTR(alert_disable,    S_IRUGO, read_lpc_callback, NULL, ATT_ALERT_DISABLE);
+static SENSOR_DEVICE_ATTR(alert_disable, S_IRUGO, read_lpc_callback, NULL, ATT_ALERT_DISABLE);
 #endif
-//SENSOR_DEVICE_ATTR - BSP
-static SENSOR_DEVICE_ATTR(bsp_version,      S_IRUGO | S_IWUSR, read_bsp_callback, write_bsp_callback, ATT_BSP_VERSION);
-static SENSOR_DEVICE_ATTR(bsp_debug,        S_IRUGO | S_IWUSR, read_bsp_callback, write_bsp_callback, ATT_BSP_DEBUG);
-static SENSOR_DEVICE_ATTR(bsp_pr_info,      S_IWUSR, NULL, write_bsp_pr_callback, ATT_BSP_PR_INFO);
-static SENSOR_DEVICE_ATTR(bsp_pr_err,       S_IWUSR, NULL, write_bsp_pr_callback, ATT_BSP_PR_ERR);
-static SENSOR_DEVICE_ATTR(bsp_reg,          S_IRUGO | S_IWUSR, read_lpc_callback, write_bsp_callback, ATT_BSP_REG);
+// SENSOR_DEVICE_ATTR - BSP
+static SENSOR_DEVICE_ATTR(bsp_version, S_IRUGO | S_IWUSR, read_bsp_callback, write_bsp_callback, ATT_BSP_VERSION);
+static SENSOR_DEVICE_ATTR(bsp_debug, S_IRUGO | S_IWUSR, read_bsp_callback, write_bsp_callback, ATT_BSP_DEBUG);
+static SENSOR_DEVICE_ATTR(bsp_pr_info, S_IWUSR, NULL, write_bsp_pr_callback, ATT_BSP_PR_INFO);
+static SENSOR_DEVICE_ATTR(bsp_pr_err, S_IWUSR, NULL, write_bsp_pr_callback, ATT_BSP_PR_ERR);
+static SENSOR_DEVICE_ATTR(bsp_reg, S_IRUGO | S_IWUSR, read_lpc_callback, write_bsp_callback, ATT_BSP_REG);
+static SENSOR_DEVICE_ATTR(bsp_gpio_max, S_IRUGO, read_gpio_max, NULL, ATT_BSP_GPIO_MAX);
 
 static struct attribute *cpu_cpld_attrs[] = {
     &sensor_dev_attr_cpu_cpld_version.dev_attr.attr,
@@ -674,6 +716,7 @@ static struct attribute *bsp_attrs[] = {
     &sensor_dev_attr_bsp_pr_info.dev_attr.attr,
     &sensor_dev_attr_bsp_pr_err.dev_attr.attr,
     &sensor_dev_attr_bsp_reg.dev_attr.attr,
+    &sensor_dev_attr_bsp_gpio_max.dev_attr.attr,
     NULL,
 };
 
@@ -702,18 +745,17 @@ static struct attribute_group bsp_attr_grp = {
     .attrs = bsp_attrs,
 };
 
-static void lpc_dev_release( struct device * dev)
+static void lpc_dev_release(struct device *dev)
 {
     return;
 }
 
 static struct platform_device lpc_dev = {
-    .name           = DRIVER_NAME,
-    .id             = -1,
+    .name = DRIVER_NAME,
+    .id = -1,
     .dev = {
-                    .release = lpc_dev_release,
-    }
-};
+        .release = lpc_dev_release,
+    }};
 
 static int lpc_drv_probe(struct platform_device *pdev)
 {
@@ -728,32 +770,37 @@ static int lpc_drv_probe(struct platform_device *pdev)
 
     mutex_init(&lpc_data->access_lock);
 
-    for (i=0; i<grp_num; ++i) {
-        switch (i) {
-            case 0:
-                grp = &cpu_cpld_attr_grp;
-                break;
-            case 1:
-                grp = &mb_cpld_attr_grp;
-                break;
-            case 2:
-                grp = &bios_attr_grp;
-                break;
-            case 3:
-                grp = &i2c_alert_attr_grp;
-                break;
-            case 4:
-                grp = &bsp_attr_grp;
-                break;
-            default:
-                break;
+    for (i = 0; i < grp_num; ++i)
+    {
+        switch (i)
+        {
+        case 0:
+            grp = &cpu_cpld_attr_grp;
+            break;
+        case 1:
+            grp = &mb_cpld_attr_grp;
+            break;
+        case 2:
+            grp = &bios_attr_grp;
+            break;
+        case 3:
+            grp = &i2c_alert_attr_grp;
+            break;
+        case 4:
+            grp = &bsp_attr_grp;
+            break;
+        default:
+            break;
         }
 
         err[i] = sysfs_create_group(&pdev->dev.kobj, grp);
-        if (err[i]) {
+        if (err[i])
+        {
             printk(KERN_ERR "Cannot create sysfs for group %s\n", grp->name);
             goto exit;
-        } else {
+        }
+        else
+        {
             continue;
         }
     }
@@ -761,33 +808,38 @@ static int lpc_drv_probe(struct platform_device *pdev)
     return 0;
 
 exit:
-    for (i=0; i<grp_num; ++i) {
-        switch (i) {
-            case 0:
-                grp = &cpu_cpld_attr_grp;
-                break;
-            case 1:
-                grp = &mb_cpld_attr_grp;
-                break;
-            case 2:
-                grp = &bios_attr_grp;
-                break;
-            case 3:
-                grp = &i2c_alert_attr_grp;
-                break;
-            case 4:
-                grp = &bsp_attr_grp;
-                break;
-            default:
-                break;
+    for (i = 0; i < grp_num; ++i)
+    {
+        switch (i)
+        {
+        case 0:
+            grp = &cpu_cpld_attr_grp;
+            break;
+        case 1:
+            grp = &mb_cpld_attr_grp;
+            break;
+        case 2:
+            grp = &bios_attr_grp;
+            break;
+        case 3:
+            grp = &i2c_alert_attr_grp;
+            break;
+        case 4:
+            grp = &bsp_attr_grp;
+            break;
+        default:
+            break;
         }
 
         sysfs_remove_group(&pdev->dev.kobj, grp);
-        if (!err[i]) {
-            //remove previous successful cases
+        if (!err[i])
+        {
+            // remove previous successful cases
             continue;
-        } else {
-            //remove first failed case, then return
+        }
+        else
+        {
+            // remove first failed case, then return
             return err[i];
         }
     }
@@ -806,10 +858,10 @@ static int lpc_drv_remove(struct platform_device *pdev)
 }
 
 static struct platform_driver lpc_drv = {
-    .probe  = lpc_drv_probe,
+    .probe = lpc_drv_probe,
     .remove = __exit_p(lpc_drv_remove),
     .driver = {
-    .name   = DRIVER_NAME,
+        .name = DRIVER_NAME,
     },
 };
 
@@ -818,17 +870,19 @@ int lpc_init(void)
     int err = 0;
 
     err = platform_driver_register(&lpc_drv);
-    if (err) {
+    if (err)
+    {
         printk(KERN_ERR "%s(#%d): platform_driver_register failed(%d)\n",
-                __func__, __LINE__, err);
+               __func__, __LINE__, err);
 
         return err;
     }
 
     err = platform_device_register(&lpc_dev);
-    if (err) {
+    if (err)
+    {
         printk(KERN_ERR "%s(#%d): platform_device_register failed(%d)\n",
-                __func__, __LINE__, err);
+               __func__, __LINE__, err);
         platform_driver_unregister(&lpc_drv);
         return err;
     }

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9301-32d/modules/x86-64-ufispace-s9301-32d-lpc.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9301-32d/modules/x86-64-ufispace-s9301-32d-lpc.c
@@ -26,15 +26,16 @@
 #include <linux/io.h>
 #include <linux/platform_device.h>
 #include <linux/hwmon-sysfs.h>
+#include <linux/gpio.h>
 
-#define BSP_LOG_R(fmt, args...) \
-    _bsp_log (LOG_READ, KERN_INFO "%s:%s[%d]: " fmt "\r\n", \
-            __FILE__, __func__, __LINE__, ##args)
-#define BSP_LOG_W(fmt, args...) \
-    _bsp_log (LOG_WRITE, KERN_INFO "%s:%s[%d]: " fmt "\r\n", \
-            __FILE__, __func__, __LINE__, ##args)
+#define BSP_LOG_R(fmt, args...)                            \
+    _bsp_log(LOG_READ, KERN_INFO "%s:%s[%d]: " fmt "\r\n", \
+             __FILE__, __func__, __LINE__, ##args)
+#define BSP_LOG_W(fmt, args...)                             \
+    _bsp_log(LOG_WRITE, KERN_INFO "%s:%s[%d]: " fmt "\r\n", \
+             __FILE__, __func__, __LINE__, ##args)
 
-#define BSP_PR(level, fmt, args...) _bsp_log (LOG_SYS, level "[BSP]" fmt "\r\n", ##args)
+#define BSP_PR(level, fmt, args...) _bsp_log(LOG_SYS, level "[BSP]" fmt "\r\n", ##args)
 
 #define DRIVER_NAME "x86_64_ufispace_s9301_32d_lpc"
 #define CPU_BDE 0
@@ -43,53 +44,54 @@
 
 /* LPC registers */
 
-#define REG_BASE_CPU                      0x600
+#define REG_BASE_CPU 0x600
 
 #if CPU_TYPE == CPU_SKY
-#define REG_BASE_MB                       0xE00
-#define REG_BASE_I2C_ALERT                0x700
+#define REG_BASE_MB 0xE00
+#define REG_BASE_I2C_ALERT 0x700
 #else
-#define REG_BASE_MB                       0x700
-#define REG_BASE_I2C_ALERT                0xF000
+#define REG_BASE_MB 0x700
+#define REG_BASE_I2C_ALERT 0xF000
 #endif
 
-//CPU CPLD
-#define REG_CPU_CPLD_VERSION              (REG_BASE_CPU + 0x00)
-#define REG_CPU_STATUS_0                  (REG_BASE_CPU + 0x01)
-#define REG_CPU_STATUS_1                  (REG_BASE_CPU + 0x02)
-#define REG_CPU_CTRL_0                    (REG_BASE_CPU + 0x03)
-#define REG_CPU_CTRL_1                    (REG_BASE_CPU + 0x04)
-#define REG_CPU_CPLD_BUILD                (REG_BASE_CPU + 0xE0)
+// CPU CPLD
+#define REG_CPU_CPLD_VERSION (REG_BASE_CPU + 0x00)
+#define REG_CPU_STATUS_0 (REG_BASE_CPU + 0x01)
+#define REG_CPU_STATUS_1 (REG_BASE_CPU + 0x02)
+#define REG_CPU_CTRL_0 (REG_BASE_CPU + 0x03)
+#define REG_CPU_CTRL_1 (REG_BASE_CPU + 0x04)
+#define REG_CPU_CPLD_BUILD (REG_BASE_CPU + 0xE0)
 
-//MB CPLD
-//TBD, need to change after CPLD spec release
-#define REG_MB_BRD_ID_0                   (REG_BASE_MB + 0x00)
-#define REG_MB_BRD_ID_1                   (REG_BASE_MB + 0x01)
-#define REG_MB_CPLD_VERSION               (REG_BASE_MB + 0x02)
-#define REG_MB_CPLD_BUILD                 (REG_BASE_MB + 0x04)
-#define REG_MB_MUX_RESET                  (REG_BASE_MB + 0x46)
-#define REG_MB_MUX_CTRL                   (REG_BASE_MB + 0x5c)
+// MB CPLD
+// TBD, need to change after CPLD spec release
+#define REG_MB_BRD_ID_0 (REG_BASE_MB + 0x00)
+#define REG_MB_BRD_ID_1 (REG_BASE_MB + 0x01)
+#define REG_MB_CPLD_VERSION (REG_BASE_MB + 0x02)
+#define REG_MB_CPLD_BUILD (REG_BASE_MB + 0x04)
+#define REG_MB_MUX_RESET (REG_BASE_MB + 0x46)
+#define REG_MB_MUX_CTRL (REG_BASE_MB + 0x5c)
 
-//I2C Alert
+// I2C Alert
 #if CPU_TYPE == CPU_SKY
-#define REG_ALERT_STATUS                  (REG_BASE_I2C_ALERT + 0x80)
+#define REG_ALERT_STATUS (REG_BASE_I2C_ALERT + 0x80)
 #else
-#define REG_ALERT_STATUS                  (REG_BASE_I2C_ALERT + 0x00)
-#define REG_ALERT_DISABLE                 (REG_BASE_I2C_ALERT + 0x11)
+#define REG_ALERT_STATUS (REG_BASE_I2C_ALERT + 0x00)
+#define REG_ALERT_DISABLE (REG_BASE_I2C_ALERT + 0x11)
 #endif
 
-#define MASK_ALL                          (0xFF)
-#define LPC_MDELAY                        (5)
+#define MASK_ALL (0xFF)
+#define LPC_MDELAY (5)
 
 /* LPC sysfs attributes index  */
-enum lpc_sysfs_attributes {
-    //CPU CPLD
+enum lpc_sysfs_attributes
+{
+    // CPU CPLD
     ATT_CPU_CPLD_VERSION,
     ATT_CPU_CPLD_VERSION_H,
     ATT_CPU_BIOS_BOOT_ROM,
     ATT_CPU_BIOS_BOOT_CFG,
     ATT_CPU_CPLD_BUILD,
-    //MB CPLD
+    // MB CPLD
     ATT_MB_BRD_ID_0,
     ATT_MB_BRD_ID_1,
     ATT_MB_CPLD_1_VERSION,
@@ -102,21 +104,23 @@ enum lpc_sysfs_attributes {
     ATT_MB_BRD_ID_TYPE,
     ATT_MB_BRD_BUILD_ID,
     ATT_MB_BRD_DEPH_ID,
-    //I2C Alert
+    // I2C Alert
     ATT_ALERT_STATUS,
 #if CPU_TYPE == CPU_BDE
     ATT_ALERT_DISABLE,
 #endif
-    //BSP
+    // BSP
     ATT_BSP_VERSION,
     ATT_BSP_DEBUG,
     ATT_BSP_PR_INFO,
     ATT_BSP_PR_ERR,
     ATT_BSP_REG,
+    ATT_BSP_GPIO_MAX,
     ATT_MAX
 };
 
-enum bsp_log_types {
+enum bsp_log_types
+{
     LOG_NONE,
     LOG_RW,
     LOG_READ,
@@ -124,29 +128,32 @@ enum bsp_log_types {
     LOG_SYS
 };
 
-enum bsp_log_ctrl {
+enum bsp_log_ctrl
+{
     LOG_DISABLE,
     LOG_ENABLE
 };
 
-struct lpc_data_s {
-    struct mutex    access_lock;
+struct lpc_data_s
+{
+    struct mutex access_lock;
 };
 
 struct lpc_data_s *lpc_data;
-char bsp_version[16]="";
-char bsp_debug[2]="0";
-char bsp_reg[8]="0x0";
-u8 enable_log_read=LOG_DISABLE;
-u8 enable_log_write=LOG_DISABLE;
-u8 enable_log_sys=LOG_ENABLE;
+char bsp_version[16] = "";
+char bsp_debug[2] = "0";
+char bsp_reg[8] = "0x0";
+u8 enable_log_read = LOG_DISABLE;
+u8 enable_log_write = LOG_DISABLE;
+u8 enable_log_sys = LOG_ENABLE;
 
 /* reg shift */
 static u8 _shift(u8 mask)
 {
-    int i=0, mask_one=1;
+    int i = 0, mask_one = 1;
 
-    for(i=0; i<8; ++i) {
+    for (i = 0; i < 8; ++i)
+    {
         if ((mask & mask_one) == 1)
             return i;
         else
@@ -159,7 +166,7 @@ static u8 _shift(u8 mask)
 /* reg mask and shift */
 static u8 _mask_shift(u8 val, u8 mask)
 {
-    int shift=0;
+    int shift = 0;
 
     shift = _shift(mask);
 
@@ -177,9 +184,10 @@ static u8 _bit_operation(u8 reg_val, u8 bit, u8 bit_val)
 
 static int _bsp_log(u8 log_type, char *fmt, ...)
 {
-    if ((log_type==LOG_READ  && enable_log_read) ||
-        (log_type==LOG_WRITE && enable_log_write) ||
-        (log_type==LOG_SYS && enable_log_sys) ) {
+    if ((log_type == LOG_READ && enable_log_read) ||
+        (log_type == LOG_WRITE && enable_log_write) ||
+        (log_type == LOG_SYS && enable_log_sys))
+    {
         va_list args;
         int r;
 
@@ -188,32 +196,35 @@ static int _bsp_log(u8 log_type, char *fmt, ...)
         va_end(args);
 
         return r;
-    } else {
+    }
+    else
+    {
         return 0;
     }
 }
 
 static int _config_bsp_log(u8 log_type)
 {
-    switch(log_type) {
-        case LOG_NONE:
-            enable_log_read = LOG_DISABLE;
-            enable_log_write = LOG_DISABLE;
-            break;
-        case LOG_RW:
-            enable_log_read = LOG_ENABLE;
-            enable_log_write = LOG_ENABLE;
-            break;
-        case LOG_READ:
-            enable_log_read = LOG_ENABLE;
-            enable_log_write = LOG_DISABLE;
-            break;
-        case LOG_WRITE:
-            enable_log_read = LOG_DISABLE;
-            enable_log_write = LOG_ENABLE;
-            break;
-        default:
-            return -EINVAL;
+    switch (log_type)
+    {
+    case LOG_NONE:
+        enable_log_read = LOG_DISABLE;
+        enable_log_write = LOG_DISABLE;
+        break;
+    case LOG_RW:
+        enable_log_read = LOG_ENABLE;
+        enable_log_write = LOG_ENABLE;
+        break;
+    case LOG_READ:
+        enable_log_read = LOG_ENABLE;
+        enable_log_write = LOG_DISABLE;
+        break;
+    case LOG_WRITE:
+        enable_log_read = LOG_DISABLE;
+        enable_log_write = LOG_ENABLE;
+        break;
+    default:
+        return -EINVAL;
     }
     return 0;
 }
@@ -224,7 +235,7 @@ static u8 _read_lpc_reg(u16 reg, u8 mask)
     u8 reg_val;
 
     mutex_lock(&lpc_data->access_lock);
-    reg_val=_mask_shift(inb(reg), mask);
+    reg_val = _mask_shift(inb(reg), mask);
     mutex_unlock(&lpc_data->access_lock);
 
     BSP_LOG_R("reg=0x%03x, reg_val=0x%02x", reg, reg_val);
@@ -236,10 +247,10 @@ static u8 _read_lpc_reg(u16 reg, u8 mask)
 static ssize_t read_lpc_reg(u16 reg, u8 mask, char *buf)
 {
     u8 reg_val;
-    int len=0;
+    int len = 0;
 
     reg_val = _read_lpc_reg(reg, mask);
-    len=sprintf(buf,"0x%x\n", reg_val);
+    len = sprintf(buf, "0x%x\n", reg_val);
 
     return len;
 }
@@ -252,8 +263,9 @@ static ssize_t write_lpc_reg(u16 reg, u8 mask, const char *buf, size_t count)
     if (kstrtou8(buf, 0, &reg_val) < 0)
         return -EINVAL;
 
-    //apply SINGLE BIT operation if mask is specified, multiple bits are not supported
-    if (mask != MASK_ALL) {
+    // apply SINGLE BIT operation if mask is specified, multiple bits are not supported
+    if (mask != MASK_ALL)
+    {
         reg_val_now = _read_lpc_reg(reg, 0x0);
         shift = _shift(mask);
         reg_val = _bit_operation(reg_val_now, shift, reg_val);
@@ -274,10 +286,10 @@ static ssize_t write_lpc_reg(u16 reg, u8 mask, const char *buf, size_t count)
 /* get bsp value */
 static ssize_t read_bsp(char *buf, char *str)
 {
-    ssize_t len=0;
+    ssize_t len = 0;
 
     mutex_lock(&lpc_data->access_lock);
-    len=sprintf(buf, "%s", str);
+    len = sprintf(buf, "%s", str);
     mutex_unlock(&lpc_data->access_lock);
 
     BSP_LOG_R("reg_val=%s", str);
@@ -299,9 +311,9 @@ static ssize_t write_bsp(const char *buf, char *str, size_t str_len, size_t coun
 
 /* get cpu cpld version in human readable format */
 static ssize_t read_cpu_cpld_version_h(struct device *dev,
-        struct device_attribute *da, char *buf)
+                                       struct device_attribute *da, char *buf)
 {
-    ssize_t len=0;
+    ssize_t len = 0;
     u16 reg = REG_CPU_CPLD_VERSION;
     u8 mask = MASK_ALL;
     u8 mask_major = 0b11000000;
@@ -325,9 +337,9 @@ static ssize_t read_cpu_cpld_version_h(struct device *dev,
 
 /* get mb cpld version in human readable format */
 static ssize_t read_mb_cpld_1_version_h(struct device *dev,
-        struct device_attribute *da, char *buf)
+                                        struct device_attribute *da, char *buf)
 {
-    ssize_t len=0;
+    ssize_t len = 0;
     u16 reg = REG_MB_CPLD_VERSION;
     u8 mask = MASK_ALL;
     u8 mask_major = 0b11000000;
@@ -351,7 +363,7 @@ static ssize_t read_mb_cpld_1_version_h(struct device *dev,
 
 /* get mux_reset register value */
 static ssize_t read_mux_reset_callback(struct device *dev,
-        struct device_attribute *da, char *buf)
+                                       struct device_attribute *da, char *buf)
 {
     int len = 0;
     u16 reg = REG_MB_MUX_RESET;
@@ -359,9 +371,9 @@ static ssize_t read_mux_reset_callback(struct device *dev,
     u8 reg_val;
 
     mutex_lock(&lpc_data->access_lock);
-    reg_val=_mask_shift(inb(reg), mask);
+    reg_val = _mask_shift(inb(reg), mask);
     BSP_LOG_R("reg=0x%03x, reg_val=0x%02x", reg, reg_val);
-    len=sprintf(buf, "%d\n", reg_val);
+    len = sprintf(buf, "%d\n", reg_val);
     mutex_unlock(&lpc_data->access_lock);
 
     return len;
@@ -369,7 +381,7 @@ static ssize_t read_mux_reset_callback(struct device *dev,
 
 /* set mux_reset register value */
 static ssize_t write_mux_reset_callback(struct device *dev,
-        struct device_attribute *da, const char *buf, size_t count)
+                                        struct device_attribute *da, const char *buf, size_t count)
 {
     u8 val = 0;
     u16 reg = REG_MB_MUX_RESET;
@@ -380,8 +392,10 @@ static ssize_t write_mux_reset_callback(struct device *dev,
     if (kstrtou8(buf, 0, &val) < 0)
         return -EINVAL;
 
-    if (mux_reset_flag == 0) {
-        if (val == 0) {
+    if (mux_reset_flag == 0)
+    {
+        if (val == 0)
+        {
             mutex_lock(&lpc_data->access_lock);
             mux_reset_flag = 1;
             BSP_LOG_W("i2c mux reset is triggered...");
@@ -397,10 +411,14 @@ static ssize_t write_mux_reset_callback(struct device *dev,
             mdelay(500);
             mux_reset_flag = 0;
             mutex_unlock(&lpc_data->access_lock);
-        } else {
+        }
+        else
+        {
             return -EINVAL;
         }
-    } else {
+    }
+    else
+    {
         BSP_LOG_W("i2c mux is resetting... (ignore)");
         mutex_lock(&lpc_data->access_lock);
         mutex_unlock(&lpc_data->access_lock);
@@ -411,165 +429,173 @@ static ssize_t write_mux_reset_callback(struct device *dev,
 
 /* get lpc register value */
 static ssize_t read_lpc_callback(struct device *dev,
-        struct device_attribute *da, char *buf)
+                                 struct device_attribute *da, char *buf)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
     u16 reg = 0;
     u8 mask = MASK_ALL;
 
-    switch (attr->index) {
-        //CPU CPLD
-        case ATT_CPU_CPLD_VERSION:
-            reg = REG_CPU_CPLD_VERSION;
-            break;
-        case ATT_CPU_BIOS_BOOT_ROM:
-            reg = REG_CPU_STATUS_1;
-            mask = 0x80;
-            break;
-        case ATT_CPU_BIOS_BOOT_CFG:
-            reg = REG_CPU_CTRL_1;
-            mask = 0x80;
-            break;
-        case ATT_CPU_CPLD_BUILD:
-            reg = REG_CPU_CPLD_BUILD;
-            break;
-        //MB CPLD
-        case ATT_MB_BRD_ID_0:
-            reg = REG_MB_BRD_ID_0;
-            break;
-        case ATT_MB_BRD_ID_1:
-            reg = REG_MB_BRD_ID_1;
-            break;
-        case ATT_MB_CPLD_1_VERSION:
-            reg = REG_MB_CPLD_VERSION;
-            break;
-        case ATT_MB_CPLD_1_BUILD:
-            reg = REG_MB_CPLD_BUILD;
-            break;
-        case ATT_MB_BRD_SKU_ID:
-            reg = REG_MB_BRD_ID_0;
-            mask = 0xFF;
-            break;
-        case ATT_MB_BRD_HW_ID:
-            reg = REG_MB_BRD_ID_1;
-            mask = 0x03;
-            break;
-        case ATT_MB_BRD_ID_TYPE:
-            reg = REG_MB_BRD_ID_1;
-            mask = 0x80;
-            break;
-        case ATT_MB_BRD_BUILD_ID:
-            reg = REG_MB_BRD_ID_1;
-            mask = 0x38;
-            break;
-        case ATT_MB_BRD_DEPH_ID:
-            reg = REG_MB_BRD_ID_1;
-            mask = 0x04;
-            break;
-        case ATT_MB_MUX_CTRL:
-            reg = REG_MB_MUX_CTRL;
-            break;
-        //I2C Alert
-        case ATT_ALERT_STATUS:
-            reg = REG_ALERT_STATUS;
-            mask = 0x20;
-            break;
+    switch (attr->index)
+    {
+    // CPU CPLD
+    case ATT_CPU_CPLD_VERSION:
+        reg = REG_CPU_CPLD_VERSION;
+        break;
+    case ATT_CPU_BIOS_BOOT_ROM:
+        reg = REG_CPU_STATUS_1;
+        mask = 0x80;
+        break;
+    case ATT_CPU_BIOS_BOOT_CFG:
+        reg = REG_CPU_CTRL_1;
+        mask = 0x80;
+        break;
+    case ATT_CPU_CPLD_BUILD:
+        reg = REG_CPU_CPLD_BUILD;
+        break;
+    // MB CPLD
+    case ATT_MB_BRD_ID_0:
+        reg = REG_MB_BRD_ID_0;
+        break;
+    case ATT_MB_BRD_ID_1:
+        reg = REG_MB_BRD_ID_1;
+        break;
+    case ATT_MB_CPLD_1_VERSION:
+        reg = REG_MB_CPLD_VERSION;
+        break;
+    case ATT_MB_CPLD_1_BUILD:
+        reg = REG_MB_CPLD_BUILD;
+        break;
+    case ATT_MB_BRD_SKU_ID:
+        reg = REG_MB_BRD_ID_0;
+        mask = 0xFF;
+        break;
+    case ATT_MB_BRD_HW_ID:
+        reg = REG_MB_BRD_ID_1;
+        mask = 0x03;
+        break;
+    case ATT_MB_BRD_ID_TYPE:
+        reg = REG_MB_BRD_ID_1;
+        mask = 0x80;
+        break;
+    case ATT_MB_BRD_BUILD_ID:
+        reg = REG_MB_BRD_ID_1;
+        mask = 0x38;
+        break;
+    case ATT_MB_BRD_DEPH_ID:
+        reg = REG_MB_BRD_ID_1;
+        mask = 0x04;
+        break;
+    case ATT_MB_MUX_CTRL:
+        reg = REG_MB_MUX_CTRL;
+        break;
+    // I2C Alert
+    case ATT_ALERT_STATUS:
+        reg = REG_ALERT_STATUS;
+        mask = 0x20;
+        break;
 #if CPU_TYPE == CPU_BDE
-        case ATT_ALERT_DISABLE:
-            reg = REG_ALERT_DISABLE;
-            mask = 0x04;
-            break;
+    case ATT_ALERT_DISABLE:
+        reg = REG_ALERT_DISABLE;
+        mask = 0x04;
+        break;
 #endif
-        //BSP
-        case ATT_BSP_REG:
-            if (kstrtou16(bsp_reg, 0, &reg) < 0)
-                return -EINVAL;
-            break;
-        default:
+    // BSP
+    case ATT_BSP_REG:
+        if (kstrtou16(bsp_reg, 0, &reg) < 0)
             return -EINVAL;
+        break;
+    default:
+        return -EINVAL;
     }
     return read_lpc_reg(reg, mask, buf);
 }
 
 /* set lpc register value */
 static ssize_t write_lpc_callback(struct device *dev,
-        struct device_attribute *da, const char *buf, size_t count)
+                                  struct device_attribute *da, const char *buf, size_t count)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
     u16 reg = 0;
     u8 mask = MASK_ALL;
 
-    switch (attr->index) {
-        case ATT_MB_MUX_CTRL:
-            reg = REG_MB_MUX_CTRL;
-            break;
-        default:
-            return -EINVAL;
+    switch (attr->index)
+    {
+    case ATT_MB_MUX_CTRL:
+        reg = REG_MB_MUX_CTRL;
+        break;
+    default:
+        return -EINVAL;
     }
     return write_lpc_reg(reg, mask, buf, count);
 }
 
 /* get bsp parameter value */
 static ssize_t read_bsp_callback(struct device *dev,
-        struct device_attribute *da, char *buf)
+                                 struct device_attribute *da, char *buf)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
-    int str_len=0;
-    char *str=NULL;
+    int str_len = 0;
+    char *str = NULL;
 
-    switch (attr->index) {
-        case ATT_BSP_VERSION:
-            str = bsp_version;
-            str_len = sizeof(bsp_version);
-            break;
-        case ATT_BSP_DEBUG:
-            str = bsp_debug;
-            str_len = sizeof(bsp_debug);
-            break;
-        case ATT_BSP_REG:
-            str = bsp_reg;
-            str_len = sizeof(bsp_reg);
-            break;
-        default:
-            return -EINVAL;
+    switch (attr->index)
+    {
+    case ATT_BSP_VERSION:
+        str = bsp_version;
+        str_len = sizeof(bsp_version);
+        break;
+    case ATT_BSP_DEBUG:
+        str = bsp_debug;
+        str_len = sizeof(bsp_debug);
+        break;
+    case ATT_BSP_REG:
+        str = bsp_reg;
+        str_len = sizeof(bsp_reg);
+        break;
+    default:
+        return -EINVAL;
     }
     return read_bsp(buf, str);
 }
 
 /* set bsp parameter value */
 static ssize_t write_bsp_callback(struct device *dev,
-        struct device_attribute *da, const char *buf, size_t count)
+                                  struct device_attribute *da, const char *buf, size_t count)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
-    int str_len=0;
-    char *str=NULL;
+    int str_len = 0;
+    char *str = NULL;
     u16 reg = 0;
     u8 bsp_debug_u8 = 0;
 
-    switch (attr->index) {
-        case ATT_BSP_VERSION:
-            str = bsp_version;
-            str_len = sizeof(bsp_version);
-            break;
-        case ATT_BSP_DEBUG:
-            str = bsp_debug;
-            str_len = sizeof(bsp_debug);
-            break;
-        case ATT_BSP_REG:
-            if (kstrtou16(buf, 0, &reg) < 0)
-                return -EINVAL;
-
-            str = bsp_reg;
-            str_len = sizeof(bsp_reg);
-            break;
-        default:
+    switch (attr->index)
+    {
+    case ATT_BSP_VERSION:
+        str = bsp_version;
+        str_len = sizeof(bsp_version);
+        break;
+    case ATT_BSP_DEBUG:
+        str = bsp_debug;
+        str_len = sizeof(bsp_debug);
+        break;
+    case ATT_BSP_REG:
+        if (kstrtou16(buf, 0, &reg) < 0)
             return -EINVAL;
+
+        str = bsp_reg;
+        str_len = sizeof(bsp_reg);
+        break;
+    default:
+        return -EINVAL;
     }
 
-    if (attr->index == ATT_BSP_DEBUG) {
-        if (kstrtou8(buf, 0, &bsp_debug_u8) < 0) {
+    if (attr->index == ATT_BSP_DEBUG)
+    {
+        if (kstrtou8(buf, 0, &bsp_debug_u8) < 0)
+        {
             return -EINVAL;
-        } else if (_config_bsp_log(bsp_debug_u8) < 0) {
+        }
+        else if (_config_bsp_log(bsp_debug_u8) < 0)
+        {
             return -EINVAL;
         }
     }
@@ -578,58 +604,74 @@ static ssize_t write_bsp_callback(struct device *dev,
 }
 
 static ssize_t write_bsp_pr_callback(struct device *dev,
-        struct device_attribute *da, const char *buf, size_t count)
+                                     struct device_attribute *da, const char *buf, size_t count)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
     int str_len = strlen(buf);
 
-    if(str_len <= 0)
+    if (str_len <= 0)
         return str_len;
 
-    switch (attr->index) {
-        case ATT_BSP_PR_INFO:
-            BSP_PR(KERN_INFO, "%s", buf);
-            break;
-        case ATT_BSP_PR_ERR:
-            BSP_PR(KERN_ERR, "%s", buf);
-            break;
-        default:
-            return -EINVAL;
+    switch (attr->index)
+    {
+    case ATT_BSP_PR_INFO:
+        BSP_PR(KERN_INFO, "%s", buf);
+        break;
+    case ATT_BSP_PR_ERR:
+        BSP_PR(KERN_ERR, "%s", buf);
+        break;
+    default:
+        return -EINVAL;
     }
 
     return str_len;
 }
 
-//SENSOR_DEVICE_ATTR - CPU
+/* get gpio max value */
+static ssize_t read_gpio_max(struct device *dev,
+                             struct device_attribute *da,
+                             char *buf)
+{
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+
+    if (attr->index == ATT_BSP_GPIO_MAX)
+    {
+        return sprintf(buf, "%d\n", ARCH_NR_GPIOS - 1);
+    }
+    return -1;
+}
+
+// SENSOR_DEVICE_ATTR - CPU
 static SENSOR_DEVICE_ATTR(cpu_cpld_version, S_IRUGO, read_lpc_callback, NULL, ATT_CPU_CPLD_VERSION);
 static SENSOR_DEVICE_ATTR(cpu_cpld_version_h, S_IRUGO, read_cpu_cpld_version_h, NULL, ATT_CPU_CPLD_VERSION_H);
-static SENSOR_DEVICE_ATTR(boot_rom,         S_IRUGO, read_lpc_callback, NULL, ATT_CPU_BIOS_BOOT_ROM);
-static SENSOR_DEVICE_ATTR(boot_cfg,         S_IRUGO, read_lpc_callback, NULL, ATT_CPU_BIOS_BOOT_CFG);
-static SENSOR_DEVICE_ATTR(cpu_cpld_build,   S_IRUGO, read_lpc_callback, NULL, ATT_CPU_CPLD_BUILD);
-//SENSOR_DEVICE_ATTR - MB
-static SENSOR_DEVICE_ATTR(board_id_0,       S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_0);
-static SENSOR_DEVICE_ATTR(board_id_1,       S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_1);
+static SENSOR_DEVICE_ATTR(boot_rom, S_IRUGO, read_lpc_callback, NULL, ATT_CPU_BIOS_BOOT_ROM);
+static SENSOR_DEVICE_ATTR(boot_cfg, S_IRUGO, read_lpc_callback, NULL, ATT_CPU_BIOS_BOOT_CFG);
+static SENSOR_DEVICE_ATTR(cpu_cpld_build, S_IRUGO, read_lpc_callback, NULL, ATT_CPU_CPLD_BUILD);
+// SENSOR_DEVICE_ATTR - MB
+static SENSOR_DEVICE_ATTR(board_id_0, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_0);
+static SENSOR_DEVICE_ATTR(board_id_1, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_1);
 static SENSOR_DEVICE_ATTR(mb_cpld_1_version, S_IRUGO, read_lpc_callback, NULL, ATT_MB_CPLD_1_VERSION);
 static SENSOR_DEVICE_ATTR(mb_cpld_1_version_h, S_IRUGO, read_mb_cpld_1_version_h, NULL, ATT_MB_CPLD_1_VERSION_H);
-static SENSOR_DEVICE_ATTR(mb_cpld_1_build,  S_IRUGO, read_lpc_callback, NULL, ATT_MB_CPLD_1_BUILD);
-static SENSOR_DEVICE_ATTR(mux_ctrl,         S_IRUGO | S_IWUSR, read_lpc_callback, write_lpc_callback, ATT_MB_MUX_CTRL);
-static SENSOR_DEVICE_ATTR(mux_reset,        S_IRUGO | S_IWUSR, read_mux_reset_callback, write_mux_reset_callback, ATT_MB_MUX_RESET);
-static SENSOR_DEVICE_ATTR(board_sku_id,     S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_SKU_ID);
-static SENSOR_DEVICE_ATTR(board_hw_id,      S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_HW_ID);
-static SENSOR_DEVICE_ATTR(board_id_type,    S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_TYPE);
-static SENSOR_DEVICE_ATTR(board_build_id,   S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_BUILD_ID);
-static SENSOR_DEVICE_ATTR(board_deph_id,    S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_DEPH_ID);
-//SENSOR_DEVICE_ATTR - I2C Alert
-static SENSOR_DEVICE_ATTR(alert_status,     S_IRUGO, read_lpc_callback, NULL, ATT_ALERT_STATUS);
+static SENSOR_DEVICE_ATTR(mb_cpld_1_build, S_IRUGO, read_lpc_callback, NULL, ATT_MB_CPLD_1_BUILD);
+static SENSOR_DEVICE_ATTR(mux_ctrl, S_IRUGO | S_IWUSR, read_lpc_callback, write_lpc_callback, ATT_MB_MUX_CTRL);
+static SENSOR_DEVICE_ATTR(mux_reset, S_IRUGO | S_IWUSR, read_mux_reset_callback, write_mux_reset_callback, ATT_MB_MUX_RESET);
+static SENSOR_DEVICE_ATTR(board_sku_id, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_SKU_ID);
+static SENSOR_DEVICE_ATTR(board_hw_id, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_HW_ID);
+static SENSOR_DEVICE_ATTR(board_id_type, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_TYPE);
+static SENSOR_DEVICE_ATTR(board_build_id, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_BUILD_ID);
+static SENSOR_DEVICE_ATTR(board_deph_id, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_DEPH_ID);
+// SENSOR_DEVICE_ATTR - I2C Alert
+static SENSOR_DEVICE_ATTR(alert_status, S_IRUGO, read_lpc_callback, NULL, ATT_ALERT_STATUS);
 #if CPU_TYPE == CPU_BDE
-static SENSOR_DEVICE_ATTR(alert_disable,    S_IRUGO, read_lpc_callback, NULL, ATT_ALERT_DISABLE);
+static SENSOR_DEVICE_ATTR(alert_disable, S_IRUGO, read_lpc_callback, NULL, ATT_ALERT_DISABLE);
 #endif
-//SENSOR_DEVICE_ATTR - BSP
-static SENSOR_DEVICE_ATTR(bsp_version,      S_IRUGO | S_IWUSR, read_bsp_callback, write_bsp_callback, ATT_BSP_VERSION);
-static SENSOR_DEVICE_ATTR(bsp_debug,        S_IRUGO | S_IWUSR, read_bsp_callback, write_bsp_callback, ATT_BSP_DEBUG);
-static SENSOR_DEVICE_ATTR(bsp_pr_info,      S_IWUSR, NULL, write_bsp_pr_callback, ATT_BSP_PR_INFO);
-static SENSOR_DEVICE_ATTR(bsp_pr_err,       S_IWUSR, NULL, write_bsp_pr_callback, ATT_BSP_PR_ERR);
-static SENSOR_DEVICE_ATTR(bsp_reg,          S_IRUGO | S_IWUSR, read_lpc_callback, write_bsp_callback, ATT_BSP_REG);
+// SENSOR_DEVICE_ATTR - BSP
+static SENSOR_DEVICE_ATTR(bsp_version, S_IRUGO | S_IWUSR, read_bsp_callback, write_bsp_callback, ATT_BSP_VERSION);
+static SENSOR_DEVICE_ATTR(bsp_debug, S_IRUGO | S_IWUSR, read_bsp_callback, write_bsp_callback, ATT_BSP_DEBUG);
+static SENSOR_DEVICE_ATTR(bsp_pr_info, S_IWUSR, NULL, write_bsp_pr_callback, ATT_BSP_PR_INFO);
+static SENSOR_DEVICE_ATTR(bsp_pr_err, S_IWUSR, NULL, write_bsp_pr_callback, ATT_BSP_PR_ERR);
+static SENSOR_DEVICE_ATTR(bsp_reg, S_IRUGO | S_IWUSR, read_lpc_callback, write_bsp_callback, ATT_BSP_REG);
+static SENSOR_DEVICE_ATTR(bsp_gpio_max, S_IRUGO, read_gpio_max, NULL, ATT_BSP_GPIO_MAX);
 
 static struct attribute *cpu_cpld_attrs[] = {
     &sensor_dev_attr_cpu_cpld_version.dev_attr.attr,
@@ -674,6 +716,7 @@ static struct attribute *bsp_attrs[] = {
     &sensor_dev_attr_bsp_pr_info.dev_attr.attr,
     &sensor_dev_attr_bsp_pr_err.dev_attr.attr,
     &sensor_dev_attr_bsp_reg.dev_attr.attr,
+    &sensor_dev_attr_bsp_gpio_max.dev_attr.attr,
     NULL,
 };
 
@@ -702,18 +745,17 @@ static struct attribute_group bsp_attr_grp = {
     .attrs = bsp_attrs,
 };
 
-static void lpc_dev_release( struct device * dev)
+static void lpc_dev_release(struct device *dev)
 {
     return;
 }
 
 static struct platform_device lpc_dev = {
-    .name           = DRIVER_NAME,
-    .id             = -1,
+    .name = DRIVER_NAME,
+    .id = -1,
     .dev = {
-                    .release = lpc_dev_release,
-    }
-};
+        .release = lpc_dev_release,
+    }};
 
 static int lpc_drv_probe(struct platform_device *pdev)
 {
@@ -728,32 +770,37 @@ static int lpc_drv_probe(struct platform_device *pdev)
 
     mutex_init(&lpc_data->access_lock);
 
-    for (i=0; i<grp_num; ++i) {
-        switch (i) {
-            case 0:
-                grp = &cpu_cpld_attr_grp;
-                break;
-            case 1:
-                grp = &mb_cpld_attr_grp;
-                break;
-            case 2:
-                grp = &bios_attr_grp;
-                break;
-            case 3:
-                grp = &i2c_alert_attr_grp;
-                break;
-            case 4:
-                grp = &bsp_attr_grp;
-                break;
-            default:
-                break;
+    for (i = 0; i < grp_num; ++i)
+    {
+        switch (i)
+        {
+        case 0:
+            grp = &cpu_cpld_attr_grp;
+            break;
+        case 1:
+            grp = &mb_cpld_attr_grp;
+            break;
+        case 2:
+            grp = &bios_attr_grp;
+            break;
+        case 3:
+            grp = &i2c_alert_attr_grp;
+            break;
+        case 4:
+            grp = &bsp_attr_grp;
+            break;
+        default:
+            break;
         }
 
         err[i] = sysfs_create_group(&pdev->dev.kobj, grp);
-        if (err[i]) {
+        if (err[i])
+        {
             printk(KERN_ERR "Cannot create sysfs for group %s\n", grp->name);
             goto exit;
-        } else {
+        }
+        else
+        {
             continue;
         }
     }
@@ -761,33 +808,38 @@ static int lpc_drv_probe(struct platform_device *pdev)
     return 0;
 
 exit:
-    for (i=0; i<grp_num; ++i) {
-        switch (i) {
-            case 0:
-                grp = &cpu_cpld_attr_grp;
-                break;
-            case 1:
-                grp = &mb_cpld_attr_grp;
-                break;
-            case 2:
-                grp = &bios_attr_grp;
-                break;
-            case 3:
-                grp = &i2c_alert_attr_grp;
-                break;
-            case 4:
-                grp = &bsp_attr_grp;
-                break;
-            default:
-                break;
+    for (i = 0; i < grp_num; ++i)
+    {
+        switch (i)
+        {
+        case 0:
+            grp = &cpu_cpld_attr_grp;
+            break;
+        case 1:
+            grp = &mb_cpld_attr_grp;
+            break;
+        case 2:
+            grp = &bios_attr_grp;
+            break;
+        case 3:
+            grp = &i2c_alert_attr_grp;
+            break;
+        case 4:
+            grp = &bsp_attr_grp;
+            break;
+        default:
+            break;
         }
 
         sysfs_remove_group(&pdev->dev.kobj, grp);
-        if (!err[i]) {
-            //remove previous successful cases
+        if (!err[i])
+        {
+            // remove previous successful cases
             continue;
-        } else {
-            //remove first failed case, then return
+        }
+        else
+        {
+            // remove first failed case, then return
             return err[i];
         }
     }
@@ -806,10 +858,10 @@ static int lpc_drv_remove(struct platform_device *pdev)
 }
 
 static struct platform_driver lpc_drv = {
-    .probe  = lpc_drv_probe,
+    .probe = lpc_drv_probe,
     .remove = __exit_p(lpc_drv_remove),
     .driver = {
-    .name   = DRIVER_NAME,
+        .name = DRIVER_NAME,
     },
 };
 
@@ -818,17 +870,19 @@ int lpc_init(void)
     int err = 0;
 
     err = platform_driver_register(&lpc_drv);
-    if (err) {
+    if (err)
+    {
         printk(KERN_ERR "%s(#%d): platform_driver_register failed(%d)\n",
-                __func__, __LINE__, err);
+               __func__, __LINE__, err);
 
         return err;
     }
 
     err = platform_device_register(&lpc_dev);
-    if (err) {
+    if (err)
+    {
         printk(KERN_ERR "%s(#%d): platform_device_register failed(%d)\n",
-                __func__, __LINE__, err);
+               __func__, __LINE__, err);
         platform_driver_unregister(&lpc_drv);
         return err;
     }

--- a/platform/broadcom/sonic-platform-modules-ufispace/s9301-32db/modules/x86-64-ufispace-s9301-32db-lpc.c
+++ b/platform/broadcom/sonic-platform-modules-ufispace/s9301-32db/modules/x86-64-ufispace-s9301-32db-lpc.c
@@ -26,15 +26,16 @@
 #include <linux/io.h>
 #include <linux/platform_device.h>
 #include <linux/hwmon-sysfs.h>
+#include <linux/gpio.h>
 
-#define BSP_LOG_R(fmt, args...) \
-    _bsp_log (LOG_READ, KERN_INFO "%s:%s[%d]: " fmt "\r\n", \
-            __FILE__, __func__, __LINE__, ##args)
-#define BSP_LOG_W(fmt, args...) \
-    _bsp_log (LOG_WRITE, KERN_INFO "%s:%s[%d]: " fmt "\r\n", \
-            __FILE__, __func__, __LINE__, ##args)
+#define BSP_LOG_R(fmt, args...)                            \
+    _bsp_log(LOG_READ, KERN_INFO "%s:%s[%d]: " fmt "\r\n", \
+             __FILE__, __func__, __LINE__, ##args)
+#define BSP_LOG_W(fmt, args...)                             \
+    _bsp_log(LOG_WRITE, KERN_INFO "%s:%s[%d]: " fmt "\r\n", \
+             __FILE__, __func__, __LINE__, ##args)
 
-#define BSP_PR(level, fmt, args...) _bsp_log (LOG_SYS, level "[BSP]" fmt "\r\n", ##args)
+#define BSP_PR(level, fmt, args...) _bsp_log(LOG_SYS, level "[BSP]" fmt "\r\n", ##args)
 
 #define DRIVER_NAME "x86_64_ufispace_s9301_32db_lpc"
 #define CPU_BDE 0
@@ -43,53 +44,54 @@
 
 /* LPC registers */
 
-#define REG_BASE_CPU                      0x600
+#define REG_BASE_CPU 0x600
 
 #if CPU_TYPE == CPU_SKY
-#define REG_BASE_MB                       0xE00
-#define REG_BASE_I2C_ALERT                0x700
+#define REG_BASE_MB 0xE00
+#define REG_BASE_I2C_ALERT 0x700
 #else
-#define REG_BASE_MB                       0x700
-#define REG_BASE_I2C_ALERT                0xF000
+#define REG_BASE_MB 0x700
+#define REG_BASE_I2C_ALERT 0xF000
 #endif
 
-//CPU CPLD
-#define REG_CPU_CPLD_VERSION              (REG_BASE_CPU + 0x00)
-#define REG_CPU_STATUS_0                  (REG_BASE_CPU + 0x01)
-#define REG_CPU_STATUS_1                  (REG_BASE_CPU + 0x02)
-#define REG_CPU_CTRL_0                    (REG_BASE_CPU + 0x03)
-#define REG_CPU_CTRL_1                    (REG_BASE_CPU + 0x04)
-#define REG_CPU_CPLD_BUILD                (REG_BASE_CPU + 0xE0)
+// CPU CPLD
+#define REG_CPU_CPLD_VERSION (REG_BASE_CPU + 0x00)
+#define REG_CPU_STATUS_0 (REG_BASE_CPU + 0x01)
+#define REG_CPU_STATUS_1 (REG_BASE_CPU + 0x02)
+#define REG_CPU_CTRL_0 (REG_BASE_CPU + 0x03)
+#define REG_CPU_CTRL_1 (REG_BASE_CPU + 0x04)
+#define REG_CPU_CPLD_BUILD (REG_BASE_CPU + 0xE0)
 
-//MB CPLD
-//TBD, need to change after CPLD spec release
-#define REG_MB_BRD_ID_0                   (REG_BASE_MB + 0x00)
-#define REG_MB_BRD_ID_1                   (REG_BASE_MB + 0x01)
-#define REG_MB_CPLD_VERSION               (REG_BASE_MB + 0x02)
-#define REG_MB_CPLD_BUILD                 (REG_BASE_MB + 0x04)
-#define REG_MB_MUX_RESET                  (REG_BASE_MB + 0x46)
-#define REG_MB_MUX_CTRL                   (REG_BASE_MB + 0x5c)
+// MB CPLD
+// TBD, need to change after CPLD spec release
+#define REG_MB_BRD_ID_0 (REG_BASE_MB + 0x00)
+#define REG_MB_BRD_ID_1 (REG_BASE_MB + 0x01)
+#define REG_MB_CPLD_VERSION (REG_BASE_MB + 0x02)
+#define REG_MB_CPLD_BUILD (REG_BASE_MB + 0x04)
+#define REG_MB_MUX_RESET (REG_BASE_MB + 0x46)
+#define REG_MB_MUX_CTRL (REG_BASE_MB + 0x5c)
 
-//I2C Alert
+// I2C Alert
 #if CPU_TYPE == CPU_SKY
-#define REG_ALERT_STATUS                  (REG_BASE_I2C_ALERT + 0x80)
+#define REG_ALERT_STATUS (REG_BASE_I2C_ALERT + 0x80)
 #else
-#define REG_ALERT_STATUS                  (REG_BASE_I2C_ALERT + 0x00)
-#define REG_ALERT_DISABLE                 (REG_BASE_I2C_ALERT + 0x11)
+#define REG_ALERT_STATUS (REG_BASE_I2C_ALERT + 0x00)
+#define REG_ALERT_DISABLE (REG_BASE_I2C_ALERT + 0x11)
 #endif
 
-#define MASK_ALL                          (0xFF)
-#define LPC_MDELAY                        (5)
+#define MASK_ALL (0xFF)
+#define LPC_MDELAY (5)
 
 /* LPC sysfs attributes index  */
-enum lpc_sysfs_attributes {
-    //CPU CPLD
+enum lpc_sysfs_attributes
+{
+    // CPU CPLD
     ATT_CPU_CPLD_VERSION,
     ATT_CPU_CPLD_VERSION_H,
     ATT_CPU_BIOS_BOOT_ROM,
     ATT_CPU_BIOS_BOOT_CFG,
     ATT_CPU_CPLD_BUILD,
-    //MB CPLD
+    // MB CPLD
     ATT_MB_BRD_ID_0,
     ATT_MB_BRD_ID_1,
     ATT_MB_CPLD_1_VERSION,
@@ -102,21 +104,23 @@ enum lpc_sysfs_attributes {
     ATT_MB_BRD_ID_TYPE,
     ATT_MB_BRD_BUILD_ID,
     ATT_MB_BRD_DEPH_ID,
-    //I2C Alert
+    // I2C Alert
     ATT_ALERT_STATUS,
 #if CPU_TYPE == CPU_BDE
     ATT_ALERT_DISABLE,
 #endif
-    //BSP
+    // BSP
     ATT_BSP_VERSION,
     ATT_BSP_DEBUG,
     ATT_BSP_PR_INFO,
     ATT_BSP_PR_ERR,
     ATT_BSP_REG,
+    ATT_BSP_GPIO_MAX,
     ATT_MAX
 };
 
-enum bsp_log_types {
+enum bsp_log_types
+{
     LOG_NONE,
     LOG_RW,
     LOG_READ,
@@ -124,30 +128,33 @@ enum bsp_log_types {
     LOG_SYS
 };
 
-enum bsp_log_ctrl {
+enum bsp_log_ctrl
+{
     LOG_DISABLE,
     LOG_ENABLE
 };
 
-struct lpc_data_s {
-    struct mutex    access_lock;
+struct lpc_data_s
+{
+    struct mutex access_lock;
 };
 
 struct lpc_data_s *lpc_data;
-char bsp_version[16]="";
-char bsp_debug[2]="0";
-char bsp_reg[8]="0x0";
-u8 enable_log_read=LOG_DISABLE;
-u8 enable_log_write=LOG_DISABLE;
-u8 enable_log_sys=LOG_ENABLE;
+char bsp_version[16] = "";
+char bsp_debug[2] = "0";
+char bsp_reg[8] = "0x0";
+u8 enable_log_read = LOG_DISABLE;
+u8 enable_log_write = LOG_DISABLE;
+u8 enable_log_sys = LOG_ENABLE;
 
 /* reg shift */
 static u8 _shift(u8 mask)
 {
-    int i=0, mask_one=1;
+    int i = 0, mask_one = 1;
 
-    for(i=0; i<8; ++i) {
-        if((mask & mask_one) == 1)
+    for (i = 0; i < 8; ++i)
+    {
+        if ((mask & mask_one) == 1)
             return i;
         else
             mask >>= 1;
@@ -159,7 +166,7 @@ static u8 _shift(u8 mask)
 /* reg mask and shift */
 static u8 _mask_shift(u8 val, u8 mask)
 {
-    int shift=0;
+    int shift = 0;
 
     shift = _shift(mask);
 
@@ -168,7 +175,7 @@ static u8 _mask_shift(u8 val, u8 mask)
 
 static u8 _bit_operation(u8 reg_val, u8 bit, u8 bit_val)
 {
-    if(bit_val == 0)
+    if (bit_val == 0)
         reg_val = reg_val & ~(1 << bit);
     else
         reg_val = reg_val | (1 << bit);
@@ -177,9 +184,10 @@ static u8 _bit_operation(u8 reg_val, u8 bit, u8 bit_val)
 
 static int _bsp_log(u8 log_type, char *fmt, ...)
 {
-    if((log_type==LOG_READ  && enable_log_read) ||
-        (log_type==LOG_WRITE && enable_log_write) ||
-        (log_type==LOG_SYS && enable_log_sys) ) {
+    if ((log_type == LOG_READ && enable_log_read) ||
+        (log_type == LOG_WRITE && enable_log_write) ||
+        (log_type == LOG_SYS && enable_log_sys))
+    {
         va_list args;
         int r;
 
@@ -188,32 +196,35 @@ static int _bsp_log(u8 log_type, char *fmt, ...)
         va_end(args);
 
         return r;
-    } else {
+    }
+    else
+    {
         return 0;
     }
 }
 
 static int _config_bsp_log(u8 log_type)
 {
-    switch(log_type) {
-        case LOG_NONE:
-            enable_log_read = LOG_DISABLE;
-            enable_log_write = LOG_DISABLE;
-            break;
-        case LOG_RW:
-            enable_log_read = LOG_ENABLE;
-            enable_log_write = LOG_ENABLE;
-            break;
-        case LOG_READ:
-            enable_log_read = LOG_ENABLE;
-            enable_log_write = LOG_DISABLE;
-            break;
-        case LOG_WRITE:
-            enable_log_read = LOG_DISABLE;
-            enable_log_write = LOG_ENABLE;
-            break;
-        default:
-            return -EINVAL;
+    switch (log_type)
+    {
+    case LOG_NONE:
+        enable_log_read = LOG_DISABLE;
+        enable_log_write = LOG_DISABLE;
+        break;
+    case LOG_RW:
+        enable_log_read = LOG_ENABLE;
+        enable_log_write = LOG_ENABLE;
+        break;
+    case LOG_READ:
+        enable_log_read = LOG_ENABLE;
+        enable_log_write = LOG_DISABLE;
+        break;
+    case LOG_WRITE:
+        enable_log_read = LOG_DISABLE;
+        enable_log_write = LOG_ENABLE;
+        break;
+    default:
+        return -EINVAL;
     }
     return 0;
 }
@@ -224,7 +235,7 @@ static u8 _read_lpc_reg(u16 reg, u8 mask)
     u8 reg_val;
 
     mutex_lock(&lpc_data->access_lock);
-    reg_val=_mask_shift(inb(reg), mask);
+    reg_val = _mask_shift(inb(reg), mask);
     mutex_unlock(&lpc_data->access_lock);
 
     BSP_LOG_R("reg=0x%03x, reg_val=0x%02x", reg, reg_val);
@@ -236,10 +247,10 @@ static u8 _read_lpc_reg(u16 reg, u8 mask)
 static ssize_t read_lpc_reg(u16 reg, u8 mask, char *buf)
 {
     u8 reg_val;
-    int len=0;
+    int len = 0;
 
     reg_val = _read_lpc_reg(reg, mask);
-    len=sprintf(buf,"0x%x\n", reg_val);
+    len = sprintf(buf, "0x%x\n", reg_val);
 
     return len;
 }
@@ -249,11 +260,12 @@ static ssize_t write_lpc_reg(u16 reg, u8 mask, const char *buf, size_t count)
 {
     u8 reg_val, reg_val_now, shift;
 
-    if(kstrtou8(buf, 0, &reg_val) < 0)
+    if (kstrtou8(buf, 0, &reg_val) < 0)
         return -EINVAL;
 
-    //apply SINGLE BIT operation if mask is specified, multiple bits are not supported
-    if(mask != MASK_ALL) {
+    // apply SINGLE BIT operation if mask is specified, multiple bits are not supported
+    if (mask != MASK_ALL)
+    {
         reg_val_now = _read_lpc_reg(reg, 0x0);
         shift = _shift(mask);
         reg_val = _bit_operation(reg_val_now, shift, reg_val);
@@ -274,10 +286,10 @@ static ssize_t write_lpc_reg(u16 reg, u8 mask, const char *buf, size_t count)
 /* get bsp value */
 static ssize_t read_bsp(char *buf, char *str)
 {
-    ssize_t len=0;
+    ssize_t len = 0;
 
     mutex_lock(&lpc_data->access_lock);
-    len=sprintf(buf, "%s", str);
+    len = sprintf(buf, "%s", str);
     mutex_unlock(&lpc_data->access_lock);
 
     BSP_LOG_R("reg_val=%s", str);
@@ -299,9 +311,9 @@ static ssize_t write_bsp(const char *buf, char *str, size_t str_len, size_t coun
 
 /* get cpu cpld version in human readable format */
 static ssize_t read_cpu_cpld_version_h(struct device *dev,
-        struct device_attribute *da, char *buf)
+                                       struct device_attribute *da, char *buf)
 {
-    ssize_t len=0;
+    ssize_t len = 0;
     u16 reg = REG_CPU_CPLD_VERSION;
     u8 mask = MASK_ALL;
     u8 mask_major = 0b11000000;
@@ -325,9 +337,9 @@ static ssize_t read_cpu_cpld_version_h(struct device *dev,
 
 /* get mb cpld version in human readable format */
 static ssize_t read_mb_cpld_1_version_h(struct device *dev,
-        struct device_attribute *da, char *buf)
+                                        struct device_attribute *da, char *buf)
 {
-    ssize_t len=0;
+    ssize_t len = 0;
     u16 reg = REG_MB_CPLD_VERSION;
     u8 mask = MASK_ALL;
     u8 mask_major = 0b11000000;
@@ -351,7 +363,7 @@ static ssize_t read_mb_cpld_1_version_h(struct device *dev,
 
 /* get mux_reset register value */
 static ssize_t read_mux_reset_callback(struct device *dev,
-        struct device_attribute *da, char *buf)
+                                       struct device_attribute *da, char *buf)
 {
     int len = 0;
     u16 reg = REG_MB_MUX_RESET;
@@ -359,9 +371,9 @@ static ssize_t read_mux_reset_callback(struct device *dev,
     u8 reg_val;
 
     mutex_lock(&lpc_data->access_lock);
-    reg_val=_mask_shift(inb(reg), mask);
+    reg_val = _mask_shift(inb(reg), mask);
     BSP_LOG_R("reg=0x%03x, reg_val=0x%02x", reg, reg_val);
-    len=sprintf(buf, "%d\n", reg_val);
+    len = sprintf(buf, "%d\n", reg_val);
     mutex_unlock(&lpc_data->access_lock);
 
     return len;
@@ -369,7 +381,7 @@ static ssize_t read_mux_reset_callback(struct device *dev,
 
 /* set mux_reset register value */
 static ssize_t write_mux_reset_callback(struct device *dev,
-        struct device_attribute *da, const char *buf, size_t count)
+                                        struct device_attribute *da, const char *buf, size_t count)
 {
     u8 val = 0;
     u16 reg = REG_MB_MUX_RESET;
@@ -377,11 +389,13 @@ static ssize_t write_mux_reset_callback(struct device *dev,
     u8 mask = 0b00011111;
     static int mux_reset_flag = 0;
 
-    if(kstrtou8(buf, 0, &val) < 0)
+    if (kstrtou8(buf, 0, &val) < 0)
         return -EINVAL;
 
-    if(mux_reset_flag == 0) {
-        if(val == 0) {
+    if (mux_reset_flag == 0)
+    {
+        if (val == 0)
+        {
             mutex_lock(&lpc_data->access_lock);
             mux_reset_flag = 1;
             BSP_LOG_W("i2c mux reset is triggered...");
@@ -397,10 +411,14 @@ static ssize_t write_mux_reset_callback(struct device *dev,
             mdelay(500);
             mux_reset_flag = 0;
             mutex_unlock(&lpc_data->access_lock);
-        } else {
+        }
+        else
+        {
             return -EINVAL;
         }
-    } else {
+    }
+    else
+    {
         BSP_LOG_W("i2c mux is resetting... (ignore)");
         mutex_lock(&lpc_data->access_lock);
         mutex_unlock(&lpc_data->access_lock);
@@ -411,165 +429,173 @@ static ssize_t write_mux_reset_callback(struct device *dev,
 
 /* get lpc register value */
 static ssize_t read_lpc_callback(struct device *dev,
-        struct device_attribute *da, char *buf)
+                                 struct device_attribute *da, char *buf)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
     u16 reg = 0;
     u8 mask = MASK_ALL;
 
-    switch(attr->index) {
-        //CPU CPLD
-        case ATT_CPU_CPLD_VERSION:
-            reg = REG_CPU_CPLD_VERSION;
-            break;
-        case ATT_CPU_BIOS_BOOT_ROM:
-            reg = REG_CPU_STATUS_1;
-            mask = 0x80;
-            break;
-        case ATT_CPU_BIOS_BOOT_CFG:
-            reg = REG_CPU_CTRL_1;
-            mask = 0x80;
-            break;
-        case ATT_CPU_CPLD_BUILD:
-            reg = REG_CPU_CPLD_BUILD;
-            break;
-        //MB CPLD
-        case ATT_MB_BRD_ID_0:
-            reg = REG_MB_BRD_ID_0;
-            break;
-        case ATT_MB_BRD_ID_1:
-            reg = REG_MB_BRD_ID_1;
-            break;
-        case ATT_MB_CPLD_1_VERSION:
-            reg = REG_MB_CPLD_VERSION;
-            break;
-        case ATT_MB_CPLD_1_BUILD:
-            reg = REG_MB_CPLD_BUILD;
-            break;
-        case ATT_MB_BRD_SKU_ID:
-            reg = REG_MB_BRD_ID_0;
-            mask = 0xFF;
-            break;
-        case ATT_MB_BRD_HW_ID:
-            reg = REG_MB_BRD_ID_1;
-            mask = 0x03;
-            break;
-        case ATT_MB_BRD_ID_TYPE:
-            reg = REG_MB_BRD_ID_1;
-            mask = 0x80;
-            break;
-        case ATT_MB_BRD_BUILD_ID:
-            reg = REG_MB_BRD_ID_1;
-            mask = 0x38;
-            break;
-        case ATT_MB_BRD_DEPH_ID:
-            reg = REG_MB_BRD_ID_1;
-            mask = 0x04;
-            break;
-        case ATT_MB_MUX_CTRL:
-            reg = REG_MB_MUX_CTRL;
-            break;
-        //I2C Alert
-        case ATT_ALERT_STATUS:
-            reg = REG_ALERT_STATUS;
-            mask = 0x20;
-            break;
+    switch (attr->index)
+    {
+    // CPU CPLD
+    case ATT_CPU_CPLD_VERSION:
+        reg = REG_CPU_CPLD_VERSION;
+        break;
+    case ATT_CPU_BIOS_BOOT_ROM:
+        reg = REG_CPU_STATUS_1;
+        mask = 0x80;
+        break;
+    case ATT_CPU_BIOS_BOOT_CFG:
+        reg = REG_CPU_CTRL_1;
+        mask = 0x80;
+        break;
+    case ATT_CPU_CPLD_BUILD:
+        reg = REG_CPU_CPLD_BUILD;
+        break;
+    // MB CPLD
+    case ATT_MB_BRD_ID_0:
+        reg = REG_MB_BRD_ID_0;
+        break;
+    case ATT_MB_BRD_ID_1:
+        reg = REG_MB_BRD_ID_1;
+        break;
+    case ATT_MB_CPLD_1_VERSION:
+        reg = REG_MB_CPLD_VERSION;
+        break;
+    case ATT_MB_CPLD_1_BUILD:
+        reg = REG_MB_CPLD_BUILD;
+        break;
+    case ATT_MB_BRD_SKU_ID:
+        reg = REG_MB_BRD_ID_0;
+        mask = 0xFF;
+        break;
+    case ATT_MB_BRD_HW_ID:
+        reg = REG_MB_BRD_ID_1;
+        mask = 0x03;
+        break;
+    case ATT_MB_BRD_ID_TYPE:
+        reg = REG_MB_BRD_ID_1;
+        mask = 0x80;
+        break;
+    case ATT_MB_BRD_BUILD_ID:
+        reg = REG_MB_BRD_ID_1;
+        mask = 0x38;
+        break;
+    case ATT_MB_BRD_DEPH_ID:
+        reg = REG_MB_BRD_ID_1;
+        mask = 0x04;
+        break;
+    case ATT_MB_MUX_CTRL:
+        reg = REG_MB_MUX_CTRL;
+        break;
+    // I2C Alert
+    case ATT_ALERT_STATUS:
+        reg = REG_ALERT_STATUS;
+        mask = 0x20;
+        break;
 #if CPU_TYPE == CPU_BDE
-        case ATT_ALERT_DISABLE:
-            reg = REG_ALERT_DISABLE;
-            mask = 0x04;
-            break;
+    case ATT_ALERT_DISABLE:
+        reg = REG_ALERT_DISABLE;
+        mask = 0x04;
+        break;
 #endif
-        //BSP
-        case ATT_BSP_REG:
-            if(kstrtou16(bsp_reg, 0, &reg) < 0)
-                return -EINVAL;
-            break;
-        default:
+    // BSP
+    case ATT_BSP_REG:
+        if (kstrtou16(bsp_reg, 0, &reg) < 0)
             return -EINVAL;
+        break;
+    default:
+        return -EINVAL;
     }
     return read_lpc_reg(reg, mask, buf);
 }
 
 /* set lpc register value */
 static ssize_t write_lpc_callback(struct device *dev,
-        struct device_attribute *da, const char *buf, size_t count)
+                                  struct device_attribute *da, const char *buf, size_t count)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
     u16 reg = 0;
     u8 mask = MASK_ALL;
 
-    switch(attr->index) {
-        case ATT_MB_MUX_CTRL:
-            reg = REG_MB_MUX_CTRL;
-            break;
-        default:
-            return -EINVAL;
+    switch (attr->index)
+    {
+    case ATT_MB_MUX_CTRL:
+        reg = REG_MB_MUX_CTRL;
+        break;
+    default:
+        return -EINVAL;
     }
     return write_lpc_reg(reg, mask, buf, count);
 }
 
 /* get bsp parameter value */
 static ssize_t read_bsp_callback(struct device *dev,
-        struct device_attribute *da, char *buf)
+                                 struct device_attribute *da, char *buf)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
-    int str_len=0;
-    char *str=NULL;
+    int str_len = 0;
+    char *str = NULL;
 
-    switch(attr->index) {
-        case ATT_BSP_VERSION:
-            str = bsp_version;
-            str_len = sizeof(bsp_version);
-            break;
-        case ATT_BSP_DEBUG:
-            str = bsp_debug;
-            str_len = sizeof(bsp_debug);
-            break;
-        case ATT_BSP_REG:
-            str = bsp_reg;
-            str_len = sizeof(bsp_reg);
-            break;
-        default:
-            return -EINVAL;
+    switch (attr->index)
+    {
+    case ATT_BSP_VERSION:
+        str = bsp_version;
+        str_len = sizeof(bsp_version);
+        break;
+    case ATT_BSP_DEBUG:
+        str = bsp_debug;
+        str_len = sizeof(bsp_debug);
+        break;
+    case ATT_BSP_REG:
+        str = bsp_reg;
+        str_len = sizeof(bsp_reg);
+        break;
+    default:
+        return -EINVAL;
     }
     return read_bsp(buf, str);
 }
 
 /* set bsp parameter value */
 static ssize_t write_bsp_callback(struct device *dev,
-        struct device_attribute *da, const char *buf, size_t count)
+                                  struct device_attribute *da, const char *buf, size_t count)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
-    int str_len=0;
-    char *str=NULL;
+    int str_len = 0;
+    char *str = NULL;
     u16 reg = 0;
     u8 bsp_debug_u8 = 0;
 
-    switch(attr->index) {
-        case ATT_BSP_VERSION:
-            str = bsp_version;
-            str_len = sizeof(bsp_version);
-            break;
-        case ATT_BSP_DEBUG:
-            str = bsp_debug;
-            str_len = sizeof(bsp_debug);
-            break;
-        case ATT_BSP_REG:
-            if(kstrtou16(buf, 0, &reg) < 0)
-                return -EINVAL;
-
-            str = bsp_reg;
-            str_len = sizeof(bsp_reg);
-            break;
-        default:
+    switch (attr->index)
+    {
+    case ATT_BSP_VERSION:
+        str = bsp_version;
+        str_len = sizeof(bsp_version);
+        break;
+    case ATT_BSP_DEBUG:
+        str = bsp_debug;
+        str_len = sizeof(bsp_debug);
+        break;
+    case ATT_BSP_REG:
+        if (kstrtou16(buf, 0, &reg) < 0)
             return -EINVAL;
+
+        str = bsp_reg;
+        str_len = sizeof(bsp_reg);
+        break;
+    default:
+        return -EINVAL;
     }
 
-    if(attr->index == ATT_BSP_DEBUG) {
-        if(kstrtou8(buf, 0, &bsp_debug_u8) < 0) {
+    if (attr->index == ATT_BSP_DEBUG)
+    {
+        if (kstrtou8(buf, 0, &bsp_debug_u8) < 0)
+        {
             return -EINVAL;
-        } else if(_config_bsp_log(bsp_debug_u8) < 0) {
+        }
+        else if (_config_bsp_log(bsp_debug_u8) < 0)
+        {
             return -EINVAL;
         }
     }
@@ -578,58 +604,74 @@ static ssize_t write_bsp_callback(struct device *dev,
 }
 
 static ssize_t write_bsp_pr_callback(struct device *dev,
-        struct device_attribute *da, const char *buf, size_t count)
+                                     struct device_attribute *da, const char *buf, size_t count)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
     int str_len = strlen(buf);
 
-    if(str_len <= 0)
+    if (str_len <= 0)
         return str_len;
 
-    switch (attr->index) {
-        case ATT_BSP_PR_INFO:
-            BSP_PR(KERN_INFO, "%s", buf);
-            break;
-        case ATT_BSP_PR_ERR:
-            BSP_PR(KERN_ERR, "%s", buf);
-            break;
-        default:
-            return -EINVAL;
+    switch (attr->index)
+    {
+    case ATT_BSP_PR_INFO:
+        BSP_PR(KERN_INFO, "%s", buf);
+        break;
+    case ATT_BSP_PR_ERR:
+        BSP_PR(KERN_ERR, "%s", buf);
+        break;
+    default:
+        return -EINVAL;
     }
 
     return str_len;
 }
 
-//SENSOR_DEVICE_ATTR - CPU
+/* get gpio max value */
+static ssize_t read_gpio_max(struct device *dev,
+                             struct device_attribute *da,
+                             char *buf)
+{
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+
+    if (attr->index == ATT_BSP_GPIO_MAX)
+    {
+        return sprintf(buf, "%d\n", ARCH_NR_GPIOS - 1);
+    }
+    return -1;
+}
+
+// SENSOR_DEVICE_ATTR - CPU
 static SENSOR_DEVICE_ATTR(cpu_cpld_version, S_IRUGO, read_lpc_callback, NULL, ATT_CPU_CPLD_VERSION);
 static SENSOR_DEVICE_ATTR(cpu_cpld_version_h, S_IRUGO, read_cpu_cpld_version_h, NULL, ATT_CPU_CPLD_VERSION_H);
-static SENSOR_DEVICE_ATTR(boot_rom,         S_IRUGO, read_lpc_callback, NULL, ATT_CPU_BIOS_BOOT_ROM);
-static SENSOR_DEVICE_ATTR(boot_cfg,         S_IRUGO, read_lpc_callback, NULL, ATT_CPU_BIOS_BOOT_CFG);
-static SENSOR_DEVICE_ATTR(cpu_cpld_build,   S_IRUGO, read_lpc_callback, NULL, ATT_CPU_CPLD_BUILD);
-//SENSOR_DEVICE_ATTR - MB
-static SENSOR_DEVICE_ATTR(board_id_0,       S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_0);
-static SENSOR_DEVICE_ATTR(board_id_1,       S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_1);
+static SENSOR_DEVICE_ATTR(boot_rom, S_IRUGO, read_lpc_callback, NULL, ATT_CPU_BIOS_BOOT_ROM);
+static SENSOR_DEVICE_ATTR(boot_cfg, S_IRUGO, read_lpc_callback, NULL, ATT_CPU_BIOS_BOOT_CFG);
+static SENSOR_DEVICE_ATTR(cpu_cpld_build, S_IRUGO, read_lpc_callback, NULL, ATT_CPU_CPLD_BUILD);
+// SENSOR_DEVICE_ATTR - MB
+static SENSOR_DEVICE_ATTR(board_id_0, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_0);
+static SENSOR_DEVICE_ATTR(board_id_1, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_1);
 static SENSOR_DEVICE_ATTR(mb_cpld_1_version, S_IRUGO, read_lpc_callback, NULL, ATT_MB_CPLD_1_VERSION);
 static SENSOR_DEVICE_ATTR(mb_cpld_1_version_h, S_IRUGO, read_mb_cpld_1_version_h, NULL, ATT_MB_CPLD_1_VERSION_H);
-static SENSOR_DEVICE_ATTR(mb_cpld_1_build,  S_IRUGO, read_lpc_callback, NULL, ATT_MB_CPLD_1_BUILD);
-static SENSOR_DEVICE_ATTR(mux_ctrl,         S_IRUGO | S_IWUSR, read_lpc_callback, write_lpc_callback, ATT_MB_MUX_CTRL);
-static SENSOR_DEVICE_ATTR(mux_reset,        S_IRUGO | S_IWUSR, read_mux_reset_callback, write_mux_reset_callback, ATT_MB_MUX_RESET);
-static SENSOR_DEVICE_ATTR(board_sku_id,     S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_SKU_ID);
-static SENSOR_DEVICE_ATTR(board_hw_id,      S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_HW_ID);
-static SENSOR_DEVICE_ATTR(board_id_type,    S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_TYPE);
-static SENSOR_DEVICE_ATTR(board_build_id,   S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_BUILD_ID);
-static SENSOR_DEVICE_ATTR(board_deph_id,    S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_DEPH_ID);
-//SENSOR_DEVICE_ATTR - I2C Alert
-static SENSOR_DEVICE_ATTR(alert_status,     S_IRUGO, read_lpc_callback, NULL, ATT_ALERT_STATUS);
+static SENSOR_DEVICE_ATTR(mb_cpld_1_build, S_IRUGO, read_lpc_callback, NULL, ATT_MB_CPLD_1_BUILD);
+static SENSOR_DEVICE_ATTR(mux_ctrl, S_IRUGO | S_IWUSR, read_lpc_callback, write_lpc_callback, ATT_MB_MUX_CTRL);
+static SENSOR_DEVICE_ATTR(mux_reset, S_IRUGO | S_IWUSR, read_mux_reset_callback, write_mux_reset_callback, ATT_MB_MUX_RESET);
+static SENSOR_DEVICE_ATTR(board_sku_id, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_SKU_ID);
+static SENSOR_DEVICE_ATTR(board_hw_id, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_HW_ID);
+static SENSOR_DEVICE_ATTR(board_id_type, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_ID_TYPE);
+static SENSOR_DEVICE_ATTR(board_build_id, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_BUILD_ID);
+static SENSOR_DEVICE_ATTR(board_deph_id, S_IRUGO, read_lpc_callback, NULL, ATT_MB_BRD_DEPH_ID);
+// SENSOR_DEVICE_ATTR - I2C Alert
+static SENSOR_DEVICE_ATTR(alert_status, S_IRUGO, read_lpc_callback, NULL, ATT_ALERT_STATUS);
 #if CPU_TYPE == CPU_BDE
-static SENSOR_DEVICE_ATTR(alert_disable,    S_IRUGO, read_lpc_callback, NULL, ATT_ALERT_DISABLE);
+static SENSOR_DEVICE_ATTR(alert_disable, S_IRUGO, read_lpc_callback, NULL, ATT_ALERT_DISABLE);
 #endif
-//SENSOR_DEVICE_ATTR - BSP
-static SENSOR_DEVICE_ATTR(bsp_version,      S_IRUGO | S_IWUSR, read_bsp_callback, write_bsp_callback, ATT_BSP_VERSION);
-static SENSOR_DEVICE_ATTR(bsp_debug,        S_IRUGO | S_IWUSR, read_bsp_callback, write_bsp_callback, ATT_BSP_DEBUG);
-static SENSOR_DEVICE_ATTR(bsp_pr_info,      S_IWUSR, NULL, write_bsp_pr_callback, ATT_BSP_PR_INFO);
-static SENSOR_DEVICE_ATTR(bsp_pr_err,       S_IWUSR, NULL, write_bsp_pr_callback, ATT_BSP_PR_ERR);
-static SENSOR_DEVICE_ATTR(bsp_reg,          S_IRUGO | S_IWUSR, read_lpc_callback, write_bsp_callback, ATT_BSP_REG);
+// SENSOR_DEVICE_ATTR - BSP
+static SENSOR_DEVICE_ATTR(bsp_version, S_IRUGO | S_IWUSR, read_bsp_callback, write_bsp_callback, ATT_BSP_VERSION);
+static SENSOR_DEVICE_ATTR(bsp_debug, S_IRUGO | S_IWUSR, read_bsp_callback, write_bsp_callback, ATT_BSP_DEBUG);
+static SENSOR_DEVICE_ATTR(bsp_pr_info, S_IWUSR, NULL, write_bsp_pr_callback, ATT_BSP_PR_INFO);
+static SENSOR_DEVICE_ATTR(bsp_pr_err, S_IWUSR, NULL, write_bsp_pr_callback, ATT_BSP_PR_ERR);
+static SENSOR_DEVICE_ATTR(bsp_reg, S_IRUGO | S_IWUSR, read_lpc_callback, write_bsp_callback, ATT_BSP_REG);
+static SENSOR_DEVICE_ATTR(bsp_gpio_max, S_IRUGO, read_gpio_max, NULL, ATT_BSP_GPIO_MAX);
 
 static struct attribute *cpu_cpld_attrs[] = {
     &sensor_dev_attr_cpu_cpld_version.dev_attr.attr,
@@ -674,6 +716,7 @@ static struct attribute *bsp_attrs[] = {
     &sensor_dev_attr_bsp_pr_info.dev_attr.attr,
     &sensor_dev_attr_bsp_pr_err.dev_attr.attr,
     &sensor_dev_attr_bsp_reg.dev_attr.attr,
+    &sensor_dev_attr_bsp_gpio_max.dev_attr.attr,
     NULL,
 };
 
@@ -702,18 +745,17 @@ static struct attribute_group bsp_attr_grp = {
     .attrs = bsp_attrs,
 };
 
-static void lpc_dev_release( struct device * dev)
+static void lpc_dev_release(struct device *dev)
 {
     return;
 }
 
 static struct platform_device lpc_dev = {
-    .name           = DRIVER_NAME,
-    .id             = -1,
+    .name = DRIVER_NAME,
+    .id = -1,
     .dev = {
-                    .release = lpc_dev_release,
-    }
-};
+        .release = lpc_dev_release,
+    }};
 
 static int lpc_drv_probe(struct platform_device *pdev)
 {
@@ -723,37 +765,42 @@ static int lpc_drv_probe(struct platform_device *pdev)
 
     lpc_data = devm_kzalloc(&pdev->dev, sizeof(struct lpc_data_s),
                             GFP_KERNEL);
-    if(!lpc_data)
+    if (!lpc_data)
         return -ENOMEM;
 
     mutex_init(&lpc_data->access_lock);
 
-    for (i=0; i<grp_num; ++i) {
-        switch(i) {
-            case 0:
-                grp = &cpu_cpld_attr_grp;
-                break;
-            case 1:
-                grp = &mb_cpld_attr_grp;
-                break;
-            case 2:
-                grp = &bios_attr_grp;
-                break;
-            case 3:
-                grp = &i2c_alert_attr_grp;
-                break;
-            case 4:
-                grp = &bsp_attr_grp;
-                break;
-            default:
-                break;
+    for (i = 0; i < grp_num; ++i)
+    {
+        switch (i)
+        {
+        case 0:
+            grp = &cpu_cpld_attr_grp;
+            break;
+        case 1:
+            grp = &mb_cpld_attr_grp;
+            break;
+        case 2:
+            grp = &bios_attr_grp;
+            break;
+        case 3:
+            grp = &i2c_alert_attr_grp;
+            break;
+        case 4:
+            grp = &bsp_attr_grp;
+            break;
+        default:
+            break;
         }
 
         err[i] = sysfs_create_group(&pdev->dev.kobj, grp);
-        if(err[i]) {
+        if (err[i])
+        {
             printk(KERN_ERR "Cannot create sysfs for group %s\n", grp->name);
             goto exit;
-        } else {
+        }
+        else
+        {
             continue;
         }
     }
@@ -761,33 +808,38 @@ static int lpc_drv_probe(struct platform_device *pdev)
     return 0;
 
 exit:
-    for (i=0; i<grp_num; ++i) {
-        switch(i) {
-            case 0:
-                grp = &cpu_cpld_attr_grp;
-                break;
-            case 1:
-                grp = &mb_cpld_attr_grp;
-                break;
-            case 2:
-                grp = &bios_attr_grp;
-                break;
-            case 3:
-                grp = &i2c_alert_attr_grp;
-                break;
-            case 4:
-                grp = &bsp_attr_grp;
-                break;
-            default:
-                break;
+    for (i = 0; i < grp_num; ++i)
+    {
+        switch (i)
+        {
+        case 0:
+            grp = &cpu_cpld_attr_grp;
+            break;
+        case 1:
+            grp = &mb_cpld_attr_grp;
+            break;
+        case 2:
+            grp = &bios_attr_grp;
+            break;
+        case 3:
+            grp = &i2c_alert_attr_grp;
+            break;
+        case 4:
+            grp = &bsp_attr_grp;
+            break;
+        default:
+            break;
         }
 
         sysfs_remove_group(&pdev->dev.kobj, grp);
-        if(!err[i]) {
-            //remove previous successful cases
+        if (!err[i])
+        {
+            // remove previous successful cases
             continue;
-        } else {
-            //remove first failed case, then return
+        }
+        else
+        {
+            // remove first failed case, then return
             return err[i];
         }
     }
@@ -806,10 +858,10 @@ static int lpc_drv_remove(struct platform_device *pdev)
 }
 
 static struct platform_driver lpc_drv = {
-    .probe  = lpc_drv_probe,
+    .probe = lpc_drv_probe,
     .remove = __exit_p(lpc_drv_remove),
     .driver = {
-    .name   = DRIVER_NAME,
+        .name = DRIVER_NAME,
     },
 };
 
@@ -818,17 +870,19 @@ int lpc_init(void)
     int err = 0;
 
     err = platform_driver_register(&lpc_drv);
-    if(err) {
+    if (err)
+    {
         printk(KERN_ERR "%s(#%d): platform_driver_register failed(%d)\n",
-                __func__, __LINE__, err);
+               __func__, __LINE__, err);
 
         return err;
     }
 
     err = platform_device_register(&lpc_dev);
-    if(err) {
+    if (err)
+    {
         printk(KERN_ERR "%s(#%d): platform_device_register failed(%d)\n",
-                __func__, __LINE__, err);
+               __func__, __LINE__, err);
         platform_driver_unregister(&lpc_drv);
         return err;
     }


### PR DESCRIPTION
<!--

     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Update platform device configruations and drivers for 
- s9300-32d
- s9301-32d
- s9301-32db

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
* change pddf config to retrieve psu status from cpld
* add port breakout modes
* align lpc driver
#### How to verify it
run following commands to check if the results are correct.
show platform psustatus 
show interfaces breakout

without the fix, the values are not correct.
<pre>
root@sonic:~# show platform psustatus 
PSU    Model    Serial    HW Rev    Voltage (V)    Current (A)    Power (W)    Status       LED
-----  -------  --------  --------  -------------  -------------  -----------  -----------  -----
PSU 1  N/A      N/A       N/A       N/A            N/A            N/A          NOT PRESENT
PSU 2  N/A      N/A       N/A       N/A            N/A            N/A          NOT PRESENT
</pre>

the correct result with the fix.
<pre>
root@sonic:~# show platform psustatus 
PSU    Model    Serial               HW Rev      Voltage (V)    Current (A)    Power (W)  Status    LED
-----  -------  -------------------  --------  -------------  -------------  -----------  --------  ------------
PSU 1  FSH082   A13200S90420Y332172  N/A                0.00           0.00         0.00  NOT OK    yellow_blink
PSU 2  FSH082   A13200S90420Y332486  N/A               12.06          22.40       270.14  OK        green
</pre>

Several breakout modes are supported. The result should be displayed below:
<pre>
root@sonic:~# show interfaces breakout
{
    "Ethernet0": {
        "index": "0,0,0,0,0,0,0,0",
        "lanes": "1,2,3,4,5,6,7,8",
        "breakout_modes": {
            "1x400G": [
                "Eth0(Port0)"
            ],
            "1x200G(4)": [
                "Eth0(Port0)"
            ],
            "1x100G(2)": [
                "Eth0(Port0)"
            ],
            "1x100G(4)": [
                "Eth0(Port0)"
            ],
            "1x50G(2)": [
                "Eth0(Port0)"
            ],
            "1x40G(4)": [
                "Eth0(Port0)"
            ],
            "1x25G(1)": [
                "Eth0(Port0)"
            ],
            "2x200G": [
                "Eth0/1(Port0)",
                "Eth0/2(Port0)"
            ],
            "2x100G": [
                "Eth0/1(Port0)",
                "Eth0/2(Port0)"
            ],
            "2x50G(2)": [
                "Eth0/1(Port0)",
                "Eth0/2(Port0)"
            ],
            "2x50G(4)": [
                "Eth0/1(Port0)",
                "Eth0/2(Port0)"
            ],
            "2x40G": [
                "Eth0/1(Port0)",
                "Eth0/2(Port0)"
            ],
            "4x100G": [
                "Eth0/1(Port0)",
                "Eth0/2(Port0)",
                "Eth0/3(Port0)",
                "Eth0/4(Port0)"
            ],
            "4x25G(4)": [
                "Eth0/1(Port0)",
                "Eth0/2(Port0)",
                "Eth0/3(Port0)",
                "Eth0/4(Port0)"
            ],
            "4x10G(4)": [
                "Eth0/1(Port0)",
                "Eth0/2(Port0)",
                "Eth0/3(Port0)",
                "Eth0/4(Port0)"
            ],
            "8x50G": [
                "Eth0/1(Port0)",
                "Eth0/2(Port0)",
                "Eth0/3(Port0)",
                "Eth0/4(Port0)",
                "Eth0/5(Port0)",
                "Eth0/6(Port0)",
                "Eth0/7(Port0)",
                "Eth0/8(Port0)"
            ],
            "8x25G": [
                "Eth0/1(Port0)",
                "Eth0/2(Port0)",
                "Eth0/3(Port0)",
                "Eth0/4(Port0)",
                "Eth0/5(Port0)",
                "Eth0/6(Port0)",
                "Eth0/7(Port0)",
                "Eth0/8(Port0)"
            ]
        },
        "default_brkout_mode": "1x400G",
        "Current Breakout Mode": "1x400G",
        "child ports": "Ethernet0",
        "child port speeds": "400G"
    },
    ...omit...
</pre>
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

