### PR TITLE
Enhancement:After port breakout, The FEC mode displayed by the show interface status command should be consistent with the value shown by sdk cli on the SOC

### DIFF
--- a/src/sonic-config-engine/tests/sample_output/platform_output.json
+++ b/src/sonic-config-engine/tests/sample_output/platform_output.json
@@ -8,7 +8,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet9": {
     "index": "3",
@@ -19,7 +20,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet36": {
     "index": "10",
@@ -30,7 +32,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet98": {
     "index": "25",
@@ -41,7 +44,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet0": {
     "index": "1",
@@ -66,7 +70,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet4": {
     "index": "2",
@@ -78,7 +83,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet109": {
     "index": "28",
@@ -89,7 +95,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet108": {
     "index": "28",
@@ -100,7 +107,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet18": {
     "index": "5",
@@ -111,7 +119,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet100": {
     "index": "26",
@@ -134,7 +143,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet104": {
     "index": "27",
@@ -145,7 +155,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet106": {
     "index": "27",
@@ -156,7 +167,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet94": {
     "index": "24",
@@ -167,7 +179,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet126": {
     "index": "32",
@@ -178,7 +191,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet96": {
     "index": "25",
@@ -189,7 +203,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet124": {
     "index": "32",
@@ -200,7 +215,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet90": {
     "index": "23",
@@ -211,7 +227,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet91": {
     "index": "23",
@@ -222,7 +239,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "4",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet92": {
     "index": "24",
@@ -233,7 +251,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet93": {
     "index": "24",
@@ -244,7 +263,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet50": {
     "index": "13",
@@ -255,7 +275,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet51": {
     "index": "13",
@@ -266,7 +287,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "4",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet52": {
     "index": "14",
@@ -277,7 +299,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet53": {
     "index": "14",
@@ -288,7 +311,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet54": {
     "index": "14",
@@ -299,7 +323,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet99": {
     "index": "25",
@@ -310,7 +335,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet56": {
     "index": "15",
@@ -321,7 +347,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet113": {
     "index": "29",
@@ -332,7 +359,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet76": {
     "index": "20",
@@ -343,7 +371,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet74": {
     "index": "19",
@@ -354,7 +383,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet39": {
     "index": "10",
@@ -365,7 +395,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet72": {
     "index": "19",
@@ -376,7 +407,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet73": {
     "index": "19",
@@ -387,7 +419,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet70": {
     "index": "18",
@@ -398,7 +431,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet71": {
     "index": "18",
@@ -409,7 +443,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "4",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet32": {
     "index": "9",
@@ -420,7 +455,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet33": {
     "index": "9",
@@ -431,7 +467,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet16": {
     "index": "5",
@@ -442,7 +479,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet111": {
     "index": "28",
@@ -453,7 +491,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "4",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet10": {
     "index": "3",
@@ -464,7 +503,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet11": {
     "index": "3",
@@ -475,7 +515,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "4",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet12": {
     "index": "4",
@@ -486,7 +527,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet13": {
     "index": "4",
@@ -497,7 +539,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet58": {
     "index": "15",
@@ -508,7 +551,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet19": {
     "index": "5",
@@ -519,7 +563,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet59": {
     "index": "15",
@@ -530,7 +575,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet38": {
     "index": "10",
@@ -541,7 +587,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet78": {
     "index": "20",
@@ -552,7 +599,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet68": {
     "index": "18",
@@ -563,7 +611,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet14": {
     "index": "4",
@@ -574,7 +623,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet89": {
     "index": "23",
@@ -585,7 +635,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet88": {
     "index": "23",
@@ -596,7 +647,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet118": {
     "index": "30",
@@ -607,7 +659,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet119": {
     "index": "30",
@@ -618,7 +671,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet116": {
     "index": "30",
@@ -629,7 +683,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet114": {
     "index": "29",
@@ -640,7 +695,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet80": {
     "index": "21",
@@ -663,7 +719,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet86": {
     "index": "22",
@@ -674,7 +731,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet110": {
     "index": "28",
@@ -685,7 +743,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet84": {
     "index": "22",
@@ -696,7 +755,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet31": {
     "index": "8",
