### PR TITLE
[Mellanox] Enhance DPU control platform logging

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -111,10 +111,14 @@ class DpuCtlPlat():
         self.verbosity = False
 
     def setup_logger(self, use_print=False):
+        def print_with_time(msg):
+            timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+            print(f"[{timestamp}] {msg}")
+
         if use_print:
-            self.logger_info = print
-            self.logger_error = print
-            self.logger_debug = print
+            self.logger_info = print_with_time
+            self.logger_error = print_with_time 
+            self.logger_debug = print_with_time
             return
         self.logger_debug = logger.log_debug
         self.logger_info = logger.log_info
@@ -219,6 +223,8 @@ class DpuCtlPlat():
     def write_file(self, file_name, content_towrite):
         """Write given value to file only if file exists"""
         try:
+            if self.verbosity:
+                self.log_debug(f'Writing {content_towrite} to file {file_name}')
             utils.write_file(file_name, content_towrite, raise_exception=True)
         except Exception as e:
             self.log_error(f'Failed to write {content_towrite} to file {file_name}')


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Enhance DPU control platform logging

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Add timestamp to print-based logging for better traceability
- Add verbosity-based debug logging for file write operations

#### How to verify it
Run `dpuctl` command with `-v` option

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

