### PR TITLE
Install pygobject from Debian instead of pip

### DIFF
--- a/files/build/versions/host-image/versions-py3
+++ b/files/build/versions/host-image/versions-py3
@@ -55,7 +55,7 @@ pyangbind==0.8.2
 pycairo==1.26.1
 pycparser==2.21
 pygments==2.19.1
-pygobject==3.50.0
+pygobject==3.42.2
 pynacl==1.5.0
 pyroute2==0.7.12
 python-apt==2.6.0

--- a/files/build/versions/host-image/versions-py3-all-armhf
+++ b/files/build/versions/host-image/versions-py3-all-armhf
@@ -1,2 +1,1 @@
 protobuf==5.29.3
-pygobject==3.42.2

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -258,14 +258,9 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark manu
 # Install systemd-python for SONiC host services
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install systemd-python
 
-if [[ $CONFIGURED_ARCH == armhf ]]; then
-    # Install pygobject from apt repos, since it has armhf prebuilt. The version in Debian is
-    # a bit older than what is in pip.
-    #
-    # When doing the next Debian upgrade (to Trixie), consider installing this package for all
-    # architectures instead of just armhf.
-    sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install python3-gi
-fi
+# Install pygobject from apt repos. The version in Debian is
+# a bit older than what is in pip, but it should be fine.
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install python3-gi
 
 # Install SONiC host services package
 install_pip_package {{sonic_host_services_py3_wheel_path}}


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This package is already available in Debian and doesn't require any compilation on SONiC's end for using this.

This also removes compilation errors related to not having `girepository` installed when upgrading to a newer version of this package from pip.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

