### PR TITLE
Revert "Update dockerfiles to do staged builds"

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -291,8 +291,8 @@ endif
 DOCKER_LOCKFILE_SAVE := $(DOCKER_LOCKDIR)/docker_save.lock
 $(shell mkdir -m 0777 -p $(DOCKER_LOCKDIR))
 $(shell [ -f $(DOCKER_LOCKFILE_SAVE) ] || (touch $(DOCKER_LOCKFILE_SAVE) && chmod 0777 $(DOCKER_LOCKFILE_SAVE)))
-$(shell [ -d $(DOCKER_ROOT) ] && docker run --rm -v $(DOCKER_ROOT)\:/mount $(DEFAULT_CONTAINER_REGISTRY)debian:bookworm sh -c 'rm -rf /mount/*')
-$(shell mkdir -p $(DOCKER_ROOT))
+$(shell [ -d $(DOCKER_ROOT) ] && docker run --rm -v $(DOCKER_ROOT)\:/mount debian sh -c 'rm -rf /mount/*')
+$(mkdir -p $(DOCKER_ROOT))
 
 ifeq ($(DOCKER_BUILDER_MOUNT),)
 override DOCKER_BUILDER_MOUNT := "$(PWD):/sonic"
@@ -302,8 +302,6 @@ ifeq ($(DOCKER_BUILDER_WORKDIR),)
 override DOCKER_BUILDER_WORKDIR := "/sonic"
 endif
 
-# Consider removing the --ulimit flag once nothing older
-# than Bullseye is being used as a slave container.
 DOCKER_RUN := docker run --rm=true --privileged --init \
     -v $(DOCKER_BUILDER_MOUNT) \
     -v "$(DOCKER_LOCKDIR):$(DOCKER_LOCKDIR)" \
@@ -312,7 +310,6 @@ DOCKER_RUN := docker run --rm=true --privileged --init \
     -e "https_proxy=$(https_proxy)" \
     -e "no_proxy=$(no_proxy)" \
     -i$(shell { if [ -t 0 ]; then echo t; fi }) \
-    --ulimit nofile=524288:524288 \
     $(SONIC_BUILDER_EXTRA_CMDLINE)
 
 # Mount the $(DOCKER_ROOT) to /var/lib/docker in the slave container, the overlay fs is not supported as dockerd root folder.

--- a/dockers/docker-base-bookworm/Dockerfile.j2
+++ b/dockers/docker-base-bookworm/Dockerfile.j2
@@ -1,14 +1,26 @@
 {% set prefix = DEFAULT_CONTAINER_REGISTRY %}
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 {% if CONFIGURED_ARCH == "armhf" and (MULTIARCH_QEMU_ENVIRON == "y" or CROSS_BUILD_ENVIRON == "y") %}
-ARG BASE=--platform=linux/arm/v7 {{ prefix }}debian:bookworm
+FROM --platform=linux/arm/v7 {{ prefix }}debian:bookworm
 {% elif CONFIGURED_ARCH == "arm64" and (MULTIARCH_QEMU_ENVIRON == "y" or CROSS_BUILD_ENVIRON == "y") %}
-ARG BASE=--platform=linux/arm64 {{ prefix }}debian:bookworm
+FROM --platform=linux/arm64 {{ prefix }}debian:bookworm
 {% else %}
-ARG BASE={{ prefix }}{{DOCKER_BASE_ARCH}}/debian:bookworm
+FROM {{ prefix }}{{DOCKER_BASE_ARCH}}/debian:bookworm
 {% endif %}
 
