### PR TITLE
Revert "Create symbol link in platform x86_64-arista_7060x6_64pe_b"

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-O128
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-O128
@@ -1,1 +1,0 @@
-../x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-O128

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-P32O64
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-P32O64
@@ -1,1 +1,0 @@
-../x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-P32O64

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-P64
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-P64
@@ -1,1 +1,0 @@
-../x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-P64


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#22602

The HWSKU can't be reused.