### PR TITLE
Add admin status to loopback interface yang model

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1311,7 +1311,8 @@
         },
         "LOOPBACK_INTERFACE": {
             "Loopback0": {
-               "nat_zone": "2"
+               "nat_zone": "2",
+               "admin_status": "up"
             },
             "Loopback0|2a04:5555:40:4::4e9/128": {
                 "scope": "global",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/loopback.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/loopback.json
@@ -13,5 +13,14 @@
     "LOOPBACK_INVALID_INTERFACE_NAME_LENGTH": {
         "desc": "Configure invalid value for loopback interface name length.",
         "eStr" : "Invalid interface name length, it must not exceed 16 characters."
+    },
+    "LOOPBACK_DEFAULT_ADMIN_STATUS_UP": {
+        "desc": "Verify admin status is default up for loopback interface",
+        "eStrKey": "Verify",
+        "verify": {
+            "xpath": "/sonic-loopback-interface:sonic-loopback-interface/LOOPBACK_INTERFACE/LOOPBACK_INTERFACE_LIST[name='lo1']/name",
+            "key": "sonic-loopback-interface:admin_status",
+            "value": "up"
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/loopback.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/loopback.json
@@ -14,12 +14,13 @@
         "desc": "Configure invalid value for loopback interface name length.",
         "eStr" : "Invalid interface name length, it must not exceed 16 characters."
     },
-    "LOOPBACK_DEFAULT_NO_ADMIN_STATUS": {
-        "desc": "Verify that by default there is no admin_status set for loopback interface",
-        "eStr": "'sonic-loopback-interface:admin_status'",
+    "LOOPBACK_DEFAULT_ADMIN_STATUS_UP": {
+        "desc": "Verify admin status is default up for loopback interface",
+        "eStrKey": "Verify",
         "verify": {
             "xpath": "/sonic-loopback-interface:sonic-loopback-interface/LOOPBACK_INTERFACE/LOOPBACK_INTERFACE_LIST[name='lo1']/name",
-            "key": "sonic-loopback-interface:admin_status"
+            "key": "sonic-loopback-interface:admin_status",
+            "value": "up"
         }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/loopback.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/loopback.json
@@ -14,13 +14,12 @@
         "desc": "Configure invalid value for loopback interface name length.",
         "eStr" : "Invalid interface name length, it must not exceed 16 characters."
     },
-    "LOOPBACK_DEFAULT_ADMIN_STATUS_UP": {
-        "desc": "Verify admin status is default up for loopback interface",
-        "eStrKey": "Verify",
+    "LOOPBACK_DEFAULT_NO_ADMIN_STATUS": {
+        "desc": "Verify that by default there is no admin_status set for loopback interface",
+        "eStr": "'sonic-loopback-interface:admin_status'",
         "verify": {
             "xpath": "/sonic-loopback-interface:sonic-loopback-interface/LOOPBACK_INTERFACE/LOOPBACK_INTERFACE_LIST[name='lo1']/name",
-            "key": "sonic-loopback-interface:admin_status",
-            "value": "up"
+            "key": "sonic-loopback-interface:admin_status"
         }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/loopback.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/loopback.json
@@ -75,5 +75,25 @@
                 ]
             }
         }
+    },
+    "LOOPBACK_DEFAULT_ADMIN_STATUS_UP": {
+        "sonic-loopback-interface:sonic-loopback-interface": {
+            "sonic-loopback-interface:LOOPBACK_INTERFACE": {
+                "LOOPBACK_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "family": "IPv4",
+                        "ip-prefix": "10.0.0.1/30",
+                        "name": "lo1",
+                        "scope": "global"
+                    }
+                ],
+                "LOOPBACK_INTERFACE_LIST": [
+                    {
+                        "name": "lo1",
+                        "nat_zone": "2"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/loopback.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/loopback.json
@@ -27,7 +27,8 @@
                 "LOOPBACK_INTERFACE_LIST": [
                     {
                         "name": "lo1",
-                        "nat_zone": "4"
+                        "nat_zone": "4",
+                        "admin_status": "up"
                     }
                 ]
             }
@@ -47,7 +48,8 @@
                 "LOOPBACK_INTERFACE_LIST": [
                     {
                         "name": "lo1",
-                        "nat_zone": "2"
+                        "nat_zone": "2",
+                        "admin_status": "up"
                     }
                 ]
             }
@@ -67,7 +69,8 @@
                 "LOOPBACK_INTERFACE_LIST": [
                     {
                         "name": "lo1lo1lo1lo1lo1lo1",
-                        "nat_zone": "2"
+                        "nat_zone": "2",
+                        "admin_status": "up"
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/loopback.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/loopback.json
@@ -76,7 +76,7 @@
             }
         }
     },
-    "LOOPBACK_DEFAULT_ADMIN_STATUS_UP": {
+    "LOOPBACK_DEFAULT_NO_ADMIN_STATUS": {
         "sonic-loopback-interface:sonic-loopback-interface": {
             "sonic-loopback-interface:LOOPBACK_INTERFACE": {
                 "LOOPBACK_INTERFACE_IPPREFIX_LIST": [

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/loopback.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/loopback.json
@@ -76,7 +76,7 @@
             }
         }
     },
-    "LOOPBACK_DEFAULT_NO_ADMIN_STATUS": {
+    "LOOPBACK_DEFAULT_ADMIN_STATUS_UP": {
         "sonic-loopback-interface:sonic-loopback-interface": {
             "sonic-loopback-interface:LOOPBACK_INTERFACE": {
                 "LOOPBACK_INTERFACE_IPPREFIX_LIST": [

--- a/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
@@ -58,6 +58,7 @@ module sonic-loopback-interface {
 
                 leaf admin_status {
                     type stypes:admin_status;
+                    default up;
                 }
             }
             /* end of LOOPBACK_INTERFACE_LIST */

--- a/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
@@ -55,6 +55,10 @@ module sonic-loopback-interface {
                     }
                     default "0";
                 }
+
+                leaf admin_status {
+                    type stypes:admin_status;
+                }
             }
             /* end of LOOPBACK_INTERFACE_LIST */
 

--- a/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
@@ -58,7 +58,6 @@ module sonic-loopback-interface {
 
                 leaf admin_status {
                     type stypes:admin_status;
-                    default up;
                 }
             }
             /* end of LOOPBACK_INTERFACE_LIST */


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Loopback interface is missing admin status therefore `config interface startup/shutdown` does not work for it. Admin status has been added to loopback interface in the below PRs. This PR adds it to the corresponding yang model.

Related PRs: https://github.com/sonic-net/sonic-swss/pull/3565 ; https://github.com/sonic-net/sonic-utilities/pull/3827

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added admin_status to loopback interface for yang models.

#### How to verify it

<img width="851" alt="image" src="https://github.com/user-attachments/assets/311ee86b-36d1-4f6e-8e87-3093736a0045" />

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

