### PR TITLE
Fix staticroutebfd's handling on blackhole static routes and static routes that only have partial info correctly

### DIFF
--- a/src/sonic-bgpcfgd/staticroutebfd/main.py
+++ b/src/sonic-bgpcfgd/staticroutebfd/main.py
@@ -414,7 +414,7 @@ class StaticRouteBfd(object):
         if nh_vrf_list is None and nh_list is not None:
             nh_vrf_list = [vrf] * len(nh_list) if len(nh_list) > 0 else None
             data['nexthop-vrf'] = ','.join(nh_vrf_list) if nh_vrf_list else ''
-        else: # preprocess empty nexthop-vrf member
+        elif nh_vrf_list is not None: # preprocess empty nexthop-vrf member
             for index in range(len(nh_vrf_list)):
                 if len(nh_vrf_list[index]) == 0:
                     nh_vrf_list[index] = vrf
@@ -423,7 +423,7 @@ class StaticRouteBfd(object):
         bkh_list    = arg_list(data['blackhole']) if 'blackhole' in data else None
         intf_list   = arg_list(data['ifname']) if 'ifname' in data else None
         dist_list   = arg_list(data['distance']) if 'distance' in data else None
-        if 'true' in bkh_list:
+        if bkh_list is not None and 'true' in bkh_list:
             log_info("Blackholing static route encountered, skipping it")
             return True
         if intf_list is None or nh_list is None or nh_vrf_list is None or \

--- a/src/sonic-bgpcfgd/staticroutebfd/main.py
+++ b/src/sonic-bgpcfgd/staticroutebfd/main.py
@@ -397,7 +397,7 @@ class StaticRouteBfd(object):
         bfd_enabled = self.isFieldTrue(bfd_field)
 
         #when bfd changed from "false" to "true", before bfd session created and state becomes up,
-        #the installed static route need to be kept in the system system, so put this route in "hold" state until at least one 
+        #the installed static route need to be kept in the system system, so put this route in "hold" state until at least one
         #bfd session becomes UP.
         data_copy = data.copy()
         data['bfd_nh_hold'] = "false"
@@ -411,7 +411,7 @@ class StaticRouteBfd(object):
         # preprocess empty nexthop-vrf list before save to LOCAL_CONFIG_TABLE, bfd session need this information
         nh_list     = arg_list(data['nexthop']) if 'nexthop' in data else None
         nh_vrf_list = arg_list(data['nexthop-vrf']) if 'nexthop-vrf' in data else None
-        if nh_vrf_list is None:
+        if nh_vrf_list is None and nh_list is not None:
             nh_vrf_list = [vrf] * len(nh_list) if len(nh_list) > 0 else None
             data['nexthop-vrf'] = ','.join(nh_vrf_list) if nh_vrf_list else ''
         else: # preprocess empty nexthop-vrf member
@@ -420,20 +420,22 @@ class StaticRouteBfd(object):
                     nh_vrf_list[index] = vrf
             data['nexthop-vrf'] = ','.join(nh_vrf_list)
 
-        if not bfd_enabled: 
+        bkh_list    = arg_list(data['blackhole']) if 'blackhole' in data else None
+        intf_list   = arg_list(data['ifname']) if 'ifname' in data else None
+        dist_list   = arg_list(data['distance']) if 'distance' in data else None
+        if 'true' in bkh_list:
+            log_info("Blackholing static route encountered, skipping it")
+            return True
+        if intf_list is None or nh_list is None or nh_vrf_list is None or \
+                len(intf_list) != len(nh_list) or len(intf_list) != len(nh_vrf_list):
+            log_err("Static route bfd set Failed, nexthop, interface and vrf lists do not match or some of them is empty.")
+            return True
+
+        if not bfd_enabled:
             #skip if bfd is not enabled, but store it to local_db to detect bfd field dynamic change
             data['bfd'] = "false"
             self.set_local_db(LOCAL_CONFIG_TABLE, route_cfg_key, data)
             return True
-
-        bkh_list    = arg_list(data['blackhole']) if 'blackhole' in data else None
-        intf_list   = arg_list(data['ifname']) if 'ifname' in data else None
-        dist_list   = arg_list(data['distance']) if 'distance' in data else None
-        if intf_list is None or nh_list is None or nh_vrf_list is None or \
-                len(intf_list) != len(nh_list) or len(intf_list) != len(nh_vrf_list):
-            log_err("Static route bfd set Failed, nexthop, interface and vrf lists do not match.")
-            return True
-
 
         if cur_data and cur_bfd_enabled:
             # route with the prefix already exist, remove the deleted nexthops