-FROM $BASE AS base
+# Clean documentation in FROM image
+RUN find /usr/share/doc -depth \( -type f -o -type l \) ! -name copyright | xargs rm || true
+
+# Clean doc directories that are empty or only contain empty directories
+RUN while [ -n "$(find /usr/share/doc -depth -type d -empty -print -exec rmdir {} +)" ]; do :; done && \
+    rm -rf               \
+    /usr/share/man/*     \
+    /usr/share/groff/*   \
+    /usr/share/info/*    \
+    /usr/share/lintian/* \
+    /usr/share/linda/*   \
+    /var/cache/man/*     \
+    /usr/share/locale/*
 
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -35,8 +47,6 @@ RUN apt update &&            \
         python-is-python3    \
         vim-tiny             \
         rsyslog              \
-# Install rsync for copying over only changes between layers
-        rsync                \
 # Install redis-tools
         redis-tools          \
 # common dependencies
@@ -74,6 +84,12 @@ RUN mkdir -p /var/log/supervisor /etc/supervisor/conf.d
 # Uninstall unused dependencies
 RUN apt autoremove -y --purge
 
+RUN apt-get -y purge   \
+    exim4              \
+    exim4-base         \
+    exim4-config       \
+    exim4-daemon-light
+
 {% if docker_base_bookworm_debs.strip() -%}
 # Copy locally-built Debian package dependencies
 {{ copy_files("debs/", docker_base_bookworm_debs.split(' '), "/debs/") }}
@@ -82,6 +98,13 @@ RUN apt autoremove -y --purge
 {{ install_debian_packages(docker_base_bookworm_debs.split(' ')) }}
 {%- endif %}
 
+# Clean up apt
+# Remove /var/lib/apt/lists/*, could be obsoleted for derived images
+RUN apt-get clean -y                     && \
+    apt-get autoclean -y                 && \
+    apt-get autoremove -y                && \
+    rm -rf /var/lib/apt/lists/* /tmp/* ~/.cache
+
 COPY ["etc/rsyslog.conf", "/etc/rsyslog.conf"]
 COPY ["etc/rsyslog.d/*", "/etc/rsyslog.d/"]
 COPY ["root/.vimrc", "/root/.vimrc"]
@@ -89,7 +112,3 @@ COPY ["root/.vimrc", "/root/.vimrc"]
 RUN ln /usr/bin/vim.tiny /usr/bin/vim
 
 COPY ["etc/supervisor/supervisord.conf", "/etc/supervisor/"]
-
-FROM scratch
-
-COPY --from=base / /

--- a/dockers/docker-base-bullseye/Dockerfile.j2
+++ b/dockers/docker-base-bullseye/Dockerfile.j2
@@ -1,14 +1,26 @@
 {% set prefix = DEFAULT_CONTAINER_REGISTRY %}
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 {% if CONFIGURED_ARCH == "armhf" and (MULTIARCH_QEMU_ENVIRON == "y" or CROSS_BUILD_ENVIRON == "y") %}
-ARG BASE={{ prefix }}multiarch/debian-debootstrap:armhf-bullseye
+FROM {{ prefix }}multiarch/debian-debootstrap:armhf-bullseye
 {% elif CONFIGURED_ARCH == "arm64" and (MULTIARCH_QEMU_ENVIRON == "y" or CROSS_BUILD_ENVIRON == "y") %}
-ARG BASE={{ prefix }}multiarch/debian-debootstrap:arm64-bullseye
+FROM {{ prefix }}multiarch/debian-debootstrap:arm64-bullseye
 {% else %}
-ARG BASE={{ prefix }}{{DOCKER_BASE_ARCH}}/debian:bullseye
+FROM {{ prefix }}{{DOCKER_BASE_ARCH}}/debian:bullseye
 {% endif %}
 
-FROM $BASE AS base
+# Clean documentation in FROM image
+RUN find /usr/share/doc -depth \( -type f -o -type l \) ! -name copyright | xargs rm || true
+
+# Clean doc directories that are empty or only contain empty directories
+RUN while [ -n "$(find /usr/share/doc -depth -type d -empty -print -exec rmdir {} +)" ]; do :; done && \
+    rm -rf               \
+    /usr/share/man/*     \
+    /usr/share/groff/*   \
+    /usr/share/info/*    \
+    /usr/share/lintian/* \
+    /usr/share/linda/*   \
+    /var/cache/man/*     \
+    /usr/share/locale/*
 
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -33,8 +45,6 @@ RUN apt-get update &&        \
         python3-pip          \
         python-is-python3    \
         vim-tiny             \
-# Install rsync for copying over only changes between layers
-        rsync                \
 # Install redis-tools
         redis-tools          \
 # common dependencies
@@ -90,6 +100,13 @@ RUN apt-get -y purge   \
 {{ install_debian_packages(docker_base_bullseye_debs.split(' ')) }}
 {%- endif %}
 
+# Clean up apt
+# Remove /var/lib/apt/lists/*, could be obsoleted for derived images
+RUN apt-get clean -y                     && \
+    apt-get autoclean -y                 && \
+    apt-get autoremove -y                && \
+    rm -rf /var/lib/apt/lists/* /tmp/* ~/.cache
+
 COPY ["etc/rsyslog.conf", "/etc/rsyslog.conf"]
 COPY ["etc/rsyslog.d/*", "/etc/rsyslog.d/"]
 COPY ["root/.vimrc", "/root/.vimrc"]
@@ -97,7 +114,3 @@ COPY ["root/.vimrc", "/root/.vimrc"]
 RUN ln /usr/bin/vim.tiny /usr/bin/vim
 
 COPY ["etc/supervisor/supervisord.conf", "/etc/supervisor/"]
-
-FROM scratch
-
-COPY --from=base / /

--- a/dockers/docker-config-engine-bookworm/Dockerfile.j2
+++ b/dockers/docker-config-engine-bookworm/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-base-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-base-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -51,17 +49,10 @@ COPY ["files/readiness_probe.sh", "/usr/bin/"]
 COPY ["files/container_startup.py", "/usr/share/sonic/scripts/"]
 
 ## Clean up
-
-{%- if CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" %}
-RUN apt-get purge -y        \
-        libxslt-dev         \
-        libz-dev
-{%- endif %}
-
-RUN apt-get purge -y        \
-        python3-dev         \
-        build-essential
-
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
+RUN apt-get purge -y               \
+        python3-dev                \
+        build-essential         && \
+    apt-get clean -y            && \
+    apt-get autoclean -y        && \
+    apt-get autoremove -y       && \
+    rm -rf /debs /python-wheels ~/.cache

--- a/dockers/docker-config-engine-bullseye/Dockerfile.j2
+++ b/dockers/docker-config-engine-bullseye/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-base-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-base-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -57,7 +55,3 @@ RUN apt-get purge -y               \
     apt-get autoclean -y        && \
     apt-get autoremove -y       && \
     rm -rf /debs /python-wheels ~/.cache
-
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /

--- a/dockers/docker-database/Dockerfile.j2
+++ b/dockers/docker-database/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -25,8 +23,12 @@ RUN pip3 install click
 {{ install_debian_packages(docker_database_debs.split(' ')) }}
 {%- endif %}
 
-# Configure redis settings
-RUN sed -ri 's/^# save ""$/save ""/g;                    \
+# Clean up
+RUN apt-get clean -y                                  && \
+    apt-get autoclean -y                              && \
+    apt-get autoremove -y                             && \
+    rm -rf /debs ~/.cache                             && \
+    sed -ri 's/^# save ""$/save ""/g;                    \
              s/^daemonize yes$/daemonize no/;            \
              s/^logfile .*$/logfile ""/;                 \
              s/^# syslog-enabled no$/syslog-enabled no/; \
@@ -48,9 +50,4 @@ COPY ["files/update_chassisdb_config", "/usr/local/bin/"]
 COPY ["flush_unused_database", "/usr/local/bin/"]
 COPY ["multi_database_config.json.j2", "/usr/share/sonic/templates/"]
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/docker-database-init.sh"]

--- a/dockers/docker-dhcp-relay/Dockerfile.j2
+++ b/dockers/docker-dhcp-relay/Dockerfile.j2
@@ -1,13 +1,14 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 ARG image_version
 
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Pass the image_version to container
+ENV IMAGE_VERSION=$image_version
 
 # Update apt's cache of available packages
 RUN apt-get update
@@ -37,6 +38,10 @@ RUN pip3 install psutil
 # Clean up
 RUN apt-get remove -y build-essential     \
                 python3-dev
+RUN apt-get clean -y         && \
+    apt-get autoclean -y     && \
+    apt-get autoremove -y    && \
+    rm -rf /debs
 
 COPY ["docker_init.sh", "start.sh", "/usr/bin/"]
 COPY ["docker-dhcp-relay.supervisord.conf.j2", "port-name-alias-map.txt.j2", "wait_for_intf.sh.j2", "/usr/share/sonic/templates/"]
@@ -44,14 +49,5 @@ COPY ["dhcp-relay.programs.j2", "dhcpv4-relay.agents.j2", "dhcpv6-relay.agents.j
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 COPY ["cli", "/cli/"]
-
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-# Pass the image_version to container
-ENV IMAGE_VERSION=$image_version
-
-ENV DEBIAN_FRONTEND=noninteractive
 
 ENTRYPOINT ["/usr/bin/docker_init.sh"]

--- a/dockers/docker-dhcp-server/Dockerfile.j2
+++ b/dockers/docker-dhcp-server/Dockerfile.j2
@@ -1,13 +1,14 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 ARG image_version
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Pass the image_version to container
+ENV IMAGE_VERSION=$image_version
 
 RUN apt-get update &&       \
     apt-get install -f -y   \
@@ -40,6 +41,11 @@ RUN pip3 install psutil
 RUN apt-get remove -y build-essential     \
                       python3-dev
 
+RUN apt-get clean -y        && \
+    apt-get autoclean -y    && \
+    apt-get autoremove -y   && \
+    rm -rf /debs
+
 COPY ["docker_init.sh", "start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
@@ -49,12 +55,4 @@ COPY ["lease_update.sh", "/etc/kea/"]
 COPY ["kea-dhcp4-init.conf", "/etc/kea/kea-dhcp4.conf"]
 COPY ["cli", "/cli/"]
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-# Pass the image_version to container
-ENV IMAGE_VERSION=$image_version
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/bin/docker_init.sh"]

--- a/dockers/docker-eventd/Dockerfile.j2
+++ b/dockers/docker-eventd/Dockerfile.j2
@@ -1,13 +1,15 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 ARG image_version
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%syslogtag%/;" /etc/rsyslog.conf
 
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Pass the image_version to container
+ENV IMAGE_VERSION=$image_version
 
 # Update apt's cache of available packages
 RUN apt-get update
@@ -19,6 +21,12 @@ RUN apt-get update
 # Install built Debian packages and implicitly install their dependencies
 {{ install_debian_packages(docker_eventd_debs.split(' ')) }}
 {%- endif %}
+
+# Clean up
+RUN apt-get clean -y         && \
+    apt-get autoclean -y     && \
+    apt-get autoremove -y    && \
+    rm -rf /debs
 
 RUN mkdir -p /etc/rsyslog.d/rsyslog_plugin_conf
 
@@ -43,12 +51,4 @@ RUN rm -f /etc/rsyslog.d/rsyslog_plugin_conf/dhcp_relay_events_info.json
 RUN rm -f /etc/rsyslog.d/rsyslog_plugin_conf/swss_events_info.json
 RUN rm -f /etc/rsyslog.d/rsyslog_plugin_conf/syncd_events_info.json
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-# Pass the image_version to container
-ENV IMAGE_VERSION=$image_version
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-fpm-frr/Dockerfile.j2
+++ b/dockers/docker-fpm-frr/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 ARG frr_user_uid
@@ -15,8 +13,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install required packages
 RUN apt-get update   && \
     apt-get install -y  \
+        libc-ares2      \
         iproute2        \
-        logrotate
+        logrotate       \
+        libunwind8
 
 RUN groupadd -g ${frr_user_gid} frr
 RUN useradd -u ${frr_user_uid} -g ${frr_user_gid} -M -s /bin/false frr
@@ -39,6 +39,12 @@ RUN useradd -u ${frr_user_uid} -g ${frr_user_gid} -M -s /bin/false frr
 
 RUN chown -R ${frr_user_uid}:${frr_user_gid} /etc/frr/
 
+# Clean up
+RUN apt-get clean -y      && \
+    apt-get autoclean -y  && \
+    apt-get autoremove -y && \
+    rm -rf /debs ~/.cache /python-wheels
+
 COPY ["frr", "/usr/share/sonic/templates"]
 COPY ["docker_init.sh", "/usr/bin/"]
 COPY ["snmp.conf", "/etc/snmp/frr.conf"]
@@ -52,11 +58,5 @@ RUN chmod a+x /usr/bin/TSA && \
     chmod a+x /usr/bin/TSB && \
     chmod a+x /usr/bin/TSC && \
     chmod a+x /usr/bin/zsocket.sh
-
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 
 ENTRYPOINT ["/usr/bin/docker_init.sh"]

--- a/dockers/docker-iccpd/Dockerfile.j2
+++ b/dockers/docker-iccpd/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -11,23 +9,25 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y iptables
 
-{% if docker_iccpd_debs.strip() -%}
-# Copy built Debian packages
-{{ copy_files("debs/", docker_iccpd_debs.split(' '), "/debs/") }}
+COPY \
+{% for deb in docker_iccpd_debs.split(' ') -%}
+debs/{{ deb }}{{' '}}
+{%- endfor -%}
+debs/
 
-# Install built Debian packages and implicitly install their dependencies
-{{ install_debian_packages(docker_iccpd_debs.split(' ')) }}
-{%- endif %}
+RUN dpkg -i \
+{% for deb in docker_iccpd_debs.split(' ') -%}
+debs/{{ deb }}{{' '}}
+{%- endfor %}
 
 COPY ["start.sh", "iccpd.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["iccpd.j2", "/usr/share/sonic/templates/"]
 
 RUN chmod +x /usr/bin/start.sh /usr/bin/iccpd.sh
+RUN apt-get clean -y      && \
+    apt-get autoclean -y  && \
+    apt-get autoremove -y && \
+    rm -rf /debs
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-lldp/Dockerfile.j2
+++ b/dockers/docker-lldp/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 ARG image_version
@@ -31,6 +29,14 @@ RUN apt-get update
 {{ install_python_wheels(docker_lldp_whls.split(' ')) }}
 {% endif %}
 
+# Clean up
+RUN apt-get clean -y            && \
+    apt-get autoclean -y        && \
+    apt-get autoremove -y       && \
+    rm -rf /debs                   \
+           /python-wheels          \
+           ~/.cache
+
 COPY ["docker-lldp-init.sh", "/usr/bin/"]
 COPY ["start.sh", "/usr/bin/"]
 COPY ["waitfor_lldp_ready.sh", "/usr/bin/"]
@@ -42,12 +48,4 @@ COPY ["lldpmgrd", "/usr/bin/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-# Pass the image_version to container
-ENV IMAGE_VERSION=$image_version
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/bin/docker-lldp-init.sh"]

--- a/dockers/docker-macsec/Dockerfile.j2
+++ b/dockers/docker-macsec/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -18,15 +16,15 @@ RUN apt-get update
 {{ install_debian_packages(docker_macsec_debs.split(' ')) }}
 {%- endif %}
 
+RUN apt-get clean -y      && \
+    apt-get autoclean -y  && \
+    apt-get autoremove -y && \
+    rm -rf /debs
+
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 COPY ["etc/wpa_supplicant.conf", "/etc/wpa_supplicant.conf"]
 COPY ["cli", "/cli/"]
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-mux/Dockerfile.j2
+++ b/dockers/docker-mux/Dockerfile.j2
@@ -1,14 +1,14 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
+RUN apt-get update &&       \
+    apt-get install -f -y   \
+        libmnl0
 
 {% if docker_mux_debs.strip() -%}
 # Copy locally-built Debian package dependencies
@@ -18,6 +18,12 @@ RUN apt-get update
 {{ install_debian_packages(docker_mux_debs.split(' ')) }}
 {%- endif %}
 
+## Clean up
+RUN apt-get clean -y        && \
+    apt-get autoclean -y    && \
+    apt-get autoremove -y   && \
+    rm -rf /debs
+
 COPY ["docker-init.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
@@ -26,9 +32,4 @@ COPY ["critical_processes", "/etc/supervisor/"]
 ## Copy all Jinja2 template files into the templates folder
 COPY ["*.j2", "/usr/share/sonic/templates/"]
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/bin/docker-init.sh"]

--- a/dockers/docker-nat/Dockerfile.j2
+++ b/dockers/docker-nat/Dockerfile.j2
@@ -1,9 +1,9 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, copy_files %}
-ARG BASE=docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
+
+RUN echo
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -12,6 +12,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ## TODO: implicitly install dependencies
 RUN apt-get update        \
 && apt-get install -f -y \
+       libelf1           \
+       libmnl0           \
        bridge-utils      \
        conntrack
 
@@ -29,9 +31,7 @@ COPY ["restore_nat_entries.py", "/usr/bin/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
-FROM $BASE
+RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
+RUN rm -rf /debs
 
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -15,12 +13,16 @@ RUN apt-get update &&       \
         iproute2            \
         ndisc6              \
         tcpdump             \
+        libelf1             \
+        libmnl0             \
         bridge-utils        \
         conntrack           \
         ndppd               \
         python3-protobuf    \
         pciutils            \
-        python3-netifaces
+        # Needed for installing netifaces Python package
+        build-essential     \
+        python3-dev
 
 {% if ( CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" ) %}
 # Fix for gcc/python/iputils-ping not found in arm docker
@@ -30,7 +32,9 @@ RUN apt-get install -y   \
 {% endif %}
 
 # Dependencies of restore_neighbors.py
-RUN pip3 install pyroute2==0.5.14
+RUN pip3 install \
+         pyroute2==0.5.14 \
+         netifaces==0.10.9
 
 {% if ( CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" ) %}
 # Remove installed gcc
@@ -54,7 +58,13 @@ RUN apt-get remove -y gcc
 {% endif %}
 
 # Clean up
-RUN apt-get purge -y build-essential python3-dev
+RUN apt-get purge -y          \
+        build-essential       \
+        python3-dev        && \
+    apt-get clean -y       && \
+    apt-get autoclean -y   && \
+    apt-get autoremove -y  && \
+    rm -rf /debs ~/.cache
 
 COPY ["files/arp_update", "/usr/bin"]
 COPY ["arp_update.conf", "files/arp_update_vars.j2", "/usr/share/sonic/templates/"]
@@ -69,11 +79,5 @@ COPY ["*.j2", "/usr/share/sonic/templates/"]
 RUN sonic-cfggen -a "{\"ENABLE_ASAN\":\"{{ENABLE_ASAN}}\"}" -t /usr/share/sonic/templates/docker-init.j2 > /usr/bin/docker-init.sh
 RUN rm -f /usr/share/sonic/templates/docker-init.j2
 RUN chmod 755 /usr/bin/docker-init.sh
-
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 
 ENTRYPOINT ["/usr/bin/docker-init.sh"]

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 ARG image_version
@@ -26,7 +24,6 @@ RUN apt-get update &&   \
         i2c-tools       \
         psmisc          \
         python3-jsonschema \
-        python3-netifaces \
         libpci3         \
         iputils-ping    \
         pciutils        \
@@ -49,8 +46,8 @@ RUN apt-get install -y -t bookworm-backports \
 RUN pip3 install grpcio==1.51.1 \
         grpcio-tools==1.51.1
 
-# Barefoot platform vendors' sonic_platform packages import these Python libraries (and netifaces)
-RUN pip3 install thrift==0.13.0
+# Barefoot platform vendors' sonic_platform packages import these Python libraries
+RUN pip3 install thrift==0.13.0 netifaces
 
 # Ragile platform vendors' sonic_platform packages import these Python libraries
 RUN pip3 install requests
@@ -95,7 +92,13 @@ RUN pip3 install smbus2
 # Clean up
 RUN apt-get purge -y           \
         build-essential        \
-        python3-dev
+        python3-dev         && \
+    apt-get clean -y        && \
+    apt-get autoclean -y    && \
+    apt-get autoremove -y   && \
+    rm -rf /debs               \
+           /python-wheels      \
+           ~/.cache
 
 COPY ["lm-sensors.sh", "/usr/bin/"]
 COPY ["docker-pmon.supervisord.conf.j2", "docker_init.j2", "/usr/share/sonic/templates/"]
@@ -109,12 +112,4 @@ RUN sonic-cfggen -a "{\"CONFIGURED_PLATFORM\":\"{{CONFIGURED_PLATFORM}}\"}" -t /
 RUN rm -f /usr/share/sonic/templates/docker_init.j2
 RUN chmod 755 /usr/bin/docker_init.sh
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-# Pass the image_version to container
-ENV IMAGE_VERSION=$image_version
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/bin/docker_init.sh"]

--- a/dockers/docker-router-advertiser/Dockerfile.j2
+++ b/dockers/docker-router-advertiser/Dockerfile.j2
@@ -1,10 +1,9 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 ARG image_version
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%syslogtag%/;" /etc/rsyslog.conf
 
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -26,18 +25,16 @@ RUN apt-get -y install radvd
 {{ install_debian_packages(docker_router_advertiser_debs.split(' ')) }}
 {%- endif %}
 
+# Clean up
+RUN apt-get clean -y        && \
+    apt-get autoclean -y    && \
+    apt-get autoremove -y   && \
+    rm -rf /debs
+
 COPY ["start.sh", "/usr/bin/"]
 COPY ["docker-init.sh", "/usr/bin/"]
 COPY ["radvd.conf.j2", "wait_for_link.sh.j2", "docker-router-advertiser.supervisord.conf.j2", "/usr/share/sonic/templates/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-# Pass the image_version to container
-ENV IMAGE_VERSION=$image_version
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/bin/docker-init.sh"]

--- a/dockers/docker-sflow/Dockerfile.j2
+++ b/dockers/docker-sflow/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -10,7 +8,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update      && \
     apt-get install -f -y  \
-            dmidecode
+            dmidecode      \
+            libmnl0
 
 {% if docker_sflow_debs.strip() -%}
 # Copy locally-built Debian package dependencies
@@ -20,6 +19,11 @@ RUN apt-get update      && \
 {{ install_debian_packages(docker_sflow_debs.split(' ')) }}
 {%- endif %}
 
+RUN apt-get clean -y      && \
+    apt-get autoclean -y  && \
+    apt-get autoremove -y && \
+    rm -rf /debs
+
 RUN sed -ri '/^DAEMON_ARGS=""/c DAEMON_ARGS="-c /var/log/hsflowd.crash"' /etc/init.d/hsflowd
 
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
@@ -27,9 +31,4 @@ COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 COPY ["port_index_mapper.py", "/usr/bin"]
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-snmp/Dockerfile.j2
+++ b/dockers/docker-snmp/Dockerfile.j2
@@ -1,13 +1,11 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python3_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 ARG image_version
 
 # Enable -O for all Python calls
-ENV PYTHONOPTIMIZE=1
+ENV PYTHONOPTIMIZE 1
 
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -32,6 +30,15 @@ RUN apt-get update   && \
 {{ install_debian_packages(docker_snmp_debs.split(' ')) }}
 {%- endif %}
 
+# Fix for hiredis compilation issues for ARM
+# python will throw for missing locale
+RUN apt-get install -y locales
+RUN locale-gen "en_US.UTF-8"
+RUN dpkg-reconfigure --frontend noninteractive locales
+ENV LC_CTYPE=en_US.UTF-8
+RUN sed -i '/^#.* en_US.* /s/^#//' /etc/locale.gen
+RUN locale-gen
+
 # Install dependencies used by some plugins
 RUN pip3 install --no-cache-dir \
         hiredis                             \
@@ -52,7 +59,12 @@ RUN python3 -m sonic_ax_impl install
 RUN apt-get -y purge     \
         python3-dev      \
         gcc              \
-        make
+        make                && \
+    apt-get clean -y        && \
+    apt-get autoclean -y    && \
+    apt-get autoremove -y --purge && \
+    find / | grep -E "__pycache__" | xargs rm -rf && \
+    rm -rf /debs /python-wheels ~/.cache
 
 COPY ["docker-snmp-init.sh", "/usr/bin/"]
 COPY ["start.sh", "/usr/bin/"]
@@ -65,18 +77,4 @@ COPY ["critical_processes", "/etc/supervisor"]
 EXPOSE 161/udp 162/udp
 
 RUN chmod +x /usr/bin/docker-snmp-init.sh
-
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-# Enable -O for all Python calls
-ENV PYTHONOPTIMIZE=1
-
-# Make apt-get non-interactive
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Pass the image_version to container
-ENV IMAGE_VERSION=$image_version
-
 ENTRYPOINT ["/usr/bin/docker-snmp-init.sh"]

--- a/dockers/docker-sonic-bmp/Dockerfile.j2
+++ b/dockers/docker-sonic-bmp/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 ARG image_version
@@ -30,7 +28,11 @@ RUN apt-get update
 {{ install_python_wheels(docker_sonic_bmp_whls.split(' ')) }}
 {% endif %}
 
-RUN mkdir -p /etc/bmp
+RUN apt-get clean -y      && \
+    apt-get autoclean -   && \
+    apt-get autoremove -y && \
+    rm -rf /debs && \
+    mkdir -p /etc/bmp
 
 COPY ["bmp.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
@@ -39,9 +41,9 @@ COPY ["critical_processes", "/etc/supervisor/"]
 
 RUN chmod +x /usr/bin/bmp.sh
 
-FROM $BASE
+RUN apt-get clean -y      && \
+    apt-get autoclean -y  && \
+    apt-get autoremove -y && \
+    rm -rf /debs
 
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-sonic-gnmi/Dockerfile.j2
+++ b/dockers/docker-sonic-gnmi/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 ARG image_version
@@ -22,20 +20,15 @@ RUN apt-get update
 {{ install_debian_packages(docker_sonic_gnmi_debs.split(' ')) }}
 {%- endif %}
 
+RUN apt-get clean -y      && \
+    apt-get autoclean -   && \
+    apt-get autoremove -y && \
+    rm -rf /debs
+
 COPY ["start.sh", "gnmi-native.sh", "dialout.sh", "/usr/bin/"]
 COPY ["telemetry_vars.j2", "/usr/share/sonic/templates/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
-
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-## Make apt-get non-interactive
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Pass the image_version to container
-ENV IMAGE_VERSION=$image_version
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
@@ -1,7 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -14,23 +11,23 @@ RUN apt-get update && \
 RUN pip3 install requests \
                  urllib3
 
-{% if docker_sonic_mgmt_framework_debs.strip() -%}
-# Copy built Debian packages
-{{ copy_files("debs/", docker_sonic_mgmt_framework_debs.split(' '), "/debs/") }}
+COPY \
+{% for deb in docker_sonic_mgmt_framework_debs.split(' ') -%}
+debs/{{ deb }}{{' '}}
+{%- endfor -%}
+debs/
 
-# Install built Debian packages and implicitly install their dependencies
-{{ install_debian_packages(docker_sonic_mgmt_framework_debs.split(' ')) }}
-{%- endif %}
+RUN dpkg -i \
+{% for deb in docker_sonic_mgmt_framework_debs.split(' ') -%}
+debs/{{ deb }}{{' '}}
+{%- endfor %}
 
 COPY ["start.sh", "rest-server.sh", "/usr/bin/"]
 COPY ["mgmt_vars.j2", "/usr/share/sonic/templates/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 
 RUN apt-get remove -y g++ python3-dev
+RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
+RUN rm -rf /debs ~/.cache
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-sonic-p4rt/Dockerfile.j2
+++ b/dockers/docker-sonic-p4rt/Dockerfile.j2
@@ -1,10 +1,9 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 ARG git_commit
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%syslogtag%/;" /etc/rsyslog.conf
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -19,15 +18,15 @@ RUN apt-get update
 {{ install_debian_packages(docker_sonic_p4rt_debs.split(' ')) }}
 {%- endif %}
 
+RUN apt-get clean -y      && \
+    apt-get autoclean -y  && \
+    apt-get autoremove -y && \
+    rm -rf /debs
+
 COPY ["start.sh", "p4rt.sh", "/usr/bin/"]
 COPY ["p4rt_vars.j2", "/usr/share/sonic/templates/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-sonic-restapi/Dockerfile.j2
+++ b/dockers/docker-sonic-restapi/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -18,14 +16,12 @@ RUN apt-get update
 {{ install_debian_packages( docker_sonic_restapi_debs.split(' ')) }}
 {%- endif %}
 
+## Clean up
+RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
+
 COPY ["start.sh", "restapi.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-sonic-telemetry/Dockerfile.j2
+++ b/dockers/docker-sonic-telemetry/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-sonic-gnmi-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 ARG image_version
@@ -22,19 +20,14 @@ RUN apt-get update
 {{ install_debian_packages(docker_sonic_telemetry_debs.split(' ')) }}
 {%- endif %}
 
+RUN apt-get clean -y      && \
+    apt-get autoclean -   && \
+    apt-get autoremove -y && \
+    rm -rf /debs
+
 COPY ["start.sh", "telemetry.sh", "dialout.sh", "/usr/bin/"]
 COPY ["telemetry_vars.j2", "/usr/share/sonic/templates/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["critical_processes", "/etc/supervisor"]
-
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-## Make apt-get non-interactive
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Pass the image_version to container
-ENV IMAGE_VERSION=$image_version
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-swss-layer-bookworm/Dockerfile.j2
+++ b/dockers/docker-swss-layer-bookworm/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -18,8 +16,9 @@ RUN apt-get install iputils-ping
 {{ install_debian_packages(docker_swss_layer_bookworm_debs.split(' ')) }}
 {%- endif %}
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
+RUN apt-get clean -y      && \
+    apt-get autoclean -y  && \
+    apt-get autoremove -y && \
+    rm -rf /debs
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-swss-layer-bullseye/Dockerfile.j2
+++ b/dockers/docker-swss-layer-bullseye/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -18,8 +16,9 @@ RUN apt-get install iputils-ping
 {{ install_debian_packages(docker_swss_layer_bullseye_debs.split(' ')) }}
 {%- endif %}
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
+RUN apt-get clean -y      && \
+    apt-get autoclean -y  && \
+    apt-get autoremove -y && \
+    rm -rf /debs
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-teamd/Dockerfile.j2
+++ b/dockers/docker-teamd/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -18,14 +16,14 @@ RUN apt-get update
 {{ install_debian_packages(docker_teamd_debs.split(' ')) }}
 {%- endif %}
 
+RUN apt-get clean -y      && \
+    apt-get autoclean -y  && \
+    apt-get autoremove -y && \
+    rm -rf /debs
+
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/files/build_templates/build_docker_cache.j2
+++ b/files/build_templates/build_docker_cache.j2
@@ -2,10 +2,10 @@
 FROM {{IMAGENAME}}
 
 # Copy the cache data to host
-FROM scratch AS output
+From scratch as output
 COPY --from={{IMAGENAME}} /cache.tgz cache.tgz
 
 # Clean up the cache data
-FROM {{IMAGENAME}} AS final
+FROM {{IMAGENAME}} as final
 RUN rm /cache.tgz
 

--- a/platform/broadcom/docker-syncd-brcm-dnx-rpc/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm-dnx-rpc/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-syncd-brcm-dnx-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-syncd-brcm-dnx-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -21,6 +19,7 @@ RUN apt-get update \
     libffi-dev          \
     wget                \
     cmake               \
+    libnanomsg5         \
     libnanomsg-dev      \
     libthrift-0.17.0
 
@@ -65,9 +64,9 @@ RUN apt-get -y purge \
     libthrift-dev    \
     build-essential
 
-FROM $BASE
+RUN apt-get clean -y && \
+    apt-get autoclean -y && \
+    apt-get autoremove -y && \
+    rm -rf /debs
 
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/broadcom/docker-syncd-brcm-dnx/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm-dnx/Dockerfile.j2
@@ -1,7 +1,5 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages %}
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -10,13 +8,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 
-{% if docker_syncd_brcm_dnx_debs.strip() -%}
-# Copy locally-built Debian package dependencies
-{{ copy_files("debs/", docker_syncd_brcm_dnx_debs.split(' '), "/debs/") }}
+COPY \
+{% for deb in docker_syncd_brcm_dnx_debs.split(' ') -%}
+debs/{{ deb }}{{' '}}
+{%- endfor -%}
+debs/
 
 # Install locally-built Debian packages and implicitly install their dependencies
 {{ install_debian_packages(docker_syncd_brcm_dnx_debs.split(' ')) }}
-{%- endif %}
 
 ## TODO: add kmod into Depends
 RUN apt-get install -yf kmod
@@ -31,9 +30,8 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor/"]
 
-FROM $BASE
+## Clean up
+RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
+RUN rm -rf /debs
 
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/broadcom/docker-syncd-brcm-rpc/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm-rpc/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-syncd-brcm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-syncd-brcm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -21,6 +19,7 @@ RUN apt-get update \
     libffi-dev          \
     wget                \
     cmake               \
+    libnanomsg5         \
     libnanomsg-dev      \
     libthrift-0.17.0
 
@@ -65,9 +64,9 @@ RUN apt-get -y purge \
     libthrift-dev    \
     build-essential
 
-FROM $BASE
+RUN apt-get clean -y && \
+    apt-get autoclean -y && \
+    apt-get autoremove -y && \
+    rm -rf /debs
 
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/broadcom/docker-syncd-brcm/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm/Dockerfile.j2
@@ -1,7 +1,5 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages %}
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -10,13 +8,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 
-{% if docker_syncd_brcm_debs.strip() -%}
-# Copy locally-built Debian package dependencies
-{{ copy_files("debs/", docker_syncd_brcm_debs.split(' '), "/debs/") }}
+COPY \
+{% for deb in docker_syncd_brcm_debs.split(' ') -%}
+debs/{{ deb }}{{' '}}
+{%- endfor -%}
+debs/
 
 # Install locally-built Debian packages and implicitly install their dependencies
 {{ install_debian_packages(docker_syncd_brcm_debs.split(' ')) }}
-{%- endif %}
 
 ## TODO: add kmod into Depends
 RUN apt-get install -yf kmod
@@ -31,9 +30,8 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor/"]
 
-FROM $BASE
+## Clean up
+RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
+RUN rm -rf /debs
 
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/components/docker-gbsyncd-broncos/Dockerfile.j2
+++ b/platform/components/docker-gbsyncd-broncos/Dockerfile.j2
@@ -1,6 +1,4 @@
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -37,8 +35,8 @@ COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["files/dsserve", "/usr/bin/"]
 RUN chmod +x /usr/bin/dsserve
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
+## Clean up
+RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
+RUN rm -rf /debs
 
 ENTRYPOINT ["/usr/bin/docker-init.sh"]

--- a/platform/components/docker-gbsyncd-credo/Dockerfile.j2
+++ b/platform/components/docker-gbsyncd-credo/Dockerfile.j2
@@ -1,6 +1,4 @@
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -35,8 +33,8 @@ COPY ["supervisord.conf.j2", "/usr/share/sonic/templates"]
 
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
+## Clean up
+RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
+RUN rm -rf /debs
 
 ENTRYPOINT ["/usr/bin/docker-init.sh"]

--- a/platform/marvell-prestera/docker-saiserver-mrvl-prestera/Dockerfile.j2
+++ b/platform/marvell-prestera/docker-saiserver-mrvl-prestera/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -34,9 +32,4 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/marvell-prestera/docker-syncd-mrvl-prestera-rpc/Dockerfile.j2
+++ b/platform/marvell-prestera/docker-syncd-mrvl-prestera-rpc/Dockerfile.j2
@@ -1,10 +1,14 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-syncd-mrvl-prestera-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-syncd-mrvl-prestera-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
+{% from "dockers/dockerfile-macros.j2" import install_python_wheels, copy_files %}
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
+
+COPY \
+{% for deb in docker_syncd_mrvl_prestera_rpc_debs.split(' ') -%}
+debs/{{ deb }}{{' '}}
+{%- endfor -%}
+debs/
 
 RUN apt-get purge -y syncd
 
@@ -26,12 +30,10 @@ RUN apt-get update \
     libnanomsg5           \
     libnanomsg-dev
 
-{% if docker_syncd_mrvl_prestera_rpc_debs.strip() -%}
-# Copy built Debian packages
-{{ copy_files("debs/", docker_syncd_mrvl_prestera_rpc_debs.split(' '), "/debs/") }}
-# Install built Debian packages and implicitly install their dependencies
-{{ install_debian_packages(docker_syncd_mrvl_prestera_rpc_debs.split(' ')) }}
-{%- endif %}
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
+{% for deb in docker_syncd_mrvl_prestera_rpc_debs.split(' ') -%}
+dpkg_apt debs/{{ deb }}{{'; '}}
+{%- endfor %}
 
 RUN pip3 install cffi    \
  && pip3 install nnpy    \
@@ -51,11 +53,7 @@ COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
 
 ## Clean up
 RUN apt-get purge -y libyaml-dev python3-dev libffi-dev libssl-dev wget build-essential
+RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /root/deps
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/marvell-prestera/docker-syncd-mrvl-prestera/Dockerfile.j2
+++ b/platform/marvell-prestera/docker-syncd-mrvl-prestera/Dockerfile.j2
@@ -1,7 +1,5 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages %}
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -10,6 +8,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 
+COPY \
+{% for deb in docker_syncd_mrvl_prestera_debs.split(' ') -%}
+debs/{{ deb }}{{' '}}
+{%- endfor -%}
+debs/
+
 RUN apt-get update \
  && apt-get -y install  \
     net-tools           \
@@ -17,20 +21,17 @@ RUN apt-get update \
 
 RUN apt-get -y install libpcap-dev libxml2-dev python3-dev swig
 
-{% if docker_syncd_mrvl_prestera_debs.strip() -%}
-# Copy locally-built Debian package dependencies
-{{ copy_files("debs/", docker_syncd_mrvl_prestera_debs.split(' '), "/debs/") }}
-# Install locally-built Debian packages and implicitly install their dependencies
-{{ install_debian_packages(docker_syncd_mrvl_prestera_debs.split(' ')) }}
-{%- endif %}
+RUN dpkg -i \
+{% for deb in docker_syncd_mrvl_prestera_debs.split(' ') -%}
+debs/{{ deb }}{{' '}}
+{%- endfor %}
 
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin/"]
 COPY ["critical_processes", "/etc/supervisor/"]
 
-FROM $BASE
+## Clean up
+RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
+RUN rm -rf /debs
 
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/marvell-teralynx/docker-saiserver-mrvl-teralynx/Dockerfile.j2
+++ b/platform/marvell-teralynx/docker-saiserver-mrvl-teralynx/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -40,9 +38,4 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/marvell-teralynx/docker-syncd-mrvl-teralynx-rpc/Dockerfile.j2
+++ b/platform/marvell-teralynx/docker-syncd-mrvl-teralynx-rpc/Dockerfile.j2
@@ -1,10 +1,14 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-syncd-mrvl-teralynx-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-syncd-mrvl-teralynx-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
+{% from "dockers/dockerfile-macros.j2" import install_python_wheels, copy_files %}
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
+
+COPY \
+{% for deb in docker_syncd_mrvl_teralynx_rpc_debs.split(' ') -%}
+debs/{{ deb }}{{' '}}
+{%- endfor -%}
+debs/
 
 RUN apt-get purge -y syncd
 
@@ -22,8 +26,17 @@ RUN apt-get update \
     libyaml-dev         \
     wget                \
     cmake               \
+    libqt5core5a        \
+    libqt5network5      \
+    libboost-atomic1.74.0 \
     libthrift-0.17.0      \
+    libnanomsg5           \
     libnanomsg-dev
+
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
+{% for deb in docker_syncd_mrvl_teralynx_rpc_debs.split(' ') -%}
+dpkg_apt debs/{{ deb }}{{'; '}}
+{%- endfor %}
 
 RUN pip3 install cffi \
  && pip3 install nnpy   \
@@ -41,21 +54,11 @@ COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
 {{ install_python_wheels(docker_syncd_mrvl_teralynx_rpc_whls.split(' ')) }}
 {% endif %}
 
-{% if docker_syncd_mrvl_teralynx_rpc_debs.strip() -%}
-# Copy built Debian packages
-{{ copy_files("debs/", docker_syncd_mrvl_teralynx_rpc_debs.split(' '), "/debs/") }}
-# Install built Debian packages and implicitly install their dependencies
-{{ install_debian_packages(docker_syncd_mrvl_teralynx_rpc_debs.split(' ')) }}
-{%- endif %}
 
 ## Clean up
 RUN apt-get purge -y libyaml-dev python3-dev libffi-dev libssl-dev wget cmake \
     build-essential
+RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /root/deps
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/marvell-teralynx/docker-syncd-mrvl-teralynx/Dockerfile.j2
+++ b/platform/marvell-teralynx/docker-syncd-mrvl-teralynx/Dockerfile.j2
@@ -1,7 +1,5 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages %}
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -10,7 +8,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 
-# Needed for Innovium Debug Shell
+COPY \
+{% for deb in docker_syncd_mrvl_teralynx_debs.split(' ') -%}
+debs/{{ deb }}{{' '}}
+{%- endfor -%}
+debs/
+
+# Needed for Marvell Teralynx Debug Shell
 RUN apt-get install -y net-tools
 RUN apt-get install -y libjansson4
 RUN apt-get install -y libyaml-dev
@@ -18,13 +22,10 @@ RUN apt-get install -y binutils
 RUN pip3 install numpy
 RUN pip3 install yamlordereddictloader
 
-{% if docker_syncd_mrvl_teralynx_debs.strip() -%}
-# Copy locally-built Debian package dependencies
-{{ copy_files("debs/", docker_syncd_mrvl_teralynx_debs.split(' '), "/debs/") }}
-
-# Install locally-built Debian packages and implicitly install their dependencies
-{{ install_debian_packages(docker_syncd_mrvl_teralynx_debs.split(' ')) }}
-{%- endif %}
+RUN dpkg -i \
+{% for deb in docker_syncd_mrvl_teralynx_debs.split(' ') -%}
+debs/{{ deb }}{{' '}}
+{%- endfor %}
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["ivm_start.sh", "/usr/bin/"]
@@ -32,9 +33,8 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor/"]
 
-FROM $BASE
+## Clean up
+RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
+RUN rm -rf /debs
 
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/mellanox/docker-saiserver-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-saiserver-mlnx/Dockerfile.j2
@@ -15,9 +15,7 @@
 ## limitations under the License.
 ##
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -58,9 +56,4 @@ COPY ["sai_2700.xml", "/usr/share/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
@@ -15,9 +15,7 @@
 ## limitations under the License.
 ##
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-syncd-mlnx-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-syncd-mlnx-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -97,9 +95,9 @@ RUN apt-get -y purge \
     libthrift-dev    \
     build-essential
 
-FROM $BASE
+RUN apt-get clean -y && \
+    apt-get autoclean -y && \
+    apt-get autoremove -y && \
+    rm -rf /debs
 
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -17,9 +17,7 @@
 ##
 
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -61,7 +59,11 @@ RUN apt-get purge -y python-pip
 ## Clean up
 RUN apt-get purge -y         \
         python3-dev          \
-        python3-pip
+        python3-pip       && \
+    apt-get clean -y      && \
+    apt-get autoclean -y  && \
+    apt-get autoremove -y && \
+    rm -rf /debs
 
 COPY ["supervisord.conf.j2", "/usr/share/sonic/templates/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
@@ -81,9 +83,4 @@ COPY ["ecmp_calculator/ecmp_calc_sdk.py", "/usr/lib/ecmp_calc"]
 COPY ["ecmp_calculator/packet_scheme.py", "/usr/lib/ecmp_calc"]
 COPY ["lib/port_utils.py", "/usr/lib"]
 
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/vs/docker-dash-engine/Dockerfile.cleanup
+++ b/platform/vs/docker-dash-engine/Dockerfile.cleanup
@@ -1,0 +1,11 @@
+# Base docker build
+FROM docker-dash-engine-sonic:latest
+
+# Copy the cache data to host
+From scratch as output
+COPY --from=docker-dash-engine-sonic:latest /cache.tgz cache.tgz
+
+# Clean up the cache data
+FROM docker-dash-engine-sonic:latest as final
+RUN rm /cache.tgz
+

--- a/platform/vs/docker-dash-engine/Dockerfile.j2
+++ b/platform/vs/docker-dash-engine/Dockerfile.j2
@@ -1,7 +1,5 @@
-ARG BASE=p4lang/behavioral-model@sha256:ce45720e28a96a50f275c1b511cd84c2558b62f2cf7a7e506765183bc3fb2e32
-## ARG BASE=docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM p4lang/behavioral-model@sha256:ce45720e28a96a50f275c1b511cd84c2558b62f2cf7a7e506765183bc3fb2e32
+## FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -17,10 +15,9 @@ COPY ["start.sh", "/usr/bin/"]
 ## COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 ## COPY ["critical_processes", "/etc/supervisor/"]
 
-FROM $BASE
-
-## RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-COPY --from=base / /
+## Clean up
+RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
+RUN rm -rf /debs
 
 ## ENTRYPOINT ["/usr/bin/supervisord"]
 ENTRYPOINT ["/usr/bin/start.sh"]

--- a/platform/vs/docker-gbsyncd-vs/Dockerfile.j2
+++ b/platform/vs/docker-gbsyncd-vs/Dockerfile.j2
@@ -1,7 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -19,13 +16,16 @@ RUN dpkg -i debs/libnl-3-dev_{{ LIBNL3_VERSION_SONIC }}_{{ CONFIGURED_ARCH }}.de
 
 RUN apt-get install -f -y libabsl20220623 libc-ares2 python3-six libboost-thread1.74.0 libboost-dev libboost-system-dev libboost-thread-dev libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-thread1.74.0 libnanomsg5 libpcap0.8 libthrift-0.17.0 libboost-dev libboost-filesystem-dev libboost-program-options-dev libgmp-dev libnanomsg-dev libpcap-dev libtool pkg-config libthrift-dev python3-thrift thrift-compiler libboost-iostreams1.74.0 libgc1 cpp libboost-dev libboost-all-dev libboost-graph-dev libboost-iostreams-dev libfl-dev libgc-dev libgmp-dev libbpf-dev tcpdump libelf-dev llvm clang python3-pyroute2 python3-ply python3-scapy python3-setuptools python3-thrift libthrift-0.17.0 libgrpc++1.51 libgrpc29 libprotobuf32 libboost-dev libboost-system-dev libboost-thread-dev libprotoc-dev protobuf-compiler python3-protobuf libgrpc++-dev libgrpc-dev protobuf-compiler-grpc python3-grpcio 
 
-{% if docker_gbsyncd_vs_debs.strip() -%}
-# Copy built Debian packages
-{{ copy_files("debs/", docker_gbsyncd_vs_debs.split(' '), "/debs/") }}
+COPY \
+{% for deb in docker_gbsyncd_vs_debs.split(' ') -%}
+debs/{{ deb }}{{' '}}
+{%- endfor -%}
+debs/
 
-# Install built Debian packages and implicitly install their dependencies
-{{ install_debian_packages(docker_gbsyncd_vs_debs.split(' ')) }}
-{%- endif %}
+RUN dpkg -i \
+{% for deb in docker_gbsyncd_vs_debs.split(' ') -%}
+debs/{{ deb }}{{' '}}
+{%- endfor %}
 
 COPY ["start.sh", "/usr/bin/"]
 
@@ -33,9 +33,8 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor/"]
 
-FROM $BASE
+## Clean up
+RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
+RUN rm -rf /debs
 
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-swss-layer-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -166,10 +164,6 @@ COPY ["frr/zebra.conf", "/etc/frr/"]
 
 # Create /var/warmboot/teamd folder for teammgrd
 RUN mkdir -p /var/warmboot/teamd
-
-FROM $BASE
-
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
 
 # Set PLATFORM and HWSKU environment variables
 ENV PLATFORM=x86_64-kvm_x86_64-r0

--- a/platform/vs/docker-syncd-vs/Dockerfile.j2
+++ b/platform/vs/docker-syncd-vs/Dockerfile.j2
@@ -1,7 +1,5 @@
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
-
-FROM $BASE AS base
+FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 
@@ -33,9 +31,8 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor/"]
 
-FROM $BASE
+## Clean up
+RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
+RUN rm -rf /debs
 
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=resolv.conf /changes-to-image/ /
-
-ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/rules/config
+++ b/rules/config
@@ -20,6 +20,14 @@ SONIC_CONFIG_MAKE_JOBS = $(shell nproc)
 # Supported format: simple, none
 DEFAULT_BUILD_LOG_TIMESTAMP = none
 
+# SONIC_USE_DOCKER_BUILDKIT - use docker buildkit for build.
+# If set to y SONiC build system will set environment variable DOCKER_BUILDKIT=1
+# to enable docker buildkit.
+# This options will speed up docker image build time.
+# NOTE: SONIC_USE_DOCKER_BUILDKIT will produce larger installable SONiC image
+# because of a docker bug (more details: https://github.com/moby/moby/issues/38903)
+# SONIC_USE_DOCKER_BUILDKIT = y
+
 # SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD - use native dockerd for build.
 # If set to y SONiC build container will use native dockerd instead of dind for faster build.
 # Special handling of the docker image file names is needed to avoid conflicts with

--- a/scripts/docker_version_control.sh
+++ b/scripts/docker_version_control.sh
@@ -16,10 +16,7 @@ mkdir -p target/versions/default
 
 . src/sonic-build-hooks/buildinfo/config/buildinfo.config
 
-image_tag=`grep "^ARG BASE=" $DOCKERFILE | cut -d= -f 2`
-if [ -z $image_tag ]; then
-	image_tag=`grep "^FROM " $DOCKERFILE | awk '{print$2}'`
-fi
+image_tag=`grep "^FROM " $DOCKERFILE | awk '{print$2}'`
 image_tag_noprefix=$image_tag
 [ -n "$DEFAULT_CONTAINER_REGISTRY" ] && image_tag_noprefix=$(echo $image_tag | sed "s#$DEFAULT_CONTAINER_REGISTRY##")
 image=`echo $image_tag | cut -f1 -d:`

--- a/scripts/prepare_docker_buildinfo.sh
+++ b/scripts/prepare_docker_buildinfo.sh
@@ -32,10 +32,7 @@ mkdir -p $BUILDINFO_VERSION_PATH
 
 # Get the debian distribution from the docker base image
 if [ -z "$DISTRO" ]; then
-    DOCKER_BASE_IMAGE=$(grep "^ARG BASE=" $DOCKERFILE | head -n 1 | awk '{print $2}' | cut -d'=' -f 2)
-    if [ -z "$DOCKER_BASE_IMAGE" ]; then
-        DOCKER_BASE_IMAGE=$(grep "^FROM" $DOCKERFILE | head -n 1 | awk '{print $2}')
-    fi
+    DOCKER_BASE_IMAGE=$(grep "^FROM" $DOCKERFILE | head -n 1 | awk '{print $2}')
     DISTRO=$(docker run --rm --entrypoint "" $DOCKER_BASE_IMAGE cat /etc/os-release | grep VERSION_CODENAME | cut -d= -f2)
     if [ -z "$DISTRO" ]; then
         DISTRO=$(docker run --rm --entrypoint "" $DOCKER_BASE_IMAGE cat /etc/apt/sources.list | grep deb.debian.org | awk '{print $3}')
@@ -61,29 +58,16 @@ ENV DISTRO='${DISTRO}'
 RUN pre_run_buildinfo '${IMAGENAME}'
 '
 
-DOCKERFILE_POST_SCRIPT='
-RUN post_run_buildinfo '${IMAGENAME}'
-RUN post_run_cleanup '${IMAGENAME}'
-'
-
 # Add the auto-generate code if it is not added in the target Dockerfile
 if [ ! -f $DOCKERFILE_TARGET ] || ! grep -q "Auto-Generated for buildinfo" $DOCKERFILE_TARGET; then
     # Insert the docker build script before the RUN command
     LINE_NUMBER=$(grep -Fn -m 1 'RUN' $DOCKERFILE | cut -d: -f1)
-    COPY_BASE_LINE_NUMBER=$(grep -n -m 1 'FROM \$BASE$' $DOCKERFILE | cut -d: -f1)
-    if [ -z "$COPY_BASE_LINE_NUMBER" ]; then
-        COPY_BASE_LINE_NUMBER=$(grep -n -m 1 'FROM scratch$' $DOCKERFILE | cut -d: -f1)
-    fi
     TEMP_FILE=$(mktemp)
-    if [ -n "$COPY_BASE_LINE_NUMBER" ]; then
-        awk -v prescript="${DOCKERFILE_PRE_SCRIPT}" -v linenumber=$LINE_NUMBER -v postscript="${DOCKERFILE_POST_SCRIPT}" -v copybaselinenumber=$COPY_BASE_LINE_NUMBER 'NR==copybaselinenumber{print postscript} NR==linenumber{print prescript}1' $DOCKERFILE > $TEMP_FILE
-    else
-        awk -v prescript="${DOCKERFILE_PRE_SCRIPT}" -v linenumber=$LINE_NUMBER 'NR==linenumber{print prescript}1' $DOCKERFILE > $TEMP_FILE
+    awk -v text="${DOCKERFILE_PRE_SCRIPT}" -v linenumber=$LINE_NUMBER 'NR==linenumber{print text}1' $DOCKERFILE > $TEMP_FILE
 
-        # Append the docker build script at the end of the docker file
-        echo -e "\nRUN post_run_buildinfo ${IMAGENAME} " >> $TEMP_FILE
-        echo -e "\nRUN post_run_cleanup ${IMAGENAME} " >> $TEMP_FILE
-    fi
+    # Append the docker build script at the end of the docker file
+    echo -e "\nRUN post_run_buildinfo ${IMAGENAME} " >> $TEMP_FILE
+    echo -e "\nRUN post_run_cleanup ${IMAGENAME} " >> $TEMP_FILE
 
     cat $TEMP_FILE > $DOCKERFILE_TARGET
     rm -f $TEMP_FILE

--- a/slave.mk
+++ b/slave.mk
@@ -519,6 +519,13 @@ $(shell DBGOPT='$(DBGOPT)' scripts/prepare_slave_container_buildinfo.sh $(SLAVE_
 endif
 include Makefile.cache
 
+ifeq ($(SONIC_USE_DOCKER_BUILDKIT),y)
+$(warning "Using SONIC_USE_DOCKER_BUILDKIT will produce larger installable SONiC image because of a docker bug (more details: https://github.com/moby/moby/issues/38903)")
+export DOCKER_BUILDKIT=1
+else
+export DOCKER_BUILDKIT=0
+endif
+
 
 ###############################################################################
 ## Generic rules section
@@ -1026,7 +1033,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_SIMPLE_DOCKER_IMAGES)) : $(TARGET_PATH)/%.g
 	DBGOPT='$(DBGOPT)' \
 	scripts/prepare_docker_buildinfo.sh $* $($*.gz_PATH)/Dockerfile $(CONFIGURED_ARCH) $(TARGET_DOCKERFILE)/Dockerfile.buildinfo $(LOG)
 	docker info $(LOG)
-	docker build --no-cache \
+	docker build --squash --no-cache \
 		--build-arg http_proxy=$(HTTP_PROXY) \
 		--build-arg https_proxy=$(HTTPS_PROXY) \
 		--build-arg no_proxy=$(NO_PROXY) \
@@ -1184,7 +1191,7 @@ $(addprefix $(TARGET_PATH)/, $(DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .platform
 		DBGOPT='$(DBGOPT)' \
 		scripts/prepare_docker_buildinfo.sh $* $($*.gz_PATH)/Dockerfile $(CONFIGURED_ARCH) $(LOG)
 		docker info $(LOG)
-		docker build --no-cache \
+		docker build --no-cache $$( [[ "$($*.gz_SQUASH)" != n ]] && echo --squash)\
 			--build-arg http_proxy=$(HTTP_PROXY) \
 			--build-arg https_proxy=$(HTTPS_PROXY) \
 			--build-arg no_proxy=$(NO_PROXY) \
@@ -1254,7 +1261,7 @@ $(addprefix $(TARGET_PATH)/, $(DOCKER_DBG_IMAGES)) : $(TARGET_PATH)/%-$(DBG_IMAG
 		scripts/prepare_docker_buildinfo.sh $*-dbg $($*.gz_PATH)/Dockerfile-dbg $(CONFIGURED_ARCH) $(LOG)
 		docker info $(LOG)
 		docker build \
-			--no-cache \
+			$(if $($*.gz_DBG_DEPENDS), --squash --no-cache, --no-cache) \
 			--build-arg http_proxy=$(HTTP_PROXY) \
 			--build-arg https_proxy=$(HTTPS_PROXY) \
 			--build-arg no_proxy=$(NO_PROXY) \

--- a/src/sonic-build-hooks/scripts/post_run_cleanup
+++ b/src/sonic-build-hooks/scripts/post_run_cleanup
@@ -15,17 +15,18 @@ if [ ! -z "$(get_version_cache_option)" ]; then
 	fi
 fi
 
-apt-get clean -y
-apt-get autoclean -y
-apt-get autoremove -y --purge
+apt-get -s clean -y
+apt-get -s autoclean -y
+apt-get -s autoremove -y
+#apt-get -s autoremove -y --purge
 rm -f /var/cache/apt/archives/*.deb /var/cache/apt/*.bin
 
 if [[ ! ${IMAGENAME} =~ -slave- ]]; then
-	rm -rf /var/lib/apt/lists/*
+	rm -f /var/lib/apt/lists/*
 fi
 
 rm -rf /sonic/target /ssh
-rm -rf /tmp/*
+rm -f /tmp/*
 rm -rf /debs /python-wheels  ~/.cache
 find / | grep -E "__pycache__" | xargs rm -rf
 
@@ -38,17 +39,3 @@ set_reproducible_mirrors -d
 # Remove the version deb preference
 rm -f $VERSION_DEB_PREFERENCE
 rm -f /etc/apt/preferences.d/01-versions-deb
-
-# Remove all doc files
-find /usr/share/doc -depth \( -type f -o -type l \) ! -name copyright | xargs rm || true
-
-# Clean doc directories that are empty or only contain empty directories
-while [ -n "$(find /usr/share/doc -depth -type d -empty -print -exec rmdir {} +)" ]; do :; done && \
-    rm -rf               \
-    /usr/share/man/*     \
-    /usr/share/groff/*   \
-    /usr/share/info/*    \
-    /usr/share/lintian/* \
-    /usr/share/linda/*   \
-    /var/cache/man/*     \
-    /usr/share/locale/*


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#19952 due to regressions in KVM debug image size, issues with certain containers (such as docker-sysmgr) not getting updated, and docker-sonic-telemetry having the wrong base container.