### PR TITLE
Override PTF_IMAGE_TAG for release branch [202305]

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -161,6 +161,7 @@ stages:
         MIN_WORKER: $(T0_INSTANCE_NUM)
         MAX_WORKER: $(T0_INSTANCE_NUM)
         MGMT_BRANCH: "202305"
+        PTF_IMAGE_TAG: "202305"
 
   - job: t0_2vlans_elastictest
     pool: sonic-ubuntu-1c
@@ -176,6 +177,7 @@ stages:
         MAX_WORKER: $(T0_2VLANS_INSTANCE_NUM)
         MGMT_BRANCH: "202305"
         DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
+        PTF_IMAGE_TAG: "202305"
 
   - job: t1_lag_elastictest
     pool: sonic-ubuntu-1c
@@ -189,6 +191,7 @@ stages:
         MIN_WORKER: $(T1_LAG_INSTANCE_NUM)
         MAX_WORKER: $(T1_LAG_INSTANCE_NUM)
         MGMT_BRANCH: "202305"
+        PTF_IMAGE_TAG: "202305"
 
   - job: multi_asic_elastictest
     displayName: "kvmtest-multi-asic-t1-lag by Elastictest"
@@ -204,6 +207,7 @@ stages:
           MAX_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
           NUM_ASIC: 4
           MGMT_BRANCH: "202305"
+          PTF_IMAGE_TAG: "202305"
 
   - job: dualtor_elastictest
     pool: sonic-ubuntu-1c
@@ -218,6 +222,7 @@ stages:
           MAX_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
           MGMT_BRANCH: "202305"
           COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
+          PTF_IMAGE_TAG: "202305"
 
   - job: sonic_t0_elastictest
     displayName: "kvmtest-t0-sonic by Elastictest"
@@ -234,6 +239,7 @@ stages:
           MGMT_BRANCH: "202305"
           COMMON_EXTRA_PARAMS: "--neighbor_type=sonic "
           VM_TYPE: vsonic
+          PTF_IMAGE_TAG: "202305"
 
 #  - job: wan_elastictest
 #    displayName: "kvmtest-wan by Elastictest"


### PR DESCRIPTION
#### Why I did it

The azure pipeline uses sonic-mgmt master branch to invoke tests. The default value of PTF_IMAGE_TAG on master branch is "latest" which is a Python 3 only image. For release branches we use mixed image which is tagged under branch specific tag name. This PR overrides it here.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Override PTF_IMAGE_TAG in pipeline

#### How to verify it

TBD

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

NA

#### Description for the changelog

Override PTF_IMAGE_TAG for release branch PR tests

The azure pipeline uses sonic-mgmt master branch to invoke tests. The default value of PTF_IMAGE_TAG on master branch is "latest" which is a Python 3 only image. For release branches we use mixed image which is tagged under branch specific tag name.

#### Link to config_db schema for YANG module changes

NA

#### A picture of a cute animal (not mandatory but encouraged)

NA