### PR TITLE
Revert "Add snappi-convergence package back in sonic-mgmt docker"

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -105,7 +105,6 @@ RUN python3 -m pip install aiohttp \
                  setuptools-rust \
                  six \
                  snappi==1.27.1 \
-                 snappi-convergence==0.4.1 \
                  snappi-ixnetwork==1.27.2 \
                  tabulate \
                  textfsm==1.1.2 \


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#22487

Build is failing, need to merge this revert PR:
![image](https://github.com/user-attachments/assets/c5278b22-d261-476a-8f9c-f898ad1a4045)

Add the new version failure is fixed with https://github.com/sonic-net/sonic-mgmt/pull/18044, we're good with the snappi new version