### PR TITLE
Fix Arista-7060X6-64PE-B-C512S2 Arista-7060X6-64PE-B-C448O16 HWSKUs and Add initial buffer config

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffer_ports.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffer_ports.j2
@@ -1,0 +1,48 @@
+{%- macro generate_port_lists(PORT_ALL) %}
+    {# Generate list of ports #}
+    {%- for i in range(0, 12) %}
+        {%- for j in range(0, 8) %}
+            {%- if PORT_ALL.append("Ethernet%d" % (i * 8 + j)) %}{%- endif %}
+        {%- endfor %}
+    {%- endfor %}
+
+    {%- if PORT_ALL.append("Ethernet96") %}{%- endif %}
+    {%- if PORT_ALL.append("Ethernet100") %}{%- endif %}
+    {%- if PORT_ALL.append("Ethernet104") %}{%- endif %}
+    {%- if PORT_ALL.append("Ethernet108") %}{%- endif %}
+
+    {%- for j in range(0, 8) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (14 * 8 + j)) %}{%- endif %}
+    {%- endfor %}
+
+    {%- if PORT_ALL.append("Ethernet128") %}{%- endif %}
+    {%- if PORT_ALL.append("Ethernet132") %}{%- endif %}
+    {%- if PORT_ALL.append("Ethernet136") %}{%- endif %}
+    {%- if PORT_ALL.append("Ethernet140") %}{%- endif %}
+
+    {%- for i in range(18, 44) %}
+        {%- for j in range(0, 8) %}
+            {%- if PORT_ALL.append("Ethernet%d" % (i * 8 + j)) %}{%- endif %}
+        {%- endfor %}
+    {%- endfor %}
+
+    {%- if PORT_ALL.append("Ethernet352") %}{%- endif %}
+    {%- if PORT_ALL.append("Ethernet356") %}{%- endif %}
+    {%- if PORT_ALL.append("Ethernet360") %}{%- endif %}
+    {%- if PORT_ALL.append("Ethernet364") %}{%- endif %}
+
+    {%- for j in range(0, 8) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (46 * 8 + j)) %}{%- endif %}
+    {%- endfor %}
+
+    {%- if PORT_ALL.append("Ethernet384") %}{%- endif %}
+    {%- if PORT_ALL.append("Ethernet388") %}{%- endif %}
+    {%- if PORT_ALL.append("Ethernet392") %}{%- endif %}
+    {%- if PORT_ALL.append("Ethernet396") %}{%- endif %}
+
+    {%- for i in range(50, 64) %}
+        {%- for j in range(0, 8) %}
+            {%- if PORT_ALL.append("Ethernet%d" % (i * 8 + j)) %}{%- endif %}
+        {%- endfor %}
+    {%- endfor %}
+{%- endmacro %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers.json.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers.json.j2
@@ -1,0 +1,2 @@
+{%- set default_topo = 't1' %}
+{%- include 'buffers_config.j2' %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t0.j2
@@ -1,17 +1,40 @@
-{%- set default_cable = '5m' %}
+{%- set default_cable = '0m' %}
 
-{# Skip BUFFER_POOL, BUFFER_PROFILE #}
+{%- include 'buffer_ports.j2' %}
+
 {%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossy_pool": {
+            "size": "164524944",
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_lossy_pool": {
+            "size": "164524944",
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool": "ingress_lossy_pool",
+            "size": "0",
+            "static_th": "163546528"
+        },
+        "egress_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "1778",
+            "dynamic_th": "1"
+        }
+    },
 {%- endmacro %}
-
-{# Skip BUFFER_QUEUE #}
 {%- macro generate_queue_buffers(ports) %}
     "BUFFER_QUEUE": {
+    {% for port in ports.split(',') %}
+        "{{ port }}|0-9": {
+            "profile" : "egress_lossy_profile"
+        }
+    {%- if not loop.last -%},{% endif %}
+    {% endfor %}
     }
-{%- endmacro %}
-
-{# Skip BUFFER_PG #}
-{%- macro generate_pg_profils(ports) %}
-    "BUFFER_PG": {
-    },
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t0.j2
@@ -5,12 +5,12 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossy_pool": {
-            "size": "164524944",
+            "size": "164624512",
             "type": "ingress",
             "mode": "dynamic"
         },
         "egress_lossy_pool": {
-            "size": "164524944",
+            "size": "164624512",
             "type": "egress",
             "mode": "dynamic"
         }
@@ -19,7 +19,7 @@
         "ingress_lossy_profile": {
             "pool": "ingress_lossy_pool",
             "size": "0",
-            "static_th": "163546528"
+            "static_th": "165364160"
         },
         "egress_lossy_profile": {
             "pool": "egress_lossy_pool",

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t1.j2
@@ -1,17 +1,40 @@
-{%- set default_cable = '5m' %}
+{%- set default_cable = '0m' %}
 
-{# Skip BUFFER_POOL, BUFFER_PROFILE #}
+{%- include 'buffer_ports.j2' %}
+
 {%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossy_pool": {
+            "size": "164524944",
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_lossy_pool": {
+            "size": "164524944",
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool": "ingress_lossy_pool",
+            "size": "0",
+            "static_th": "163546528"
+        },
+        "egress_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "1778",
+            "dynamic_th": "1"
+        }
+    },
 {%- endmacro %}
-
-{# Skip BUFFER_QUEUE #}
 {%- macro generate_queue_buffers(ports) %}
     "BUFFER_QUEUE": {
+    {% for port in ports.split(',') %}
+        "{{ port }}|0-9": {
+            "profile" : "egress_lossy_profile"
+        }
+    {%- if not loop.last -%},{% endif %}
+    {% endfor %}
     }
-{%- endmacro %}
-
-{# Skip BUFFER_PG #}
-{%- macro generate_pg_profils(ports) %}
-    "BUFFER_PG": {
-    },
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t1.j2
@@ -5,12 +5,12 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossy_pool": {
-            "size": "164524944",
+            "size": "164624512",
             "type": "ingress",
             "mode": "dynamic"
         },
         "egress_lossy_pool": {
-            "size": "164524944",
+            "size": "164624512",
             "type": "egress",
             "mode": "dynamic"
         }
@@ -19,7 +19,7 @@
         "ingress_lossy_profile": {
             "pool": "ingress_lossy_pool",
             "size": "0",
-            "static_th": "163546528"
+            "static_th": "165364160"
         },
         "egress_lossy_profile": {
             "pool": "egress_lossy_pool",

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/port_config.ini
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/port_config.ini
@@ -41,6 +41,7 @@ Ethernet38   63               Ethernet5/7   5      100000  rs
 Ethernet39   64               Ethernet5/8   5      100000  rs
 Ethernet40   41               Ethernet6/1   6      100000  rs
 Ethernet41   42               Ethernet6/2   6      100000  rs
+Ethernet42   43               Ethernet6/3   6      100000  rs
 Ethernet43   44               Ethernet6/4   6      100000  rs
 Ethernet44   45               Ethernet6/5   6      100000  rs
 Ethernet45   46               Ethernet6/6   6      100000  rs

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/qos.json.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/qos.json.j2
@@ -1,1 +1,143 @@
+{%- macro generate_dscp_to_tc_map_per_sku() -%}
+    "DSCP_TO_TC_MAP": {
+        "AZURE": {
+            "0" : "0",
+            "1" : "1",
+            "2" : "2",
+            "3" : "3",
+            "4" : "4",
+            "5" : "4",
+            "6" : "4",
+            "7" : "0",
+            "8" : "0",
+            "9" : "0",
+            "10": "5",
+            "11": "0",
+            "12": "0",
+            "13": "0",
+            "14": "0",
+            "15": "0",
+            "16": "0",
+            "17": "0",
+            "18": "0",
+            "19": "0",
+            "20": "0",
+            "21": "0",
+            "22": "0",
+            "23": "0",
+            "24": "0",
+            "25": "0",
+            "26": "0",
+            "27": "0",
+            "28": "0",
+            "29": "0",
+            "30": "0",
+            "31": "0",
+            "32": "0",
+            "33": "0",
+            "34": "0",
+            "35": "0",
+            "36": "0",
+            "37": "0",
+            "38": "0",
+            "39": "0",
+            "40": "0",
+            "41": "0",
+            "42": "0",
+            "43": "0",
+            "44": "0",
+            "45": "0",
+            "46": "0",
+            "47": "0",
+            "48": "0",
+            "49": "0",
+            "50": "0",
+            "51": "0",
+            "52": "0",
+            "53": "0",
+            "54": "0",
+            "55": "0",
+            "56": "0",
+            "57": "0",
+            "58": "0",
+            "59": "0",
+            "60": "0",
+            "61": "0",
+            "62": "0",
+            "63": "0"
+        }
+    },
+{%- endmacro -%}
+
+{%- macro generate_tc_to_queue_map_per_sku() -%}
+    "TC_TO_QUEUE_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "1",
+            "2": "2",
+            "3": "3",
+            "4": "4",
+            "5": "5",
+            "6": "6",
+            "7": "7",
+            "8": "8",
+            "9": "9"
+        }
+    },
+{%- endmacro -%}
+
+{%- macro generate_scheduler_per_sku() -%}
+    "SCHEDULER": {
+        "scheduler.0": {
+            "type"  : "DWRR",
+            "weight": "1"
+        },
+        "scheduler.1": {
+            "type"  : "DWRR",
+            "weight": "10"
+        },
+        "scheduler.2": {
+            "type"  : "DWRR",
+            "weight": "20"
+        },
+        "scheduler.3": {
+            "type"  : "DWRR",
+            "weight": "30"
+        }
+    },
+{%- endmacro -%}
+
+{%- macro generate_single_queue_per_sku(port) -%}
+        "{{ port }}|0": {
+            "scheduler": "scheduler.0"
+        },
+        "{{ port }}|1": {
+            "scheduler": "scheduler.1"
+        },
+        "{{ port }}|2": {
+            "scheduler": "scheduler.2"
+        },
+        "{{ port }}|3": {
+            "scheduler": "scheduler.3"
+        },
+        "{{ port }}|4": {
+            "scheduler": "scheduler.1"
+        },
+        "{{ port }}|5": {
+            "scheduler": "scheduler.1"
+        },
+        "{{ port }}|6": {
+            "scheduler": "scheduler.1"
+        },
+        "{{ port }}|7": {
+            "scheduler": "scheduler.1"
+        },
+        "{{ port }}|8": {
+            "scheduler": "scheduler.1"
+        },
+        "{{ port }}|9": {
+            "scheduler": "scheduler.1"
+        }
+{%- endmacro -%}
+
 {%- include 'qos_config.j2' %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/th5-a7060x6-64pe.config.bcm
@@ -3390,3 +3390,12 @@ device:
         DEVICE_CONFIG:
             AUTOLOAD_BOARD_SETTINGS: 0
 ...
+---
+device:
+    0:
+        TM_THD_CONFIG:
+            SKIP_BUFFER_RESERVATION: 0
+            THRESHOLD_MODE: LOSSY
+        TM_SCHEDULER_CONFIG:
+            NUM_MC_Q: NUM_MC_Q_2
+...

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffer_ports.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffer_ports.j2
@@ -1,0 +1,6 @@
+{%- macro generate_port_lists(PORT_ALL) %}
+    {# Generate list of ports #}
+    {%- for port_idx in range(0, 513) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
+    {%- endfor %}
+{%- endmacro %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers.json.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers.json.j2
@@ -1,0 +1,2 @@
+{%- set default_topo = 't1' %}
+{%- include 'buffers_config.j2' %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t0.j2
@@ -1,17 +1,40 @@
-{%- set default_cable = '5m' %}
+{%- set default_cable = '0m' %}
 
-{# Skip BUFFER_POOL, BUFFER_PROFILE #}
+{%- include 'buffer_ports.j2' %}
+
 {%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossy_pool": {
+            "size": "164524944",
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_lossy_pool": {
+            "size": "164524944",
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool": "ingress_lossy_pool",
+            "size": "0",
+            "static_th": "163546528"
+        },
+        "egress_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "1778",
+            "dynamic_th": "1"
+        }
+    },
 {%- endmacro %}
-
-{# Skip BUFFER_QUEUE #}
 {%- macro generate_queue_buffers(ports) %}
     "BUFFER_QUEUE": {
+    {% for port in ports.split(',') %}
+        "{{ port }}|0-9": {
+            "profile" : "egress_lossy_profile"
+        }
+    {%- if not loop.last -%},{% endif %}
+    {% endfor %}
     }
-{%- endmacro %}
-
-{# Skip BUFFER_PG #}
-{%- macro generate_pg_profils(ports) %}
-    "BUFFER_PG": {
-    },
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t0.j2
@@ -5,12 +5,12 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossy_pool": {
-            "size": "164524944",
+            "size": "165307264",
             "type": "ingress",
             "mode": "dynamic"
         },
         "egress_lossy_pool": {
-            "size": "164524944",
+            "size": "165307264",
             "type": "egress",
             "mode": "dynamic"
         }
@@ -19,7 +19,7 @@
         "ingress_lossy_profile": {
             "pool": "ingress_lossy_pool",
             "size": "0",
-            "static_th": "163546528"
+            "static_th": "165364160"
         },
         "egress_lossy_profile": {
             "pool": "egress_lossy_pool",

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t1.j2
@@ -1,17 +1,40 @@
-{%- set default_cable = '5m' %}
+{%- set default_cable = '0m' %}
 
-{# Skip BUFFER_POOL, BUFFER_PROFILE #}
+{%- include 'buffer_ports.j2' %}
+
 {%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossy_pool": {
+            "size": "164524944",
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_lossy_pool": {
+            "size": "164524944",
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool": "ingress_lossy_pool",
+            "size": "0",
+            "static_th": "163546528"
+        },
+        "egress_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "1778",
+            "dynamic_th": "1"
+        }
+    },
 {%- endmacro %}
-
-{# Skip BUFFER_QUEUE #}
 {%- macro generate_queue_buffers(ports) %}
     "BUFFER_QUEUE": {
+    {% for port in ports.split(',') %}
+        "{{ port }}|0-9": {
+            "profile" : "egress_lossy_profile"
+        }
+    {%- if not loop.last -%},{% endif %}
+    {% endfor %}
     }
-{%- endmacro %}
-
-{# Skip BUFFER_PG #}
-{%- macro generate_pg_profils(ports) %}
-    "BUFFER_PG": {
-    },
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t1.j2
@@ -5,12 +5,12 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossy_pool": {
-            "size": "164524944",
+            "size": "165307264",
             "type": "ingress",
             "mode": "dynamic"
         },
         "egress_lossy_pool": {
-            "size": "164524944",
+            "size": "165307264",
             "type": "egress",
             "mode": "dynamic"
         }
@@ -19,7 +19,7 @@
         "ingress_lossy_profile": {
             "pool": "ingress_lossy_pool",
             "size": "0",
-            "static_th": "163546528"
+            "static_th": "165364160"
         },
         "egress_lossy_profile": {
             "pool": "egress_lossy_pool",

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/qos.json.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/qos.json.j2
@@ -1,1 +1,143 @@
+{%- macro generate_dscp_to_tc_map_per_sku() -%}
+    "DSCP_TO_TC_MAP": {
+        "AZURE": {
+            "0" : "0",
+            "1" : "1",
+            "2" : "2",
+            "3" : "3",
+            "4" : "4",
+            "5" : "4",
+            "6" : "4",
+            "7" : "0",
+            "8" : "0",
+            "9" : "0",
+            "10": "5",
+            "11": "0",
+            "12": "0",
+            "13": "0",
+            "14": "0",
+            "15": "0",
+            "16": "0",
+            "17": "0",
+            "18": "0",
+            "19": "0",
+            "20": "0",
+            "21": "0",
+            "22": "0",
+            "23": "0",
+            "24": "0",
+            "25": "0",
+            "26": "0",
+            "27": "0",
+            "28": "0",
+            "29": "0",
+            "30": "0",
+            "31": "0",
+            "32": "0",
+            "33": "0",
+            "34": "0",
+            "35": "0",
+            "36": "0",
+            "37": "0",
+            "38": "0",
+            "39": "0",
+            "40": "0",
+            "41": "0",
+            "42": "0",
+            "43": "0",
+            "44": "0",
+            "45": "0",
+            "46": "0",
+            "47": "0",
+            "48": "0",
+            "49": "0",
+            "50": "0",
+            "51": "0",
+            "52": "0",
+            "53": "0",
+            "54": "0",
+            "55": "0",
+            "56": "0",
+            "57": "0",
+            "58": "0",
+            "59": "0",
+            "60": "0",
+            "61": "0",
+            "62": "0",
+            "63": "0"
+        }
+    },
+{%- endmacro -%}
+
+{%- macro generate_tc_to_queue_map_per_sku() -%}
+    "TC_TO_QUEUE_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "1",
+            "2": "2",
+            "3": "3",
+            "4": "4",
+            "5": "5",
+            "6": "6",
+            "7": "7",
+            "8": "8",
+            "9": "9"
+        }
+    },
+{%- endmacro -%}
+
+{%- macro generate_scheduler_per_sku() -%}
+    "SCHEDULER": {
+        "scheduler.0": {
+            "type"  : "DWRR",
+            "weight": "1"
+        },
+        "scheduler.1": {
+            "type"  : "DWRR",
+            "weight": "10"
+        },
+        "scheduler.2": {
+            "type"  : "DWRR",
+            "weight": "20"
+        },
+        "scheduler.3": {
+            "type"  : "DWRR",
+            "weight": "30"
+        }
+    },
+{%- endmacro -%}
+
+{%- macro generate_single_queue_per_sku(port) -%}
+        "{{ port }}|0": {
+            "scheduler": "scheduler.0"
+        },
+        "{{ port }}|1": {
+            "scheduler": "scheduler.1"
+        },
+        "{{ port }}|2": {
+            "scheduler": "scheduler.2"
+        },
+        "{{ port }}|3": {
+            "scheduler": "scheduler.3"
+        },
+        "{{ port }}|4": {
+            "scheduler": "scheduler.1"
+        },
+        "{{ port }}|5": {
+            "scheduler": "scheduler.1"
+        },
+        "{{ port }}|6": {
+            "scheduler": "scheduler.1"
+        },
+        "{{ port }}|7": {
+            "scheduler": "scheduler.1"
+        },
+        "{{ port }}|8": {
+            "scheduler": "scheduler.1"
+        },
+        "{{ port }}|9": {
+            "scheduler": "scheduler.1"
+        }
+{%- endmacro -%}
+
 {%- include 'qos_config.j2' %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
@@ -3405,3 +3405,12 @@ device:
         DEVICE_CONFIG:
             AUTOLOAD_BOARD_SETTINGS: 0
 ...
+---
+device:
+    0:
+        TM_THD_CONFIG:
+            SKIP_BUFFER_RESERVATION: 0
+            THRESHOLD_MODE: LOSSY
+        TM_SCHEDULER_CONFIG:
+            NUM_MC_Q: NUM_MC_Q_2
+...


### PR DESCRIPTION
#### Why I did it

Found multiple issues when onboarding Arista-7060X6-64PE-B-C512S2 Arista-7060X6-64PE-B-C448O16 HWSKUs.

- config qos reload will fail due to missing buffers.json.j2 file.
- buffers default objects failing to be set to each port, due to buffer ports missing.
- 1 port is missing in port_config.ini.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

This change fixes the issues above by updating the HWSKU files.

This PR also contains an initial MMU config based of the paper calculation from Broadcom team.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Validated on real hardware switch:

- qos reload works:

  ```
  sudo config qos reload --no-dynamic-buffer                                                                              
                                                                                                                                                                                                                                        
  Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers.json.j2,/tmp/cfg_buffer.json -t /usr/share/sonic/device/x86_64-arista_7060x6_64pe_b/Arista
  -7060X6-64PE-B-C448O16/qos.json.j2,/tmp/cfg_qos.json -y /etc/sonic/sonic_version.yml                               
  Running command: /usr/local/bin/sonic-cfggen -j /tmp/cfg_buffer.json -j /tmp/cfg_qos.json --write-to-db                                                                                                                               
  ```

- Critical processing not crashing:

  ```
  docker ps
  CONTAINER ID   IMAGE                            COMMAND                  CREATED        STATUS          PORTS     NAMES
  92a75bae3290   docker-snmp:latest               "/usr/bin/docker-snm…"   39 hours ago   Up 40 minutes             snmp
  a203f85ee18c   docker-sonic-gnmi:latest         "/usr/local/bin/supe…"   39 hours ago   Up 40 minutes             gnmi
  49fe3de31e5d   docker-platform-monitor:latest   "/usr/bin/docker_ini…"   39 hours ago   Up 41 minutes             pmon
  19cfb13f47dd   docker-eventd:latest             "/usr/local/bin/supe…"   39 hours ago   Up 41 minutes             eventd
  7dbb30ff6b29   docker-syncd-brcm:latest         "/usr/local/bin/supe…"   39 hours ago   Up 41 minutes             syncd
  e64623de7519   docker-orchagent:latest          "/usr/bin/docker-ini…"   39 hours ago   Up 41 minutes             swss
  5fa40b49fb0b   docker-database:latest           "/usr/local/bin/dock…"   39 hours ago   Up 39 hours               database
  ```

- MMU settings can be applied:

  ```
  $ show mmu
  Pool: egress_lossy_pool
  ----  ---------
  mode  dynamic
  size  164624512
  type  egress
  ----  ---------
  
  Pool: ingress_lossy_pool
  ----  ---------
  mode  dynamic
  size  164624512
  type  ingress
  ----  ---------
  
  Profile: egress_lossy_profile
  ----------  -----------------
  dynamic_th  1
  pool        egress_lossy_pool
  size        1778
  ----------  -----------------
  
  Profile: ingress_lossy_profile
  ---------  ------------------
  pool       ingress_lossy_pool
  size       0
  static_th  165364160
  ---------  ------------------
  ```

- All ports can be up:

  ```
  admin@str4-7060x6-512-fan-2:~$ show int sta | grep "up *up"
    Ethernet0               17     100G   9100     rs   Ethernet1/1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
    Ethernet8                1     100G   9100     rs   Ethernet2/1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
   Ethernet16                9     100G   9100     rs   Ethernet3/1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
   Ethernet24               25     100G   9100     rs   Ethernet4/1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
   Ethernet32               57     100G   9100     rs   Ethernet5/1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
   Ethernet40               41     100G   9100     rs   Ethernet6/1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
   Ethernet48               33     100G   9100     rs   Ethernet7/1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
   Ethernet56               49     100G   9100     rs   Ethernet8/1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
   Ethernet64               89     100G   9100     rs   Ethernet9/1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
  ```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

