### PR TITLE
Improve monit_gnmi.2 to support smartswitch

### DIFF
--- a/dockers/docker-sonic-gnmi/base_image_files/monit_gnmi.j2
+++ b/dockers/docker-sonic-gnmi/base_image_files/monit_gnmi.j2
@@ -1,9 +1,9 @@
 ###############################################################################
 ## Monit configuration for telemetry container
 ###############################################################################
-{% if SMARTSWITCH is defined and SMARTSWITCH == 1 %}
+{%- if SMARTSWITCH is defined and SMARTSWITCH == "1" %}
 check program container_memory_gnmi with path "/usr/bin/memory_checker gnmi 1073741824"
-{% else %}
+{%- else %}
 check program container_memory_gnmi with path "/usr/bin/memory_checker gnmi 419430400"
-{% endif %}
+{%- endif %}
     if status == 3 for 10 times within 20 cycles then exec "/usr/bin/restart_service gnmi" repeat every 2 cycles


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix #21590
While pushing dash_config to gnmi, the gnmi exceed memory threshold and is reset by monit. Config won't be applied as expected in this case.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Fix jinja2 syntax, and remove empty line.

#### How to verify it
Build sonic image and check monit_gnmi file.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

