### PR TITLE
[TACACS] Fix TACACS config revert to old config when device reboot issue.

### DIFF
--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -139,6 +139,9 @@ apply_tacacs()
         sonic-cfggen -j /etc/sonic/old_config/${TACACS_JSON_BACKUP} --write-to-db
         echo "Applied tacacs json to restore tacacs credentials"
         config save -y
+
+        # Change tacacs config file name, so tacacs config will not be revert when device reboot.
+        mv /etc/sonic/old_config/${TACACS_JSON_BACKUP}_backup
     else
         echo "Missing tacacs json to restore tacacs credentials"
     fi


### PR DESCRIPTION
Fix TACACS config revert to old config when device reboot issue.

#### Why I did it
When SONiC TACACS config changed after OS upgrade, and device reboot, the TACACS config been reverted back to old config in /etc/sonic/old_config/tacacs.json

##### Work item tracking
- Microsoft ADO **(number only)**:32338799

#### How I did it
Move /etc/sonic/old_config/tacacs.json to /etc/sonic/old_config/tacacs.json_backup

#### How to verify it
Pass all test case.
Manually verify.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Fix TACACS config revert to old config when device reboot issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

