### PR TITLE
[Mellanox] Fix test test_setup_logger for mellanox platform

### DIFF
--- a/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
@@ -66,9 +66,12 @@ class TestDpuCtlPlatInit:
         """Test logger setup"""
         # Test with print mode
         dpuctl_obj.setup_logger(True)
-        assert dpuctl_obj.logger_info == print
-        assert dpuctl_obj.logger_error == print
-        assert dpuctl_obj.logger_debug == print
+        # Test that the logger functions add timestamps
+        with patch('time.strftime') as mock_time:
+            mock_time.return_value = "2024-01-01 12:00:00"
+            with patch('builtins.print') as mock_print:
+                dpuctl_obj.logger_info("test message")
+                mock_print.assert_called_once_with("[2024-01-01 12:00:00] test message")
 
         # Test with syslogger mode
         dpuctl_obj.setup_logger(False)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
As the function `setup_logger` was changed to not use print anymore the test case `test_setup_logger` fails during pytest execution. This is the fix PR

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

