### PR TITLE
Limit auditd event rate to 1000 per second

### DIFF
--- a/dockers/docker-auditd/auditd_config_files/audit.rules
+++ b/dockers/docker-auditd/auditd_config_files/audit.rules
@@ -10,3 +10,6 @@
 
 ## Set failure mode to syslog
 -f 1
+
+## Set auditd rate limit
+-r 1000


### PR DESCRIPTION
Limit auditd event rate to 1000 per second

#### Why I did it
Auditd generate too much record.

#### How I did it
Set -r parameter in audit.rules

##### Work item tracking
- Microsoft ADO: 32313402

#### How to verify it
Pass all test cases.

Manually verified, will create a sonic-mgmt test case to cover this change:

admin@vlab-01:~$ sudo vi /etc/audit/rules.d/audit.rules

admin@vlab-01:~$ sudo cat /etc/audit/rules.d/audit.rules
## First rule - delete all
-D

## Increase the buffers to survive stress events.
## Make this bigger for busy systems
-b 8192

## This determine how long to wait in burst of events
--backlog_wait_time 60000

## Set failure mode to syslog
-f 1

-r 1000 <== change rate by -r command
admin@vlab-01:~$


admin@vlab-01:~$ sudo service auditd restart
admin@vlab-01:~$ sudo auditctl -s
enabled 1
failure 1
pid 110032
rate_limit 1000 <== rate updated
...


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Limit auditd event rate to 1000 per second

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

