### PR TITLE
skip frr_bmp container from monit

### DIFF
--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -69,6 +69,9 @@ def get_expected_running_containers():
 
     container_list = []
     for container_name in feature_table.keys():
+        # skip frr_bmp since it's not container just bmp option used by bgpd
+        if container_name == "frr_bmp":
+            continue
         # slim image does not have telemetry container and corresponding docker image
         if container_name == "telemetry":
             ret = check_docker_image("docker-sonic-telemetry")


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
frr_bmp is only feature switch used for bgpd to start as "/usr/lib/frr/bgpd -A 127.0.0.1 -M bmp", so that bmp container later rollout could work, thus is should be skipped from container check.

##### Work item tracking
- Microsoft ADO **(number only)**:30807821

#### How I did it
skip container check from monit.

#### How to verify it
before fix
![image](https://github.com/user-attachments/assets/b9e2c58f-3f57-47fd-94ae-8afb4b129f14)

after fix, the error log disappears.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

