### PR TITLE
[nvidia-bluefield] Add firmware configuration reset support

### DIFF
--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -67,6 +67,7 @@ IMAGE_UPGRADE="${NO_PARAM}"
 SYSLOG_LOGGER="${NO_PARAM}"
 VERBOSE_LEVEL="${VERBOSE_MIN}"
 MFT_DIAGNOSIS_FLAGS=""
+RESET_CONFIG="${NO_PARAM}"
 
 function PrintHelp() {
     echo
@@ -78,11 +79,17 @@ function PrintHelp() {
     echo "  -v, --verbose  Verbose mode (enabled when -u|--upgrade)"
     echo "  -d, --dry-run  Compare the FW versions without installation. Return code "0" means the FW is up-to-date, return code "10" means an upgrade is required, otherwise an error is detected."
     echo "  -c, --clear-semaphore   Clear hw resources before updating firmware"
+{% if sonic_asic_platform == "nvidia-bluefield" %}
+    echo "  -r, --reset    Reset firmware configuration (NVIDIA BlueField platform only)"
+{% endif %}
     echo "  -h, --help     Print help"
     echo
     echo "Examples:"
     echo "  ./${SCRIPT_NAME} --verbose"
     echo "  ./${SCRIPT_NAME} --upgrade"
+{% if sonic_asic_platform == "nvidia-bluefield" %}
+    echo "  ./${SCRIPT_NAME} --reset"
+{% endif %}
     echo "  ./${SCRIPT_NAME} --help"
     echo
 }
@@ -107,6 +114,11 @@ function ParseArguments() {
             -c|--clear-semaphore)
                 CLEAR_SEMAPHORE="${YES_PARAM}"
             ;;
+{% if sonic_asic_platform == "nvidia-bluefield" %}
+            -r|--reset)
+                RESET_CONFIG="${YES_PARAM}"
+            ;;
+{% endif %}
             -h|--help)
                 PrintHelp
                 exit "${EXIT_SUCCESS}"
@@ -523,6 +535,18 @@ function ClearSemaphore() {
     fi
 }
 
+function ResetFirmwareConfig() {
+    local -r _MST_DEVICE="$(GetSPCMstDevice)"
+
+    if [[ "${_MST_DEVICE}" = "${UNKN_MST}" ]]; then
+        ExitFailure "Could not find MST device for firmware reset"
+    fi
+
+    LogInfo "Resetting firmware configuration for device ${_MST_DEVICE}"
+    RunCmd "mlxconfig -d ${_MST_DEVICE} -y r"
+    LogInfo "Firmware configuration reset completed successfully"
+}
+
 trap Cleanup EXIT
 
 ParseArguments "$@"
@@ -534,6 +558,11 @@ LockStateChange
 WaitForDevice
 
 ClearSemaphore
+
+if [[ "${RESET_CONFIG}" = "${YES_PARAM}" ]]; then
+    ResetFirmwareConfig
+    ExitSuccess "firmware configuration reset completed"
+fi
 
 if [ "${IMAGE_UPGRADE}" != "${YES_PARAM}" ]; then
     UpgradeFW

--- a/platform/nvidia-bluefield/installer/install.sh.j2
+++ b/platform/nvidia-bluefield/installer/install.sh.j2
@@ -41,16 +41,6 @@ declare -r device_emmc=/dev/mmcblk0
 pn=$(dmidecode -t 4 | grep "Part Number" | awk '{split($NF,a,"-"); print tolower(a[1])}')
 declare -r platform=arm64-nvda_bf-$pn
 
-# The reboot of the DPU from the installer is required only for standalon platform.
-# In Smart Switch the reboot is triggered by the host when the DPU notifies it that the installation is finished.
-if [[ $(echo $platform | grep 9009d3b600) != "" ]]; then
-	declare -r reboot_is_needed=true
-	declare -r fw_upgrade_is_needed=false
-else
-	declare -r reboot_is_needed=false
-	declare -r fw_upgrade_is_needed=true
-fi
-
 declare -r capsule=/lib/firmware/mellanox/boot/capsule/boot_update2.cap
 
 run_bash_session()
@@ -107,6 +97,10 @@ fi
 if [ -e /etc/bf.cfg ]; then
 	. /etc/bf.cfg
 fi
+
+# Flags that can be overwritten by the bf.cfg
+declare -r SKIP_FIRMWARE_UPGRADE="${SKIP_FIRMWARE_UPGRADE:-false}"
+declare -r FORCE_FW_CONFIG_RESET="${FORCE_FW_CONFIG_RESET:-false}"
 
 ex() {
     echo "Executing command: $@" > /dev/ttyAMA0
@@ -228,7 +222,7 @@ chmod a+r /mnt/machine.conf
 
 sync
 
-if [[ $fw_upgrade_is_needed == "true" ]]; then
+if [[ $SKIP_FIRMWARE_UPGRADE != "true" ]]; then
 	sonic_fs_path="/mnt/$image_dir/fs.squashfs"
 	sonic_fs_mountpoint="/tmp/$image_dir-fs"
 
@@ -260,6 +254,10 @@ if [[ $fw_upgrade_is_needed == "true" ]]; then
 	ex $sonic_fs_mountpoint/usr/bin/mlnx-fw-upgrade.sh -v
 	if [[ $? != 0 ]]; then
 		log "ERROR: FW update failed"
+	fi
+
+	if [[ $FORCE_FW_CONFIG_RESET == "true" ]]; then
+		ex $sonic_fs_mountpoint/usr/bin/mlnx-fw-upgrade.sh -v -r
 	fi
 
 	ex umount $sonic_fs_mountpoint
@@ -442,12 +440,7 @@ fi
 
 rshim_log "Installation finished"
 
-if [[ $reboot_is_needed == "true" ]]; then
-	rshim_log "Rebooting..."
-	reboot -f
-else
-	rshim_log "Waiting for reset from the host..."
-	while true; do
-		sleep 1
-	done
-fi
+rshim_log "Waiting for reset from the host..."
+while true; do
+	sleep 1
+done


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add firmware configuration reset support to the Nvidia Bluefile BFB image installer.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Add new option (-r/--reset) to mlnx-fw-upgrade.j2 script to reset firmware configuration on NVIDIA BlueField platform
- Add FORCE_FW_CONFIG_RESET flag to installer/install.sh.j2 to control firmware configuration reset during installation
- Add SKIP_FIRMWARE_UPGRADE flag to installer/install.sh.j2 to control firmware upgrade during installation
- Remove platform-specific reboot logic from installer/install.sh.j2 as it's handled by the host

#### How to verify it
Install BFB image with FORCE_FW_CONFIG_RESET=true set in bf.cfg configuration.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

