### PR TITLE
Tell chrony that the RTC is always in UTC

### DIFF
--- a/files/image_config/chrony/chrony.conf.j2
+++ b/files/image_config/chrony/chrony.conf.j2
@@ -149,6 +149,7 @@ maxupdateskew 100.0
 # up with the actual time from the real-time clock.
 rtcfile /var/lib/chrony/rtc
 hwclockfile /etc/adjtime
+rtconutc
 rtcautotrim 15
 
 # Step the system clock instead of slewing it if the adjustment is larger than

--- a/src/sonic-config-engine/tests/sample_output/py3/chrony.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/chrony.conf
@@ -54,6 +54,7 @@ maxupdateskew 100.0
 # up with the actual time from the real-time clock.
 rtcfile /var/lib/chrony/rtc
 hwclockfile /etc/adjtime
+rtconutc
 rtcautotrim 15
 
 # Step the system clock instead of slewing it if the adjustment is larger than

--- a/src/sonic-config-engine/tests/sample_output/py3/chrony_smartswitch.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/chrony_smartswitch.conf
@@ -56,6 +56,7 @@ maxupdateskew 100.0
 # up with the actual time from the real-time clock.
 rtcfile /var/lib/chrony/rtc
 hwclockfile /etc/adjtime
+rtconutc
 rtcautotrim 15
 
 # Step the system clock instead of slewing it if the adjustment is larger than


### PR DESCRIPTION


Fixes #22437

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Tell chrony that the RTC on devices is always stored in UTC and not the local time zone. For devices that are running on UTC, this won't change anything; for devices that are not running on UTC, this will correct some time issues where the kernel interprets the time in the RTC as being in UTC, but Chrony interprets that time as being in the local time zone.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

