### PR TITLE
Fixed mac null issue in DEVICE_METADATA and sensor values

### DIFF
--- a/platform/pensando/sonic-platform-modules-dpu/sonic_platform/chassis.py
+++ b/platform/pensando/sonic-platform-modules-dpu/sonic_platform/chassis.py
@@ -22,7 +22,7 @@ except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 NUM_THERMAL = 2
-NUM_VOLTAGE_SENSORS = 3
+NUM_VOLTAGE_SENSORS = 6
 NUM_CURRENT_SENSORS = 3
 HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"

--- a/platform/pensando/sonic-platform-modules-dpu/sonic_platform/chassis.py
+++ b/platform/pensando/sonic-platform-modules-dpu/sonic_platform/chassis.py
@@ -139,7 +139,7 @@ class Chassis(ChassisBase):
         from sonic_platform.thermal import Thermal
         global NUM_THERMAL
         board_id = self._api_helper.get_board_id()
-        if board_id == 130:
+        if board_id == self._api_helper.mtfuji_board_id:
             NUM_THERMAL = 5
         if Thermal._thermals_available():
             for index in range(0, NUM_THERMAL):

--- a/platform/pensando/sonic-platform-modules-dpu/sonic_platform/helper.py
+++ b/platform/pensando/sonic-platform-modules-dpu/sonic_platform/helper.py
@@ -24,6 +24,8 @@ DOCKER_HWSKU_PATH = '/usr/share/sonic/platform'
 
 class APIHelper():
 
+    mtfuji_board_id = 130
+
     def __init__(self):
         pass
 

--- a/platform/pensando/sonic-platform-modules-dpu/sonic_platform/sensor.py
+++ b/platform/pensando/sonic-platform-modules-dpu/sonic_platform/sensor.py
@@ -16,18 +16,22 @@ try:
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
-# [ Sensor-Name, sysfs]
+NOT_AVAILABLE = "N/A"
+# [ Sensor-Name, sysfs, low_threshold, high_threshold, critical_low, critical_high]
 VOLTAGE_SENSOR_MAPPING = [
-    ["Voltage sensor 1", "/sys/class/hwmon/hwmon0/in2_input"],
-    ["Voltage sensor 2", "/sys/class/hwmon/hwmon1/in2_input"],
-    ["Voltage sensor 3", "/sys/class/hwmon/hwmon2/in2_input"]
+    ["VP0P85_VDD_DDR_DPU0", "/sys/bus/i2c/devices/0-0044/hwmon/hwmon2/in2_input", "0.816", "0.884", "0.7905", "0.9095"],
+    ["VP1P2_DDR_VDDQ_DPU0", "/sys/bus/i2c/devices/0-0044/hwmon/hwmon2/in3_input", "1.152", "1.248", "1.116", "1.284"],
+    ["VP0P75_VDD_CORE_DPU0 1", "/sys/bus/i2c/devices/0-0055/hwmon/hwmon1/in2_input", "0.72", "0.78", "0.6975", "0.8025"],
+    ["VP0P75_VDD_CORE_DPU0 2", "/sys/bus/i2c/devices/0-0055/hwmon/hwmon1/in3_input", "0.72", "0.78", "0.6975", "0.8025"],
+    ["VP0P75_VDD_CORE_DPU0 3", "/sys/bus/i2c/devices/0-0066/hwmon/hwmon0/in2_input", "0.72", "0.78", "0.6975", "0.8025"],
+    ["VP0P85_VDD_ARM_DPU0", "/sys/bus/i2c/devices/0-0066/hwmon/hwmon0/in3_input", "0.816", "0.884", "0.7905", "0.9095"]
 ]
 
-# [ Sensor-Name, sysfs]
+# [ Sensor-Name, sysfs, low_threshold, high_threshold, critical_low, critical_high]
 CURRENT_SENSOR_MAPPING = [
-    ["Current sensor 1", "/sys/class/hwmon/hwmon0/curr1_input"],
-    ["Current sensor 2", "/sys/class/hwmon/hwmon1/curr1_input"],
-    ["Current sensor 3", "/sys/class/hwmon/hwmon2/curr1_input"]
+    ["Current sensor 1", "/sys/class/hwmon/hwmon0/curr1_input", "0", "15100", NOT_AVAILABLE, "30000"],
+    ["Current sensor 2", "/sys/class/hwmon/hwmon1/curr1_input", "0", "13800", NOT_AVAILABLE, "30000"],
+    ["Current sensor 3", "/sys/class/hwmon/hwmon2/curr1_input", "0", "79100", NOT_AVAILABLE, "30000"]
 ]
 
 class VoltageSensor(SensorBase):
