### PR TITLE
Add remote dpu db to bfdmon.

### DIFF
--- a/src/sonic-bgpcfgd/bfdmon/bfdmon.py
+++ b/src/sonic-bgpcfgd/bfdmon/bfdmon.py
@@ -2,6 +2,7 @@ import json
 import subprocess
 import time
 import syslog
+from datetime import datetime, timezone
 from swsscommon import swsscommon
 from sonic_py_common import device_info
 from sonic_py_common.general import getstatusoutput_noshell
@@ -126,6 +127,13 @@ class BfdFrrMon:
                 ("v4_bfd_up_sessions", json.dumps(list(self.local_v4_peers)).strip("[]")),
                 ("v6_bfd_up_sessions", json.dumps(list(self.local_v6_peers)).strip("[]"))
             ]
+
+            timestamp = datetime.now(timezone.utc).strftime("%a %b %d %I:%M:%S %p UTC %Y")
+            if new_v4_peers or removed_v4_peers:
+                values.append(("v4_bfd_up_sessions_timestamp", json.dumps(timestamp)))
+            if new_v6_peers or removed_v6_peers:
+                values.append(("v6_bfd_up_sessions_timestamp", json.dumps(timestamp)))
+
             self.table.set("", values)
             syslog.syslog(syslog.LOG_INFO,
                 "{} table in STATE_DB updated. v4_peers: {}, v6_peers: {}".format(


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To bring DPU software BFD (bfdmon) database updates inline with https://github.com/sonic-net/SONiC/blob/4fc4f481e24414eb3f5c6c557842723480f6c9cd/doc/smart-switch/smart-switch-database-architecture/smart-switch-database-design.md#architecture-design. Currently the software BFD session info is stored in the local STATE_DB; adding these changes for software BFD session status to be sent to the remote DPU_STATE_DB.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added connection to DPU_STATE_DB to update DASH_BFD_PROBE_STATE with DPU software BFD session info in bfdmon.py

#### How to verify it
Loaded on Smartswitch DPU and checked that the software BFD session entries are added/deleted in DPU_STATE_DB for the corresponding DPU in switch SONiC. 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

