### PR TITLE
Issue #22354: Support SET-REPLACE in gnxi/gnmi_cli_py

### DIFF
--- a/dockers/docker-ptf/gnxi-patches/0005-Enhance-gnmi_cli_py-4.patch
+++ b/dockers/docker-ptf/gnxi-patches/0005-Enhance-gnmi_cli_py-4.patch
@@ -140,7 +140,7 @@ index c46592a..0ea6f3d 100644
    Returns:
      a gnmi_pb2.GetResponse object representing a gNMI GetResponse.
    """
-@@ -300,35 +362,36 @@ def _get(stub, paths, username, password, prefix):
+@@ -300,35 +366,40 @@ def _get(stub, paths, username, password, prefix):
    if username:  # User/pass supplied for Authentication.
      kwargs = {'metadata': [('username', username), ('password', password)]}
    return stub.Get(
@@ -171,13 +171,17 @@ index c46592a..0ea6f3d 100644
 -
 +  delete_list = []
 +  update_list = []
++  replace_list = []
 +  for path, value in zip(paths, value_list):
 +    val = _get_val(value)
 +    if val is None:
 +      delete_list.append(path)
-+    else:
++    elif set_type == 'update':
 +      path_val = gnmi_pb2.Update(path=path, val=val,)
 +      update_list.append(path_val)
++    elif set_type == 'replace':
++      path_val = gnmi_pb2.Update(path=path, val=val,)
++      replace_list.append(path_val)
    kwargs = {}
    if username:
      kwargs = {'metadata': [('username', username), ('password', password)]}
@@ -186,7 +190,7 @@ index c46592a..0ea6f3d 100644
 -  elif set_type == 'update':
 -    return stub.Set(gnmi_pb2.SetRequest(update=[path_val]), **kwargs)
 -  return stub.Set(gnmi_pb2.SetRequest(replace=[path_val]), **kwargs)
-+  return stub.Set(gnmi_pb2.SetRequest(prefix=prefix, delete=delete_list, update=update_list), **kwargs)
++  return stub.Set(gnmi_pb2.SetRequest(prefix=prefix, delete=delete_list, update=update_list, replace=replace_list), **kwargs)
  
  
  def _build_creds(target, port, get_cert, certs, notls):


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
By default, gnxi/gnmi_cli_py supports SET-REPLACE. It has been patched in to extend it to accept lists of paths. This patch did not preserve the REPLACE functionality. Fix the patch to keep the extended behavior but retain REPLACE handling.

#### Why I did it

gNMI is being extended to allow configs to be modified using GCU ConfigReplace. The syntax will be a JSON config passed as a file through gNMI using SET-REPLACE. sonic-mgmt tests use gnxi/gnmi_cli_py to test gNMI behavior, so in order to add tests for the new behavior gnxi/gnmi_cli_py must be support SET-REPLACE (see [Issue#357](https://github.com/sonic-net/sonic-gnmi/pull/369)).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

We can modify the offending patch directly. This seems better than adding a new patch just to rollback a previous one. It is also the last patch in the series, so there is no chance of downstream changes relying on it. There is already a set-type argument passed in to the _set() function which can be used to differentiate SET-REPLACE from SET-UPDATE.

#### How to verify it

sonic-mgmt/tests/gnmi/test_gnmi_configdb.py can be extended to test ConfigReplace by calling gnmi_set with a single config file as the replace_list. Without these change, this test will fail because the existing code will treat it as an update. With this change, the code sends the SET-REPLACE correctly and the test passes.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Support SET-REPLACE in gnxi/gnmi_cli_py

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

