### PR TITLE
add snappi-convergence back to fix PR test

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -105,6 +105,7 @@ RUN python3 -m pip install aiohttp \
                  setuptools-rust \
                  six \
                  snappi==1.27.1 \
+                 snappi-convergence==0.4.1 \
                  snappi-ixnetwork==1.27.2 \
                  tabulate \
                  textfsm==1.1.2 \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
After change in https://github.com/sonic-net/sonic-buildimage/pull/22345, PR pipeline for release branch failed with the following error:

```
____________ ERROR collecting snappi_tests/test_multidut_snappi.py _____________
ImportError while importing test module '/var/src/sonic-mgmt/tests/snappi_tests/test_multidut_snappi.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
snappi_tests/test_multidut_snappi.py:7: in <module>
    from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, snappi_api, \
common/snappi_tests/snappi_fixtures.py:10: in <module>
    import snappi_convergence
E   ModuleNotFoundError: No module named 'snappi_convergence'
```
As snappi_convergence is still needed until https://github.com/sonic-net/sonic-mgmt/pull/18044 is merged into release branches.  Once [\#18044](https://github.com/sonic-net/sonic-mgmt/pull/18044) is merged into all release branch, we can open another PR to remove snappi_convergence package.

Adding the library back to fix the PR pipeline

##### Work item tracking

#### How I did it

Adding the missing package back to sonic-mgmt container.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Manually ran pytest collect-only on internal-202405-chassis branch, and passed.
```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================================================== 3935 tests collected in 4.95s ====================================================================================================
dashuaizhang@sonic-mgmt-int:/data/sonic-mgmt-int/tests$ 
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

