### PR TITLE
[anchor] Add as path manager for anchor

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -26,6 +26,7 @@ from .managers_chassis_app_db import ChassisAppDbMgr
 from .managers_bfd import BfdMgr
 from .managers_srv6 import SRv6Mgr
 from .managers_prefix_list import PrefixListMgr
+from .managers_as_path import AsPathMgr
 from .static_rt_timer import StaticRouteTimer
 from .runner import Runner, signal_handler
 from .template import TemplateFabric
@@ -82,12 +83,16 @@ def do_work():
         # SRv6 Manager
         SRv6Mgr(common_objs, "CONFIG_DB", "SRV6_MY_SIDS"),
         SRv6Mgr(common_objs, "CONFIG_DB", "SRV6_MY_LOCATORS"),
-        # Prefix List Manager
-        PrefixListMgr(common_objs, "CONFIG_DB", "PREFIX_LIST")
     ]
 
     if device_info.is_chassis():
         managers.append(ChassisAppDbMgr(common_objs, "CHASSIS_APP_DB", "BGP_DEVICE_GLOBAL"))
+
+    device_metadata = config_db.get_table("DEVICE_METADATA")
+    if "localhost" in device_metadata and "type" in device_metadata["localhost"] and device_metadata["localhost"]["type"] == "SpineRouter" and "subtype" in device_metadata["localhost"] and device_metadata["localhost"]["subtype"] == "UpstreamLC":
+        # Prefix List Manager
+        managers.append(PrefixListMgr(common_objs, "CONFIG_DB", "PREFIX_LIST"))
+        managers.append(AsPathMgr(common_objs, "CONFIG_DB", "DEVICE_METADATA"))
 
     config_db = ConfigDBConnector()
     config_db.connect()

--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -88,18 +88,18 @@ def do_work():
     if device_info.is_chassis():
         managers.append(ChassisAppDbMgr(common_objs, "CHASSIS_APP_DB", "BGP_DEVICE_GLOBAL"))
 
-    device_metadata = config_db.get_table("DEVICE_METADATA")
-    if "localhost" in device_metadata and "type" in device_metadata["localhost"] and device_metadata["localhost"]["type"] == "SpineRouter" and "subtype" in device_metadata["localhost"] and device_metadata["localhost"]["subtype"] == "UpstreamLC":
-        # Prefix List Manager
-        managers.append(PrefixListMgr(common_objs, "CONFIG_DB", "PREFIX_LIST"))
-        managers.append(AsPathMgr(common_objs, "CONFIG_DB", "DEVICE_METADATA"))
-
     config_db = ConfigDBConnector()
     config_db.connect()
     sys_defaults = config_db.get_table('SYSTEM_DEFAULTS')
     if 'software_bfd' in sys_defaults and 'status' in sys_defaults['software_bfd'] and sys_defaults['software_bfd']['status'] == 'enabled':
         log_notice("software_bfd feature is enabled, starting bfd manager")
         managers.append(BfdMgr(common_objs, "STATE_DB", swsscommon.STATE_BFD_SOFTWARE_SESSION_TABLE_NAME))
+
+    device_metadata = config_db.get_table("DEVICE_METADATA")
+    if "localhost" in device_metadata and "type" in device_metadata["localhost"] and device_metadata["localhost"]["type"] == "SpineRouter" and "subtype" in device_metadata["localhost"] and device_metadata["localhost"]["subtype"] == "UpstreamLC":
+        # Prefix List Manager
+        managers.append(PrefixListMgr(common_objs, "CONFIG_DB", "PREFIX_LIST"))
+        managers.append(AsPathMgr(common_objs, "CONFIG_DB", "DEVICE_METADATA"))
 
     runner = Runner(common_objs['cfg_mgr'])
     for mgr in managers:

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_as_path.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_as_path.py
@@ -24,10 +24,8 @@ class AsPathMgr(Manager):
             db,
             table,
         )
-        
-    
+
     def set_handler(self, key, data):
-        log_info("AsPathMgr: set handler")
         if key != "localhost":
             return
         asns = None
@@ -35,19 +33,21 @@ class AsPathMgr(Manager):
             if key_inside == "t2_group_asns":
                 asns = value
                 break