--- a/src/sonic-bgpcfgd/staticroutebfd/main.py
+++ b/src/sonic-bgpcfgd/staticroutebfd/main.py
@@ -428,7 +428,7 @@ class StaticRouteBfd(object):
             return True
         if intf_list is None or nh_list is None or nh_vrf_list is None or \
                 len(intf_list) != len(nh_list) or len(intf_list) != len(nh_vrf_list):
-            log_err("Static route bfd set Failed, nexthop, interface and vrf lists do not match or some of them is empty.")
+            log_warn("Static route bfd set Failed, nexthop, interface and vrf lists do not match or some of them is empty.")
             return True
 
         if not bfd_enabled:

--- a/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
@@ -114,7 +114,7 @@ def intf_setup(dut):
         ),
         {},
         {}
-    )    
+    )
 
 def test_set_del_ipv6():
     dut = constructor()
@@ -127,7 +127,7 @@ def test_set_del_ipv6():
             "ifname": "if1, if2, if3",
             "nexthop": "2603:10E2:400:1::2,2603:10E2:400:2::2,2603:10e2:400:3::2"
         }),
-        { 
+        {
             "set_default:default:2603:10e2:400:1::2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '2603:10E2:400:1::1'},
             "set_default:default:2603:10e2:400:2::2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '2603:10E2:400:2::1'},
             "set_default:default:2603:10e2:400:3::2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '2603:10E2:400:3::1'}
@@ -200,7 +200,7 @@ def test_set_del():
             "nexthop": "192.168.1.2 , 192.168.2.2, 192.168.3.2",
             "ifname": "if1, if2, if3",
         }),
-        { 
+        {
             "set_default:default:192.168.1.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.1.1'},
             "set_default:default:192.168.2.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.2.1'},
             "set_default:default:192.168.3.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.3.1'}
@@ -241,7 +241,7 @@ def test_set_del():
             "nexthop": "192.168.1.2 , 192.168.2.2",
             "ifname": "if1, if2",
         }),
-        { 
+        {
             "del_default:default:192.168.3.2" : {}
         },
         {'set_default:2.2.2.0/24': {'nexthop': '192.168.2.2,192.168.1.2 ', 'ifname': 'if2,if1', 'nexthop-vrf': 'default,default', 'expiry': 'false'}}
@@ -255,7 +255,7 @@ def test_set_del():
             "nexthop": "192.168.1.2 , 192.168.2.2",
             "ifname": "if1, if2",
         }),
-        { 
+        {
             "del_default:default:192.168.1.2" : {},
             "del_default:default:192.168.2.2" : {}
         },
@@ -293,7 +293,7 @@ def test_set_del_vrf():
             "ifname": "if1, if2, if3",
             "nexthop-vrf": "testvrf1, , default",
         }),
-        { 
+        {
             "set_testvrf1:default:192.168.1.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.1.1'},
             "set_vrfred:default:192.168.2.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.2.1'},
             "set_default:default:192.168.3.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.3.1'}
@@ -334,7 +334,7 @@ def test_set_del_vrf():
             "ifname": "if1, if2",
             "nexthop-vrf": "testvrf1,",
         }),
