### PR TITLE
Fix for second warm_reboot failure

### DIFF
--- a/src/sonic-sysmgr/rebootbackend/rebootbe.cpp
+++ b/src/sonic-sysmgr/rebootbackend/rebootbe.cpp
@@ -50,12 +50,6 @@ void RebootBE::Start() {
   s.addSelectable(&m_Done);
   s.addSelectable(&m_RebootThreadFinished);
 
-  if (swss::WarmStart::isWarmStart()) {
-    SetCurrentStatus(RebManagerStatus::WARM_INIT_WAIT);
-  } else {
-    SWSS_LOG_NOTICE("Warm restart not enabled");
-  }
-
   SWSS_LOG_NOTICE("RebootBE entering operational loop");
   while (true) {
     swss::Selectable *sel;
@@ -177,9 +171,6 @@ bool RebootBE::RebootAllowed(const gnoi::system::RebootMethod rebMethod) {
     case RebManagerStatus::HALT_REBOOT_IN_PROGRESS:
     case RebManagerStatus::WARM_REBOOT_IN_PROGRESS: {
       return false;
-    }
-    case RebManagerStatus::WARM_INIT_WAIT: {
-      return rebMethod == gnoi::system::RebootMethod::COLD;
     }
     case RebManagerStatus::IDLE: {
       return true;

--- a/src/sonic-sysmgr/rebootbackend/rebootbe.h
+++ b/src/sonic-sysmgr/rebootbackend/rebootbe.h
@@ -21,7 +21,6 @@ constexpr char DATA_TUPLE_KEY[] = "MESSAGE";
 class RebootBE {
  public:
   enum class RebManagerStatus {
-    WARM_INIT_WAIT,
     IDLE,
     COLD_REBOOT_IN_PROGRESS,
     HALT_REBOOT_IN_PROGRESS,

--- a/src/sonic-sysmgr/tests/rebootbe_test.cpp
+++ b/src/sonic-sysmgr/tests/rebootbe_test.cpp
@@ -205,48 +205,6 @@ class RebootBETest : public RebootBETestWithoutStop {
   }
 };
 
-TEST_F(RebootBETest, WarmbootInProgressBlocksNewWarmboot) {
-  force_warm_start_state(true);
-
-  start_rebootbe();
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  EXPECT_EQ(m_rebootbe.GetCurrentStatus(),
-            RebootBE::RebManagerStatus::WARM_INIT_WAIT);
-
-  // Send a warmboot request, confirm it fails.
-  RebootRequest request;
-  request.set_method(RebootMethod::WARM);
-  start_reboot_via_rpc(request, swss::StatusCode::SWSS_RC_IN_USE);
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(TENTH_SECOND_MS));
-  EXPECT_EQ(m_rebootbe.GetCurrentStatus(),
-            RebootBE::RebManagerStatus::WARM_INIT_WAIT);
-  force_warm_start_state(false);
-}
-
-TEST_F(RebootBETest, ColdbootWhileWarmbootInProgress) {
-  force_warm_start_state(true);
-  set_mock_defaults();
-
-  start_rebootbe();
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  EXPECT_EQ(m_rebootbe.GetCurrentStatus(),
-            RebootBE::RebManagerStatus::WARM_INIT_WAIT);
-
-  // Send a coldboot request, confirm it starts.
-  RebootRequest request;
-  request.set_method(RebootMethod::COLD);
-  start_reboot_via_rpc(request);
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(TENTH_SECOND_MS));
-  EXPECT_EQ(m_rebootbe.GetCurrentStatus(),
-            RebootBE::RebManagerStatus::COLD_REBOOT_IN_PROGRESS);
-
-  // Cleanup without going through the whole reboot.
-  send_stop_reboot_thread();
-  force_warm_start_state(false);
-}
-
 // Test fixture to skip through the startup sequence into the main loop.
 // Param indicates if RebootBE should be initialized into a state where the
 // system came up in warmboot.


### PR DESCRIPTION
Fix to second warm_reboot fails.

Fix Details:
WARM_INIT_WAIT was initially added for a different purpose. Since it is Obsolete, I have removed that code since it was blocking the trigger of second WARM reboot. 


