### PR TITLE
[Mellanox] platform: Enable cache on init

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
@@ -23,6 +23,7 @@
 
 try:
     from sonic_platform_base.platform_base import PlatformBase
+    from sonic_platform_base.sonic_xcvr.api.public.cmis import CmisApi
     from .chassis import Chassis, ModularChassis, SmartSwitchChassis
     from .device_data import DeviceDataManager
 except ImportError as e:
@@ -31,6 +32,7 @@ except ImportError as e:
 class Platform(PlatformBase):
     def __init__(self):
         PlatformBase.__init__(self)
+        CmisApi.set_cache_enabled(True)
         if DeviceDataManager.get_dpu_count():
             self._chassis = SmartSwitchChassis()
         elif DeviceDataManager.get_linecard_count() == 0:


### PR DESCRIPTION
Depends on: https://github.com/sonic-net/sonic-platform-common/pull/562

Set cache enabled flag.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Centralize the XCVR cache enablement logic in the Mellanox platform API so that CMIS cache is configured automatically at Platform initialization for Mellanox platform.

#### How I did it
In Platform.init, call CmisApi.set_cache_enabled(True) to set as cache_enabled in cmis.

#### How to verify it
Build and deploy the updated platform daemon package.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
- [x] 202411
- [x] 202412

#### Tested branch (Please provide the tested image version)
master.637-eafe0ccb9_Internal