-        { 
+        {
             "del_default:default:192.168.3.2" : {}
         },
         {'set_vrfred:2.2.2.0/24': {'nexthop': '192.168.2.2,192.168.1.2 ', 'ifname': 'if2,if1', 'nexthop-vrf': 'vrfred, testvrf1', 'expiry': 'false'}}
@@ -343,7 +343,7 @@ def test_set_del_vrf():
     set_del_test(dut, "srt",
         "DEL",
         ("vrfred|2.2.2.0/24", { }),
-        { 
+        {
             "del_testvrf1:default:192.168.1.2" : {},
             "del_vrfred:default:192.168.2.2" : {}
         },
@@ -361,7 +361,7 @@ def test_bfd_del():
             "nexthop": "192.168.1.2 , 192.168.2.2, 192.168.3.2",
             "ifname": "if1, if2, if3",
         }),
-        { 
+        {
             "set_default:default:192.168.1.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.1.1'},
             "set_default:default:192.168.2.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.2.1'},
             "set_default:default:192.168.3.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.3.1'}
@@ -414,7 +414,7 @@ def test_set_2routes():
             "nexthop": "192.168.1.2 , 192.168.2.2, 192.168.3.2",
             "ifname": "if1, if2, if3",
         }),
-        { 
+        {
             "set_default:default:192.168.1.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.1.1'},
             "set_default:default:192.168.2.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.2.1'},
             "set_default:default:192.168.3.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.3.1'}
@@ -491,7 +491,7 @@ def test_set_bfd_change_hold():
             "nexthop": "192.168.1.2 , 192.168.2.2, 192.168.3.2",
             "ifname": "if1, if2, if3",
         }),
-        { 
+        {
             "set_default:default:192.168.1.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.1.1'},
             "set_default:default:192.168.2.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.2.1'},
             "set_default:default:192.168.3.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.3.1'}
@@ -531,7 +531,7 @@ def test_set_bfd_change_hold():
             "nexthop": "192.168.1.2 , 192.168.2.2, 192.168.3.2",
             "ifname": "if1, if2, if3",
         }),
-        { 
+        {
             "del_default:default:192.168.1.2" : {},
             "del_default:default:192.168.2.2" : {},
             "del_default:default:192.168.3.2" : {}
@@ -550,7 +550,7 @@ def test_set_bfd_change_hold():
             "nexthop": "192.168.1.2 , 192.168.2.2, 192.168.3.2",
             "ifname": "if1, if2, if3",
         }),
-        { 
+        {
             "set_default:default:192.168.1.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.1.1'},
             "set_default:default:192.168.2.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.2.1'},
             "set_default:default:192.168.3.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.3.1'}
@@ -596,7 +596,7 @@ def test_set_bfd_change_no_hold():
             "nexthop": "192.168.1.2 , 192.168.2.2, 192.168.3.2",
             "ifname": "if1, if2, if3",
         }),
-        { 
+        {
             "set_default:default:192.168.1.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.1.1'},
             "set_default:default:192.168.2.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.2.1'},
             "set_default:default:192.168.3.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.3.1'}
@@ -645,7 +645,7 @@ def test_set_bfd_change_no_hold():
             "nexthop": "192.168.1.2 , 192.168.2.2, 192.168.3.2",
             "ifname": "if1, if2, if3",
         }),
-        { 
+        {
             "del_default:default:192.168.1.2" : {},
             "del_default:default:192.168.3.2" : {}
         },
@@ -654,7 +654,7 @@ def test_set_bfd_change_no_hold():
         }
     )
 
-    #test #10 change 'bfd': false to true, because the bfd session "default:default:192.168.2.2" is up, so add that nexthop right after "bfd" change to "true" 
+    #test #10 change 'bfd': false to true, because the bfd session "default:default:192.168.2.2" is up, so add that nexthop right after "bfd" change to "true"
     set_del_test(dut, "srt",
         "SET",
         ("2.2.2.0/24", {
@@ -662,7 +662,7 @@ def test_set_bfd_change_no_hold():
             "nexthop": "192.168.1.2 , 192.168.2.2, 192.168.3.2",
             "ifname": "if1, if2, if3",
         }),
-        { 
+        {
             "set_default:default:192.168.1.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.1.1'},
             "set_default:default:192.168.3.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.3.1'}
         },
@@ -695,4 +695,43 @@ def test_set_bfd_change_no_hold():
     )
 
 
+def test_set_blackhole_route():
+    dut = constructor()
+    intf_setup(dut)
 
+    test_set_blackhole_route.logs = []
+
+    _log_info = log_info
+    log_info = lambda msg: test_set_blackhole_route.logs.append(msg)
+
+    set_del_test(dut, "srt",
+        "SET",
+        ("2.2.2.0/24", {
+            "blackhole": "true",
+        }),
+        {},
+        {}
+    )
+
+    assert "Blackholing static route encountered, skipping it" in test_set_blackhole_route.logs
+    log_info = _log_info
+
+def test_set_blackhole_route():
+    dut = constructor()
+    intf_setup(dut)
+
+    _log_warn = log_warn
+    log_warn = lambda msg: test_set_blackhole_route.logs.append(msg)
+
+    set_del_test(dut, "srt",
+        "SET",
+        ("2.2.2.0/24", {
+            "ifname": "if1,if2",
+        }),
+        {},
+        {}
+    )
+
+    assert "Static route bfd set Failed, nexthop, interface and vrf lists do not match or some of them is empty."\
+        in test_set_blackhole_route.logs
+    log_warn = _log_warn

--- a/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
@@ -695,14 +695,14 @@ def test_set_bfd_change_no_hold():
     )
 
 
-def test_set_blackhole_route():
+def test_set_del_blackhole_route():
     dut = constructor()
     intf_setup(dut)
 
-    test_set_blackhole_route.logs = []
+    test_set_del_blackhole_route.logs = []
 
     _log_info = log_info
-    log_info = lambda msg: test_set_blackhole_route.logs.append(msg)
+    log_info = lambda msg: test_set_del_blackhole_route.logs.append(msg)
 
     set_del_test(dut, "srt",
         "SET",
@@ -713,15 +713,24 @@ def test_set_blackhole_route():
         {}
     )
 
