### PR TITLE
[PDDF] Fix expected i2c path

### DIFF
--- a/platform/pddf/i2c/utils/pddfparse.py
+++ b/platform/pddf/i2c/utils/pddfparse.py
@@ -635,7 +635,7 @@ class PddfParse():
                     real_name = attr['attr_name']
 
                 dsysfs_path = self.show_device_sysfs(dev, ops) + \
-                    "/%d-00%x" % (int(dev['i2c']['topo_info']['parent_bus'], 0),
+                    "/%d-00%02x" % (int(dev['i2c']['topo_info']['parent_bus'], 0),
                                   int(dev['i2c']['topo_info']['dev_addr'], 0)) + \
                     "/%s" % real_name
                 if dsysfs_path not in self.data_sysfs_obj[KEY]:
@@ -694,7 +694,7 @@ class PddfParse():
                             real_dev = dev
 
                         dsysfs_path = self.show_device_sysfs(real_dev, ops) + \
-                            "/%d-00%x" % (int(real_dev['i2c']['topo_info']['parent_bus'], 0),
+                            "/%d-00%02x" % (int(real_dev['i2c']['topo_info']['parent_bus'], 0),
                                           int(real_dev['i2c']['topo_info']['dev_addr'], 0)) + \
                             "/%s" % real_name
                         if dsysfs_path not in self.data_sysfs_obj[KEY]:
@@ -738,7 +738,7 @@ class PddfParse():
                         real_dev = dev
 
                     dsysfs_path = self.show_device_sysfs(real_dev, ops) + \
-                        "/%d-00%x" % (int(real_dev['i2c']['topo_info']['parent_bus'], 0),
+                        "/%d-00%02x" % (int(real_dev['i2c']['topo_info']['parent_bus'], 0),
                                       int(real_dev['i2c']['topo_info']['dev_addr'], 0)) + \
                         "/%s" % real_name
                     if dsysfs_path not in self.data_sysfs_obj[KEY]:
@@ -760,7 +760,7 @@ class PddfParse():
         for attr in attr_list:
             if attr_name == attr['attr_name'] or attr_name == 'all':
                 path = self.show_device_sysfs(dev, ops) + \
-                    "/%d-00%x/" % (int(dev['i2c']['topo_info']['parent_bus'], 0),
+                    "/%d-00%02x/" % (int(dev['i2c']['topo_info']['parent_bus'], 0),
                                    int(dev['i2c']['topo_info']['dev_addr'], 0))
                 if 'drv_attr_name' in attr.keys():
                     real_name = attr['drv_attr_name']
@@ -827,7 +827,7 @@ class PddfParse():
                             real_dev = dev
 
                         dsysfs_path = self.show_device_sysfs(real_dev, ops) + \
-                            "/%d-00%x" % (int(real_dev['i2c']['topo_info']['parent_bus'], 0),
+                            "/%d-00%02x" % (int(real_dev['i2c']['topo_info']['parent_bus'], 0),
                                           int(real_dev['i2c']['topo_info']['dev_addr'], 0)) + \
                             "/%s" % real_name
                         if dsysfs_path not in self.data_sysfs_obj[KEY]:

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
@@ -293,7 +293,7 @@ class PddfApi():
                     real_name = attr['attr_name']
 
                 dsysfs_path = self.show_device_sysfs(dev, ops) + \
-                    "/%d-00%x" % (int(dev['i2c']['topo_info']['parent_bus'], 0),
+                    "/%d-00%02x" % (int(dev['i2c']['topo_info']['parent_bus'], 0),
                                   int(dev['i2c']['topo_info']['dev_addr'], 0)) + \
                     "/%s" % real_name
                 if dsysfs_path not in self.data_sysfs_obj[KEY]:
@@ -402,7 +402,7 @@ class PddfApi():
                             real_dev = dev
 
                         dsysfs_path = self.show_device_sysfs(real_dev, ops) + \
-                            "/%d-00%x" % (int(real_dev['i2c']['topo_info']['parent_bus'], 0),
+                            "/%d-00%02x" % (int(real_dev['i2c']['topo_info']['parent_bus'], 0),
                                           int(real_dev['i2c']['topo_info']['dev_addr'], 0)) + \
                             "/%s" % real_name
                         if dsysfs_path not in self.data_sysfs_obj[KEY]:
@@ -445,7 +445,7 @@ class PddfApi():
                         real_dev = dev
 
                     dsysfs_path = self.show_device_sysfs(real_dev, ops) + \
-                        "/%d-00%x" % (int(real_dev['i2c']['topo_info']['parent_bus'], 0),
+                        "/%d-00%02x" % (int(real_dev['i2c']['topo_info']['parent_bus'], 0),
                                       int(real_dev['i2c']['topo_info']['dev_addr'], 0)) + \
                         "/%s" % real_name
                     if dsysfs_path not in self.data_sysfs_obj[KEY]:
@@ -504,7 +504,7 @@ class PddfApi():
                             real_dev = dev
 
                         dsysfs_path = self.show_device_sysfs(real_dev, ops) + \
-                            "/%d-00%x" % (int(real_dev['i2c']['topo_info']['parent_bus'], 0),
+                            "/%d-00%02x" % (int(real_dev['i2c']['topo_info']['parent_bus'], 0),
                                           int(real_dev['i2c']['topo_info']['dev_addr'], 0)) + \
                             "/%s" % real_name
                         if dsysfs_path not in self.data_sysfs_obj[KEY]:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The i2c device address is padded to 4 digits in sysfs:
```
root@sonic:/sys/bus/i2c/devices# ls
10-0048  26-0050  31-0050  36-0050  41-0050  46-0050  51-0050  56-0050  61-0050  66-0050  71-0050  76-0050  81-0050  86-0050  i2c-23  i2c-32  i2c-41  i2c-50  i2c-6   i2c-69  i2c-78  i2c-9
10-0050  27-0008  32-0008  37-0008  42-0008  47-0008  52-0008  57-0008  62-0008  67-0008  72-0008  77-0008  82-0008  i2c-0    i2c-24  i2c-33  i2c-42  i2c-51  i2c-60  i2c-7   i2c-79
19-0008  27-0050  32-0050  37-0050  42-0050  47-0050  52-0050  57-0050  62-0050  67-0050  72-0050  77-0050  82-0050  i2c-1    i2c-25  i2c-34  i2c-43  i2c-52  i2c-61  i2c-70  i2c-8
23-0008  28-0008  33-0008  38-0008  43-0008  48-0008  53-0008  58-0008  63-0008  68-0008  73-0008  78-0008  83-0008  i2c-10   i2c-26  i2c-35  i2c-44  i2c-53  i2c-62  i2c-71  i2c-80
23-0050  28-0050  33-0050  38-0050  43-0050  48-0050  53-0050  58-0050  63-0050  68-0050  73-0050  78-0050  83-0050  i2c-11   i2c-27  i2c-36  i2c-45  i2c-54  i2c-63  i2c-72  i2c-81
24-0008  29-0008  34-0008  39-0008  44-0008  49-0008  54-0008  59-0008  64-0008  69-0008  74-0008  79-0008  84-0008  i2c-19   i2c-28  i2c-37  i2c-46  i2c-55  i2c-64  i2c-73  i2c-82
24-0050  29-0050  34-0050  39-0050  44-0050  49-0050  54-0050  59-0050  64-0050  69-0050  74-0050  79-0050  84-0050  i2c-2    i2c-29  i2c-38  i2c-47  i2c-56  i2c-65  i2c-74  i2c-83
25-0008  30-0008  35-0008  40-0008  45-0008  50-0008  55-0008  60-0008  65-0008  70-0008  75-0008  80-0008  85-0008  i2c-20   i2c-3   i2c-39  i2c-48  i2c-57  i2c-66  i2c-75  i2c-84
25-0050  30-0050  35-0050  40-0050  45-0050  50-0050  55-0050  60-0050  65-0050  70-0050  75-0050  80-0050  85-0050  i2c-21   i2c-30  i2c-4   i2c-49  i2c-58  i2c-67  i2c-76  i2c-85
26-0008  31-0008  36-0008  41-0008  46-0008  51-0008  56-0008  61-0008  66-0008  71-0008  76-0008  81-0008  86-0008  i2c-22   i2c-31  i2c-40  i2c-5   i2c-59  i2c-68  i2c-77  i2c-86
```
Multiple functions in pddfparse.py and pddfapi.py will read the wrong sysfs path due to incorrect padding for devices with 1-digit addresses. For example, expecting the device to be 19-008 instead of 19-0008. 


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Fix the zero padding for every i2c device sysfs path

#### How to verify it
Tested on NH-4010 sonic platform API object.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

