### PR TITLE
Make pmbus data formats user-space configurable

### DIFF
--- a/platform/pddf/i2c/modules/include/pddf_psu_defs.h
+++ b/platform/pddf/i2c/modules/include/pddf_psu_defs.h
@@ -26,6 +26,7 @@
 #define ATTR_NAME_LEN 32
 #define STR_ATTR_SIZE 32
 #define DEV_TYPE_LEN 32
+#define ATTR_DATA_FORMAT_SIZE 32
 
 /* Each client has this additional data 
  */
@@ -33,6 +34,7 @@
 typedef struct PSU_DATA_ATTR
 {
     char aname[ATTR_NAME_LEN];                    // attr name, taken from enum psu_sysfs_attributes
+    char data_format[ATTR_DATA_FORMAT_SIZE];      // PMBUS number format, either linear11, linear16, or direct   
     char devtype[DEV_TYPE_LEN];       // either a 'eeprom' or 'cpld', or 'pmbus' attribute
     char devname[DEV_TYPE_LEN];       // Name of the device from where this sysfs attr is read
     uint32_t devaddr;
@@ -40,6 +42,9 @@ typedef struct PSU_DATA_ATTR
     uint32_t mask;
     uint32_t cmpval;
     uint32_t len;
+    int m;
+    int b;
+    int r;
     void *access_data;
 
 }PSU_DATA_ATTR;

--- a/platform/pddf/i2c/modules/psu/driver/pddf_psu_api.c
+++ b/platform/pddf/i2c/modules/psu/driver/pddf_psu_api.c
@@ -40,6 +40,7 @@
 #define psu_dbg(...)
 #endif
 
