### PR TITLE
Fix package version conflict introduced by PR #15890

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -528,8 +528,6 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'docke
 # Install scapy
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'scapy==2.4.4'
 
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'PyYAML==6.0.1'
-
 ## Note: keep pip installed for maintainance purpose
 
 # Install GCC, needed for building/installing some Python packages

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -528,8 +528,7 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'docke
 # Install scapy
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'scapy==2.4.4'
 
-# The option --no-build-isolation can be removed when upgrading PyYAML to 6.0.1
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'PyYAML==5.4.1' --no-build-isolation
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'PyYAML==6.0.1'
 
 ## Note: keep pip installed for maintainance purpose
 

--- a/dockers/docker-config-engine-bullseye/Dockerfile.j2
+++ b/dockers/docker-config-engine-bullseye/Dockerfile.j2
@@ -23,9 +23,7 @@ RUN apt-get install -y        \
 RUN pip3 install pyangbind==0.8.1
 RUN pip3 uninstall -y enum34
 
-# Fix armhf build failure
-# The option --no-build-isolation can be removed when upgrading PyYAML to 6.0.1
-RUN pip3 install PyYAML==5.4.1 --no-build-isolation
+RUN pip3 install PyYAML==6.0.1
 
 # Install python-redis
 RUN pip3 install redis==4.5.4

--- a/dockers/docker-config-engine-bullseye/Dockerfile.j2
+++ b/dockers/docker-config-engine-bullseye/Dockerfile.j2
@@ -23,8 +23,6 @@ RUN apt-get install -y        \
 RUN pip3 install pyangbind==0.8.1
 RUN pip3 uninstall -y enum34
 
-RUN pip3 install PyYAML==6.0.1
-
 # Install python-redis
 RUN pip3 install redis==4.5.4
 

--- a/dockers/docker-config-engine-buster/Dockerfile.j2
+++ b/dockers/docker-config-engine-buster/Dockerfile.j2
@@ -23,10 +23,6 @@ RUN apt-get install -y        \
 RUN pip3 install pyangbind==0.8.1
 RUN pip3 uninstall -y enum34
 
-# Fix armhf build failure
-# The option --no-build-isolation can be removed when upgrading PyYAML to 6.0.1
-RUN pip3 install PyYAML==5.4.1 --no-build-isolation
-
 # Install python-redis
 RUN pip3 install redis==4.5.4
 

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -590,8 +590,7 @@ RUN pip3 uninstall -y enum34
 RUN pip3 install j2cli==0.3.10
 
 # For sonic-mgmt-framework
-# The option --no-build-isolation can be removed when upgrading PyYAML to 6.0.1
-RUN pip3 install "PyYAML==5.4.1" --no-build-isolation
+
 {%- if CROSS_BUILD_ENVIRON != "y" %}
 RUN pip3 install "lxml==4.9.1"
 {%- endif %}

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -551,9 +551,6 @@ RUN pip3 install MarkupSafe==2.0.1
 RUN pip3 install Jinja2==3.0.3
 
 # For sonic-mgmt-framework
-# The option --no-build-isolation can be removed when upgrading PyYAML to 6.0.1
-RUN pip2 install "PyYAML==5.4.1" --no-build-isolation
-RUN pip3 install "PyYAML==5.4.1" --no-build-isolation
 
 {%- if CROSS_BUILD_ENVIRON != "y" %}
 RUN pip2 install "lxml==4.9.1"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In PR #15890, to address an armhf build failure, the PyYAML version was pinned to 5.4.1 and the `--no-build-isolation` flag was introduced. However, our reproducible build has since been upgraded to use PyYAML 6.0.1, which leads to version conflicts.
```
target/sonic-cisco-8000.bin__cisco-8000__rfs.squashfs.log-+ sudo https_proxy= LANG=C chroot ./fsroot-cisco-8000 pip3 install PyYAML==5.4.1 --no-build-isolation
target/sonic-cisco-8000.bin__cisco-8000__rfs.squashfs.log-ERROR: Cannot install PyYAML==5.4.1 because these package versions have conflicting dependencies.
target/sonic-cisco-8000.bin__cisco-8000__rfs.squashfs.log-
target/sonic-cisco-8000.bin__cisco-8000__rfs.squashfs.log-The conflict is caused by:
target/sonic-cisco-8000.bin__cisco-8000__rfs.squashfs.log-    The user requested PyYAML==5.4.1
target/sonic-cisco-8000.bin__cisco-8000__rfs.squashfs.log-    The user requested (constraint) pyyaml==6.0.1
```
```
target/docker-config-engine-bullseye.gz.log-Step 14/28 : RUN pip3 install PyYAML==5.4.1 --no-build-isolation
target/docker-config-engine-bullseye.gz.log- ---> Running in 87fe7ac9e1ef
target/docker-config-engine-bullseye.gz.log-ERROR: Cannot install PyYAML==5.4.1 because these package versions have conflicting dependencies.
target/docker-config-engine-bullseye.gz.log-
target/docker-config-engine-bullseye.gz.log-The conflict is caused by:
target/docker-config-engine-bullseye.gz.log-    The user requested PyYAML==5.4.1
target/docker-config-engine-bullseye.gz.log-    The user requested (constraint) pyyaml==6.0.1
```
This PR resolves the conflict by removing the explicit installation of PyYAML 5.4.1 introduced in PR #15890.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
This PR resolves the conflict by removing the explicit installation of PyYAML 5.4.1 introduced in PR #15890.

#### How to verify it
Tested by pipeline itself, we can sucessfully build the images. And we will install PyYAML 6.0.1, which will not cause the version conflict. 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

