### PR TITLE
[chassis] Cisco-8000: Use syseeprom for mac only as last option

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -857,9 +857,17 @@ def get_system_mac(namespace=None, hostname=None):
             profile_cmd = ["false"]
             (mac, err) = run_command(profile_cmd)
         hw_mac_entry_outputs.append((mac, err))
-        (mac, err) = run_command(syseeprom_cmd)
-        hw_mac_entry_outputs.append((mac, err))
         (mac, err) = run_command_pipe(iplink_cmd0, iplink_cmd1, iplink_cmd2)
+        hw_mac_entry_outputs.append((mac, err))
+        for (mac, err) in hw_mac_entry_outputs:
+            if err:
+                continue
+            mac = mac.strip()
+            if _valid_mac_address(mac):
+                return mac
+        # If mac not found, fetch from syseeprom
+        hw_mac_entry_outputs = []
+        (mac, err) = run_command(syseeprom_cmd)
         hw_mac_entry_outputs.append((mac, err))
     elif (version_info['asic_type'] == 'pensando'):
         iplink_cmd0 = ["ip", 'link', 'show', 'eth0-midplane']


### PR DESCRIPTION
    syseepromg access is slower than getting the mac from eth0 interface and profile.ini file when available. On Chassis supervisor as many swss services spawns around same time and each try to access DEVICE info via sonic-cfggen, these make parallel calls to syseepromg to fetch mac. This sometimes lows the response during high cpu utilization. 
   For multi-asic namespace locations, mac is available from profile.ini and for others, eth0 should provide the correct mac.
Limiting the syseeprom access only when the mac is not retrieved from these options.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
On supervisor, sometimes syncd process start get delayed during boot when parallel swss processes try to access syseeprom to get mac which doing DEVICE_METADATA.localhost.platform call via sonic-cfggen. This in some rare instances causes swss failure when syncd is not ready within 1 min and responds back to INIT_VIEW.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
   For multi-asic namespace locations, mac is available from profile.ini and for others, eth0 should provide the correct mac.
Limiting the syseeprom access only when the mac is not retrieved from these options.

#### How to verify it
```
root@yy39-lc5:/home/cisco# time sonic-cfggen -H -v DEVICE_METADATA.localhost.mac
8c:84:42:90:97:20

real    0m0.532s
user    0m0.360s
sys     0m0.064s
root@yy39-lc5:/home/cisco# ifconfig  eth0
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 1.75.46.11  netmask 255.255.0.0  broadcast 1.75.255.255
        inet6 fc0b::11  prefixlen 64  scopeid 0x0<global>
        inet6 fe80::8e84:42ff:fe90:9720  prefixlen 64  scopeid 0x20<link>
        ether 8c:84:42:90:97:20  txqueuelen 1000  (Ethernet)
        RX packets 7501239  bytes 889985239 (848.7 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 8052387  bytes 646097128 (616.1 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