-    assert "Blackholing static route encountered, skipping it" in test_set_blackhole_route.logs
+    set_del_test(dut, "srt",
+        "DEL",
+        ("2.2.2.0/24", {
+            "blackhole": "true",
+        }),
+        {},
+        {}
+    )
+
+    assert "Blackholing static route encountered, skipping it" in test_set_del_blackhole_route.logs
     log_info = _log_info
 
-def test_set_blackhole_route():
+def test_set_del_ifname_only_route():
     dut = constructor()
     intf_setup(dut)
 
     _log_warn = log_warn
-    log_warn = lambda msg: test_set_blackhole_route.logs.append(msg)
+    log_warn = lambda msg: test_set_del_ifname_only_route.logs.append(msg)
 
     set_del_test(dut, "srt",
         "SET",
@@ -732,6 +741,15 @@ def test_set_blackhole_route():
         {}
     )
 
+    set_del_test(dut, "srt",
+        "DEL",
+        ("2.2.2.0/24", {
+            "ifname": "if1,if2",
+        }),
+        {},
+        {}
+    )
+
     assert "Static route bfd set Failed, nexthop, interface and vrf lists do not match or some of them is empty."\
-        in test_set_blackhole_route.logs
+        in test_set_del_ifname_only_route.logs
     log_warn = _log_warn

--- a/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
@@ -701,55 +701,52 @@ def test_set_del_blackhole_route():
 
     test_set_del_blackhole_route.logs = []
 
-    _log_info = log_info
-    log_info = lambda msg: test_set_del_blackhole_route.logs.append(msg)
+    with patch('staticroutebfd.main.log_info', new=lambda msg: test_set_del_blackhole_route.logs.append(msg)):
+        set_del_test(dut, "srt",
+            "SET",
+            ("2.2.2.0/24", {
+                "blackhole": "true",
+            }),
+            {},
+            {}
+        )
 
-    set_del_test(dut, "srt",
-        "SET",
-        ("2.2.2.0/24", {
-            "blackhole": "true",
-        }),
-        {},
-        {}
-    )
-
-    set_del_test(dut, "srt",
-        "DEL",
-        ("2.2.2.0/24", {
-            "blackhole": "true",
-        }),
-        {},
-        {}
-    )
+        set_del_test(dut, "srt",
+            "DEL",
+            ("2.2.2.0/24", {
+                "blackhole": "true",
+            }),
+            {},
+            {}
+        )
 
     assert "Blackholing static route encountered, skipping it" in test_set_del_blackhole_route.logs
-    log_info = _log_info
+
 
 def test_set_del_ifname_only_route():
     dut = constructor()
     intf_setup(dut)
 
-    _log_warn = log_warn
-    log_warn = lambda msg: test_set_del_ifname_only_route.logs.append(msg)
+    test_set_del_ifname_only_route.logs = []
 
-    set_del_test(dut, "srt",
-        "SET",
-        ("2.2.2.0/24", {
-            "ifname": "if1,if2",
-        }),
-        {},
-        {}
-    )
+    with patch('staticroutebfd.main.log_warn', new=lambda msg: test_set_del_ifname_only_route.logs.append(msg)):
+        set_del_test(dut, "srt",
+            "SET",
+            ("2.2.2.0/24", {
+                "ifname": "if1,if2",
+            }),
+            {},
+            {}
+        )
 
-    set_del_test(dut, "srt",
-        "DEL",
-        ("2.2.2.0/24", {
-            "ifname": "if1,if2",
-        }),
-        {},
-        {}
-    )
+        set_del_test(dut, "srt",
+            "DEL",
+            ("2.2.2.0/24", {
+                "ifname": "if1,if2",
+            }),
+            {},
+            {}
+        )
 
     assert "Static route bfd set Failed, nexthop, interface and vrf lists do not match or some of them is empty."\
         in test_set_del_ifname_only_route.logs
-    log_warn = _log_warn


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Previously, the staticroutebfd module assume that static routes always have both ifname and nexthop configured, which is not true. First, a static route can have only either ifname or nexthop. Second, for blackhole routes, usually it is not configured with any ifname or nexthop. The staticroutebfd will encounter runtime error when those static routes are configured even if bfd is not enabled.

Fixes issue: #22344

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Change the staticroutebfd's implementation to skip the processing if the route is a blackhole route or it only has partial info. I also added UT to verify it.

#### How to verify it

* Run UT.
* Test the new implementation on a SONiC devie.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

