### PR TITLE
Addition of prober_type field for MUX_CABLE

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2460,6 +2460,7 @@
         "MUX_CABLE": {
             "Ethernet4": {
                 "cable_type": "active-active",
+                "prober_type": "software",
                 "server_ipv4": "192.168.0.2/32",
                 "server_ipv6": "fc02:1000::30/128",
                 "soc_ipv4": "192.168.0.3/32",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mux_cable.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mux_cable.json
@@ -54,6 +54,7 @@
                     {
                         "ifname": "Ethernet4",
                         "cable_type": "active-active",
+                        "prober_type": "software",
                         "server_ipv4": "192.168.0.2/32",
                         "server_ipv6": "fc02:1000::30/128",
                         "soc_ipv4": "192.168.0.3/32",

--- a/src/sonic-yang-models/yang-models/sonic-mux-cable.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mux-cable.yang
@@ -50,6 +50,15 @@ module sonic-mux-cable {
                     description "SONiC DualToR interface cable type.";
                 }
 
+                leaf prober_type {
+                    type enumeration {
+                        enum hardware;
+                        enum software;
+                    }
+                    default software;
+                    description "DualToR LinkMrgrd Icmp Prober mode.";
+                }
+
                 leaf server_ipv4 {
                     type inet:ipv4-prefix;
 


### PR DESCRIPTION


#### Why I did it

New prober_type harware is being added to linkmgrd. This is config knob yang addition for the specific field in mUX_CABLE

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