-        log_info("AsPathMgr: Clear asns group {}".format(T2_GROUP_ASNS))
-        self.cfg_mgr.push("no bgp as-path access-list {}".format(T2_GROUP_ASNS))
+        cmd = "no bgp as-path access-list {}".format(T2_GROUP_ASNS)
+        log_info("AsPathMgr: Clear asns group with cmd: [{}]".format(cmd))
+        self.cfg_mgr.push(cmd)
         if asns is not None:
             for asn in asns.split(","):
-                log_info("AsPathMgr: Add asn {} to {}".format(asn, T2_GROUP_ASNS))
-                self.cfg_mgr.push("bgp as-path access-list {} permit _{}_".format(T2_GROUP_ASNS, asn))
+                cmd = "bgp as-path access-list {} permit _{}_".format(T2_GROUP_ASNS, asn)
+                log_info("AsPathMgr: Add as-path with cmd: [{}]".format(cmd))
+                self.cfg_mgr.push(cmd)
         return True
 
     def del_handler(self, key):
-        log_info("AsPathMgr: del handler")
         if key != "localhost":
             return True
         # It would be trigger when we deleta all `localhost` entry in DEVICE_METADATA, then clear t2 group asns
-        log_info("AsPathMgr: Clear asns group {}".format(T2_GROUP_ASNS))
-        self.cfg_mgr.push("no bgp as-path access-list {}".format(T2_GROUP_ASNS))
+        cmd = "no bgp as-path access-list {}".format(T2_GROUP_ASNS)
+        log_info("AsPathMgr: Clear asns group with cmd: [{}]".format(cmd))
+        self.cfg_mgr.push(cmd)
         return True

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_as_path.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_as_path.py
@@ -28,28 +28,26 @@ class AsPathMgr(Manager):
     
     def set_handler(self, key, data):
         log_info("AsPathMgr: set handler")
-        if not "|" in key:
-            log_info("AsPathMgr: no \"|\" in {}".format(key))
-            return True
-        splits = key.split("|")
-        if splits != 2 or splits[0] != "localhost" or "t2_group_asns" not in splits[1]:
-            log_info("AsPathMgr: Cannot find t2_group_asns")
-            return True
-        for asn in splits[1]:
-            log_info("AsPathMgr: Add asn {} to {}".format(asn, T2_GROUP_ASNS))
-            self.cfg_mgr.push("bgp as-path access-list {} permit _{}_".format(T2_GROUP_ASNS, asn))
+        if key != "localhost":
+            return
+        asns = None
+        for key_inside, value in data.items():
+            if key_inside == "t2_group_asns":
+                asns = value
+                break
+        log_info("AsPathMgr: Clear asns group {}".format(T2_GROUP_ASNS))
+        self.cfg_mgr.push("no bgp as-path access-list {}".format(T2_GROUP_ASNS))
+        if asns is not None:
+            for asn in asns.split(","):
+                log_info("AsPathMgr: Add asn {} to {}".format(asn, T2_GROUP_ASNS))
+                self.cfg_mgr.push("bgp as-path access-list {} permit _{}_".format(T2_GROUP_ASNS, asn))
         return True
 
-    def del_handler(self, key, data):
+    def del_handler(self, key):
         log_info("AsPathMgr: del handler")
-        if not "|" in key:
-            log_info("AsPathMgr: no \"|\" in {}".format(key))
+        if key != "localhost":
             return True
-        splits = key.split("|")
-        if splits != 2 or splits[0] != "localhost" or "t2_group_asns" not in splits[1]:
-            log_info("AsPathMgr: Cannot find t2_group_asns")
-            return True
-        for asn in splits[1]:
-            log_info("AsPathMgr: Add asn {} to {}".format(asn, T2_GROUP_ASNS))
-            self.cfg_mgr.push("bgp as-path access-list {} permit _{}_".format(T2_GROUP_ASNS, asn))
+        # It would be trigger when we deleta all `localhost` entry in DEVICE_METADATA, then clear t2 group asns
+        log_info("AsPathMgr: Clear asns group {}".format(T2_GROUP_ASNS))
+        self.cfg_mgr.push("no bgp as-path access-list {}".format(T2_GROUP_ASNS))
         return True

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_as_path.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_as_path.py
@@ -27,27 +27,24 @@ class AsPathMgr(Manager):
 
     def set_handler(self, key, data):
         if key != "localhost":
