### PR TITLE
[202411] Fixed hwsku.json for Mellanox-SN4280-C48 Mellanox-SN4280-O8C40 Mellanox-SN4280-O8V40

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-C48/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-C48/hwsku.json
@@ -243,22 +243,26 @@
         "Ethernet224": {
             "default_brkout_mode": "1x400G",
             "subport": "1",
-            "autoneg": "off"
+            "autoneg": "on",
+            "role"   : "Dpc"
         },
         "Ethernet232": {
             "default_brkout_mode": "1x400G",
             "subport": "1",
-            "autoneg": "off"
+            "autoneg": "on",
+            "role"   : "Dpc"
         },
         "Ethernet240": {
             "default_brkout_mode": "1x400G",
             "subport": "1",
-            "autoneg": "off"
+            "autoneg": "on",
+            "role"   : "Dpc"
         },
         "Ethernet248": {
             "default_brkout_mode": "1x400G",
             "subport": "1",
-            "autoneg": "off"
+            "autoneg": "on",
+            "role"   : "Dpc"
         }
     }
 }

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/hwsku.json
@@ -243,22 +243,26 @@
         "Ethernet224": {
             "default_brkout_mode": "1x400G",
             "subport": "1",
-            "autoneg": "off"
+            "autoneg": "on",
+            "role"   : "Dpc"
         },
         "Ethernet232": {
             "default_brkout_mode": "1x400G",
             "subport": "1",
-            "autoneg": "off"
+            "autoneg": "on",
+            "role"   : "Dpc"
         },
         "Ethernet240": {
             "default_brkout_mode": "1x400G",
             "subport": "1",
-            "autoneg": "off"
+            "autoneg": "on",
+            "role"   : "Dpc"
         },
         "Ethernet248": {
             "default_brkout_mode": "1x400G",
             "subport": "1",
-            "autoneg": "off"
+            "autoneg": "on",
+            "role"   : "Dpc"
         }
     }
 }

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8V40/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8V40/hwsku.json
@@ -243,22 +243,26 @@
         "Ethernet224": {
             "default_brkout_mode": "1x400G",
             "subport": "1",
-            "autoneg": "off"
+            "autoneg": "on",
+            "role"   : "Dpc"
         },
         "Ethernet232": {
             "default_brkout_mode": "1x400G",
             "subport": "1",
-            "autoneg": "off"
+            "autoneg": "on",
+            "role"   : "Dpc"
         },
         "Ethernet240": {
             "default_brkout_mode": "1x400G",
             "subport": "1",
-            "autoneg": "off"
+            "autoneg": "on",
+            "role"   : "Dpc"
         },
         "Ethernet248": {
             "default_brkout_mode": "1x400G",
             "subport": "1",
-            "autoneg": "off"
+            "autoneg": "on",
+            "role"   : "Dpc"
         }
     }
 }


### PR DESCRIPTION
Fixed missing Dpc role and and AN for DPU ports in hwsku.json for Mellanox-SN4280-C48 Mellanox-SN4280-O8C40 Mellanox-SN4280-O8V40 SKUs

Why I did it
DPU ports on hwsku.json were missing the Dpc role and AN was set to off
#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

