### PR TITLE
[build] Upgrade natsort pypi package from 6.2.1 to 8.4.0

### DIFF
--- a/files/build/versions/build/build-sonic-slave-bookworm/versions-py3
+++ b/files/build/versions/build/build-sonic-slave-bookworm/versions-py3
@@ -19,7 +19,7 @@ jsonpatch==1.33
 jsonpointer==3.0.0
 jsonschema==2.6.0
 lxml==4.9.1
-natsort==6.2.1
+natsort==8.4.0
 netaddr==0.8.0
 netifaces==0.11.0
 ordered-set==4.1.0

--- a/files/build/versions/build/build-sonic-slave-bullseye/versions-py3
+++ b/files/build/versions/build/build-sonic-slave-bullseye/versions-py3
@@ -2,7 +2,7 @@ bitarray==2.8.1
 ijson==3.2.3
 ipaddress==1.0.23
 jsondiff==2.2.1
-natsort==6.2.1
+natsort==8.4.0
 netaddr==0.8.0
 pyyaml==6.0.1
 tabulate==0.9.0

--- a/files/build/versions/dockers/docker-config-engine-bookworm/versions-py3
+++ b/files/build/versions/dockers/docker-config-engine-bookworm/versions-py3
@@ -4,7 +4,7 @@ ijson==3.2.3
 ipaddress==1.0.23
 jsondiff==2.2.1
 lxml==4.9.1
-natsort==6.2.1
+natsort==8.4.0
 netaddr==0.8.0
 pyang==2.6.1
 pyangbind==0.8.2

--- a/files/build/versions/dockers/docker-config-engine-bullseye/versions-py3
+++ b/files/build/versions/dockers/docker-config-engine-bullseye/versions-py3
@@ -4,7 +4,7 @@ ijson==3.2.3
 ipaddress==1.0.23
 jsondiff==2.2.1
 lxml==4.9.1
-natsort==6.2.1
+natsort==8.4.0
 netaddr==0.8.0
 pyang==2.6.1
 pyangbind==0.8.1

--- a/files/build/versions/host-image/versions-py3
+++ b/files/build/versions/host-image/versions-py3
@@ -34,7 +34,7 @@ lazy-object-proxy==1.10.0
 lxml==4.9.1
 m2crypto==0.38.0
 markupsafe==2.1.2
-natsort==6.2.1
+natsort==8.4.0
 netaddr==0.8.0
 netifaces==0.11.0
 nose==1.3.7


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix issue #22569
PyPi package version will not be automatically updated. However natsort old version has a known performance issue.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Upgrade natsort package version in version file.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