-            return
+            return True
         asns = None
         for key_inside, value in data.items():
             if key_inside == "t2_group_asns":
                 asns = value
                 break
-        cmd = "no bgp as-path access-list {}".format(T2_GROUP_ASNS)
-        log_info("AsPathMgr: Clear asns group with cmd: [{}]".format(cmd))
-        self.cfg_mgr.push(cmd)
+        log_info("AsPathMgr: Clear asns group {}".format(T2_GROUP_ASNS))
+        self.cfg_mgr.push("no bgp as-path access-list {}".format(T2_GROUP_ASNS))
         if asns is not None:
             for asn in asns.split(","):
-                cmd = "bgp as-path access-list {} permit _{}_".format(T2_GROUP_ASNS, asn)
-                log_info("AsPathMgr: Add as-path with cmd: [{}]".format(cmd))
-                self.cfg_mgr.push(cmd)
+                log_info("AsPathMgr: Add as-path {} to group {}".format(asn, T2_GROUP_ASNS))
+                self.cfg_mgr.push("bgp as-path access-list {} permit _{}_".format(T2_GROUP_ASNS, asn))
         return True
 
     def del_handler(self, key):
         if key != "localhost":
             return True
         # It would be trigger when we deleta all `localhost` entry in DEVICE_METADATA, then clear t2 group asns
-        cmd = "no bgp as-path access-list {}".format(T2_GROUP_ASNS)
-        log_info("AsPathMgr: Clear asns group with cmd: [{}]".format(cmd))
-        self.cfg_mgr.push(cmd)
+        log_info("AsPathMgr: Clear asns group {}".format(T2_GROUP_ASNS))
+        self.cfg_mgr.push("no bgp as-path access-list {}".format(T2_GROUP_ASNS))
         return True

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_as_path.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_as_path.py
@@ -1,0 +1,55 @@
+from .manager import Manager
+from .log import log_debug, log_warn, log_info
+from swsscommon import swsscommon
+
+T2_GROUP_ASNS = "T2_GROUP_ASNS"
+
+
+class AsPathMgr(Manager):
+    """This class responds to initialize as-path"""
+
+    def __init__(self, common_objs, db, table):
+        """
+        Initialize the object
+        :param common_objs: common object dictionary
+        :param db: name of the db
+        :param table: name of the table in the db
+        """
+        self.directory = common_objs['directory']
+        self.cfg_mgr = common_objs['cfg_mgr']
+        self.constants = common_objs['constants']
+        super(AsPathMgr, self).__init__(
+            common_objs,
+            [],
+            db,
+            table,
+        )
+        
+    
+    def set_handler(self, key, data):
+        log_info("AsPathMgr: set handler")
+        if not "|" in key:
+            log_info("AsPathMgr: no \"|\" in {}".format(key))
+            return True
+        splits = key.split("|")
+        if splits != 2 or splits[0] != "localhost" or "t2_group_asns" not in splits[1]:
+            log_info("AsPathMgr: Cannot find t2_group_asns")
+            return True
+        for asn in splits[1]:
+            log_info("AsPathMgr: Add asn {} to {}".format(asn, T2_GROUP_ASNS))
+            self.cfg_mgr.push("bgp as-path access-list {} permit _{}_".format(T2_GROUP_ASNS, asn))
+        return True
+
+    def del_handler(self, key, data):
+        log_info("AsPathMgr: del handler")
+        if not "|" in key:
+            log_info("AsPathMgr: no \"|\" in {}".format(key))
+            return True
+        splits = key.split("|")
+        if splits != 2 or splits[0] != "localhost" or "t2_group_asns" not in splits[1]:
+            log_info("AsPathMgr: Cannot find t2_group_asns")
+            return True
+        for asn in splits[1]:
+            log_info("AsPathMgr: Add asn {} to {}".format(asn, T2_GROUP_ASNS))
+            self.cfg_mgr.push("bgp as-path access-list {} permit _{}_".format(T2_GROUP_ASNS, asn))
+        return True

