### PR TITLE
[staticroutebfd] creating single-hop bfd session with nexthop if platform supports this capability

### DIFF
--- a/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
@@ -171,6 +171,34 @@ def test_set_del_ipv6():
         {'del_default:2603:10e2:400::4/128': { }}
     )
 
+    #test BFD session with nexthop, put interface name in the BFD session key
+    dut.inject_next_hop_capable = True
+    set_del_test(dut, "srt",
+        "SET",
+        ("2603:10e2:400::4/128", {
+            "bfd": "true",
+            "ifname": "if1, if2, if3",
+            "nexthop": "2603:10E2:400:1::2,2603:10E2:400:2::2,2603:10e2:400:3::2"
+        }),
+        {
+            "set_default:if1:2603:10e2:400:1::2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '2603:10E2:400:1::1'},
+            "set_default:if2:2603:10e2:400:2::2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '2603:10E2:400:2::1'},
+            "set_default:if3:2603:10e2:400:3::2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '2603:10E2:400:3::1'}
+        },
+        {}
+    )
+    set_del_test(dut, "srt",
+        "DEL",
+        ("2603:10e2:400::4/128", { }),
+        {
+            "del_default:if1:2603:10e2:400:1::2" : {},
+            "del_default:if2:2603:10e2:400:2::2" : {},
+            "del_default:if3:2603:10e2:400:3::2" : {}
+        },
+        {'del_default:2603:10e2:400::4/128': { }}
+    )
+    dut.inject_next_hop_capable = False
+
 @patch('staticroutebfd.main.log_err')
 def test_invalid_key(mocked_log_err):
     dut = constructor()
@@ -280,6 +308,38 @@ def test_set_del():
         {},
         {}
     )
+
+    #test BFD session with nexthop, put interface name in the BFD session key
+    dut.inject_next_hop_capable = True
+    set_del_test(dut, "srt",
+        "SET",
+        ("2.2.2.0/24", {
+            "bfd": "true",
+            "nexthop": "192.168.1.2 , 192.168.2.2, 192.168.3.2",
+            "ifname": "if1, if2, if3",
+        }),
+        {
+            "set_default:if1:192.168.1.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.1.1'},
+            "set_default:if2:192.168.2.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.2.1'},
+            "set_default:if3:192.168.3.2" : {'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50', 'multiplier': '3', 'local_addr': '192.168.3.1'}
+        },
+        {}
+    )
+    set_del_test(dut, "srt",
+        "DEL",
+        ("2.2.2.0/24", {
+            "bfd": "true",
+            "nexthop": "192.168.1.2 , 192.168.2.2, 192.168.3.2",
+            "ifname": "if1, if2, if3",
+        }),
+        {
+            "del_default:if1:192.168.1.2" : {},
+            "del_default:if2:192.168.2.2" : {}
+            "del_default:if3:192.168.3.2" : {}
+        },
+        {'del_default:2.2.2.0/24': {}}
+    )
+    dut.inject_next_hop_capable = False
 
 def test_set_del_vrf():
     dut = constructor()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For single hop bfd session, we need to bind the session to nexthop interface, BFD session should become DOWN when the interface is down, bfd packet should not take other interface/route to remote system. 


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
To achieve this, one approach is associating the bfd session to a nexthop. See related BFD SAI attributes here. (https://github.com/opencomputeproject/SAI/pull/2127, https://github.com/sonic-net/SONiC/pull/1932). if the platform supports this capability, staticroutebfd creates bfd session with interface specified (but don't need destination mac address).
SWSS orchagent sets the capability based on different platform. (https://github.com/sonic-net/sonic-swss/pull/3629)

#### How to verify it
1, UT to verify that staticroutebfd provides correct bfd key when write to appl_db to create bfd session.
2, built prototype image end to end (staticroutebfd with this change, plus swss change and SAI/SDK design change to support BFD session associating a next hop).

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

