### PR TITLE
[Arista] Change lodoga CPU freq to 2GHz

### DIFF
--- a/platform/broadcom/sonic-platform-modules-arista.patch/0001-Lodoga-change-max-cpu-frequency-to-2GHz.patch
+++ b/platform/broadcom/sonic-platform-modules-arista.patch/0001-Lodoga-change-max-cpu-frequency-to-2GHz.patch
@@ -1,0 +1,93 @@
+From 8c8f0c11bd9bda663c1ef671ebc6314a3d6d625f Mon Sep 17 00:00:00 2001
+From: Boyang Yu <byu@arista.com>
+Date: Thu, 22 May 2025 22:26:18 +0000
+Subject: [PATCH] Lodoga: change max cpu frequency to 2GHz
+
+Change-Id: Ia2c39c92fe2e71f0b162b31a3e4aaa60da1042b4
+---
+ arista/components/cpu/crow.py | 17 +++++++++++++++++
+ arista/platforms/cpu/crow.py  |  4 ++++
+ arista/platforms/lodoga.py    |  6 +++++-
+ 3 files changed, 26 insertions(+), 1 deletion(-)
+
+diff --git a/arista/components/cpu/crow.py b/arista/components/cpu/crow.py
+index 3c8a2619..b1552dca 100644
+--- a/arista/components/cpu/crow.py
++++ b/arista/components/cpu/crow.py
+@@ -67,6 +67,23 @@ class DramScrubberQuirk(Quirk):
+       with open(path, 'w', encoding='utf8') as f:
+          f.write(str(self.rate))
+ 
++class CrowCpuFreqQuirk(Quirk):
++   def __init__(self, freq=2000000, description='change CPU max frequency'):
++      self.freq = freq
++      self.cores = 4
++      self.description = description
++
++   def __str__(self):
++      return self.description
++
++   def run(self, component):
++      if inSimulation():
++         return
++      pathFmt = '/sys/devices/system/cpu/cpu%d/cpufreq/scaling_max_freq'
++      for i in range(self.cores):
++         with open(pathFmt % i, 'w', encoding='utf8') as f:
++            f.write(str(self.freq))
++
+ class CrowSysCpld(SysCpld):
+    REGISTER_CLS = CrowCpldRegisters
+    QUIRKS = [
+diff --git a/arista/platforms/cpu/crow.py b/arista/platforms/cpu/crow.py
+index ba57c950..434337e6 100644
+--- a/arista/platforms/cpu/crow.py
++++ b/arista/platforms/cpu/crow.py
+@@ -65,3 +65,7 @@ class CrowCpu(Cpu):
+       }[num]
+       bridge = self.pciRoot.pciBridge(device=device, func=func)
+       return bridge.downstreamPort(port=0)
++
++   def setup(self):
++      self.applyQuirks()
++      super(CrowCpu, self).setup()
+diff --git a/arista/platforms/lodoga.py b/arista/platforms/lodoga.py
+index 1d56f865..049eb8d1 100644
+--- a/arista/platforms/lodoga.py
++++ b/arista/platforms/lodoga.py
+@@ -11,6 +11,7 @@ from ..components.cpld import (
+    SysCpldCommonRegistersV2,
+    SysCpldReloadCauseRegistersV2,
+ )
++from ..components.cpu.crow import CrowCpuFreqQuirk
+ from ..components.dpm.ucd import Ucd90120A, UcdGpi
+ from ..components.max6658 import Max6658
+ from ..components.psu.delta import DPS495CB, DPS500AB
+@@ -42,6 +43,7 @@ class LodogaPrimeCpldRegisters(SysCpldCommonRegistersV2):
+    pass
+ 
+ class LodogaBase(FixedSystem):
++   LODOGA_QUIRKS = []
+ 
+    PORTS = PortLayout(
+       (Qsfp28(i, leds=4) for i in incrange(1, 32)),
+@@ -51,7 +53,8 @@ class LodogaBase(FixedSystem):
+    def __init__(self, cpuCls, syscpldRegisters):
+       super().__init__()
+ 
+-      cpu = self.newComponent(cpuCls, registerCls=syscpldRegisters)
++      cpu = self.newComponent(cpuCls, registerCls=syscpldRegisters,
++                              quirks=self.LODOGA_QUIRKS)
+       self.cpu = cpu
+       self.syscpld = cpu.syscpld
+ 
+@@ -153,6 +156,7 @@ class Lodoga(LodogaBase):
+    PSU_CLS = [DPS495CB, DS495SPE]
+    SCD_PCI_PORT_IDX = 1
+    SWITCH_CHIPSET_PCI_PORT_IDX = 0
++   LODOGA_QUIRKS = [CrowCpuFreqQuirk()]
+ 
+    class SmBusAddresses(object):
+       TS  = 9
+-- 
+2.41.0
+

--- a/platform/broadcom/sonic-platform-modules-arista.patch/series
+++ b/platform/broadcom/sonic-platform-modules-arista.patch/series
@@ -1,0 +1,1 @@
+0001-Lodoga-change-max-cpu-frequency-to-2GHz.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Experimental change for setting CPU freq of Lodoga to 2GHz

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

