### PR TITLE
Fix incorrect scd address in platform.json

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/platform.json
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/platform.json
@@ -6,10 +6,10 @@
                 "name": "Aboot()"
             },
             {
-                "name": "Scd(addr=0000:04:00.0)"
+                "name": "Scd(addr=0000:03:00.0)"
             },
             {
-                "name": "Scd(addr=0000:08:00.0)"
+                "name": "Scd(addr=0000:05:00.0)"
             },
             {
                 "name": "RedstartSysCpld(addr=13-0023)"


### PR DESCRIPTION
#### Why I did it
We were seeing platform test failures on `x86_64-arista_7060x6_64pe_b`. We identified that the PCI addresses listed in the corresponding `platform.json` file were incorrect.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated the `platform.json` file with the correct scd addresses per `ls /sys/bus/pci/drivers/scd` on dut.

#### How to verify it

Ran `sonic-mgmt/tests/platform_tests/api/test_component.py` with and without the change. With the change I no longer see an assertion error related to the scd components.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

