### PR TITLE
[QoS] Make broadcom asic detection more robust in ipinip json template

### DIFF
--- a/dockers/docker-orchagent/docker-init.j2
+++ b/dockers/docker-orchagent/docker-init.j2
@@ -10,7 +10,7 @@ CFGGEN_PARAMS=" \
 {% if ENABLE_ASAN == "y" %}
      -a "{\"ENABLE_ASAN\":\"{{ENABLE_ASAN}}\"}" \
 {% endif %}
-    -a "{\"ASIC_VENDOR\":\"${ASIC_VENDOR:-unknown}\",\"SONIC_ASIC_PLATFORM\":\"${sonic_asic_platform:-unknown}\"}" \
+    -a "{\"ASIC_VENDOR\":\"${ASIC_VENDOR:-unknown}\"}" \
     -y /etc/sonic/constants.yml \
     -t /usr/share/sonic/templates/orch_zmq_tables.conf.j2,/etc/swss/orch_zmq_tables.conf \
     -t /usr/share/sonic/templates/switch.json.j2,/etc/swss/config.d/switch.json \

--- a/dockers/docker-orchagent/docker-init.j2
+++ b/dockers/docker-orchagent/docker-init.j2
@@ -10,6 +10,7 @@ CFGGEN_PARAMS=" \
 {% if ENABLE_ASAN == "y" %}
      -a "{\"ENABLE_ASAN\":\"{{ENABLE_ASAN}}\"}" \
 {% endif %}
+    -a "{\"ASIC_VENDOR\":\"${ASIC_VENDOR:-unknown}\",\"SONIC_ASIC_PLATFORM\":\"${sonic_asic_platform:-unknown}\"}" \
     -y /etc/sonic/constants.yml \
     -t /usr/share/sonic/templates/orch_zmq_tables.conf.j2,/etc/swss/orch_zmq_tables.conf \
     -t /usr/share/sonic/templates/switch.json.j2,/etc/swss/config.d/switch.json \

--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -7,12 +7,6 @@
 {% if ASIC_VENDOR is defined and "broadcom" in ASIC_VENDOR|lower %}
   {% set is_broadcom = true %}
 {% endif %}
-{% if not is_broadcom and asic_type is defined and "broadcom" in asic_type|lower %}
-  {% set is_broadcom = true %}
-{% endif %}
-{% if not is_broadcom and SONIC_ASIC_PLATFORM is defined and "broadcom" in SONIC_ASIC_PLATFORM|lower %}
-  {% set is_broadcom = true %}
-{% endif %}
 
 {% set ipv4_addresses = [] %}
 {% set ipv6_addresses = [] %}

--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -4,14 +4,14 @@
 
 {# Check if the ASIC is Broadcom #}
 {% set is_broadcom = false %}
-{% if asic_type is defined and "broadcom" in asic_type|lower %}
+{% if ASIC_VENDOR is defined and ASIC_VENDOR|lower == "broadcom" %}
   {% set is_broadcom = true %}
 {% endif %}
-{% if not is_broadcom and DEVICE_METADATA.localhost.hwsku is defined %}
-  {% set hwsku_lower = DEVICE_METADATA.localhost.hwsku|lower %}
-  {% if "arista" in hwsku_lower or "nexus" in hwsku_lower or "force" in hwsku_lower or "celestica" in hwsku_lower or "dell" in hwsku_lower or "nokia" in hwsku_lower %}
-    {% set is_broadcom = true %}
-  {% endif %}
+{% if not is_broadcom and asic_type is defined and "broadcom" in asic_type|lower %}
+  {% set is_broadcom = true %}
+{% endif %}
+{% if not is_broadcom and SONIC_ASIC_PLATFORM is defined and "broadcom" in SONIC_ASIC_PLATFORM|lower %}
+  {% set is_broadcom = true %}
 {% endif %}
 
 {% set ipv4_addresses = [] %}
@@ -72,6 +72,7 @@
 {%- set ipv4_addresses = [] %}
 {%- set ipv6_addresses = [] %}
 {% endif %}
+
 [
 {% if ipv4_loopback_addresses %}
 {% if subnet_decap.enable %}

--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -1,6 +1,19 @@
 {% if DEVICE_METADATA['localhost']['switch_type'] == "dpu" %}
 []
 {% else %}
+
+{# Check if the ASIC is Broadcom #}
+{% set is_broadcom = false %}
+{% if asic_type is defined and "broadcom" in asic_type|lower %}
+  {% set is_broadcom = true %}
+{% endif %}
+{% if not is_broadcom and DEVICE_METADATA.localhost.hwsku is defined %}
+  {% set hwsku_lower = DEVICE_METADATA.localhost.hwsku|lower %}
+  {% if "arista" in hwsku_lower or "nexus" in hwsku_lower or "force" in hwsku_lower or "celestica" in hwsku_lower or "dell" in hwsku_lower or "nokia" in hwsku_lower %}
+    {% set is_broadcom = true %}
+  {% endif %}
+{% endif %}
+
 {% set ipv4_addresses = [] %}
 {% set ipv6_addresses = [] %}
 {% set ipv4_vlan_addresses = [] %}
@@ -65,7 +78,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_SUBNET" : {
             "tunnel_type":"IPINIP",
-{% if "broadcom" in asic_type %}
+{% if is_broadcom %}
             "dscp_mode":"uniform",
 {% else %}
             "dscp_mode":"pipe",
@@ -89,7 +102,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-{% if "broadcom" in asic_type %}
+{% if is_broadcom %}
             "dscp_mode":"uniform",
 {% else %}
             "dscp_mode":"pipe",
@@ -120,7 +133,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_SUBNET_V6" : {
             "tunnel_type":"IPINIP",
-{% if "broadcom" in asic_type %}
+{% if is_broadcom %}
             "dscp_mode":"uniform",
 {% else %}
             "dscp_mode":"pipe",
@@ -144,7 +157,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-{% if "broadcom" in asic_type %}
+{% if is_broadcom %}
             "dscp_mode":"uniform",
 {% else %}
             "dscp_mode":"pipe",

--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -4,7 +4,7 @@
 
 {# Check if the ASIC is Broadcom #}
 {% set is_broadcom = false %}
-{% if ASIC_VENDOR is defined and ASIC_VENDOR|lower == "broadcom" %}
+{% if ASIC_VENDOR is defined and "broadcom" in ASIC_VENDOR|lower %}
   {% set is_broadcom = true %}
 {% endif %}
 {% if not is_broadcom and asic_type is defined and "broadcom" in asic_type|lower %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes #22797 
Make broadcom asic detection more robust in ipinip json template

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Check if device is in the list of specified hwskus

#### How to verify it
Tested on switch:

```
{
        "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
            "tunnel_type":"IPINIP",
            "dscp_mode":"uniform",
            "ecn_mode":"copy_from_outer",
            "ttl_mode":"pipe"
        },
        "OP": "SET"
    },
...
```

The `ASIC_VENDOR` env var is used which is defined inside the swss container [here](https://github.com/sonic-net/sonic-buildimage/blob/80d660de2f04335ccdd26c3f19b3083528793a92/files/build_templates/docker_image_ctl.j2#L710).

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[QoS] Make broadcom asic detection more robust in ipinip json template
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