@@ -707,7 +767,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "4",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet49": {
     "index": "13",
@@ -718,7 +779,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet48": {
     "index": "13",
@@ -729,7 +791,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet46": {
     "index": "12",
@@ -740,7 +803,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet30": {
     "index": "8",
@@ -751,7 +815,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet29": {
     "index": "8",
@@ -762,12 +827,13 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet40": {
     "index": "11",
     "lanes": "40,41,42,43",
-    "fec": "rs",
+    "fec": "none",
     "description": "Eth11",
     "mtu": "9100",
     "alias": "Eth11",
@@ -797,7 +863,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet66": {
     "index": "17",
@@ -808,7 +875,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet60": {
     "index": "16",
@@ -831,7 +899,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet44": {
     "index": "12",
@@ -842,7 +911,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet20": {
     "index": "6",
@@ -866,7 +936,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "3",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet69": {
     "index": "18",
@@ -877,7 +948,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet24": {
     "index": "7",
@@ -888,7 +960,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "1",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet26": {
     "index": "7",
@@ -899,7 +972,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "2",
-    "tpid": "0x8100"
+    "tpid": "0x8100",
+    "fec": "none"
   },
   "Ethernet128": {
     "index": "33",
@@ -910,7 +984,8 @@
     "alias": "Eth33",
     "pfc_asym": "off",
     "speed": "40000",
-    "subport": "0"
+    "subport": "0",
+    "fec": "none"
   },
   "Ethernet132": {
     "index": "34",
@@ -921,7 +996,8 @@
     "alias": "Eth34",
     "pfc_asym": "off",
     "speed": "25000",
-    "subport": "0"
+    "subport": "0",
+    "fec": "none"
   },
   "Ethernet136": {
     "index": "35",
@@ -932,7 +1008,8 @@
     "alias": "Eth35/1",
     "pfc_asym": "off",
     "speed": "10000",
-    "subport": "1"
+    "subport": "1",
+    "fec": "none"
   },
   "Ethernet137": {
     "index": "35",
@@ -943,7 +1020,8 @@
     "alias": "Eth35/2",
     "pfc_asym": "off",
     "speed": "10000",
-    "subport": "2"
+    "subport": "2",
+    "fec": "none"
   },
   "Ethernet138": {
     "index": "35",
@@ -954,7 +1032,8 @@
     "alias": "Eth35/3",
     "pfc_asym": "off",
     "speed": "10000",
-    "subport": "3"
+    "subport": "3",
+    "fec": "none"
   },
   "Ethernet139": {
     "index": "35",
@@ -965,7 +1044,8 @@
     "alias": "Eth35/4",
     "pfc_asym": "off",
     "speed": "10000",
-    "subport": "4"
+    "subport": "4",
+    "fec": "none"
   },
   "Ethernet140": {
     "index": "36",
@@ -977,7 +1057,8 @@
     "pfc_asym": "off",
     "subport": "1",
     "speed": "25000",
-    "role": "Dpc"
+    "role": "Dpc",
+    "fec": "none"
   },
   "Ethernet141": {
     "index": "36",
@@ -989,7 +1070,8 @@
     "pfc_asym": "off",
     "speed": "25000",
     "subport": "2",
-    "role": "Dpc"
+    "role": "Dpc",
+    "fec": "none"
   },
   "Ethernet142": {
     "index": "36",
@@ -1001,7 +1083,8 @@
     "pfc_asym": "off",
     "speed": "50000",
     "subport": "3",
-    "role": "Dpc"
+    "role": "Dpc",
+    "fec": "none"
   },
   "Ethernet144": {
     "index": "37",
@@ -1013,6 +1096,6 @@
     "pfc_asym": "off",
     "speed": "100000",
     "subport": "0",
-    "fec": "rs"
+    "fec": "none"
   }
 }

