### PR TITLE
[TACACS] Fix TACACS per-command authorization send host as remote address bug.

### DIFF
--- a/src/tacacs/bash_tacplus/bash_tacplus.c
+++ b/src/tacacs/bash_tacplus/bash_tacplus.c
@@ -235,14 +235,14 @@ void get_remote_address(char* dst, size_t size)
     // SSHD will create environment variable SSH_CONNECTION after user session created.
     char *ssh_connection = getenv("SSH_CONNECTION");
     if (ssh_connection != NULL) {
-        snprintf(dst, size, ssh_connection);
+        snprintf(dst, size, "%s", ssh_connection);
         return;
     }
 
     // Before user session created, SSHD will create environment variable SSH_CLIENT_IPADDR_PORT.
     char *client_ip = getenv("SSH_CLIENT_IPADDR_PORT");
     if (client_ip != NULL) {
-        snprintf(dst, size, client_ip);
+        snprintf(dst, size, "%s", client_ip);
         return;
     }
 }

--- a/src/tacacs/bash_tacplus/bash_tacplus.c
+++ b/src/tacacs/bash_tacplus/bash_tacplus.c
@@ -242,37 +242,25 @@ int get_environment_variable_first_part(char* dst, socklen_t size, const char* n
 
     const char* variable = getenv(name);
     if (variable == NULL) {
-        if (debug) {
-            syslog(LOG_DEBUG, "%s: can't get environment variable %s, errno=%d", nssname, name, errno);
-        }
-
+        output_debug("Can't get environment variable %s, errno=%d", name, errno);
         return GET_ENV_VARIABLE_NOT_FOUND;
     }
 
     char* context = NULL;
     char* first_part = strtok_r((char *)variable, delimiters, &context);
     if (first_part == NULL) {
-        if (debug) {
-            syslog(LOG_DEBUG, "%s: can't split %s by delimiters %s", nssname, variable, delimiters);
-        }
-
+        output_debug("Can't split %s by delimiters %s", variable, delimiters);
         return GET_ENV_VARIABLE_INCORRECT_FORMAT;
     }
 
     int first_part_len = strlen(first_part);
     if (first_part_len >= size) {
-        if (debug) {
-            syslog(LOG_DEBUG, "%s: dest buffer size %d not enough for %s", nssname, size, first_part);
-        }
-
+        output_debug("Dest buffer size %d not enough for %s", size, first_part);
         return GET_ENV_VARIABLE_NOT_ENOUGH_BUFFER;
     }
 
     strcpy_s(dst, size, first_part);
-    if (debug) {
-        syslog(LOG_DEBUG, "%s: remote address=%s", nssname, dst);
-    }
-
+    output_debug("Remote address=%s", dst);
     return GET_ENV_VARIABLE_OK;
 }
 
@@ -307,7 +295,7 @@ int authorization_with_host_and_tty(const char *user, const char *cmd, char **ar
     int result = get_remote_address(remote_addr, sizeof(remote_addr));
     if ((result != GET_REMOTE_ADDRESS_OK)) {
         snprintf(remote_addr, sizeof(remote_addr), "UNK");
-        output_error("Failed to determine remote address, passing %s\n", remote);
+        output_error("Failed to determine remote address, passing %s\n", remote_addr);
     }
 
     // try get tty name
@@ -413,7 +401,7 @@ void plugin_uninit()
 /*
  * Check if current user is local user.
  */
-int is_local_user(char *user)
+int is_local_user(const char *user)
 {
     if (user == unknown_username) {
         // for unknown user name, when tacacs enabled, always authorization with tacacs.
@@ -460,7 +448,7 @@ int is_local_user(char *user)
 /*
  * Get user name.
  */
-char* get_user_name(char *user)
+const char* get_user_name(char *user)
 {
     if (user != NULL && strlen(user) != 0) {
         return user;
@@ -491,7 +479,7 @@ char* get_user_name(char *user)
  */
 int on_shell_execve (char *user, int shell_level, char *cmd, char **argv)
 {
-    char* user_namd = get_user_name(user);
+    const char* user_namd = get_user_name(user);
     output_debug("Authorization parameters:\n");
     output_debug("    Shell level: %d\n", shell_level);
     output_debug("    Current user: %s\n", user_namd);

--- a/src/tacacs/bash_tacplus/bash_tacplus.c
+++ b/src/tacacs/bash_tacplus/bash_tacplus.c
@@ -259,7 +259,7 @@ int get_environment_variable_first_part(char* dst, socklen_t size, const char* n
         return GET_ENV_VARIABLE_NOT_ENOUGH_BUFFER;
     }
 
-    strcpy_s(dst, size, first_part);
+    snprintf(dst, size, "%s", first_part);
     output_debug("Remote address=%s", dst);
     return GET_ENV_VARIABLE_OK;
 }

--- a/src/tacacs/bash_tacplus/bash_tacplus.c
+++ b/src/tacacs/bash_tacplus/bash_tacplus.c
@@ -268,7 +268,7 @@ int get_environment_variable_first_part(char* dst, socklen_t size, const char* n
         return GET_ENV_VARIABLE_NOT_ENOUGH_BUFFER;
     }
 
-    strncpy(dst, first_part, size);
+    strcpy_s(dst, size, first_part);
     if (debug) {
         syslog(LOG_DEBUG, "%s: remote address=%s", nssname, dst);
     }


### PR DESCRIPTION
Fix TACACS per-command authorization send host as remote address bug.

#### Why I did it
TACACS per-command authorization send host as remote address.

##### Work item tracking
- Microsoft ADO **(number only)**:32291587

#### How I did it
Send correct remote address in TACACS per-command authorization request.

#### How to verify it
Pass all test case.

Add test case:
https://github.com/sonic-net/sonic-mgmt/pull/18055

Manually verified:
![image](https://github.com/user-attachments/assets/76acc917-6371-4265-b6ce-0f54c353fef4)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Fix TACACS per-command authorization send host as remote address bug.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

