### PR TITLE
Security Cipher Module: Enabled Backup and Restore support for NOS Upgrades

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -642,6 +642,12 @@ j2 files/build_templates/config-setup.service.j2 | sudo tee $FILESYSTEM_ROOT_USR
 sudo cp $IMAGE_CONFIGS/config-setup/config-setup $FILESYSTEM_ROOT/usr/bin/config-setup
 sudo mkdir -p $FILESYSTEM_ROOT/etc/config-setup
 sudo cp $IMAGE_CONFIGS/config-setup/config-setup.conf $FILESYSTEM_ROOT/etc/config-setup/config-setup.conf
+sudo mkdir -p $FILESYSTEM_ROOT/etc/config-setup/config-migration-pre-hooks.d
+sudo cp $IMAGE_CONFIGS/config-setup/01-pre-security-cipher $FILESYSTEM_ROOT/etc/config-setup/config-migration-pre-hooks.d/01-pre-security-cipher
+chmod +x $FILESYSTEM_ROOT/etc/config-setup/config-migration-pre-hooks.d/01-pre-security-cipher
+sudo mkdir -p $FILESYSTEM_ROOT/etc/config-setup/config-migration-post-hooks.d
+sudo cp $IMAGE_CONFIGS/config-setup/01-post-security-cipher $FILESYSTEM_ROOT/etc/config-setup/config-migration-post-hooks.d/01-post-security-cipher
+chmod +x $FILESYSTEM_ROOT/etc/config-setup/config-migration-post-hooks.d/01-post-security-cipher
 echo "config-setup.service" | sudo tee -a $GENERATED_SERVICE_FILE
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable config-setup.service
 

--- a/files/image_config/config-setup/01-post-security-cipher
+++ b/files/image_config/config-setup/01-post-security-cipher
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+# Restore cipher_pass file from persistent storage
+if [ -f /host/security_cipher/cipher_pass ]; then
+    cp /host/security_cipher/cipher_pass /etc/cipher_pass
+    chmod 640 /etc/cipher_pass
+    echo "Restored /host/security_cipher/cipher_pass  to /etc/"
+fi
+

--- a/files/image_config/config-setup/01-pre-security-cipher
+++ b/files/image_config/config-setup/01-pre-security-cipher
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Ensure old_config directory exists
+mkdir -p /host/security_cipher
+
+# Copy cipher_pass file to persistent storage
+if [ -f /etc/cipher_pass ]; then
+    cp /etc/cipher_pass /host/security_cipher/cipher_pass 
+    echo "Saved /etc/cipher_pass to /host/security_cipher/"
+fi
+

--- a/src/sonic-yang-models/yang-models/sonic-system-tacacs.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-tacacs.yang
@@ -131,10 +131,11 @@ module sonic-system-tacacs {
                     default 5;
                 }
 
-		leaf key_encrypt {
-		    type boolean;
-		    description "Indicates if the passkey is encrypted.";
-		}
+                leaf key_encrypt {
+                    type boolean;
+                    default false;
+                    description "Indicates if the passkey is encrypted.";
+                }
 
                 leaf passkey {
                     type string {


### PR DESCRIPTION
<!--
   Enabled Backup and Restore support in Security Cipher Module for NOS Upgrades
   Reference PR: https://github.com/sonic-net/sonic-buildimage/pull/17201
-->

#### Why I did it
This is required majorly for NOS upgrade scenario to backup cipher_pass file stored at /etc dir.

#### How I did it
Added pre/post migration scripts

#### How to verify it
NOS upgrade


#### Which release branch to backport (provide reason below if selected)
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)
- [x] 202311

#### Link to config_db schema for YANG module changes
https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md