@@ -36,7 +40,7 @@ class VoltageSensor(SensorBase):
     """
     @classmethod
     def _validate_voltage_sensors(cls):
-        for [sensor_name, sensor_hwmon] in VOLTAGE_SENSOR_MAPPING:
+        for sensor_name, sensor_hwmon, *_ in VOLTAGE_SENSOR_MAPPING:
             if not os.path.exists(sensor_hwmon):
                 return False
         return True
@@ -69,13 +73,61 @@ class VoltageSensor(SensorBase):
             return None
         return voltage
 
+    def get_high_threshold(self):
+        """
+        Retrieves the high threshold of sensor
+
+        Returns:
+            High threshold 
+        """
+        value = VOLTAGE_SENSOR_MAPPING[self.index][3]
+        if value == NOT_AVAILABLE:
+            return NOT_AVAILABLE
+        return float(value)
+
+    def get_low_threshold(self):
+        """
+        Retrieves the low threshold 
+
+        Returns:
+            Low threshold 
+        """
+        value = VOLTAGE_SENSOR_MAPPING[self.index][2]
+        if value == NOT_AVAILABLE:
+            return NOT_AVAILABLE
+        return float(value)
+
+    def get_high_critical_threshold(self):
+        """
+        Retrieves the high critical threshold value of sensor
+
+        Returns:
+            The high critical threshold value of sensor 
+        """
+        value = VOLTAGE_SENSOR_MAPPING[self.index][5]
+        if value == NOT_AVAILABLE:
+            return NOT_AVAILABLE
+        return float(value)
+
+    def get_low_critical_threshold(self):
+        """
+        Retrieves the low critical threshold value of sensor
+
+        Returns:
+            The low critical threshold value of sensor 
+        """
+        value = VOLTAGE_SENSOR_MAPPING[self.index][4]
+        if value == NOT_AVAILABLE:
+            return NOT_AVAILABLE
+        return float(value)
+
 class CurrentSensor(SensorBase):
     """
     Abstract base class for interfacing with a current sensor module
     """
     @classmethod
     def _validate_current_sensors(cls):
-        for [sensor_name, sensor_hwmon] in CURRENT_SENSOR_MAPPING:
+        for sensor_name, sensor_hwmon, *_ in CURRENT_SENSOR_MAPPING:
             if not os.path.exists(sensor_hwmon):
                 return False
         return True
@@ -107,3 +159,51 @@ class CurrentSensor(SensorBase):
         except Exception:
             return None
         return current
+
+    def get_high_threshold(self):
+        """
+        Retrieves the high threshold of sensor
+
+        Returns:
+            High threshold 
+        """
+        value = CURRENT_SENSOR_MAPPING[self.index][3]
+        if value == NOT_AVAILABLE:
+            return NOT_AVAILABLE
+        return float(value)
+
+    def get_low_threshold(self):
+        """
+        Retrieves the low threshold 
+
+        Returns:
+            Low threshold 
+        """
+        value = CURRENT_SENSOR_MAPPING[self.index][2]
+        if value == NOT_AVAILABLE:
+            return NOT_AVAILABLE
+        return float(value)
+
+    def get_high_critical_threshold(self):
+        """
+        Retrieves the high critical threshold value of sensor
+
+        Returns:
+            The high critical threshold value of sensor 
+        """
+        value = CURRENT_SENSOR_MAPPING[self.index][5]
+        if value == NOT_AVAILABLE:
+            return NOT_AVAILABLE
+        return float(value)
+
+    def get_low_critical_threshold(self):
+        """
+        Retrieves the low critical threshold value of sensor
+
+        Returns:
+            The low critical threshold value of sensor 
+        """
+        value = CURRENT_SENSOR_MAPPING[self.index][4]
+        if value == NOT_AVAILABLE:
+            return NOT_AVAILABLE
+        return float(value)

--- a/platform/pensando/sonic-platform-modules-dpu/sonic_platform/thermal.py
+++ b/platform/pensando/sonic-platform-modules-dpu/sonic_platform/thermal.py
@@ -12,7 +12,6 @@
 try:
     from sonic_platform_base.thermal_base import ThermalBase
     import os
-    import syslog
     from .helper import APIHelper
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -44,7 +43,7 @@ class Thermal(ThermalBase):
         apiHelper = APIHelper()
         g_board_id = apiHelper.get_board_id()
         temp_hwmon = '/sys/bus/i2c/devices/i2c-0/0-004c/hwmon'
-        if g_board_id == 130:
+        if g_board_id == self._api_helper.mtfuji_board_id:
             temp_hwmon = '/sys/class/hwmon/hwmon0/temp1_input'
         if os.path.exists(temp_hwmon):
             return True
@@ -53,9 +52,10 @@ class Thermal(ThermalBase):
     def __init__(self, thermal_index, sfp = None):
         global g_board_id
         ThermalBase.__init__(self)
+        self._api_helper = APIHelper()
         self.index = thermal_index + 1
         self.board_id = g_board_id
-        if self.board_id != 130:
+        if self.board_id != self._api_helper.mtfuji_board_id:
             temp_hwmon = '/sys/bus/i2c/devices/i2c-0/0-004c/hwmon'
             self.temp_dir = None
             if os.path.exists(temp_hwmon):
@@ -67,7 +67,7 @@ class Thermal(ThermalBase):
         Returns:
             string: The name of the thermal
         """
