### PR TITLE
[Arista SKUs] Use more generic JSON reboot cause extra info file

### DIFF
--- a/device/arista/x86_64-arista_common/platform_update_reboot_cause
+++ b/device/arista/x86_64-arista_common/platform_update_reboot_cause
@@ -1,19 +1,25 @@
 #!/usr/bin/env python3
 
+import json
 import os
 from datetime import datetime, timezone
 
 REBOOT_CAUSE_DIR = "/host/reboot-cause/"
-REBOOT_LC_BY_SUPERVISOR_FILE = os.path.join(REBOOT_CAUSE_DIR, "reboot-lc-by-supervisor.txt")
+REBOOT_CAUSE_PLATFORM_DIR = "/host/reboot-cause/platform"
+REBOOT_EXTRA_INFO_FILE = os.path.join(REBOOT_CAUSE_PLATFORM_DIR, "reboot-extra-info.json")
 
 def main():
-    reboot_time = datetime.now(timezone.utc).strftime("%a %b %d %I:%M:%S %p %Z %Y")
-
-    if os.path.exists(REBOOT_LC_BY_SUPERVISOR_FILE):
-        os.remove(REBOOT_LC_BY_SUPERVISOR_FILE)
-        with open(os.path.join(REBOOT_CAUSE_DIR, "reboot-cause.txt"), 'w') as reboot_cause_file:
-            reboot_msg = "User issued 'Reboot from Supervisor' command [User: Supervisor, Time: {}]".format(reboot_time)
-            reboot_cause_file.write(reboot_msg)
+    if os.path.exists(REBOOT_EXTRA_INFO_FILE):
+        with open(REBOOT_EXTRA_INFO_FILE, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        os.remove(REBOOT_EXTRA_INFO_FILE)
+        who = data.get('from', None)
+        when = data.get('when', None)
+        if who is not None:
+            who = who.capitalize()
+            with open(os.path.join(REBOOT_CAUSE_DIR, "reboot-cause.txt"), 'w') as reboot_cause_file:
+                reboot_msg = f"User issued 'Reboot from {who}' command [User: {who}, Time: {when}]"
+                reboot_cause_file.write(reboot_msg)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Use a more structured file format to hold reboot cause information.
Also match the cause and user to that used in the tests.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

During design discussion, it was pointed out that having a file with no schema to
hold the reboot cause info is a bad idea. This patch addresses that change.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

