### PR TITLE
[Arista SKUs] check for flag file created by supervisor to update LC reboot cause

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/platform_update_reboot_cause
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/platform_update_reboot_cause
@@ -1,0 +1,1 @@
+./../x86_64-arista_common/platform_update_reboot_cause

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/platform_update_reboot_cause
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/platform_update_reboot_cause
@@ -1,0 +1,1 @@
+./../x86_64-arista_common/platform_update_reboot_cause

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/platform_update_reboot_cause
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/platform_update_reboot_cause
@@ -1,0 +1,1 @@
+./../x86_64-arista_common/platform_update_reboot_cause

--- a/device/arista/x86_64-arista_7800r3a_36d_lc/platform_update_reboot_cause
+++ b/device/arista/x86_64-arista_7800r3a_36d_lc/platform_update_reboot_cause
@@ -1,0 +1,1 @@
+./../x86_64-arista_common/platform_update_reboot_cause

--- a/device/arista/x86_64-arista_7800r3a_36dm2_lc/platform_update_reboot_cause
+++ b/device/arista/x86_64-arista_7800r3a_36dm2_lc/platform_update_reboot_cause
@@ -1,0 +1,1 @@
+./../x86_64-arista_common/platform_update_reboot_cause

--- a/device/arista/x86_64-arista_7800r3a_36p_lc/platform_update_reboot_cause
+++ b/device/arista/x86_64-arista_7800r3a_36p_lc/platform_update_reboot_cause
@@ -1,0 +1,1 @@
+./../x86_64-arista_common/platform_update_reboot_cause

--- a/device/arista/x86_64-arista_7800r3ak_36d2_lc/platform_update_reboot_cause
+++ b/device/arista/x86_64-arista_7800r3ak_36d2_lc/platform_update_reboot_cause
@@ -1,0 +1,1 @@
+./../x86_64-arista_common/platform_update_reboot_cause

--- a/device/arista/x86_64-arista_7800r3ak_36dm2_lc/platform_update_reboot_cause
+++ b/device/arista/x86_64-arista_7800r3ak_36dm2_lc/platform_update_reboot_cause
@@ -1,0 +1,1 @@
+./../x86_64-arista_common/platform_update_reboot_cause

--- a/device/arista/x86_64-arista_common/platform_update_reboot_cause
+++ b/device/arista/x86_64-arista_common/platform_update_reboot_cause
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import os
+from datetime import datetime, timezone
+
+REBOOT_CAUSE_DIR = "/host/reboot-cause/"
+REBOOT_LC_BY_SUPERVISOR_FILE = os.path.join(REBOOT_CAUSE_DIR, "reboot-lc-by-supervisor.txt")
+
+def main():
+    reboot_time = datetime.now(timezone.utc).strftime("%a %b %d %I:%M:%S %p %Z %Y")
+
+    if os.path.exists(REBOOT_LC_BY_SUPERVISOR_FILE):
+        os.remove(REBOOT_LC_BY_SUPERVISOR_FILE)
+        with open(os.path.join(REBOOT_CAUSE_DIR, "reboot-cause.txt"), 'w') as reboot_cause_file:
+            reboot_msg = "User issued 'Reboot from Supervisor' command [User: Supervisor, Time: {}]".format(reboot_time)
+            reboot_cause_file.write(reboot_msg)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes graceful reboot part of https://github.com/aristanetworks/sonic/issues/118.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

https://github.com/aristanetworks/sonic/issues/118 indicates that when reboot is issued
by supervisor, in the `reboot-cause history` of LC, correct cause is not printed out. This
can lead to test failures and also potentially issues while debugging problems related to
reboot.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

A temporary flag file is used for this purpose. When the flag file is created by
supervisor via RPC before it reboots the LC, this can indicate that previous
reboot command for LC has been issued by the supervisor via RPC. This
information can be used to update the reboot cause as 
'reboot from Supervisor' and the user as 'Supervisor' to distinguish
it from typical reboot by admin on LC.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