-        if self.board_id == 130:
+        if self.board_id == self._api_helper.mtfuji_board_id:
             return self.SENSOR_MAPPING_MTFUJI[self.index - 1][0]
         return self.SENSOR_MAPPING[self.index - 1]
 
@@ -115,7 +115,7 @@ class Thermal(ThermalBase):
         if(self.get_presence()):
             try :
                 temp_file = None
-                if self.board_id == 130:
+                if self.board_id == self._api_helper.mtfuji_board_id:
                     temp_file = self.SENSOR_MAPPING_MTFUJI[self.index - 1][1]
                 else:
                     temp_file = self.temp_dir +'/temp{0}_input'.format(str(self.index))
@@ -132,7 +132,7 @@ class Thermal(ThermalBase):
             A float number, the high threshold temperature of thermal in Celsius
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
-        if self.board_id == 130:
+        if self.board_id == self._api_helper.mtfuji_board_id:
             return float(self.SENSOR_MAPPING_MTFUJI[self.index - 1][3])
         raise NotImplementedError
 
@@ -144,7 +144,7 @@ class Thermal(ThermalBase):
             A float number, the low threshold temperature of thermal in Celsius
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
-        if self.board_id == 130:
+        if self.board_id == self._api_helper.mtfuji_board_id:
             return float(self.SENSOR_MAPPING_MTFUJI[self.index - 1][2])
         raise NotImplementedError
 
@@ -157,7 +157,7 @@ class Thermal(ThermalBase):
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
         temperature = 0.0
-        if self.board_id != 130:
+        if self.board_id != self._api_helper.mtfuji_board_id:
             try :
                 temp_file = self.temp_dir +'/temp{0}_crit'.format(str(self.index))
                 temperature = float(open(temp_file).read()) / 1000.0
@@ -175,7 +175,7 @@ class Thermal(ThermalBase):
             A float number, the low critical threshold temperature of thermal in Celsius
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
-        if self.board_id == 130:
+        if self.board_id == self._api_helper.mtfuji_board_id:
             return float(self.SENSOR_MAPPING_MTFUJI[self.index - 1][4])
         raise NotImplementedError
 

--- a/platform/pensando/sonic-platform-modules-dpu/sonic_platform/thermal.py
+++ b/platform/pensando/sonic-platform-modules-dpu/sonic_platform/thermal.py
@@ -28,12 +28,13 @@ class Thermal(ThermalBase):
         'Die Temperature'
     ]
 