--- a/src/sonic-config-engine/tests/sample_platform.json
+++ b/src/sonic-config-engine/tests/sample_platform.json
@@ -15,6 +15,13 @@
         "Ethernet0": {
             "index": "1,1,1,1",
             "lanes": "0,1,2,3",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["Enone", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth1"],
                 "2x50G": ["Eth1/1", "Eth1/2"],
@@ -26,6 +33,11 @@
         "Ethernet4": {
             "index": "2,2,2,2",
             "lanes": "4,5,6,7",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "Enone", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth2"],
                 "2x50G": ["Eth2/1", "Eth2/2"],
@@ -35,6 +47,13 @@
         "Ethernet8": {
             "index": "3,3,3,3",
             "lanes": "8,9,10,11",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth3"],
                 "2x50G": ["Eth3/1", "Eth3/2"],
@@ -46,6 +65,13 @@
         "Ethernet12": {
             "index": "4,4,4,4",
             "lanes": "12,13,14,15",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth4"],
                 "2x50G": ["Eth4/1", "Eth4/2"],
@@ -57,6 +83,13 @@
         "Ethernet16": {
             "index": "5,5,5,5",
             "lanes": "16,17,18,19",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth5"],
                 "2x50G": ["Eth5/1", "Eth5/2"],
@@ -68,6 +101,13 @@
         "Ethernet20": {
             "index": "6,6,6,6",
             "lanes": "20,21,22,23",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth6"],
                 "2x50G": ["Eth6/1", "Eth6/2"],
@@ -79,6 +119,13 @@
         "Ethernet24": {
             "index": "7,7,7,7",
             "lanes": "24,25,26,27",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth7"],
                 "2x50G": ["Eth7/1", "Eth7/2"],
@@ -90,6 +137,13 @@
         "Ethernet28": {
             "index": "8,8,8,8",
             "lanes": "28,29,30,31",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth8"],
                 "2x50G": ["Eth8/1", "Eth8/2"],
@@ -101,6 +155,13 @@
         "Ethernet32": {
             "index": "9,9,9,9",
             "lanes": "32,33,34,35",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth9"],
                 "2x50G": ["Eth9/1", "Eth9/2"],
@@ -112,6 +173,13 @@
         "Ethernet36": {
             "index": "10,10,10,10",
             "lanes": "36,37,38,39",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth10"],
                 "2x50G": ["Eth10/1", "Eth10/2"],
@@ -123,6 +191,13 @@
         "Ethernet40": {
             "index": "11,11,11,11",
             "lanes": "40,41,42,43",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[50G,40G,25G,10G,1G]": ["Eth11"],
                 "2x50G[40G,25G,10G,1G]": ["Eth11/1", "Eth11/2"],
@@ -134,6 +209,13 @@
         "Ethernet44": {
             "index": "12,12,12,12",
             "lanes": "44,45,46,47",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[50G,40G,25G,10G,1G]": ["Eth12"],
                 "2x50G[40G,25G,10G,1G]": ["Eth12/1", "Eth12/2"],
@@ -145,6 +227,13 @@
         "Ethernet48": {
             "index": "13,13,13,13",
             "lanes": "48,49,50,51",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth13"],
                 "2x50G": ["Eth13/1", "Eth13/2"],
@@ -156,6 +245,13 @@
         "Ethernet52": {
             "index": "14,14,14,14",
             "lanes": "52,53,54,55",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth14"],
                 "2x50G": ["Eth14/1", "Eth14/2"],
@@ -167,6 +263,13 @@
         "Ethernet56": {
             "index": "15,15,15,15",
             "lanes": "56,57,58,59",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth15"],
                 "2x50G": ["Eth15/1", "Eth15/2"],
@@ -178,6 +281,13 @@
         "Ethernet60": {
             "index": "16,16,16,16",
             "lanes": "60,61,62,63",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth16"],
                 "2x50G": ["Eth16/1", "Eth16/2"],
@@ -189,6 +299,13 @@
         "Ethernet64": {
             "index": "17,17,17,17",
             "lanes": "64,65,66,67",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth17"],
                 "2x50G": ["Eth17/1", "Eth17/2"],
@@ -200,6 +317,13 @@
         "Ethernet68": {
             "index": "18,18,18,18",
             "lanes": "68,69,70,71",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth18"],
                 "2x50G": ["Eth18/1", "Eth18/2"],
@@ -211,6 +335,13 @@
         "Ethernet72": {
             "index": "19,19,19,19",
             "lanes": "72,73,74,75",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth19"],
                 "2x50G": ["Eth19/1", "Eth19/2"],
@@ -222,6 +353,13 @@
         "Ethernet76": {
             "index": "20,20,20,20",
             "lanes": "76,77,78,79",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth20"],
                 "2x50G": ["Eth20/1", "Eth20/2"],
@@ -233,6 +371,13 @@
         "Ethernet80": {
             "index": "21,21,21,21",
             "lanes": "80,81,82,83",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth21"],
                 "2x50G": ["Eth21/1", "Eth21/2"],
@@ -244,6 +389,13 @@
         "Ethernet84": {
             "index": "22,22,22,22",
             "lanes": "84,85,86,87",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth22"],
                 "2x50G": ["Eth22/1", "Eth22/2"],
@@ -256,6 +408,13 @@
             "index": "23,23,23,23",
             "lanes": "88,89,90,91",
             "alias_at_lanes": "Eth23/1, Eth23/2, Eth23/3, Eth23/4",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth23"],
                 "2x50G": ["Eth23/1", "Eth23/2"],
@@ -267,6 +426,13 @@
         "Ethernet92": {
             "index": "24,24,24,24",
             "lanes": "92,93,94,95",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth24"],
                 "2x50G": ["Eth24/1", "Eth24/2"],
@@ -278,6 +444,13 @@
         "Ethernet96": {
             "index": "25,25,25,25",
             "lanes": "96,97,98,99",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth25"],
                 "2x50G": ["Eth25/1", "Eth25/2"],
@@ -289,6 +462,13 @@
         "Ethernet100": {
             "index": "26,26,26,26",
             "lanes": "100,101,102,103",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth26"],
                 "2x50G": ["Eth26/1", "Eth26/2"],
@@ -300,6 +480,13 @@
         "Ethernet104": {
             "index": "27,27,27,27",
             "lanes": "104,105,106,107",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth27"],
                 "2x50G": ["Eth27/1", "Eth27/2"],
@@ -311,6 +498,13 @@
         "Ethernet108": {
             "index": "28,28,28,28",
             "lanes": "108,109,110,111",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth28"],
                 "2x50G": ["Eth28/1", "Eth28/2"],
@@ -322,6 +516,13 @@
         "Ethernet112": {
             "index": "29,29,29,29",
             "lanes": "112,113,114,115",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth29"],
                 "2x50G": ["Eth29/1", "Eth29/2"],
@@ -333,6 +534,13 @@
         "Ethernet116": {
             "index": "30,30,30,30",
             "lanes": "116,117,118,119",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth30"],
                 "2x50G": ["Eth30/1", "Eth30/2"],
@@ -344,6 +552,13 @@
         "Ethernet120": {
             "index": "31,31,31,31",
             "lanes": "120,121,122,123",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth31"],
                 "2x50G": ["Eth31/1", "Eth31/2"],
@@ -355,6 +570,13 @@
         "Ethernet124": {
             "index": "32,32,32,32",
             "lanes": "124,125,126,127",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth32"],
                 "2x50G": ["Eth32/1", "Eth32/2"],
@@ -366,6 +588,13 @@
         "Ethernet128": {
             "index": "33,33,33,33",
             "lanes": "128,129,130,131",
+            "fec_modes": {
+                "1x100G[40G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[40G]": ["Eth33"],
                 "2x50G": ["Eth33/1", "Eth33/2"],
@@ -377,6 +606,13 @@
         "Ethernet132": {
             "index": "34,34,34,34",
             "lanes": "132,133,134,135",
+            "fec_modes": {
+                "1x100G[50G,40G,25G,10G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[50G,40G,25G,10G]": ["Eth34"],
                 "2x50G": ["Eth34/1", "Eth34/2"],
@@ -388,6 +624,13 @@
         "Ethernet136": {
             "index": "35,35,35,35",
             "lanes": "136,137,138,139",
+            "fec_modes": {
+                "1x100G[50G,40G,25G,10G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10G]": ["none", "none", "none", "none"],
+                "2x25G(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50G(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[50G,40G,25G,10G]": ["Eth35"],
                 "2x50G": ["Eth35/1", "Eth35/2"],
@@ -399,6 +642,13 @@
         "Ethernet140": {
             "index": "36,36,36,36",
             "lanes": "140,141,142,143",
+            "fec_modes": {
+                "1x100G[50G,40G,25G,10G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10000]": ["none", "none", "none", "none"],
+                "2x25000(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50000(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100000[50G,40000,25000,10G]": ["Eth36"],
                 "2x50G": ["Eth36/1", "Eth36/2"],
@@ -410,6 +660,13 @@
         "Ethernet144": {
             "index": "37,37,37,37",
             "lanes": "144,145,146,147",
+            "fec_modes": {
+                "1x100G[50G,40G,25G,10G]": ["rs"],
+                "2x50G": ["none", "none"],
+                "4x25G[10000]": ["none", "none", "none", "none"],
+                "2x25000(2)+1x50G(2)": ["none", "none", "none"],
+                "1x50000(2)+2x25G(2)": ["none", "none", "none"]
+            },
             "breakout_modes": {
                 "1x100G[50G,40G,25G,10G]": ["Eth37"],
                 "2x50G": ["Eth37/1", "Eth37/2"],

--- a/src/sonic-config-engine/tests/test_cfggen_platformJson.py
+++ b/src/sonic-config-engine/tests/test_cfggen_platformJson.py
@@ -79,19 +79,19 @@ class TestCfgGenPlatformJson(TestCase):
         argument = ['-m', self.platform_sample_graph, '-p', self.platform_json, '-S', self.hwsku_json, '-v', "PORT[\'Ethernet8\']"]
         output = self.run_script(argument)
         self.maxDiff = None
-        expected = "{'index': '3', 'lanes': '8', 'description': 'Eth3/1', 'mtu': '9100', 'alias': 'Eth3/1', 'pfc_asym': 'off', 'speed': '25000', 'subport': '1', 'tpid': '0x8100'}"
+        expected = "{'index': '3', 'lanes': '8', 'description': 'Eth3/1', 'mtu': '9100', 'alias': 'Eth3/1', 'pfc_asym': 'off', 'speed': '25000', 'subport': '1', 'tpid': '0x8100', 'fec': 'none'}"
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict(expected))
 
         argument = ['-m', self.platform_sample_graph, '-p', self.platform_json, '-S', self.hwsku_json, '-v', "PORT[\'Ethernet112\']"]
         output = self.run_script(argument)
         self.maxDiff = None
-        expected = "{'index': '29', 'lanes': '112', 'description': 'Eth29/1', 'mtu': '9100', 'alias': 'Eth29/1', 'pfc_asym': 'off', 'speed': '25000', 'subport': '1', 'tpid': '0x8100'}"
+        expected = "{'index': '29', 'lanes': '112', 'description': 'Eth29/1', 'mtu': '9100', 'alias': 'Eth29/1', 'pfc_asym': 'off', 'speed': '25000', 'subport': '1', 'tpid': '0x8100', 'fec': 'none'}"
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict(expected))
 
         argument = ['-m', self.platform_sample_graph, '-p', self.platform_json, '-S', self.hwsku_json, '-v', "PORT[\'Ethernet4\']"]
         output = self.run_script(argument)
         self.maxDiff = None
-        expected = "{'index': '2', 'lanes': '4,5', 'description': 'Eth2/1', 'admin_status': 'up', 'mtu': '9100', 'alias': 'Eth2/1', 'pfc_asym': 'off', 'speed': '50000', 'subport': '1', 'tpid': '0x8100'}"
+        expected = "{'index': '2', 'lanes': '4,5', 'description': 'Eth2/1', 'admin_status': 'up', 'mtu': '9100', 'alias': 'Eth2/1', 'pfc_asym': 'off', 'speed': '50000', 'subport': '1', 'tpid': '0x8100', 'fec': 'none'}"
         print(output.strip())
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict(expected))
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1.When the device is not configured with a FEC mode, the FEC value displayed by the show interface status command is inconsistent with the FEC value shown by sdk cli on the SOC.
2.After port breakout, the FEC value displayed by the show interface status command is inconsistent with the FEC value shown by sdk cli on the SOC.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

