### PR TITLE
Add a new switch_type called dummy-sup for voq chassis

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -592,7 +592,7 @@ def is_multi_npu():
 
 def is_voq_chassis():
     switch_type = get_platform_info().get('switch_type')
-    return True if switch_type and (switch_type == 'voq' or switch_type == 'fabric' or switch_type == "dummy-sup") else False
+    return True if switch_type and (switch_type == 'voq' or switch_type == 'fabric') else False
 
 
 def is_packet_chassis():
@@ -616,8 +616,13 @@ def is_disaggregated_chassis():
         return False
 
 
+def is_virtual_chassis():
+    switch_type = get_platform_info().get('switch_type')
+    return True if switch_type and (switch_type == 'voq' or switch_type == "dummy-sup") else False
+
+
 def is_chassis():
-    return (is_voq_chassis() and not is_disaggregated_chassis()) or is_packet_chassis()
+    return (is_voq_chassis() and not is_disaggregated_chassis()) or is_packet_chassis() or is_virtual_chassis()
 
 
 def is_smartswitch():

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -592,7 +592,7 @@ def is_multi_npu():
 
 def is_voq_chassis():
     switch_type = get_platform_info().get('switch_type')
-    return True if switch_type and (switch_type == 'voq' or switch_type == 'fabric') else False
+    return True if switch_type and (switch_type == 'voq' or switch_type == 'fabric' or switch_type == "dummy-sup") else False
 
 
 def is_packet_chassis():
@@ -615,7 +615,7 @@ def is_disaggregated_chassis():
                     return True
         return False
 
-    
+
 def is_chassis():
     return (is_voq_chassis() and not is_disaggregated_chassis()) or is_packet_chassis()
 

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -618,7 +618,11 @@ def is_disaggregated_chassis():
 
 def is_virtual_chassis():
     switch_type = get_platform_info().get('switch_type')
-    return True if switch_type and (switch_type == 'voq' or switch_type == "dummy-sup") else False
+    asic_type = get_platform_info().get('asic_type')
+    if asic_type == "vs" and (switch_type == "dummy-sup" or switch_type == "voq"):
+        return True
+    else:
+        return False
 
 
 def is_chassis():

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -619,7 +619,8 @@ def is_disaggregated_chassis():
 def is_virtual_chassis():
     switch_type = get_platform_info().get('switch_type')
     asic_type = get_platform_info().get('asic_type')
-    if asic_type == "vs" and (switch_type == "dummy-sup" or switch_type == "voq"):
+    if asic_type == "vs" and (switch_type == "dummy-sup" or switch_type == "voq"
+                              or switch_type == "chassis-packet"):
         return True
     else:
         return False

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -619,8 +619,7 @@ def is_disaggregated_chassis():
 def is_virtual_chassis():
     switch_type = get_platform_info().get('switch_type')
     asic_type = get_platform_info().get('asic_type')
-    if asic_type == "vs" and (switch_type == "dummy-sup" or switch_type == "voq"
-                              or switch_type == "chassis-packet"):
+    if asic_type == "vs" and switch_type in ["dummy-sup", "voq", "chassis-packet"]:
         return True
     else:
         return False

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -134,7 +134,7 @@ class TestDeviceInfo(object):
         assert device_info.is_voq_chassis() == True
         assert device_info.is_packet_chassis() == False
         assert device_info.is_chassis() == True
-        
+
         mock_platform_info.return_value = {"switch_type": "voq"}
         mock_is_disaggregated_chassis.return_value = True
         assert device_info.is_voq_chassis() == True
@@ -145,6 +145,14 @@ class TestDeviceInfo(object):
         mock_is_disaggregated_chassis.return_value = False
         assert device_info.is_voq_chassis() == False
         assert device_info.is_packet_chassis() == True
+        assert device_info.is_chassis() == True
+
+        mock_platform_info.return_value = {"switch_type": "dummy-sup",
+                                           "asic_type": "vs"}
+        mock_is_disaggregated_chassis.return_value = False
+        assert device_info.is_voq_chassis() == False
+        assert device_info.is_packet_chassis() == False
+        assert device_info.is_virtual_chassis() == True
         assert device_info.is_chassis() == True
 
         mock_platform_info.return_value = {}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Supervisor on virtual VoQ chassis does not perform any functionality of a fabric card and does not have necessary config for being either a "voq" or "fabric" type of switch. Thus, we should mark it as a new type of switch object. I set the new type to be 'dummy-sup'. With this change, we should modify the criteria of determining whether a device is chassis.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Define a new is_virtual_chassis function.

#### How to verify it

Setup a virtual chassis

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