--- a/src/sonic-bgpcfgd/tests/test_as_path.py
+++ b/src/sonic-bgpcfgd/tests/test_as_path.py
@@ -1,0 +1,76 @@
+from unittest.mock import MagicMock, patch, call
+
+import os
+from bgpcfgd.directory import Directory
+from bgpcfgd.template import TemplateFabric
+from . import swsscommon_test
+from swsscommon import swsscommon
+
+from bgpcfgd.managers_as_path import AsPathMgr
+
+TEMPLATE_PATH = os.path.abspath('../../dockers/docker-fpm-frr/frr')
+
+
+def constructor():
+    cfg_mgr = MagicMock()
+    common_objs = {
+        'directory': Directory(),
+        'cfg_mgr':   cfg_mgr,
+        'tf':        TemplateFabric(TEMPLATE_PATH),
+        'constants': {},
+    }
+
+    m = AsPathMgr(common_objs, "CONFIG_DB", "DEVICE_METADATA")
+    m.directory.put("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost", {"bgp_asn": "65100", "type": "SpineRouter", "subtype": "UpstreamLC"})
+
+    return m
+
+
+def set_handler_test(manager, key, value):
+    res = manager.set_handler(key, value)
+    assert res, "Returns always True"
+
+
+def del_handler_test(manager, key):
+    res = manager.del_handler(key)
+    assert res, "Returns always True"
+
+
+# test if T2_GROUP_ASNS has been cleared
+@patch('bgpcfgd.managers_as_path.log_info')
+def test_metadata_without_asns(mocked_log_info):
+    m = constructor()
+    set_handler_test(m, "DEVICE_METADATA|localhost", {"bgp_asn": "65100", "type": "SpineRouter",
+                                                      "subtype": "UpstreamLC"})
+    mocked_log_info.assert_called_with("AsPathMgr: Clear asns group with cmd: " + 
+                                       "[no bgp as-path access-list T2_GROUP_ASNS]")
+
+
+# test if T2_GROUP_ASNS has been added
+@patch('bgpcfgd.managers_as_path.log_info')
+def test_metadata_with_asns(mocked_log_info):
+    m = constructor()
+    set_handler_test(m, "DEVICE_METADATA|localhost",
+                     {"bgp_asn": "65100", "type": "SpineRouter",
+                      "subtype": "UpstreamLC", "t2_group_asns": ["64120", "64121"]})
+    mocked_log_info.assert_has_calls([
+            call("AsPathMgr: Clear asns group with cmd: [no bgp as-path access-list T2_GROUP_ASNS]"),
+            call("AsPathMgr: Add as-path with cmd: [bgp as-path access-list T2_GROUP_ASNS permit _64120_]"),
+            call("AsPathMgr: Add as-path with cmd: [bgp as-path access-list T2_GROUP_ASNS permit _64121_]")
+        ])
+
+
+# test if T2_GROUP_ASNS has been cleared
+@patch('bgpcfgd.managers_as_path.log_info')
+def test_del_handler(mocked_log_info):
+    m = constructor()
+    set_handler_test(m, "DEVICE_METADATA|localhost",
+                     {"bgp_asn": "65100", "type": "SpineRouter",
+                      "subtype": "UpstreamLC", "t2_group_asns": ["64120", "64121"]})
+    del_handler_test(m, "DEVICE_METADATA|localhost")
+    mocked_log_info.assert_has_calls([
+            call("AsPathMgr: Clear asns group with cmd: [no bgp as-path access-list T2_GROUP_ASNS]"),
+            call("AsPathMgr: Add as-path with cmd: [bgp as-path access-list T2_GROUP_ASNS permit _64120_]"),
+            call("AsPathMgr: Add as-path with cmd: [bgp as-path access-list T2_GROUP_ASNS permit _64121_]"),
+            call("AsPathMgr: Clear asns group with cmd: [no bgp as-path access-list T2_GROUP_ASNS]")
+        ])

--- a/src/sonic-bgpcfgd/tests/test_as_path.py
+++ b/src/sonic-bgpcfgd/tests/test_as_path.py
@@ -37,40 +37,36 @@ def del_handler_test(manager, key):
 
 
 # test if T2_GROUP_ASNS has been cleared
-@patch('bgpcfgd.managers_as_path.log_info')
-def test_metadata_without_asns(mocked_log_info):
+def test_metadata_without_asns():
     m = constructor()
