### PR TITLE
Added armed support in watchdog.py for watchdog-control.service

### DIFF
--- a/platform/pensando/sonic-platform-modules-dpu/sonic_platform/watchdog.py
+++ b/platform/pensando/sonic-platform-modules-dpu/sonic_platform/watchdog.py
@@ -16,6 +16,10 @@ try:
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
+WATCHDOG_STATUS = "/sys/class/watchdog/watchdog1/status"
+WATCHDOG_TIMEOUT = "/sys/class/watchdog/watchdog1/timeout"
+WATCHDOG_ARMED_MASK = 0x8000
+
 class Watchdog(WatchdogBase):
 
     def __init__(self):
@@ -24,22 +28,25 @@ class Watchdog(WatchdogBase):
     def arm(self, seconds):
         """
         For Pensando, watchdog gets handled by pensando image running on
-        docker:dpu docker. returning -1.
+        docker:dpu docker. it is armed but with default seconds, cannot be changed.
         """
+        timeout = open(WATCHDOG_TIMEOUT, "r").read()
+        if self.is_armed():
+            return timeout
         return -1
 
     def disarm(self):
         """
         For Pensando, watchdog gets handled by pensando image running on
-        docker:dpu docker. Setting disarm true to avoid watchdog-timer.service errors
+        docker:dpu docker. It cannot be disarmed
         """
-        return True
+        return False
 
     def is_armed(self):
-        """
-        For Pensando, watchdog gets handled by pensando image running on
-        docker:dpu docker. returning False
-        """
+        status_hex = open(WATCHDOG_STATUS, "r").read()
+        status = int(status_hex, 16)
+        if status & WATCHDOG_ARMED_MASK:
+            return True
         return False
 
     def get_remaining_time(self):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Watchdog is controlled by Pensando firmware container for Pensando DPU which is crucial for services running under docker container, hence it cannot be controlled. For watchdog-control.service (as per latest https://github.com/sonic-net/sonic-buildimage/pull/22315), in case of dpu, it is going to be armed hence added support to check if watchdog is armed and what is timeout set for it.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

```
git clone https://github.com/sonic-net/sonic-buildimage.git

make init
make configure PLATFORM=pensando PLATFORM_ARCH=arm64
NOJESSIE=1 NOSTRETCH=1 NOBUSTER=0 NOBULLSEYE=0 make target/sonic-pensando.tar
```
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Load the SONiC image from ONIE and make sure the interfaces are UP. All containers are up.
watchdogutil status should show status as armed.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

#### CLI Output
```
root@sonic:/home/admin# systemctl status watchdog-control.service
○ watchdog-control.service - watchdog control service
     Loaded: loaded (/lib/systemd/system/watchdog-control.service; enabled-runtime; preset: enabled)
     Active: inactive (dead) since Mon 2025-05-19 05:10:51 UTC; 1s ago
   Duration: 576ms
    Process: 98374 ExecStart=/usr/local/bin/watchdog-control.sh (code=exited, status=0/SUCCESS)
   Main PID: 98374 (code=exited, status=0/SUCCESS)
        CPU: 395ms

May 19 05:10:51 sonic systemd[1]: Started watchdog-control.service - watchdog control service.
May 19 05:10:51 sonic watchdog-control.sh[98380]: Watchdog armed for 60 seconds
May 19 05:10:51 sonic systemd[1]: watchdog-control.service: Deactivated successfully.

root@sonic:/home/admin# watchdogutil status
Status: Armed
Time remaining: -1 seconds
```