+    # [ Sensor-Name, sysfs, low_threshold, high_threshold, critical_low, critical_high]
     SENSOR_MAPPING_MTFUJI = [
-        ["Die temperature", "/sys/class/hwmon/hwmon0/temp2_input"],
-        ["Board temperature", "/sys/class/hwmon/hwmon0/temp1_input"],
-        ["Thermal sensor 1", "/sys/class/hwmon/hwmon0/temp1_input"],
-        ["Thermal sensor 2", "/sys/class/hwmon/hwmon1/temp1_input"],
-        ["Thermal sensor 3", "/sys/class/hwmon/hwmon2/temp1_input"]
+        ["Die temperature", "/sys/class/hwmon/hwmon0/temp2_input", 1, 110, -10, 130],
+        ["Board temperature", "/sys/class/hwmon/hwmon0/temp1_input", 1, 110, -10, 130],
+        ["Thermal sensor 1", "/sys/class/hwmon/hwmon0/temp1_input", 1, 110, -10, 130],
+        ["Thermal sensor 2", "/sys/class/hwmon/hwmon1/temp1_input", 1, 110, -10, 130],
+        ["Thermal sensor 3", "/sys/class/hwmon/hwmon2/temp1_input", 1, 110, -10, 130]
     ]
 
     @classmethod
@@ -123,6 +124,30 @@ class Thermal(ThermalBase):
                 pass
         return float(temperature)
 
+    def get_high_threshold(self):
+        """
+        Retrieves the high threshold temperature of thermal
+
+        Returns:
+            A float number, the high threshold temperature of thermal in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        if self.board_id == 130:
+            return float(self.SENSOR_MAPPING_MTFUJI[self.index - 1][3])
+        raise NotImplementedError
+
+    def get_low_threshold(self):
+        """
+        Retrieves the low threshold temperature of thermal
+
+        Returns:
+            A float number, the low threshold temperature of thermal in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        if self.board_id == 130:
+            return float(self.SENSOR_MAPPING_MTFUJI[self.index - 1][2])
+        raise NotImplementedError
+
     def get_high_critical_threshold(self):
         """
         Retrieves the high critical threshold temperature of thermal
@@ -132,25 +157,26 @@ class Thermal(ThermalBase):
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
         temperature = 0.0
-        if(self.get_presence()):
+        if self.board_id != 130:
             try :
                 temp_file = self.temp_dir +'/temp{0}_crit'.format(str(self.index))
                 temperature = float(open(temp_file).read()) / 1000.0
             except Exception:
                 pass
+        else:
+            return float(self.SENSOR_MAPPING_MTFUJI[self.index - 1][5])
         return float(temperature)
 
-    def set_high_critical_threshold(self, temperature):
+    def get_low_critical_threshold(self):
         """
-        Sets the critical high threshold temperature of thermal
-
-        Args :
-            temperature: A float number up to nearest thousandth of one degree Celsius,
-            e.g. 30.125
+        Retrieves the low critical threshold temperature of thermal
 
         Returns:
-            A boolean, True if threshold is set successfully, False if not
+            A float number, the low critical threshold temperature of thermal in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
-        return True
+        if self.board_id == 130:
+            return float(self.SENSOR_MAPPING_MTFUJI[self.index - 1][4])
+        raise NotImplementedError
 
 

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -861,6 +861,10 @@ def get_system_mac(namespace=None, hostname=None):
         hw_mac_entry_outputs.append((mac, err))
         (mac, err) = run_command_pipe(iplink_cmd0, iplink_cmd1, iplink_cmd2)
         hw_mac_entry_outputs.append((mac, err))
+    elif (version_info['asic_type'] == 'pensando'):
+        iplink_cmd0 = ["ip", 'link', 'show', 'eth0-midplane']
+        (mac, err) = run_command_pipe(iplink_cmd0, iplink_cmd1, iplink_cmd2)
+        hw_mac_entry_outputs.append((mac, err))
     else:
         mac_address_cmd = ["cat", "/sys/class/net/eth0/address"]
         if namespace is not None:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- mac address was null causing sonic-cfggen reload command to fail. Fixed it by using eth0-midplane interface mac addr as DEVICE_METADATA:localhost mac
- Added and modified threshold values for thermal, current and voltage sensors

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
```
git clone https://github.com/sonic-net/sonic-buildimage.git

make init
make configure PLATFORM=pensando PLATFORM_ARCH=arm64
NOJESSIE=1 NOSTRETCH=1 NOBUSTER=0 NOBULLSEYE=0 make target/sonic-pensando.tar
```
#### How to verify it
Load the SONiC image from ONIE and make sure the interfaces are UP. All containers are up.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

