### PR TITLE
Add rate_limit check to auditd container watchdog

### DIFF
--- a/dockers/docker-auditd-watchdog/watchdog/Cargo.lock
+++ b/dockers/docker-auditd-watchdog/watchdog/Cargo.lock
@@ -3,5 +3,52 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "watchdog"
 version = "0.1.0"
+dependencies = [
+ "regex",
+]

--- a/dockers/docker-auditd-watchdog/watchdog/Cargo.toml
+++ b/dockers/docker-auditd-watchdog/watchdog/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+regex = "1.11.1"

--- a/dockers/docker-auditd-watchdog/watchdog/src/main.rs
+++ b/dockers/docker-auditd-watchdog/watchdog/src/main.rs
@@ -153,7 +153,7 @@ fn check_auditd_rate_limit_status() -> String {
                 }
             }
         }
-        Err(_e) => {
+        Err(e) => {
             // config file missing
             format!("FAIL (open config file failed, error message = {})", e)
         }

--- a/dockers/docker-auditd-watchdog/watchdog/src/main.rs
+++ b/dockers/docker-auditd-watchdog/watchdog/src/main.rs
@@ -148,14 +148,14 @@ fn check_auditd_rate_limit_status() -> String {
                     }
                 }
                 None => {
-                    // rate limit disabled when config file missing
+                    // rate limit disabled when -r missing in config file
                     "OK".to_string()
                 }
             }
         }
         Err(_e) => {
-            // config file not exist, ignore rate check
-            "OK".to_string()
+            // config file missing
+            format!("FAIL (open config file failed, error message = {})", e)
         }
     }
 }

--- a/dockers/docker-auditd-watchdog/watchdog/src/main.rs
+++ b/dockers/docker-auditd-watchdog/watchdog/src/main.rs
@@ -122,8 +122,8 @@ fn check_auditd_rate_limit_status() -> String {
     match run_command(&cmd) {
         Ok(s) => {
             let re = Regex::new(r"rate_limit (?<rate>\d+)").unwrap();
-            let caps = re.captures(s).unwrap();
-            if caps["rate"] != "0" {
+            let caps = re.captures(&s).unwrap();
+            if &caps["rate"] != "0" {
                 "OK".to_string()
             } else {
                 format!("FAIL (rate_limit not set = {})", s)


### PR DESCRIPTION
Add rate_limit check to auditd container watchdog

#### Why I did it
Auditd container recently enable rate limit, need watch dock to check this change applied correctly.

##### Work item tracking
- Microsoft ADO **(number only)**:32313402

#### How I did it
Add rate_limit check to auditd container watchdog

#### How to verify it
Pass all test case.

New test case added by: https://github.com/sonic-net/sonic-mgmt/pull/18555

Manually verified the feature works, checked 4 cases:
1. running config match with /etc/audit/audit.rules, will return: OK
2. running config mismatch with /etc/audit/audit.rules, will return: FAIL (rate_limit: {} mismatch with config file setting: {})
2. running config rate limit no set, but rate limit set in /etc/audit/audit.rules, will return: FAIL (rate_limit not set = {}, config file setting: {})
3. rate limit disabled in /etc/audit/audit.rules, will return: OK

root@vlab-01:/# curl -v http://localhost:50058/
*   Trying 127.0.0.1:50058...
* Connected to localhost (127.0.0.1) port 50058 (#0)
> GET / HTTP/1.1
> Host: localhost:50058
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 500 Internal Server Error
< Content-Type: application/json
< Content-Length: 709
<
{
  "auditd_conf":"OK",
  "syslog_conf":"OK",
  "auditd_rules":"OK",
  "auditd_service":"OK",
  "auditd_active":"OK",
  "auditd_reload":"OK",
  "rate_limit":"OK"
* Connection #0 to host localhost left intact
}r

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Add rate_limit check to auditd container watchdog

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)


