### PR TITLE
[PDDF] Fix Failed to register i2c client optoe2

### DIFF
--- a/platform/pddf/i2c/utils/pddfparse.py
+++ b/platform/pddf/i2c/utils/pddfparse.py
@@ -409,9 +409,9 @@ class PddfParse():
                 cmd = "echo {} > /sys/bus/i2c/devices/{}-00{:02x}/port_name".format(
                     dev['dev_info']['virt_parent'].lower(), int(dev['i2c']['topo_info']['parent_bus'], 0),
                     int(dev['i2c']['topo_info']['dev_addr'], 0))
-            ret = self.runcmd(cmd)
-            if ret != 0:
-                return create_ret.append(ret)
+                ret = self.runcmd(cmd)
+                if ret != 0:
+                    return create_ret.append(ret)
 
         return create_ret.append(ret)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
On NH-4010, fix kernel msg: `i2c i2c-97: Failed to register i2c client optoe2 at 0x50 (-16)`
Should is a problem which can hit all PDDF platforms

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
This is caused by a bug in pddfparse.py. The logic that creates the xcvr eeprom wants to conditionally run another cmd if the `port_name_sysfs` path exists. However, the current logic will rerun the previous `cmd` if `port_name_sysfs` does not exist. This results in a device re-instantiation error.

#### How to verify it
Verified on NH-4010

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

