### PR TITLE
[nvidia-bluefield] Update DPU CPU isolation configuration based on NASA requirements.

### DIFF
--- a/device/nvidia-bluefield/arm64-nvda_bf-bf3comdpu/installer.conf
+++ b/device/nvidia-bluefield/arm64-nvda_bf-bf3comdpu/installer.conf
@@ -1,2 +1,2 @@
 GRUB_CMDLINE_LINUX="console=ttyAMA1 console=hvc0 console=ttyAMA0 earlycon=pl011,0x13010000 quiet"
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="isolcpus=1-13 nohz_full=1-13 rcu_nocbs=1-13"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="isolcpus=1-10 nohz_full=1-10 rcu_nocbs=1-10"

--- a/platform/nvidia-bluefield/installer/create_sonic_image
+++ b/platform/nvidia-bluefield/installer/create_sonic_image
@@ -42,7 +42,7 @@ GRUB_CFG="" # Common Grub Config
 BF2_BOOT_ARGS="console=ttyAMA1 console=hvc0 console=ttyAMA0 earlycon=pl011,0x01000000 earlycon=pl011,0x01800000"
 BF2_GRUB_CFG="$BF2_BOOT_ARGS isolcpus=1-7 nohz_full=1-7 rcu_nocbs=1-7"
 BF3_BOOT_ARGS="console=ttyAMA1 console=hvc0 console=ttyAMA0 earlycon=pl011,0x13010000"
-BF3_GRUB_CFG="$BF3_BOOT_ARGS isolcpus=1-13 nohz_full=1-13 rcu_nocbs=1-13"
+BF3_GRUB_CFG="$BF3_BOOT_ARGS isolcpus=1-10 nohz_full=1-10 rcu_nocbs=1-10"
 
 usage() {
 cat << EOF


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Update DPU CPU isolation configuration based on NASA requirements. This optimizes the performance of the SDN application.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update GRUB configuration.

#### How to verify it
Compile and run image.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

