### PR TITLE
[Bgpcfgd]Add a mechanism in SRv6Mgr to force deletion of locator to be after deletion of all SIDs

### DIFF
--- a/src/sonic-bgpcfgd/tests/test_srv6.py
+++ b/src/sonic-bgpcfgd/tests/test_srv6.py
@@ -224,3 +224,52 @@ def test_out_of_order_add_wait_for_all_deps():
     # verify that both of the sids are programmed because all dependencies are satisfied
     assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:20::\\48")
     assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc2|fcbb:bbbb:21::\\48")
+
+
+def test_out_of_order_del():
+    loc_mgr, sid_mgr = constructor()
+    SRv6Mgr.fading_locators = dict()
+    loc_mgr.cfg_mgr.push_list = MagicMock()
+    sid_mgr.cfg_mgr.push_list = MagicMock()
+
+    # add the locator loc1
+    loc_mgr.handler(op='SET', key="loc1", data={'prefix': 'fcbb:bbbb:20::'})
+
+    # verify that the locator is added
+    assert loc_mgr.directory.path_exist(loc_mgr.db_name, loc_mgr.table_name, "loc1")
+
+    # add two sids
+    sid_mgr.handler(op='SET', key="loc1|FCBB:BBBB:20::/48", data={'action': 'uN'})
+    sid_mgr.handler(op='SET', key="loc1|FCBB:BBBB:20:1::/64", data={'action': 'DT46', 'decap_vrf': 'Vrf1'})
+
+    # verify that the sids are added
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:20::\\48")
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:20:1::\\64")
+
+    # delete the locator loc1 firt
+    # verify that the FRR command of deleting the locator loc1 is not sent
+    op_test(loc_mgr, 'DEL', ("loc1",), expected_ret=True, expected_cmds=[])
+    assert "loc1" in SRv6Mgr.fading_locators and SRv6Mgr.fading_locators["loc1"].num_of_sids() == 2
+
+    # delete the second sid
+    # verify that the FRR command of deleting the sid is sent
+    op_test(sid_mgr, 'DEL', ("loc1|FCBB:BBBB:20:1::/64",), expected_ret=True, expected_cmds=[
+        'segment-routing',
+        'srv6',
+        'static-sids',
+        'no sid fcbb:bbbb:20:1::/64 locator loc1 behavior DT46 vrf Vrf1'
+    ])
+    assert SRv6Mgr.fading_locators["loc1"].num_of_sids() == 1
+
+    # delete the first sid
+    # verify that the FRR commands of deleting the sid and deleting the locator are both sent
+    op_test(sid_mgr, 'DEL', ("loc1|FCBB:BBBB:20::/48",), expected_ret=True, expected_cmds=[
+        'segment-routing',
+        'srv6',
+        'static-sids',
+        'no sid fcbb:bbbb:20::/48 locator loc1 behavior uN',
+        'exit',
+        'locators',
+        'no locator loc1'
+    ])
+    assert "loc1" not in SRv6Mgr.fading_locators


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Nvidia found an issue of FRR in testing: Issue #22690. This essentially indicates that FRR is not safe to handle out-of-oder deleteion of SRv6 locators and SRv6 sids.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

I added a bookkeeping dictionary in SRv6Mgr to hold fading locators (i.e. locators that have been deleted in CONFIG_DB but still have SIDs associated). We delete those locators only after all associate SIDs have been deleted.

#### How to verify it

1. Run UT
2. Test the new bgpcfgd on a SONIC device.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

