### PR TITLE
Remove uid and gid exclusion

### DIFF
--- a/dockers/docker-auditd/auditd_config_files/39-exclusions.rules
+++ b/dockers/docker-auditd/auditd_config_files/39-exclusions.rules
@@ -1,4 +1,3 @@
 -a always,exclude -F msgtype=EOE
 -a always,exclude -F msgtype=EXECVE
 -a always,exclude -F msgtype=PATH -F auid<1000
--a always,exclude -F msgtype=PATH -F uid=0 -F gid=0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The original PR: https://github.com/sonic-net/sonic-buildimage/pull/22316 introduced the `gid=0` and `uid=0`rule which will lost syscall and path for sudo operation.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Remove over strict rule if user was using sudo to do operation.

#### How to verify it

With the rule `-a always,exclude -F msgtype=PATH -F uid=0 -F gid=0`, we cannot see any `x99.json` file deletion event
```
stli@STG01-0101-0101-10T0:~$ sudo touch x99.json
stli@STG01-0101-0101-10T0:~$ sudo rm x99.json
stli@STG01-0101-0101-10T0:~$ sudo grep x99.json /var/log/syslog

```

After removed the rule `-a always,exclude -F msgtype=PATH -F uid=0 -F gid=0`, then we can see corresponding events for both syscall and path with same eventID: 1203041 

```
stli@STG01-0101-0101-10T0:~$ sudo grep x99.json /var/log/syslog
Apr 22 01:22:38.237049 STG01-0101-0101-10T0 INFO audisp-syslog: type=PATH msg=audit(1745284958.194:1203041): item=1 name="x99.json" inode=1831862 dev=08:01 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0 OUID="root" OGID="root"
stli@STG01-0101-0101-10T0:~$ sudo grep 1203041 /var/log/syslog
Apr 22 01:22:38.236676 STG01-0101-0101-10T0 INFO audisp-syslog: type=SYSCALL msg=audit(1745284958.194:1203041): arch=c000003e syscall=263 success=yes exit=0 a0=ffffff9c a1=55596e8e94d0 a2=0 a3=fffffffffffffb8c items=3 ppid=2598264 pid=2598269 auid=1008 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=14171 comm="rm" exe="/usr/bin/rm" subj=unconfined key="file_deletion" ARCH=x86_64 SYSCALL=unlinkat AUID="stli" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"
Apr 22 01:22:38.236867 STG01-0101-0101-10T0 INFO audisp-syslog: type=PATH msg=audit(1745284958.194:1203041): item=0 name="/home/stli" inode=25889 dev=00:18 mode=040755 ouid=1008 ogid=1000 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0 OUID="stli" OGID="admin"
Apr 22 01:22:38.237049 STG01-0101-0101-10T0 INFO audisp-syslog: type=PATH msg=audit(1745284958.194:1203041): item=1 name="x99.json" inode=1831862 dev=08:01 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0 OUID="root" OGID="root"
Apr 22 01:22:38.237227 STG01-0101-0101-10T0 INFO audisp-syslog: type=PATH msg=audit(1745284958.194:1203041): item=2 name=(null) inode=1831795 dev=08:01 mode=040755 ouid=1008 ogid=1000 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0 OUID="stli" OGID="admin"
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