-    set_handler_test(m, "DEVICE_METADATA|localhost", {"bgp_asn": "65100", "type": "SpineRouter",
-                                                      "subtype": "UpstreamLC"})
-    mocked_log_info.assert_called_with("AsPathMgr: Clear asns group with cmd: " + 
-                                       "[no bgp as-path access-list T2_GROUP_ASNS]")
+    set_handler_test(m, "localhost", {"bgp_asn": "65100", "type": "SpineRouter",
+                                      "subtype": "UpstreamLC"})
+    m.cfg_mgr.push.assert_called_with("no bgp as-path access-list T2_GROUP_ASNS")
 
 
 # test if T2_GROUP_ASNS has been added
-@patch('bgpcfgd.managers_as_path.log_info')
-def test_metadata_with_asns(mocked_log_info):
+def test_metadata_with_asns():
     m = constructor()
-    set_handler_test(m, "DEVICE_METADATA|localhost",
+    set_handler_test(m, "localhost",
                      {"bgp_asn": "65100", "type": "SpineRouter",
-                      "subtype": "UpstreamLC", "t2_group_asns": ["64120", "64121"]})
-    mocked_log_info.assert_has_calls([
-            call("AsPathMgr: Clear asns group with cmd: [no bgp as-path access-list T2_GROUP_ASNS]"),
-            call("AsPathMgr: Add as-path with cmd: [bgp as-path access-list T2_GROUP_ASNS permit _64120_]"),
-            call("AsPathMgr: Add as-path with cmd: [bgp as-path access-list T2_GROUP_ASNS permit _64121_]")
-        ])
+                      "subtype": "UpstreamLC", "t2_group_asns": "64120,64121"})
+    m.cfg_mgr.push.assert_has_calls([
+        call("no bgp as-path access-list T2_GROUP_ASNS"),
+        call("bgp as-path access-list T2_GROUP_ASNS permit _64120_"),
+        call("bgp as-path access-list T2_GROUP_ASNS permit _64121_")
+    ])
 
 
 # test if T2_GROUP_ASNS has been cleared
-@patch('bgpcfgd.managers_as_path.log_info')
-def test_del_handler(mocked_log_info):
+def test_del_handler():
     m = constructor()
-    set_handler_test(m, "DEVICE_METADATA|localhost",
+    set_handler_test(m, "localhost",
                      {"bgp_asn": "65100", "type": "SpineRouter",
-                      "subtype": "UpstreamLC", "t2_group_asns": ["64120", "64121"]})
-    del_handler_test(m, "DEVICE_METADATA|localhost")
-    mocked_log_info.assert_has_calls([
-            call("AsPathMgr: Clear asns group with cmd: [no bgp as-path access-list T2_GROUP_ASNS]"),
-            call("AsPathMgr: Add as-path with cmd: [bgp as-path access-list T2_GROUP_ASNS permit _64120_]"),
-            call("AsPathMgr: Add as-path with cmd: [bgp as-path access-list T2_GROUP_ASNS permit _64121_]"),
-            call("AsPathMgr: Clear asns group with cmd: [no bgp as-path access-list T2_GROUP_ASNS]")
-        ])
+                      "subtype": "UpstreamLC", "t2_group_asns": "64120,64121"})
+    del_handler_test(m, "localhost")
+    m.cfg_mgr.push.assert_has_calls([
+        call("no bgp as-path access-list T2_GROUP_ASNS"),
+        call("bgp as-path access-list T2_GROUP_ASNS permit _64120_"),
+        call("bgp as-path access-list T2_GROUP_ASNS permit _64121_"),
+        call("no bgp as-path access-list T2_GROUP_ASNS")
+    ])


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add bgp manager to read T2 group asns from DEVICE_METADATA

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
1. Add bgp manager to read T2 group asns from DEVICE_METADATA
1.1. For set action for DEVICE_METADATA["localhost"]["t2_group_asns"], we would clear all T2 group as path then add new per new data
1.2. For del action for DEVICE_METADATA["localhost"]["t2_group_asns"], we would clear all T2 group as path
2. Only add prefix_manager and as_path_manager for T2 upstreamLC

#### How to verify it
1. UT
4. Manually test

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

