### PR TITLE
DHCPv4 Relay Yang Model

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1010,6 +1010,11 @@ instance is supported in SONiC.
 ```
 {
 "DHCP_RELAY": {
+    "dhcp_servers": [
+        "192.168.0.1",
+        "192.168.0.2"
+    ],
+    "server_vrf": "Vrf11",
     "dhcpv6_servers": [
         "fc02:2000::1",
         "fc02:2000::2",

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -115,6 +115,7 @@ setup(
                          './yang-models/sonic-device_neighbor.yang',
                          './yang-models/sonic-device_neighbor_metadata.yang',
                          './yang-models/sonic-dhcp-server.yang',
+                         './yang-models/sonic-dhcpv4-relay.yang',
                          './yang-models/sonic-dhcpv6-relay.yang',
                          './yang-models/sonic-dns.yang',
                          './yang-models/sonic-events-bgp.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2105,6 +2105,36 @@
                 "interface_id": "true"
             }
         },
+        "DHCPV4_RELAY": {
+            "Vlan111": {
+                "dhcpv4_servers": [
+                    "10.222.72.116"
+                ],
+                "server_vrf": "Vrf_blue",
+                "source_interface": "Loopback0",
+                "link_selection": "enable",
+                "vrf_selection": "enable",
+                "server_id_override": "enable",
+                "agent_relay_mode": "forward_untouched",
+                "max_hop_count": "4"
+            },
+            "Vlan222": {
+                "dhcpv4_servers": [
+                    "10.222.72.116",
+                    "10.222.82.226"
+                ]
+            },
+            "Vlan777": {
+                "dhcpv4_servers": [
+                    "10.222.82.226"
+                ],
+                "source_interface": "Loopback0",
+                "link_selection": "enable",
+                "vrf_selection": "disable",
+                "server_id_override": "disable",
+                "agent_relay_mode": "discard"
+            }
+        },
         "DHCP_SERVER_IPV4": {
             "Vlan100": {
                 "gateway": "100.1.1.1",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/dhcpv4_relay.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/dhcpv4_relay.json
@@ -1,0 +1,40 @@
+{
+    "DHCPv4_RELAY_VALID_FORMAT_BASE": {
+        "desc": "Add dhcpv4 relay with minimum config."
+    },
+    "DHCPv4_RELAY_WITH_MULTIPLE_SERVERS": {
+        "desc": "Add dhcpv4 relay with multiple servers."
+    },
+    "DHCPv4_RELAY_WITH_SERVER_VRF": {
+        "desc": "Add dhcpv4 relay with server VRF and required options."
+    },
+    "DHCPv4_RELAY_WITH_LINK_SELECT": {
+        "desc": "Add dhcpv4 relay with link-select option enabled."
+    },
+    "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_DISCARD": {
+        "desc": "Add dhcpv4 relay with minimum config."
+    },
+    "DHCPv4_RELAY_WITH_VALID_MAX_HOP_CNT": {
+        "desc": "Add dhcpv4 relay with valid max_hop_cnt."
+    },
+    "DHCPv4_RELAY_WITH_MISSING_SERVER_IP": {
+        "desc": "Add dhcpv4 relay with missing server_ip.",
+        "eStrKey": "MinElements"
+    },
+    "DHCPv4_RELAY_WITH_SERVER_VRF_AND_MISSING_LINK_SELECT_OPTION": {
+        "desc": "Add dhcpv4 relay with server_vrf and missing link-selection option.",
+        "eStrKey": "Must"
+    },
+    "DHCPv4_RELAY_WITH_SERVER_VRF_AND_MISSING_VRF_SELECT_OPTION": {
+        "desc": "Add dhcpv4 relay with server_vrf and missing vrf-selection option.",
+        "eStrKey": "Must"
+    },
+    "DHCPv4_RELAY_WITH_SERVER_VRF_AND_MISSING_SERVER_OVERRIDE_OPTION": {
+        "desc": "Add dhcpv4 relay with server_vrf and missing lserver-override option.",
+        "eStrKey": "Must"
+    },
+    "DHCPv4_RELAY_WITH_SERVER_VRF_AND_MISSING_SOURCE_INTERFACE_OPTION": {
+        "desc": "Add dhcpv4 relay with server_vrf and missing source-interface option.",
+        "eStrKey": "Must"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcpv4_relay.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcpv4_relay.json
@@ -1,0 +1,293 @@
+{
+    "DHCPv4_RELAY_VALID_FORMAT_BASE": {
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan777",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "DHCPv4_RELAY_WITH_MULTIPLE_SERVERS": {
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan777",
+                        "dhcpv4_servers": [
+                            "192.168.20.100",
+                            "10.11.12.13"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "DHCPv4_RELAY_WITH_SERVER_VRF": {
+        "sonic-vrf:sonic-vrf": {
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [
+                    {
+                        "name": "Vrf1"
+                    }
+                ]
+            }
+        },
+        "sonic-loopback-interface:sonic-loopback-interface": {
+            "sonic-loopback-interface:LOOPBACK_INTERFACE": {
+                "LOOPBACK_INTERFACE_LIST": [
+                    {
+                        "name": "Loopback0"
+                    }
+                ]
+            }
+        },
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan888",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "server_vrf": "Vrf1",
+                        "source_interface": "Loopback0",
+                        "link_selection": "enable",
+                        "vrf_selection": "enable",
+                        "server_id_override": "enable"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCPv4_RELAY_WITH_LINK_SELECT": {
+        "sonic-loopback-interface:sonic-loopback-interface": {
+            "sonic-loopback-interface:LOOPBACK_INTERFACE": {
+                "LOOPBACK_INTERFACE_LIST": [
+                    {
+                        "name": "Loopback0"
+                    }
+                ]
+            }
+        },
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan777",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "link_selection": "enable",
+                        "source_interface": "Loopback0"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_DISCARD": {
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan777",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "agent_relay_mode": "discard"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCPv4_RELAY_WITH_VALID_MAX_HOP_CNT": {
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan777",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "max_hop_count": 16
+                    }
+                ]
+            }
+        }
+    },
+    "DHCPv4_RELAY_WITH_MISSING_SERVER_IP": {
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan777"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCPv4_RELAY_WITH_SERVER_VRF_AND_MISSING_LINK_SELECT_OPTION": {
+        "sonic-loopback-interface:sonic-loopback-interface": {
+            "sonic-loopback-interface:LOOPBACK_INTERFACE": {
+                "LOOPBACK_INTERFACE_LIST": [
+                    {
+                        "name": "Loopback0"
+                    }
+                ]
+            }
+        },
+        "sonic-vrf:sonic-vrf": {
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [
+                    {
+                        "name": "Vrf1"
+                    }
+                ]
+            }
+        },
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan888",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "server_vrf": "Vrf1",
+                        "source_interface": "Loopback0",
+                        "vrf_selection": "enable",
+                        "server_id_override": "enable"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCPv4_RELAY_WITH_SERVER_VRF_AND_MISSING_VRF_SELECT_OPTION": {
+        "sonic-loopback-interface:sonic-loopback-interface": {
+            "sonic-loopback-interface:LOOPBACK_INTERFACE": {
+                "LOOPBACK_INTERFACE_LIST": [
+                    {
+                        "name": "Loopback0"
+                    }
+                ]
+            }
+        },
+        "sonic-vrf:sonic-vrf": {
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [
+                    {
+                        "name": "Vrf1"
+                    }
+                ]
+            }
+        },
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan888",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "server_vrf": "Vrf1",
+                        "source_interface": "Loopback0",
+                        "server_id_override": "enable",
+                        "link_selection": "enable"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCPv4_RELAY_WITH_SERVER_VRF_AND_MISSING_SERVER_OVERRIDE_OPTION": {
+        "sonic-loopback-interface:sonic-loopback-interface": {
+            "sonic-loopback-interface:LOOPBACK_INTERFACE": {
+                "LOOPBACK_INTERFACE_LIST": [
+                    {
+                        "name": "Loopback0"
+                    }
+                ]
+            }
+        },
+        "sonic-vrf:sonic-vrf": {
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [
+                    {
+                        "name": "Vrf1"
+                    }
+                ]
+            }
+        },
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan888",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "server_vrf": "Vrf1",
+                        "source_interface": "Loopback0",
+                        "vrf_selection": "enable",
+                        "link_selection": "enable"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCPv4_RELAY_WITH_SERVER_VRF_AND_MISSING_SOURCE_INTERFACE_OPTION": {
+        "sonic-loopback-interface:sonic-loopback-interface": {
+            "sonic-loopback-interface:LOOPBACK_INTERFACE": {
+                "LOOPBACK_INTERFACE_LIST": [
+                    {
+                        "name": "Loopback0"
+                    }
+                ]
+            }
+        },
+        "sonic-vrf:sonic-vrf": {
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [
+                    {
+                        "name": "Vrf1"
+                    }
+                ]
+            }
+        },
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan888",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "server_vrf": "Vrf1",
+                        "vrf_selection": "enable",
+                        "server_id_override": "enable",
+                        "link_selection": "enable"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCPv4_RELAY_WITH_INVALID_MAX_HOP_CNT": {
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan999",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "max_hop_count": 17
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-dhcpv4-relay.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dhcpv4-relay.yang
@@ -1,0 +1,138 @@
+module sonic-dhcpv4-relay {
+
+    namespace "http://github.com/sonic-net/sonic-dhcpv4-relay";
+    prefix dhcpv4relay;
+    yang-version 1.1;
+
+    import ietf-inet-types {
+        prefix inet;
+    }
+
+    import sonic-types {
+        prefix stypes;
+    }
+
+    import sonic-vrf {
+        prefix vrf;
+    }
+
+    import sonic-port {
+        prefix port;
+    }
+
+    import sonic-portchannel {
+        prefix lag;
+    }
+
+    import sonic-loopback-interface {
+        prefix loopback;
+    }
+
+    organization "SONiC";
+    contact "SONiC";
+    description "DHCPv4 Relay yang Module for SONiC OS";
+
+    revision 2024-12-30 {
+        description "First Revision";
+    }
+
+    container sonic-dhcpv4-relay {
+        container DHCPV4_RELAY {
+            description "DHCPV4_RELAY part of config_db.json";
+
+            list DHCPV4_RELAY_LIST {
+                key "name";
+
+                leaf name {
+                    description "VLAN ID";
+                    type union {
+                        // Comment VLAN leaf reference here until libyang back-links issue is resolved and use VLAN string pattern
+                        // type leafref {
+                        //     path "/vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:name";
+                        // }
+                        type string {
+                            pattern 'Vlan([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
+                        }
+                    }
+               }
+
+                leaf-list dhcpv4_servers {
+                    description "Server IPv4 address list";
+                    min-elements 1;
+                    type inet:ipv4-address;
+                }
+
+                leaf server_vrf {
+                    description "Server VRF";
+                    type leafref {
+                        path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
+                    }
+                    must "(current()/../server_id_override = 'enable' and
+                           current()/../link_selection = 'enable')" {
+                        description "when server_vrf is set, link_selection and server_id_override must be enabled";
+                    }
+                    must "current()/../vrf_selection = 'enable'" {
+                        description "if vrf_selection is enabled, server-vrf must be set";
+                    }
+                }
+
+                leaf source_interface {
+                    description "Used to determine the source IP address of the relayed packet";
+                    type union {
+                        type leafref {
+                            path "/port:sonic-port/port:PORT/port:PORT_LIST/port:name";
+                        }
+                        type leafref {
+                            path "/lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name";
+                        }
+                        type string {
+                            pattern 'Vlan([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
+                        }
+                        type leafref {
+                            path "/loopback:sonic-loopback-interface/loopback:LOOPBACK_INTERFACE/loopback:LOOPBACK_INTERFACE_LIST/loopback:name";
+                        }
+                    }
+                }
+
+                leaf link_selection {
+                    description "Enable link selection";
+                    type stypes:mode-status;
+                    default disable;
+                    must "current() = 'disable' or current()/../source_interface != ''" {
+                        description "if link_selection is enabled, source_interface must be set";
+                    }
+                }
+
+                leaf vrf_selection {
+                    description "Enable VRF selection";
+                    type stypes:mode-status;
+                    default disable;
+                }
+
+                leaf server_id_override {
+                    description "Enable server id override";
+                    type stypes:mode-status;
+                    default disable;
+                }
+
+                leaf agent_relay_mode {
+                    description "How to forward packets that already have a relay option";
+                    type stypes:relay-agent-mode;
+                    default forward_untouched;
+                }
+
+                leaf max_hop_count {
+                    description "Maximum hop count for relayed packets";
+                    type uint8 {
+                        range "1..16";
+                    }
+                    default 4;
+                }
+            }
+            /* end of DHCPV4_RELAY_LIST */
+        }
+        /* end of container DHCPV4_RELAY */
+    }
+    /* end of container sonic-dhcpv4-relay */
+}
+/* end of module sonic-dhcpv4-relay */

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -403,6 +403,24 @@ module sonic-types {
         }
     }
 
+    typedef relay-agent-mode {
+        type enumeration {
+            enum forward_and_append {
+                description "Forward and append our own relay option";
+            }
+            enum forward_and_replace {
+                description "Forward, but replace theirs with ours";
+            }
+            enum forward_untouched {
+                description "Forward without changes";
+            }
+            enum discard {
+                description "Discard the packet";
+            }
+        }
+        description "This enumeration type defines what to do about a dhcp packets that already has a relay option.";
+    }
+
     {% if yang_model_type == "cvl" %}
     /* Required for CVL */
     container operation {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Added a Yang Model for DHCPv4 Relay

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
New Yang Model for DHCPv4 Relay
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

