### PR TITLE
Voltage and Current Sensors support with PDDF

### DIFF
--- a/platform/pddf/i2c/utils/pddfparse.py
+++ b/platform/pddf/i2c/utils/pddfparse.py
@@ -214,14 +214,23 @@ class PddfParse():
 
         return create_ret.append(ret)
 
-    def create_temp_sensor_device(self, dev, ops):
+    def create_non_pddf_i2c_device(self, dev, ops):
+        # Create i2c devices for which a PDDF specific driver is not needed
         create_ret = []
         ret = 0
-        # NO PDDF driver for temp_sensors device
         cmd = "echo %s 0x%x > /sys/bus/i2c/devices/i2c-%d/new_device" % (dev['i2c']['topo_info']['dev_type'],
                 int(dev['i2c']['topo_info']['dev_addr'], 0), int(dev['i2c']['topo_info']['parent_bus'], 0))
         ret = self.runcmd(cmd)
         return create_ret.append(ret)
+
+    def create_temp_sensor_device(self, dev, ops):
+        return self.create_non_pddf_i2c_device(dev, ops)
+
+    def create_dpm_device(self, dev, ops):
+        return self.create_non_pddf_i2c_device(dev, ops)
+
+    def create_dcdc_device(self, dev, ops):
+        return self.create_non_pddf_i2c_device(dev, ops)
 
     def create_cpld_device(self, dev, ops):
         create_ret = []
@@ -534,11 +543,20 @@ class PddfParse():
             cmd = "echo 'delete' > /sys/kernel/pddf/devices/cpldmux/dev_ops"
             self.runcmd(cmd)
 
-    def delete_temp_sensor_device(self, dev, ops):
-        # NO PDDF driver for temp_sensors device
+    def delete_non_pddf_i2c_device(self, dev, ops):
+        # Delete i2c devices for which a PDDF specific driver is not needed
         cmd = "echo 0x%x > /sys/bus/i2c/devices/i2c-%d/delete_device" % (
                 int(dev['i2c']['topo_info']['dev_addr'], 0), int(dev['i2c']['topo_info']['parent_bus'], 0))
         self.runcmd(cmd)
+
+    def delete_temp_sensor_device(self, dev, ops):
+        return self.delete_non_pddf_i2c_device(dev, ops)
+
+    def delete_dpm_device(self, dev, ops):
+        return self.delete_non_pddf_i2c_device(dev, ops)
+
+    def delete_dcdc_device(self, dev, ops):
+        return self.delete_non_pddf_i2c_device(dev, ops)
 
     def delete_fan_device(self, dev, ops):
         if dev['i2c']['topo_info']['dev_type'] in self.data['PLATFORM']['pddf_dev_types']['FAN']:
@@ -1402,6 +1420,28 @@ class PddfParse():
 
         return ret
 
+    def dpm_parse(self, dev, ops):
+        ret = []
+        ret = getattr(self, ops['cmd']+"_dpm_device")(dev, ops)
+        if ret:
+            if str(ret[0]).isdigit():
+                if ret[0] != 0:
+                    # in case if 'create' functions
+                    print("{}_dpm_device failed for {}".format(ops['cmd'], dev['dev_info']['device_name']))
+
+        return ret
+
+    def dcdc_parse(self, dev, ops):
+        ret = []
+        ret = getattr(self, ops['cmd']+"_dcdc_device")(dev, ops)
+        if ret:
+            if str(ret[0]).isdigit():
+                if ret[0] != 0:
+                    # in case if 'create' functions
+                    print("{}_dcdc_device failed for {}".format(ops['cmd'], dev['dev_info']['device_name']))
+
+        return ret
+
     def cpld_parse(self, dev, ops):
         ret = []
         ret = getattr(self, ops['cmd']+"_cpld_device")(dev, ops)
@@ -1678,6 +1718,12 @@ class PddfParse():
 
         if attr['device_type'] == 'SYSSTAT':
             return self.sysstatus_parse(dev, ops)
