### PR TITLE
Bound eventd data cache vector and map and call malloc trim after emptied

### DIFF
--- a/src/sonic-eventd/Makefile
+++ b/src/sonic-eventd/Makefile
@@ -11,7 +11,7 @@ EVENTD_MONIT_CONF := tools/monit_events
 CP := cp
 MKDIR := mkdir
 CC := g++
-LIBS := -levent -lhiredis -lswsscommon -lpthread -lboost_thread -lboost_system -lzmq -lboost_serialization -luuid -llua5.1
+LIBS := -levent -lhiredis -lswsscommon -lpthread -lboost_thread -lboost_system -lzmq -lboost_serialization -luuid -llua5.1 -ljemalloc
 TEST_LIBS := -L/usr/src/gtest -lgtest -lgtest_main -lgmock -lgmock_main
 
 CFLAGS += -Wall -std=c++17 -fPIE -I$(PWD)/../sonic-swss-common/common

--- a/src/sonic-eventd/Makefile
+++ b/src/sonic-eventd/Makefile
@@ -11,7 +11,7 @@ EVENTD_MONIT_CONF := tools/monit_events
 CP := cp
 MKDIR := mkdir
 CC := g++
-LIBS := -levent -lhiredis -lswsscommon -lpthread -lboost_thread -lboost_system -lzmq -lboost_serialization -luuid -llua5.1 -ljemalloc
+LIBS := -levent -lhiredis -lswsscommon -lpthread -lboost_thread -lboost_system -lzmq -lboost_serialization -luuid -llua5.1
 TEST_LIBS := -L/usr/src/gtest -lgtest -lgtest_main -lgmock -lgmock_main
 
 CFLAGS += -Wall -std=c++17 -fPIE -I$(PWD)/../sonic-swss-common/common

--- a/src/sonic-eventd/src/eventd.cpp
+++ b/src/sonic-eventd/src/eventd.cpp
@@ -1,5 +1,6 @@
 #include <thread>
 #include <memory>
+#include <malloc.h>
 #include "eventd.h"
 #include "dbconnector.h"
 #include "zmq.h"
@@ -681,7 +682,7 @@ run_eventd_service()
     RET_ON_ERR(stats_instance.is_running(), "Failed to start stats instance");
 
     while(code != EVENT_EXIT) {
-        int resp = -1;
+        int resp = -1, rv = -1;
         event_serialized_lst_t req_data, resp_data;
 
         RET_ON_ERR(service.channel_read(code, req_data) == 0,
@@ -730,6 +731,12 @@ run_eventd_service()
                 }
                 capture.reset();
 
+                rv = malloc_trim(0);
+                if (rv == 1) {
+                    SWSS_LOG_INFO("Memory released successfully");
+                } else {
+                    SWSS_LOG_INFO("No memory released by malloc_trim");
+                }
                 /* Unpause heartbeat upon stop caching */
                 stats_instance.heartbeat_ctrl();
                 break;

--- a/src/sonic-eventd/tests/eventd_ut.cpp
+++ b/src/sonic-eventd/tests/eventd_ut.cpp
@@ -716,7 +716,7 @@ TEST(eventd, service)
 
 void
 wait_for_heartbeat(stats_collector &stats_instance, long unsigned int cnt,
-        int wait_ms = 3000)
+        int wait_ms = 61000)
 {
     int diff = 0;
 
@@ -763,6 +763,7 @@ TEST(eventd, heartbeat)
 
     /* Wait for any non-zero heartbeat */
     wait_for_heartbeat(stats_instance, 0);
+
 
     /* Pause heartbeat */
     stats_instance.heartbeat_ctrl(true);


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

