### PR TITLE
switch to use host syslog to for openbmp logging

### DIFF
--- a/dockers/docker-sonic-bmp/Dockerfile.j2
+++ b/dockers/docker-sonic-bmp/Dockerfile.j2
@@ -40,7 +40,6 @@ COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor/"]
 
 RUN chmod +x /usr/bin/bmp.sh
-RUN touch /var/log/openbmpd.log
 
 RUN apt-get clean -y      && \
     apt-get autoclean -y  && \

--- a/dockers/docker-sonic-bmp/supervisord.conf
+++ b/dockers/docker-sonic-bmp/supervisord.conf
@@ -55,7 +55,7 @@ stderr_syslog=true
 dependent_startup=true
 
 [program:openbmpd]
-command=/usr/bin/openbmpd -f -l /var/log/openbmpd.log -c /etc/bmp/openbmpd.conf
+command=/usr/bin/openbmpd -f -c /etc/bmp/openbmpd.conf
 priority=3
 autostart=false
 autorestart=false


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
openbmp is using dedicated logging now, which has potential log spawn issue

##### Work item tracking
- Microsoft ADO **(number only)**: 27588893

#### How I did it
switch to use syslog and rotate will be done together with syslog.

#### How to verify it
verified on device which works fine

![image](https://github.com/user-attachments/assets/e91a89a0-0eb5-439c-af3c-84eea44b1bd8)

![image](https://github.com/user-attachments/assets/a4296a9b-c6f5-4976-8acf-fce6a0a1c9ed)


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