+
+        if attr['device_type'] == 'DCDC':
+            return self.dcdc_parse(dev, ops)
+
+        if attr['device_type'] == 'DPM':
+            return self.dpm_parse(dev, ops)
 
     def is_supported_sysled_state(self, sysled_name, sysled_state):
         if not sysled_name in self.data.keys():

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_chassis.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_chassis.py
@@ -16,6 +16,17 @@ try:
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
+voltage_sensor_present = True
+try:
+    from sonic_platform.voltage_sensor import VoltageSensor
+except ImportError as e:
+    voltage_sensor_present = False
+
+current_sensor_present = True
+try:
+    from sonic_platform.current_sensor import CurrentSensor
+except ImportError as e:
+    current_sensor_present = False
 
 class PddfChassis(ChassisBase):
     """
@@ -70,6 +81,18 @@ class PddfChassis(ChassisBase):
         for i in range(self.platform_inventory['num_temps']):
             thermal = Thermal(i, self.pddf_obj, self.plugin_data)
             self._thermal_list.append(thermal)
+
+        if voltage_sensor_present:
+            # VOLTAGE SENSORs
+            for i in range(self.platform_inventory['num_voltage_sensors']):
+                voltage = VoltageSensor(i, self.pddf_obj, self.plugin_data)
+                self._voltage_sensor_list.append(voltage)
+
+        if current_sensor_present:
+            # CURRENT SENSORs
+            for i in range(self.platform_inventory['num_current_sensors']):
+                current = CurrentSensor(i, self.pddf_obj, self.plugin_data)
+                self._current_sensor_list.append(current)
 
 
     def get_name(self):

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_current_sensor.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_current_sensor.py
@@ -1,0 +1,95 @@
+try:
+    from sonic_platform_base.sensor_base import CurrentSensorBase, SensorBase
+    from subprocess import getstatusoutput
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+class PddfCurrentSensor(CurrentSensorBase):
+    """PDDF generic Current Sensor class"""
+    pddf_obj = {}
+    plugin_data = {}
+
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
+        if not pddf_data or not pddf_plugin_data:
+            raise ValueError('PDDF JSON data error')
+
+        self.pddf_obj = pddf_data
+        self.plugin_data = pddf_plugin_data
+        self.sensor_index = index + 1
+
+        self.platform = self.pddf_obj.get_platform()
+
+        self.sensor_obj_name = f"CURRENT{self.sensor_index}"
+        if self.sensor_obj_name not in self.pddf_obj.data:
+            raise ValueError(f"Current sensor {self.sensor_obj_name} not found in PDDF data")
+
+        self.sensor_obj = self.pddf_obj.data[self.sensor_obj_name]
+        self.display_name = self.sensor_data.get('dev_attr', {}).get('display_name', self.sensor_obj_name)
+
+    def get_name(self):
+        if 'dev_attr' in self.sensor_obj.keys():
+            if 'display_name' in self.sensor_obj['dev_attr']:
+                return str(self.sensor_obj['dev_attr']['display_name'])
+        # In case of errors
+        return (self.sensor_obj_name)
+    
+
+    def get_value(self):
+        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "current1_input")
+        if not output:
+            return None
+
+        if output['status'].isalpha():
+            attr_value = None
+        else:
+            attr_value = float(output['status'])
+        
+        return attr_value
+
+    def get_low_threshold(self):
+        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "current1_low_threshold")
+        if not output:
+            return None
+
+        if output['status'].isalpha():
+            attr_value = None
+        else:
+            attr_value = float(output['status'])
+
+        return attr_value
+
+    def get_high_threshold(self):
+        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "current1_high_threshold")
+        if not output:
+            return None
+
+        if output['status'].isalpha():
+            attr_value = None
+        else:
+            attr_value = float(output['status'])
+
+        return attr_value
+    
+    def get_high_critical_threshold(self):
+        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "current1_crit_high_threshold")
+        if not output:
+            return None
+
+        if output['status'].isalpha():
+            attr_value = None
+        else:
+            attr_value = float(output['status'])
+
+        return attr_value
+    
+    def get_low_critical_threshold(self):
+        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "current1_crit_low_threshold")
+        if not output:
+            return None
+
+        if output['status'].isalpha():
+            attr_value = None
+        else:
+            attr_value = float(output['status'])
+
+        return attr_value

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_voltage_sensor.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_voltage_sensor.py
@@ -1,0 +1,95 @@
+
+try:
+    from sonic_platform_base.sensor_base import VoltageSensorBase, SensorBase
+    from subprocess import getstatusoutput
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+class PddfVoltageSensor(VoltageSensorBase):
+    """PDDF generic Voltage Sensor class"""
+    pddf_obj = {}
+    plugin_data = {}
+
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
+        if not pddf_data or not pddf_plugin_data:
+            raise ValueError('PDDF JSON data error')
+
+        self.pddf_obj = pddf_data
+        self.plugin_data = pddf_plugin_data
+        self.sensor_index = index + 1
+        
+        self.sensor_obj_name = f"VOLTAGE{self.sensor_index}"
+        if self.sensor_obj_name not in self.pddf_obj.data:
+            raise ValueError(f"Voltage sensor {self.sensor_obj_name} not found in PDDF data")
+
+        self.sensor_obj = self.pddf_obj.data[self.sensor_obj_name]
+        self.display_name = self.sensor_obj.get('dev_attr', {}).get('display_name', self.sensor_obj_name)
+        
+
+    def get_name(self):
+        if 'dev_attr' in self.sensor_obj.keys():
+            if 'display_name' in self.sensor_obj['dev_attr']:
+                return str(self.sensor_obj['dev_attr']['display_name'])
+        # In case of errors
+        return (self.sensor_obj_name)
+    
+
+    def get_value(self):
+        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "volt1_input")
+        if not output:
+            return None
+
+        if output['status'].isalpha():
+            attr_value = None
+        else:
+            attr_value = float(output['status'])
+        
+        return attr_value
+
+    def get_low_threshold(self):
+        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "volt1_low_threshold")
+        if not output:
+            return None
+
+        if output['status'].isalpha():
+            attr_value = None
+        else:
+            attr_value = float(output['status'])
+
+        return attr_value
+
+    def get_high_threshold(self):
+        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "volt1_high_threshold")
+        if not output:
+            return None
+
+        if output['status'].isalpha():
+            attr_value = None
+        else:
+            attr_value = float(output['status'])
+
+        return attr_value
+    
+    def get_high_critical_threshold(self):
+        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "volt1_crit_high_threshold")
+        if not output:
+            return None
+
+        if output['status'].isalpha():
+            attr_value = None
+        else:
+            attr_value = float(output['status'])
+
+        return attr_value
+    
+    def get_low_critical_threshold(self):
+        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "volt1_crit_low_threshold")
+        if not output:
+            return None
+
+        if output['status'].isalpha():
+            attr_value = None
+        else:
+            attr_value = float(output['status'])
+
+        return attr_value

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
@@ -317,6 +317,57 @@ class PddfApi():
 
         return ret
 
+    def show_attr_hwmon_device(self, dev, ops, data_sysfs_key):
+        ret = []
+        if 'i2c' not in dev.keys():
+            return ret
+        attr_name = ops['attr']
+        attr_list = dev['i2c']['attr_list'] if 'i2c' in dev else []
+        KEY = data_sysfs_key
+        dsysfs_path = ""
+
+        if KEY not in self.data_sysfs_obj:
+            self.data_sysfs_obj[KEY] = []
+
+        # Current/Voltage sensors are oftentimes rails that are part of a DPM/DCDC
+        if "virt_parent" in dev['dev_info']:
+            i2c_dev = self.data[dev['dev_info']['virt_parent']]
+        else:
+            i2c_dev = dev
+
+        for attr in attr_list:
+            if attr_name == attr['attr_name'] or attr_name == 'all':
+                if 'drv_attr_name' in attr.keys():
+                    real_name = attr['drv_attr_name']
+                else:
+                    real_name = attr['attr_name']
+
+                if 'topo_info' in i2c_dev['i2c']:
+                    path = self.show_device_sysfs(i2c_dev, ops)+"/%d-00%02x/"%(int(i2c_dev['i2c']['topo_info']['parent_bus'], 0),
+                            int(i2c_dev['i2c']['topo_info']['dev_addr'], 0))
+                    if (os.path.exists(path)):
+                        full_path = glob.glob(path + 'hwmon/hwmon*/' + real_name)[0]
+                elif 'path_info' in i2c_dev['i2c']:
+                    path = i2c_dev['i2c']['path_info']['sysfs_base_path']
+                    if (os.path.exists(path)):
+                        full_path = "/".join([path, real_name])
+
+                dsysfs_path = full_path
+                if dsysfs_path not in self.data_sysfs_obj[KEY]:
+                    self.data_sysfs_obj[KEY].append(dsysfs_path)
+                ret.append(full_path)
+
+        return ret
+
+    def show_attr_voltage_sensor_device(self, dev, ops):
+        return self.show_attr_hwmon_device(dev, ops, "voltage-sensors")
+
+    def show_attr_current_sensor_device(self, dev, ops):
+        return self.show_attr_hwmon_device(dev, ops, "current-sensors")
+
+    def show_attr_temp_sensor_device(self, dev, ops):
+        return self.show_attr_hwmon_device(dev, ops, "temp-sensors")
+
     def show_attr_psu_i2c_device(self, dev, ops):
         target = ops['target']
         attr_name = ops['attr']
@@ -400,41 +451,6 @@ class PddfApi():
                     if dsysfs_path not in self.data_sysfs_obj[KEY]:
                         self.data_sysfs_obj[KEY].append(dsysfs_path)
                     ret.append(dsysfs_path)
-        return ret
-
-    def show_attr_temp_sensor_device(self, dev, ops):
-        ret = []
-        if 'i2c' not in dev.keys():
-            return ret
-        attr_name = ops['attr']
-        attr_list = dev['i2c']['attr_list'] if 'i2c' in dev else []
-        KEY = "temp-sensors"
-        dsysfs_path = ""
-
-        if KEY not in self.data_sysfs_obj:
-            self.data_sysfs_obj[KEY] = []
-
-        for attr in attr_list:
-            if attr_name == attr['attr_name'] or attr_name == 'all':
-                if 'drv_attr_name' in attr.keys():
-                    real_name = attr['drv_attr_name']
-                else:
-                    real_name = attr['attr_name']
-
-                if 'topo_info' in dev['i2c']:
-                    path = self.show_device_sysfs(dev, ops)+"/%d-00%x/"%(int(dev['i2c']['topo_info']['parent_bus'], 0),
-                            int(dev['i2c']['topo_info']['dev_addr'], 0))
-                    if (os.path.exists(path)):
-                        full_path = glob.glob(path + 'hwmon/hwmon*/' + real_name)[0]
-                elif 'path_info' in dev['i2c']:
-                    path = dev['i2c']['path_info']['sysfs_base_path']
-                    if (os.path.exists(path)):
-                        full_path = "/".join([path, real_name])
-
-                dsysfs_path = full_path
-                if dsysfs_path not in self.data_sysfs_obj[KEY]:
-                    self.data_sysfs_obj[KEY].append(dsysfs_path)
-                ret.append(full_path)
         return ret
 
     def show_attr_sysstatus_device(self, dev, ops):
@@ -644,6 +660,28 @@ class PddfApi():
 
         return ret
 
+    def voltage_sensor_parse(self, dev, ops):
+        ret = []
+        ret = getattr(self, ops['cmd']+"_voltage_sensor_device")(dev, ops)
+        if ret:
+            if str(ret[0]).isdigit():
+                if ret[0] != 0:
+                    # in case if 'create' functions
+                    print("{}_voltage_sensor_device failed for {}".format(ops['cmd'], dev['dev_info']['device_name']))
+
+        return ret
+
+    def current_sensor_parse(self, dev, ops):
+        ret = []
+        ret = getattr(self, ops['cmd']+"_current_sensor_device")(dev, ops)
+        if ret:
+            if str(ret[0]).isdigit():
+                if ret[0] != 0:
+                    # in case if 'create' functions
+                    print("{}_current_sensor_device failed for {}".format(ops['cmd'], dev['dev_info']['device_name']))
+
+        return ret
+
     def cpld_parse(self, dev, ops):
         ret = []
         ret = getattr(self, ops['cmd']+"_cpld_device")(dev, ops)
@@ -807,6 +845,12 @@ class PddfApi():
 
         if attr['device_type'] == 'TEMP_SENSOR':
             return self.temp_sensor_parse(dev, ops)
+
+        if attr['device_type'] == 'VOLTAGE_SENSOR':
+            return self.voltage_sensor_parse(dev, ops)
+
+        if attr['device_type'] == 'CURRENT_SENSOR':
+            return self.current_sensor_parse(dev, ops)
 
         if attr['device_type'] == 'SFP' or attr['device_type'] == 'QSFP' or \
                 attr['device_type'] == 'SFP+' or attr['device_type'] == 'QSFP+' or \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Sensormon is currently not integrated with PDDF. Adding voltage and current sensor monitoring with PDDF support in order to expose system-level current and voltage readouts from peripheral sensors. 
Fixes https://github.com/sonic-net/sonic-buildimage/issues/17032

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Implement pddf parsing for current and voltage sensors, as well as pddf_voltage_sensor and pddf_current_sensor classes. 

#### How to verify it
Run commands "show platform voltage" and "show platform current". 
Should see "Sensor not detected" for platforms that do not have current/voltage sensors implemented. 
For platforms that do have it implemented, should see an output like this:
```
admin@sonic:~$ show platform voltage
    Sensor     Voltage    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
----------  ----------  ---------  --------  --------------  -------------  ---------  -----------------
POS0V75_S0    749.0 mV        825       674               0              0      False  20250409 21:00:23
POS0V75_S5    747.0 mV        825       674               0              0      False  20250409 21:00:23
POS0V78_S0    781.0 mV        858       701               0              0      False  20250409 21:00:23
    POS1V0    998.0 mV       1100       899               0              0      False  20250409 21:00:23
 POS1V0_A7    996.0 mV       1100       899               0              0      False  20250409 21:00:23
 POS1V1_S0   1101.0 mV       1200       990               0              0      False  20250409 21:00:23
 POS1V2_A7   1191.0 mV       1320      1080               0              0      False  20250409 21:00:23
 POS1V8_A7   1796.0 mV       1979      1619               0              0      False  20250409 21:00:23
 POS1V8_S0   1811.0 mV       1979      1619               0              0      False  20250409 21:00:23
 POS1V8_S5   1796.0 mV       1979      1619               0              0      False  20250409 21:00:23
    POS3V3   3312.0 mV       3630      2970               0              0      False  20250409 21:00:23
 POS3V3_S0   3370.0 mV       3630      2970               0              0      False  20250409 21:00:23
 POS3V3_S5   3298.0 mV       3630      2970               0              0      False  20250409 21:00:23
    POS5V0   4978.0 mV       5500      4500               0              0      False  20250409 21:00:23
 POS5V0_S0   5030.0 mV       5500      4500               0              0      False  20250409 21:00:23
   POS12V0  12397.0 mV      13199     10800               0              0      False  20250409 21:00:23
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