+#define PSU_REG_VOUT_MODE 0x20
 
 void get_psu_duplicate_sysfs(int idx, char *str)
 {
@@ -152,6 +153,144 @@ int psu_update_attr(struct device *dev, struct psu_attr_info *data, PSU_DATA_ATT
     return 0;
 }
 
+static u8 psu_get_vout_mode(struct i2c_client *client)
+{
+    u8 status = 0, retry = 10;
+    uint8_t offset = PSU_REG_VOUT_MODE;
+
+    while (retry)
+    {
+        status = i2c_smbus_read_byte_data((struct i2c_client *)client, offset);
+        if (unlikely(status < 0)) 
+        {
+            msleep(60);
+            retry--;
+            continue;
+        }
+        break;
+    }
+
+    if (status < 0)
+    {
+        printk(KERN_ERR "%s: Get PSU Vout mode failed\n", __func__);
+        return 0;
+    }
+    else
+    {
+        return status;
+    }
+}
+
+static long pmbus_linear11_to_int(u16 value, int multiplier)
+{
+    s16 exponent;
+    s32 mantissa;
+
+    exponent = two_complement_to_int(value >> 11, 5, 0x1f);
+    mantissa = two_complement_to_int(value & 0x7ff, 11, 0x7ff);
+
+    if (exponent >= 0)
+        return (mantissa << exponent) * multiplier;
+    else
+        return (mantissa * multiplier) / (1 << -exponent);
+}
+
+static long pmbus_linear16_to_int(u16 value, u8 vout_mode, int multiplier)
+{
+    s16 exponent;
+    long result;
+    
+    /* Extract exponent from VOUT_MODE */
+    if ((vout_mode >> 5) == 0) /* Mode is linear */
+        exponent = two_complement_to_int(vout_mode & 0x1f, 5, 0x1f);
+    else
+        exponent = 0;
+    
+    result = value;
+    result *= multiplier;
+    
+    if (exponent >= 0)
+        result <<= exponent;
+    else
+        result >>= -exponent;
+        
+    return result;
+}
+
+static long pmbus_direct_to_int(s16 value, s32 m, s32 b, s32 R, int multiplier)
+{
+    s64 val = value;
+    s64 result;
+    
+    if (m == 0) {
+        return 0; /* Avoid division by zero */
+    }
+    
+    /* X = 1/m * (Y * 10^-R - b) */
+    /* First, handle the 10^-R term by scaling val */
+    R = -R; /* Invert R to make the calculations more intuitive */
+    
+    /* Scale result to the requested multiplier */
+    val *= multiplier;
+    b *= multiplier;
+    
+    /* Apply power of 10 scaling */
+    while (R > 0) {
+        val *= 10;
+        R--;
+    }
+    while (R < 0) {
+        val = div_s64(val + 5, 10); /* Round to nearest */
+        R++;
+    }
+    
+    /* Now calculate (Y - b) / m */
+    val -= b;
+    result = div_s64(val, m);
+    
+    return (long)result;
+}
+
+static long get_real_world_value(struct i2c_client *client,
+                                PSU_DATA_ATTR *usr_data,
+                                struct psu_attr_info *sysfs_attr_info,
+                                const char *default_format,
+                                int multiplier)
+{
+    u16 reg_value;
+    u8 vout_mode;
+    const char *data_format;
+ 
+    reg_value = sysfs_attr_info->val.shortval;
+
+    if (usr_data->data_format && usr_data->data_format[0] != '\0') {
+        data_format = usr_data->data_format;
+    } else {
+        data_format = default_format;
+    }
+
+    if (strcmp(data_format, "linear11") == 0) {
+        return pmbus_linear11_to_int(reg_value, multiplier);
+    }
+    else if (strcmp(data_format, "direct") == 0) {
+        return pmbus_direct_to_int(reg_value, usr_data->m, usr_data->b, usr_data->r, multiplier);
+    }
+    else if (strcmp(data_format, "linear16") == 0) {
+        vout_mode = psu_get_vout_mode(client);
+        return pmbus_linear16_to_int(reg_value, vout_mode, multiplier);
+    }
+    else {
+        /* Default to linear11 if format is unknown or NULL */
+        if (data_format) {
+            printk(KERN_WARNING "%s: Unknown data format '%s', defaulting to linear11\n",
+                   __func__, data_format);
+        } else {
+            printk(KERN_WARNING "%s: NULL data format, defaulting to linear11\n", __func__);
+        }
+        return pmbus_linear11_to_int(reg_value, multiplier);
+    }
+}
+
 ssize_t psu_show_default(struct device *dev, struct device_attribute *da, char *buf)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
@@ -162,6 +301,7 @@ ssize_t psu_show_default(struct device *dev, struct device_attribute *da, char *
     struct psu_attr_info *sysfs_attr_info = NULL;
     int i, status=0;
     u16 value = 0;
+    u8 vout_mode = 0;
     int exponent, mantissa;
     int multiplier = 1000;
     char new_str[ATTR_NAME_LEN] = "";
@@ -208,48 +348,21 @@ ssize_t psu_show_default(struct device *dev, struct device_attribute *da, char *
         case PSU_I_IN:
         case PSU_P_OUT_MAX:
             multiplier = 1000;
-            value = sysfs_attr_info->val.shortval;
-            exponent = two_complement_to_int(value >> 11, 5, 0x1f);
-            mantissa = two_complement_to_int(value & 0x7ff, 11, 0x7ff);
-            if (exponent >= 0)
-                return sprintf(buf, "%d\n", (mantissa << exponent) * multiplier);
-            else
-                return sprintf(buf, "%d\n", (mantissa * multiplier) / (1 << -exponent));
-
+            return sprintf(buf, "%ld\n", get_real_world_value(client, usr_data, sysfs_attr_info, "linear11", multiplier));
             break;
         case PSU_P_IN:
         case PSU_P_OUT:
             multiplier = 1000000;
-            value = sysfs_attr_info->val.shortval;
-            exponent = two_complement_to_int(value >> 11, 5, 0x1f);
-            mantissa = two_complement_to_int(value & 0x7ff, 11, 0x7ff);
-            if (exponent >= 0)
-                return sprintf(buf, "%d\n", (mantissa << exponent) * multiplier);
-            else
-                return sprintf(buf, "%d\n", (mantissa * multiplier) / (1 << -exponent));
-
+            return sprintf(buf, "%ld\n", get_real_world_value(client, usr_data, sysfs_attr_info, "linear11", multiplier));
             break;
         case PSU_FAN1_SPEED:
-            value = sysfs_attr_info->val.shortval;
-            exponent = two_complement_to_int(value >> 11, 5, 0x1f);
-            mantissa = two_complement_to_int(value & 0x7ff, 11, 0x7ff);
-            if (exponent >= 0)
-                return sprintf(buf, "%d\n", (mantissa << exponent));
-            else
-                return sprintf(buf, "%d\n", (mantissa) / (1 << -exponent));
-
+            multiplier = 1;
+            return sprintf(buf, "%ld\n", get_real_world_value(client, usr_data, sysfs_attr_info, "linear11", multiplier));
             break;
         case PSU_TEMP1_INPUT:
         case PSU_TEMP1_HIGH_THRESHOLD:
             multiplier = 1000;
-            value = sysfs_attr_info->val.shortval;
-            exponent = two_complement_to_int(value >> 11, 5, 0x1f);
-            mantissa = two_complement_to_int(value & 0x7ff, 11, 0x7ff);
-            if (exponent >= 0)
-                return sprintf(buf, "%d\n", (mantissa << exponent) * multiplier);
-            else
-                return sprintf(buf, "%d\n", (mantissa * multiplier) / (1 << -exponent));
-
+            return sprintf(buf, "%ld\n", get_real_world_value(client, usr_data, sysfs_attr_info, "linear11", multiplier));
             break;
         default:
             printk(KERN_ERR "%s: Unable to find attribute index for %s\n", __FUNCTION__, usr_data->aname);

--- a/platform/pddf/i2c/modules/psu/pddf_psu_module.c
+++ b/platform/pddf/i2c/modules/psu/pddf_psu_module.c
@@ -50,11 +50,15 @@ PDDF_DATA_ATTR(psu_fans, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_
 PDDF_DATA_ATTR(attr_name, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_CHAR, 32, (void*)&psu_data.psu_attr.aname, NULL);
 PDDF_DATA_ATTR(attr_devtype, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_CHAR, 8, (void*)&psu_data.psu_attr.devtype, NULL);
 PDDF_DATA_ATTR(attr_devname, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_CHAR, 8, (void*)&psu_data.psu_attr.devname, NULL);
+PDDF_DATA_ATTR(attr_data_format, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_CHAR, 32, (void*)&psu_data.psu_attr.data_format, NULL);
 PDDF_DATA_ATTR(attr_devaddr, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_UINT32, sizeof(uint32_t), (void*)&psu_data.psu_attr.devaddr, NULL);
 PDDF_DATA_ATTR(attr_offset, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_UINT32, sizeof(uint32_t), (void*)&psu_data.psu_attr.offset, NULL);
 PDDF_DATA_ATTR(attr_mask, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_UINT32, sizeof(uint32_t), (void*)&psu_data.psu_attr.mask, NULL);
 PDDF_DATA_ATTR(attr_cmpval, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_UINT32, sizeof(uint32_t), (void*)&psu_data.psu_attr.cmpval, NULL);
 PDDF_DATA_ATTR(attr_len, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_INT_DEC, sizeof(int), (void*)&psu_data.psu_attr.len, NULL);
+PDDF_DATA_ATTR(attr_m, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_INT_DEC, sizeof(int), (void*)&psu_data.psu_attr.m, NULL);
+PDDF_DATA_ATTR(attr_b, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_INT_DEC, sizeof(int), (void*)&psu_data.psu_attr.b, NULL);
+PDDF_DATA_ATTR(attr_r, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_INT_DEC, sizeof(int), (void*)&psu_data.psu_attr.r, NULL);
 PDDF_DATA_ATTR(attr_ops, S_IWUSR, NULL, do_attr_operation, PDDF_CHAR, 8, (void*)&psu_data, NULL);
 PDDF_DATA_ATTR(dev_ops, S_IWUSR, NULL, do_device_operation, PDDF_CHAR, 8, (void*)&psu_data, (void*)&pddf_data);
 
@@ -67,11 +71,15 @@ static struct attribute *psu_attributes[] = {
     &attr_attr_name.dev_attr.attr,
     &attr_attr_devtype.dev_attr.attr,
     &attr_attr_devname.dev_attr.attr,
+    &attr_attr_data_format.dev_attr.attr,
     &attr_attr_devaddr.dev_attr.attr,
     &attr_attr_offset.dev_attr.attr,
     &attr_attr_mask.dev_attr.attr,
     &attr_attr_cmpval.dev_attr.attr,
     &attr_attr_len.dev_attr.attr,
+    &attr_attr_m.dev_attr.attr,
+    &attr_attr_b.dev_attr.attr,
+    &attr_attr_r.dev_attr.attr,
     &attr_attr_ops.dev_attr.attr,
     &attr_dev_ops.dev_attr.attr,
     NULL

--- a/platform/pddf/i2c/utils/schema/PSU-PMBUS.schema
+++ b/platform/pddf/i2c/utils/schema/PSU-PMBUS.schema
@@ -76,6 +76,18 @@
                     },
                     "attr_len": {
                       "type": "string"
+                    },
+                    "attr_data_format": {
+                      "type": "string"
+                    },
+                    "attr_m" : {
+                      "type": "string"
+                    },
+                    "attr_b" : {
+                      "type": "string"
+                    },
+                    "attr_r" : {
+                      "type": "string"
                     }
                   },
                   "required": [


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently, the stock pddf drivers for PSUs default their formatting to Linear11. However, this is not true for all PSU types on all their attributes, and it leads to incorrect voltage/current/power reporting numbers. PMBus supports Linear11, Linear16, and Direct modes depending on the vendor implemenation. Instead, their attributes should be configurable through sysfs, as it is done for other pddf based drivers.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add a new pddf data attr to the pddf_psu_module
Update the "show_default" function in pddf_psu_api to scale according to the data formatting specified in the sysfs path

#### How to verify it
```
root@sonic:/home/admin# show platform psustatus
PSU    Model                Serial      HW Rev      Voltage (V)    Current (A)    Power (W)  Status    LED
-----  -------------------  ----------  --------  -------------  -------------  -----------  --------  -----
PSU 1  D1U74T-W-3200-12-HB  M42448RAC0  N/A               12.27          31.38       386.50  OK        green
PSU 2  D1U74T-W-3200-12-HB  M42448RAC0  N/A                0.00           0.00         0.00  NOT OK    off
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

