### PR TITLE
[docker-ptf] Pin ExaBGP version for Python 3 to 4.2.25

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -205,13 +205,13 @@ RUN python3 -m pip install --upgrade --ignore-installed pip
 # setuptools on Python 3.9. The packages downgrade setuptools 
 # to 40.x causing further installations to fail
 {% if PTF_ENV_PY_VER == "py3" %}
-{% set offending_packages = ["supervisor", "ipython==5.4.1", "exabgp", "grpcio-tools", "pybrctl", "pyrasite", "scapy==2.5.0", "thrift"] %}
+{% set offending_packages = ["supervisor", "ipython==5.4.1", "exabgp==4.2.25", "grpcio-tools", "pybrctl", "pyrasite", "scapy==2.5.0", "thrift"] %}
 {{ install_offending_packages(offending_packages) }}
 {% else %}
 RUN pip3 install setuptools \
         && pip3 install supervisor \
         && pip3 install ipython==5.4.1 \
-        && pip3 install exabgp \
+        && pip3 install exabgp==4.2.25 \
         && pip3 install grpcio-tools \
         && pip3 install pybrctl \
         && pip3 install pyrasite \


### PR DESCRIPTION
#### Why I did it

Untested upgrades to ExaBGP can lead to unstable test environment. Last upgrade from 4.2.22 -> 4.2.25 caused the `-e` flag to stop working and failed the tests. Pinning it to 4.2.25 with https://github.com/sonic-net/sonic-mgmt/pull/18181 fix in place.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Pin the version in Dockerfile

#### How to verify it

Manually verified on local environment.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

NA

#### Description for the changelog

[docker-ptf] Pin ExaBGP version for Python 3 to 4.2.25

* Untested upgrades to ExaBGP can lead to unstable test environment. Last upgrade from 4.2.22 -> 4.2.25 caused the `-e` flag to stop working and failed the tests. Pinning it to 4.2.25 with https://github.com/sonic-net/sonic-mgmt/pull/18181 fix in place.

#### Link to config_db schema for YANG module changes

NA

#### A picture of a cute animal (not mandatory but encouraged)