### PR TITLE
Per queue direction priority config

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/traffic_config.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/traffic_config.j2
@@ -1,0 +1,1 @@
+../../x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/traffic_config.j2

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_defaults_objects.j2
@@ -16,6 +16,8 @@
     limitations under the License.
 #}
 
+{% import 'traffic_config.j2' as traffic_config %}
+
 {%- macro generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) %}
     "BUFFER_POOL": {
         {% if dynamic_mode is not defined and port_names_inactive|length > 0 -%}
@@ -73,50 +75,98 @@
             "size":"0",
             "dynamic_th":"7"
         },
-        "egress_lossless_profile": {
-            "pool":"egress_lossless_pool",
-            "size":"0",
-            "dynamic_th":"7"
-        },
         "egress_lossy_profile": {
             "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"-6"
         },
-        "queue0_lossy_profile": {
-            "pool":"egress_lossy_pool",
-            "size":"0",
-            "dynamic_th":"0"
+        "queue0_downlink_lossy_profile": {
+            "dynamic_th": "0",
+            "size": "0",
+            "pool": "egress_lossy_pool"
         },
-        "queue1_lossy_profile": {
-            "pool":"egress_lossy_pool",
-            "size":"0",
-            "dynamic_th":"0"
-        },
-        "queue2_lossy_profile": {
-            "pool":"egress_lossy_pool",
-            "size":"0",
-            "dynamic_th":"0"
-        },
-        "queue3_lossy_profile": {
-            "pool":"egress_lossy_pool",
-            "size":"0",
-            "dynamic_th":"0"
-        },
-        "queue4_lossy_profile": {
+        "queue1_downlink_lossy_profile": {
+            {% if traffic_config.traffic_classification_enable %}
+            "packet_discard_action": "trim",
+            {% endif %}
             "pool": "egress_lossy_pool",
             "size": "0",
-            "dynamic_th" : "7"
+            "dynamic_th": "0"
         },
-        "queue5_lossy_profile": {
+        "queue2_downlink_lossy_profile": {
+            {% if traffic_config.traffic_classification_enable %}
+            "packet_discard_action": "trim",
+            {% endif %}
             "pool": "egress_lossy_pool",
             "size": "0",
-            "dynamic_th" : "-3"
+            "dynamic_th": "0"
         },
-        "queue6_lossy_profile": {
+        "queue3_downlink_lossy_profile": {
+            {% if traffic_config.traffic_classification_enable %}
+            "packet_discard_action": "trim",
+            {% endif %}
             "pool": "egress_lossy_pool",
             "size": "0",
-            "dynamic_th" : "0"
+            "dynamic_th": "0"
+        },
+        "queue4_downlink_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "7"
+        },
+        "queue5_downlink_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "-3"
+        },
+        "queue6_downlink_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "0"
+        },
+        "queue0_uplink_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "0"
+        },
+        "queue1_uplink_lossy_profile": {
+            {% if traffic_config.traffic_classification_enable %}
+            "packet_discard_action": "trim",
+            {% endif %}
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "0"
+        },
+        "queue2_uplink_lossy_profile": {
+            {% if traffic_config.traffic_classification_enable %}
+            "packet_discard_action": "trim",
+            {% endif %}
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "0"
+        },
+        "queue3_uplink_lossy_profile": {
+            {% if traffic_config.traffic_classification_enable %}
+            "packet_discard_action": "trim",
+            {% endif %}
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "0"
+        },
+        "queue4_uplink_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "7"
+        },
+        "queue5_uplink_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "-3"
+        },
+        "queue6_uplink_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "0"
         }
     },
 {%- endmacro %}
@@ -146,7 +196,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names_active.split(',') %}
         "{{ port }}": {
-            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
+            "profile_list" : "egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -155,9 +205,9 @@
 {% for port in port_names_inactive.split(',') %}
         "{{ port }}": {
 {% if dynamic_mode is defined %}
-            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
+            "profile_list" : "egress_lossy_profile"
 {% else %}
-            "profile_list" : "egress_lossless_zero_profile,egress_lossy_zero_profile"
+            "profile_list" : "egress_lossy_zero_profile"
 {% endif %}
         }{% if not loop.last %},{% endif %}
 
@@ -170,52 +220,51 @@
     "BUFFER_QUEUE": {
 {% for port in port_names_active.split(',') %}
         "{{ port }}|0": {
-            "profile" : "queue0_lossy_profile"
+            "profile" : "queue0_{{ 'uplink' if port in PORT_UPLINK else 'downlink' }}_lossy_profile"
         },
         "{{ port }}|1": {
-            "profile" : "queue1_lossy_profile"
+            "profile" : "queue1_{{ 'uplink' if port in PORT_UPLINK else 'downlink' }}_lossy_profile"
         },
         "{{ port }}|2": {
-            "profile" : "queue2_lossy_profile"
+            "profile" : "queue2_{{ 'uplink' if port in PORT_UPLINK else 'downlink' }}_lossy_profile"
         },
         "{{ port }}|3": {
-            "profile" : "queue3_lossy_profile"
+            "profile" : "queue3_{{ 'uplink' if port in PORT_UPLINK else 'downlink' }}_lossy_profile"
         },
         "{{ port }}|4": {
-            "profile" : "queue4_lossy_profile"
+            "profile" : "queue4_{{ 'uplink' if port in PORT_UPLINK else 'downlink' }}_lossy_profile"
         },
         "{{ port }}|5": {
-            "profile" : "queue5_lossy_profile"
+            "profile" : "queue5_{{ 'uplink' if port in PORT_UPLINK else 'downlink' }}_lossy_profile"
         },
         "{{ port }}|6": {
-            "profile" : "queue6_lossy_profile"
+            "profile" : "queue6_{{ 'uplink' if port in PORT_UPLINK else 'downlink' }}_lossy_profile"
         }{% if not loop.last %},{% endif %}
-
 {% endfor %}
 {% if port_names_inactive|length > 0 %}
 {% if dynamic_mode is defined %}
 {% if port_names_active.split(',')|length > 0 %},{% endif %}
 {% for port in port_names_inactive.split(',') %}
         "{{ port }}|0": {
-            "profile" : "queue0_lossy_profile"
+            "profile" : "queue0_{{ 'uplink' if port in PORT_UPLINK else 'downlink' }}_lossy_profile"
         },
         "{{ port }}|1": {
-            "profile" : "queue1_lossy_profile"
+            "profile" : "queue1_{{ 'uplink' if port in PORT_UPLINK else 'downlink' }}_lossy_profile"
         },
         "{{ port }}|2": {
-            "profile" : "queue2_lossy_profile"
+            "profile" : "queue2_{{ 'uplink' if port in PORT_UPLINK else 'downlink' }}_lossy_profile"
         },
         "{{ port }}|3": {
-            "profile" : "queue3_lossy_profile"
+            "profile" : "queue3_{{ 'uplink' if port in PORT_UPLINK else 'downlink' }}_lossy_profile"
         },
         "{{ port }}|4": {
-            "profile" : "queue4_lossy_profile"
+            "profile" : "queue4_{{ 'uplink' if port in PORT_UPLINK else 'downlink' }}_lossy_profile"
         },
         "{{ port }}|5": {
-            "profile" : "queue5_lossy_profile"
+            "profile" : "queue5_{{ 'uplink' if port in PORT_UPLINK else 'downlink' }}_lossy_profile"
         },
         "{{ port }}|6": {
-            "profile" : "queue6_lossy_profile"
+            "profile" : "queue6_{{ 'uplink' if port in PORT_UPLINK else 'downlink' }}_lossy_profile"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
 {% else %}

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2
@@ -198,6 +198,7 @@
 {%- macro generate_wred_profiles() %}
     {# Default threshold values for both ToR and Leaf routers #}
     {%- set min_threshold = "166912" %}
+    {%- set disable_wred = traffic_config.wred_threshold_limit %}
 
     {%- if 'type' in DEVICE_METADATA['localhost'] %}
         {%- if DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
@@ -260,12 +261,12 @@
             "wred_yellow_enable": "true",
             "wred_red_enable": "true",
             "ecn": "ecn_all",
-            "green_max_threshold": "{{ max_threshold }}",
-            "green_min_threshold": "{{ min_threshold }}",
-            "yellow_max_threshold": "{{ max_threshold }}",
-            "yellow_min_threshold": "{{ min_threshold }}",
-            "red_max_threshold": "{{ max_threshold }}",
-            "red_min_threshold": "{{ min_threshold }}",
+            "green_max_threshold": "{{ disable_wred }}",
+            "green_min_threshold": "{{ disable_wred }}",
+            "yellow_max_threshold": "{{ disable_wred }}",
+            "yellow_min_threshold": "{{ disable_wred }}",
+            "red_max_threshold": "{{ disable_wred }}",
+            "red_min_threshold": "{{ disable_wred }}",
             "green_drop_probability": "5",
             "yellow_drop_probability": "5",
             "red_drop_probability": "5"
@@ -275,12 +276,12 @@
             "wred_yellow_enable": "true",
             "wred_red_enable": "true",
             "ecn": "ecn_all",
-            "green_max_threshold": "{{ max_threshold }}",
-            "green_min_threshold": "{{ min_threshold }}",
-            "yellow_max_threshold": "{{ max_threshold }}",
-            "yellow_min_threshold": "{{ min_threshold }}",
-            "red_max_threshold": "{{ max_threshold }}",
-            "red_min_threshold": "{{ min_threshold }}",
+            "green_max_threshold": "{{ disable_wred }}",
+            "green_min_threshold": "{{ disable_wred }}",
+            "yellow_max_threshold": "{{ disable_wred }}",
+            "yellow_min_threshold": "{{ disable_wred }}",
+            "red_max_threshold": "{{ disable_wred }}",
+            "red_min_threshold": "{{ disable_wred }}",
             "green_drop_probability": "5",
             "yellow_drop_probability": "5",
             "red_drop_probability": "5"
@@ -335,12 +336,12 @@
             "wred_yellow_enable": "true",
             "wred_red_enable": "true",
             "ecn": "ecn_all",
-            "green_max_threshold": "{{ max_threshold }}",
-            "green_min_threshold": "{{ min_threshold }}",
-            "yellow_max_threshold": "{{ max_threshold }}",
-            "yellow_min_threshold": "{{ min_threshold }}",
-            "red_max_threshold": "{{ max_threshold }}",
-            "red_min_threshold": "{{ min_threshold }}",
+            "green_max_threshold": "{{ disable_wred }}",
+            "green_min_threshold": "{{ disable_wred }}",
+            "yellow_max_threshold": "{{ disable_wred }}",
+            "yellow_min_threshold": "{{ disable_wred }}",
+            "red_max_threshold": "{{ disable_wred }}",
+            "red_min_threshold": "{{ disable_wred }}",
             "green_drop_probability": "5",
             "yellow_drop_probability": "5",
             "red_drop_probability": "5"
@@ -350,12 +351,12 @@
             "wred_yellow_enable": "true",
             "wred_red_enable": "true",
             "ecn": "ecn_all",
-            "green_max_threshold": "{{ max_threshold }}",
-            "green_min_threshold": "{{ min_threshold }}",
-            "yellow_max_threshold": "{{ max_threshold }}",
-            "yellow_min_threshold": "{{ min_threshold }}",
-            "red_max_threshold": "{{ max_threshold }}",
-            "red_min_threshold": "{{ min_threshold }}",
+            "green_max_threshold": "{{ disable_wred }}",
+            "green_min_threshold": "{{ disable_wred }}",
+            "yellow_max_threshold": "{{ disable_wred }}",
+            "yellow_min_threshold": "{{ disable_wred }}",
+            "red_max_threshold": "{{ disable_wred }}",
+            "red_min_threshold": "{{ disable_wred }}",
             "green_drop_probability": "5",
             "yellow_drop_probability": "5",
             "red_drop_probability": "5"

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2
@@ -13,6 +13,8 @@
     limitations under the License.
 #}
 
+{% import 'traffic_config.j2' as traffic_config %}
+
 {%- macro generate_dscp_to_tc_map_per_sku() -%}
     "DSCP_TO_TC_MAP": {
         "AZURE": {
@@ -47,26 +49,26 @@
             "28": "4",
             "29": "4",
             "30": "4",
-            "31": "5",
-            "32": "5",
-            "33": "5",
-            "34": "5",
-            "35": "5",
-            "36": "5",
-            "37": "5",
-            "38": "5",
-            "39": "5",
-            "40": "5",
-            "41": "0",
-            "42": "0",
-            "43": "0",
-            "44": "0",
-            "45": "0",
-            "46": "0",
-            "47": "0",
-            "48": "0",
-            "49": "0",
-            "50": "0",
+            "31": "4",
+            "32": "4",
+            "33": "4",
+            "34": "4",
+            "35": "4",
+            "36": "4",
+            "37": "4",
+            "38": "4",
+            "39": "4",
+            "40": "4",
+            "41": "5",
+            "42": "5",
+            "43": "5",
+            "44": "5",
+            "45": "5",
+            "46": "5",
+            "47": "5",
+            "48": "5",
+            "49": "5",
+            "50": "5",
             "51": "0",
             "52": "0",
             "53": "0",
@@ -100,113 +102,263 @@
 
 {%- macro generate_scheduler_per_sku() -%}
     "SCHEDULER": {
-        "scheduler.4": {
-            "type"  : "DWRR",
+        "scheduler_q0_downlink": {
+            "type": "DWRR",
             "weight": "4"
         },
-        "scheduler.8": {
-            "type"  : "DWRR",
+        "scheduler_q1_downlink": {
+            "type": "DWRR",
             "weight": "8"
         },
-        "scheduler.18": {
-            "type"  : "DWRR",
+        "scheduler_q2_downlink": {
+            "type": "DWRR",
             "weight": "18"
         },
-        "scheduler.22": {
-            "type"  : "DWRR",
+        "scheduler_q3_downlink": {
+            "type": "DWRR",
             "weight": "22"
+        },
+        "scheduler_q4_downlink": {
+            "type": "DWRR",
+            "weight": "22"
+        },
+        "scheduler_q5_downlink": {
+            "type": "DWRR",
+            "weight": "22"
+        },
+        "scheduler_q6_downlink": {
+            "type": "DWRR",
+            "weight": "4"
+        },
+        "scheduler_q0_uplink": {
+            "type": "DWRR",
+            "weight": "4"
+        },
+        "scheduler_q1_uplink": {
+            "type": "DWRR",
+            "weight": "8"
+        },
+        "scheduler_q2_uplink": {
+            "type": "DWRR",
+            "weight": "18"
+        },
+        "scheduler_q3_uplink": {
+            "type": "DWRR",
+            "weight": "22"
+        },
+        "scheduler_q4_uplink": {
+            "type": "DWRR",
+            "weight": "22"
+        },
+        "scheduler_q5_uplink": {
+            "type": "DWRR",
+            "weight": "22"
+        },
+        "scheduler_q6_uplink": {
+            "type": "DWRR",
+            "weight": "4"
         }
     },
 {%- endmacro -%}
 
-{%- macro generate_single_queue_per_sku(port) -%}
-        "{{ port }}|0": {
-            "scheduler": "scheduler.4"
-        },
-        "{{ port }}|1": {
-            "scheduler": "scheduler.8",
-            "wred_profile": "AZURE_LOSSY_Q1"
-        },
-        "{{ port }}|2": {
-            "scheduler": "scheduler.18",
-            "wred_profile": "AZURE_LOSSY_Q2"
-        },
-        "{{ port }}|3": {
-            "scheduler": "scheduler.22",
-            "wred_profile": "AZURE_LOSSY_Q3"
-        },
-        "{{ port }}|4": {
-            "scheduler": "scheduler.22"
-        },
-        "{{ port }}|5": {
-            "scheduler": "scheduler.22"
-        },
-        "{{ port }}|6": {
-            "scheduler": "scheduler.4"
-        }
+{%- macro generate_direction_based_queue_per_sku(port, direction) -%}
+    "{{ port }}|0": {
+        "scheduler": "scheduler_q0_{{ direction }}"
+    },
+    "{{ port }}|1": {
+        "scheduler": "scheduler_q1_{{ direction }}",
+        "wred_profile": "AZURE_LOSSY_{{ direction.upper() }}_Q1"
+    },
+    "{{ port }}|2": {
+        "scheduler": "scheduler_q2_{{ direction }}",
+        "wred_profile": "AZURE_LOSSY_{{ direction.upper() }}_Q2"
+    },
+    "{{ port }}|3": {
+        "scheduler": "scheduler_q3_{{ direction }}",
+        "wred_profile": "AZURE_LOSSY_{{ direction.upper() }}_Q3"
+    },
+    "{{ port }}|4": {
+        "scheduler": "scheduler_q4_{{ direction }}",
+        "wred_profile": "AZURE_LOSSY_{{ direction.upper() }}_Q4"
+    },
+    "{{ port }}|5": {
+        "scheduler": "scheduler_q5_{{ direction }}",
+        "wred_profile": "AZURE_LOSSY_{{ direction.upper() }}_Q5"
+    },
+    "{{ port }}|6": {
+        "scheduler": "scheduler_q6_{{ direction }}"
+    }
 {%- endmacro -%}
 
 {%- macro generate_global_dscp_to_tc_map() %}
 {# This is an empty macro since the global DSCP_TO_TC map is not required #}
 {%- endmacro %}
 
+{# downlink Q use t0, uplink Q use t1 #}
 {%- macro generate_wred_profiles() %}
-    {%- set max_threshold = "282624" %}
+    {# Default threshold values for both ToR and Leaf routers #}
     {%- set min_threshold = "166912" %}
 
     {%- if 'type' in DEVICE_METADATA['localhost'] %}
         {%- if DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
+            {# ToR Router thresholds - only override if different from defaults #}
             {%- set max_threshold = "282624" %}
         {%- elif DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
+            {# Leaf Router thresholds - only override if different from defaults #}
             {%- set max_threshold = "239616" %}
         {%- endif %}
     {%- endif %}
 
     "WRED_PROFILE": {
-        "AZURE_LOSSY_Q1" : {
-            "wred_green_enable"      : "true",
-            "wred_yellow_enable"     : "true",
-            "wred_red_enable"        : "true",
-            "ecn"                    : "ecn_all",
-            "green_max_threshold"    : "{{ max_threshold }}",
-            "green_min_threshold"    : "{{ min_threshold }}",
-            "yellow_max_threshold"   : "{{ max_threshold }}",
-            "yellow_min_threshold"   : "{{ min_threshold }}",
-            "red_max_threshold"      : "{{ max_threshold }}",
-            "red_min_threshold"      : "{{ min_threshold }}",
-            "green_drop_probability" : "5",
+        "AZURE_LOSSY_DOWNLINK_Q1": {
+            "wred_green_enable": "true",
+            "wred_yellow_enable": "true",
+            "wred_red_enable": "true",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
             "yellow_drop_probability": "5",
-            "red_drop_probability"   : "5"
+            "red_drop_probability": "5"
         },
-        "AZURE_LOSSY_Q2" : {
-            "wred_green_enable"      : "true",
-            "wred_yellow_enable"     : "true",
-            "wred_red_enable"        : "true",
-            "ecn"                    : "ecn_all",
-            "green_max_threshold"    : "{{ max_threshold }}",
-            "green_min_threshold"    : "{{ min_threshold }}",
-            "yellow_max_threshold"   : "{{ max_threshold }}",
-            "yellow_min_threshold"   : "{{ min_threshold }}",
-            "red_max_threshold"      : "{{ max_threshold }}",
-            "red_min_threshold"      : "{{ min_threshold }}",
-            "green_drop_probability" : "5",
+        "AZURE_LOSSY_DOWNLINK_Q2": {
+            "wred_green_enable": "true",
+            "wred_yellow_enable": "true",
+            "wred_red_enable": "true",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
             "yellow_drop_probability": "5",
-            "red_drop_probability"   : "5"
+            "red_drop_probability": "5"
         },
-        "AZURE_LOSSY_Q3" : {
-            "wred_green_enable"      : "true",
-            "wred_yellow_enable"     : "true",
-            "wred_red_enable"        : "true",
-            "ecn"                    : "ecn_all",
-            "green_max_threshold"    : "{{ max_threshold }}",
-            "green_min_threshold"    : "{{ min_threshold }}",
-            "yellow_max_threshold"   : "{{ max_threshold }}",
-            "yellow_min_threshold"   : "{{ min_threshold }}",
-            "red_max_threshold"      : "{{ max_threshold }}",
-            "red_min_threshold"      : "{{ min_threshold }}",
-            "green_drop_probability" : "5",
+        "AZURE_LOSSY_DOWNLINK_Q3": {
+            "wred_green_enable": "true",
+            "wred_yellow_enable": "true",
+            "wred_red_enable": "true",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
             "yellow_drop_probability": "5",
-            "red_drop_probability"   : "5"
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_DOWNLINK_Q4": {
+            "wred_green_enable": "true",
+            "wred_yellow_enable": "true",
+            "wred_red_enable": "true",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_DOWNLINK_Q5": {
+            "wred_green_enable": "true",
+            "wred_yellow_enable": "true",
+            "wred_red_enable": "true",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_UPLINK_Q1": {
+            "wred_green_enable": "true",
+            "wred_yellow_enable": "true",
+            "wred_red_enable": "true",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_UPLINK_Q2": {
+            "wred_green_enable": "true",
+            "wred_yellow_enable": "true",
+            "wred_red_enable": "true",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_UPLINK_Q3": {
+            "wred_green_enable": "true",
+            "wred_yellow_enable": "true",
+            "wred_red_enable": "true",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_UPLINK_Q4": {
+            "wred_green_enable": "true",
+            "wred_yellow_enable": "true",
+            "wred_red_enable": "true",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_UPLINK_Q5": {
+            "wred_green_enable": "true",
+            "wred_yellow_enable": "true",
+            "wred_red_enable": "true",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
         }
     },
 {%- endmacro %}
@@ -219,5 +371,68 @@
     {%- if lossless_tc_list.append('4') -%}{%- endif -%}
 #}
 {%- endmacro %}
+
+{%- macro generate_tc_to_queue_map_per_sku() -%}
+    "TC_TO_QUEUE_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "1",
+            "2": "2",
+            "3": "3",
+            "4": "4",
+            "5": "5",
+            "6": "6",
+            "7": "7"
+{%- if traffic_config.traffic_classification_enable %}
+            ,
+            "8": "4"
+{%- endif %}
+        }
+    },
+{%- endmacro -%}
+
+{% macro generate_tc_to_dscp_map_per_sku() %}
+{%- if traffic_config.traffic_classification_enable %}
+    "TC_TO_DSCP_MAP": {
+        {% if 'type' in DEVICE_METADATA['localhost'] %}
+            {%- if DEVICE_METADATA['localhost']['type'] == 'ToRRouter' -%}
+                "AZURE_DOWNLINK_BT0": {
+                    "8": "21"
+                },
+                "AZURE_UPLINK_BT0": {
+                    "8": "11"
+                }
+            {%- elif DEVICE_METADATA['localhost']['type'] == 'LeafRouter' -%}
+                "AZURE_DOWNLINK_BT1": {
+                    "8": "11"
+                }
+            {% endif %}
+        {% endif -%}
+    },
+{%- endif %}
+{%- endmacro -%}
+
+{%- macro generate_port_qos_map_per_sku(ports, direction) -%}
+{%- for port in ports.split(',') %}
+        "{{ port }}": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_to_pg_map"   : "AZURE",
+            "pfc_enable"      : "",
+            "pfcwd_sw_enable" : "",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+            {% if traffic_config.traffic_classification_enable %}
+            {% if direction == 'downlink' and DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
+                ,"tc_to_dscp_map": "AZURE_DOWNLINK_BT0"
+            {% elif direction == 'uplink' and DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
+                ,"tc_to_dscp_map": "AZURE_UPLINK_BT0"
+            {% elif direction == 'downlink' and DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
+                ,"tc_to_dscp_map": "AZURE_DOWNLINK_BT1"
+            {% endif %}
+            {% endif %}
+        }{% if not loop.last %},{% endif %}
+{%- endfor %}
+{%- endmacro -%}
 
 {%- include 'qos_config.j2' %}

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2
@@ -212,9 +212,9 @@
 
     "WRED_PROFILE": {
         "AZURE_LOSSY_DOWNLINK_Q1": {
-            "wred_green_enable": "true",
-            "wred_yellow_enable": "true",
-            "wred_red_enable": "true",
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
             "ecn": "ecn_all",
             "green_max_threshold": "{{ max_threshold }}",
             "green_min_threshold": "{{ min_threshold }}",
@@ -227,9 +227,9 @@
             "red_drop_probability": "5"
         },
         "AZURE_LOSSY_DOWNLINK_Q2": {
-            "wred_green_enable": "true",
-            "wred_yellow_enable": "true",
-            "wred_red_enable": "true",
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
             "ecn": "ecn_all",
             "green_max_threshold": "{{ max_threshold }}",
             "green_min_threshold": "{{ min_threshold }}",
@@ -242,9 +242,9 @@
             "red_drop_probability": "5"
         },
         "AZURE_LOSSY_DOWNLINK_Q3": {
-            "wred_green_enable": "true",
-            "wred_yellow_enable": "true",
-            "wred_red_enable": "true",
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
             "ecn": "ecn_all",
             "green_max_threshold": "{{ max_threshold }}",
             "green_min_threshold": "{{ min_threshold }}",
@@ -257,9 +257,9 @@
             "red_drop_probability": "5"
         },
         "AZURE_LOSSY_DOWNLINK_Q4": {
-            "wred_green_enable": "true",
-            "wred_yellow_enable": "true",
-            "wred_red_enable": "true",
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
             "ecn": "ecn_all",
             "green_max_threshold": "{{ disable_wred }}",
             "green_min_threshold": "{{ disable_wred }}",
@@ -272,9 +272,9 @@
             "red_drop_probability": "5"
         },
         "AZURE_LOSSY_DOWNLINK_Q5": {
-            "wred_green_enable": "true",
-            "wred_yellow_enable": "true",
-            "wred_red_enable": "true",
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
             "ecn": "ecn_all",
             "green_max_threshold": "{{ disable_wred }}",
             "green_min_threshold": "{{ disable_wred }}",
@@ -287,9 +287,9 @@
             "red_drop_probability": "5"
         },
         "AZURE_LOSSY_UPLINK_Q1": {
-            "wred_green_enable": "true",
-            "wred_yellow_enable": "true",
-            "wred_red_enable": "true",
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
             "ecn": "ecn_all",
             "green_max_threshold": "{{ max_threshold }}",
             "green_min_threshold": "{{ min_threshold }}",
@@ -302,9 +302,9 @@
             "red_drop_probability": "5"
         },
         "AZURE_LOSSY_UPLINK_Q2": {
-            "wred_green_enable": "true",
-            "wred_yellow_enable": "true",
-            "wred_red_enable": "true",
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
             "ecn": "ecn_all",
             "green_max_threshold": "{{ max_threshold }}",
             "green_min_threshold": "{{ min_threshold }}",
@@ -317,9 +317,9 @@
             "red_drop_probability": "5"
         },
         "AZURE_LOSSY_UPLINK_Q3": {
-            "wred_green_enable": "true",
-            "wred_yellow_enable": "true",
-            "wred_red_enable": "true",
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
             "ecn": "ecn_all",
             "green_max_threshold": "{{ max_threshold }}",
             "green_min_threshold": "{{ min_threshold }}",
@@ -332,9 +332,9 @@
             "red_drop_probability": "5"
         },
         "AZURE_LOSSY_UPLINK_Q4": {
-            "wred_green_enable": "true",
-            "wred_yellow_enable": "true",
-            "wred_red_enable": "true",
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
             "ecn": "ecn_all",
             "green_max_threshold": "{{ disable_wred }}",
             "green_min_threshold": "{{ disable_wred }}",
@@ -347,9 +347,9 @@
             "red_drop_probability": "5"
         },
         "AZURE_LOSSY_UPLINK_Q5": {
-            "wred_green_enable": "true",
-            "wred_yellow_enable": "true",
-            "wred_red_enable": "true",
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
             "ecn": "ecn_all",
             "green_max_threshold": "{{ disable_wred }}",
             "green_min_threshold": "{{ disable_wred }}",

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/traffic_config.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/traffic_config.j2
@@ -15,3 +15,20 @@
 
 {# Set traffic_classification_enable to false for Moose platform #}
 {%- set traffic_classification_enable = false %}
+
+{#
+The calculation formula for wred_threshold_limit is as follows:
+egress_lossless_pool total size / 12 / 1024
+Where:
+- egress_lossless_pool total size = 136209408 bytes
+- 12 represents the number of queues
+- 1024 is used to convert the unit from bytes to KB
+
+The result is 11084 (rounded down).
+
+So, wred_threshold_limit = 136209408 / 12 / 1024 = 11084 (KB per queue)
+
+The final total value is:
+11084 (KB) * 12 (queues) * 1024 = 136200192 bytes
+#}
+{% set wred_threshold_limit = 136200192 %}

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/traffic_config.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/traffic_config.j2
@@ -1,0 +1,17 @@
+{#
+    SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+    Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    Apache-2.0
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
+
+{# Set traffic_classification_enable to false for Moose platform #}
+{%- set traffic_classification_enable = false %}

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-V256/traffic_config.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-V256/traffic_config.j2
@@ -1,0 +1,1 @@
+../../x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/traffic_config.j2

--- a/device/mellanox/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C224O8/traffic_config.j2
+++ b/device/mellanox/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C224O8/traffic_config.j2
@@ -1,0 +1,1 @@
+../../x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/traffic_config.j2

--- a/device/mellanox/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C256S2/traffic_config.j2
+++ b/device/mellanox/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C256S2/traffic_config.j2
@@ -1,0 +1,1 @@
+../../x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/traffic_config.j2

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C448O16/traffic_config.j2
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C448O16/traffic_config.j2
@@ -1,0 +1,1 @@
+../../x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/traffic_config.j2

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/traffic_config.j2
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/traffic_config.j2
@@ -1,0 +1,17 @@
+{#
+    SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+    Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    Apache-2.0
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
+
+{# Set traffic_classification_enable to true for Bison platform #}
+{%- set traffic_classification_enable = true %}

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/traffic_config.j2
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/traffic_config.j2
@@ -15,3 +15,20 @@
 
 {# Set traffic_classification_enable to true for Bison platform #}
 {%- set traffic_classification_enable = true %}
+
+{#
+The calculation formula for wred_threshold_limit is as follows:
+egress_lossless_pool total size / 12 / 1024
+Where:
+- egress_lossless_pool total size = 158229504 bytes
+- 12 represents the number of queues
+- 1024 is used to convert the unit from bytes to KB
+
+The result is 12876 (rounded down).
+
+So, wred_threshold_limit = 158229504 / 12 / 1024 = 12876 (KB per queue)
+
+The final total value is:
+12876 (KB) * 12 (queues) * 1024 = 158220288 bytes
+#}
+{% set wred_threshold_limit = 158220288 %}

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -3,6 +3,8 @@
 {%- set PORT_DPC  = [] %}
 {%- set SYSTEM_PORT_ALL = [] %}
 {%- set PORT_QOS_BYPASS = [] %}
+{%- set PORT_UPLINK = [] %}
+{%- set PORT_DOWNLINK = [] %}
 
 {%- set voq_chassis = false %}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost']['switch_type'] is defined and  DEVICE_METADATA['localhost']['switch_type']  == 'voq' %}
@@ -61,6 +63,32 @@
 {%- endif %}
 {%- set PORT_ACTIVE = PORT_ACTIVE | reject('in', PORT_QOS_BYPASS) | list %}
 {%- if PORT_ACTIVE | sort_by_port_index %}{% endif %}
+
+{# Generate uplink and downlink port lists based on router type and neighbors #}
+{%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined %}
+    {%- if 'type' in DEVICE_METADATA['localhost'] %}
+        {%- for port in PORT_ACTIVE %}
+            {%- if DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA %}
+                {%- if DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
+                    {%- if DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'ToRRouter' %}
+                        {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
+                    {%- elif DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'SpineRouter' %}
+                        {%- if PORT_UPLINK.append(port) %}{%- endif %}
+                    {%- endif %}
+                {%- elif DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
+                    {%- if DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'LeafRouter' %}
+                        {%- if PORT_UPLINK.append(port) %}{%- endif %}
+                    {%- elif DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'Server' %}
+                        {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
+                    {%- endif %}
+                {%- endif %}
+            {%- endif %}
+        {%- endfor %}
+    {%- endif %}
+{%- endif %}
+
+{%- set port_names_downlink = PORT_DOWNLINK | join(',') -%}
+{%- set port_names_uplink = PORT_UPLINK | join(',') -%}
 
 {%- set port_names_list_active = [] %}
 {%- for port in PORT_ACTIVE %}
@@ -337,6 +365,15 @@
 {% endif %}
 {% if (generate_port_qos_map is defined) %}
     {{- generate_port_qos_map(port_names_active) }}
+{% elif (generate_port_qos_map_per_sku is defined) %}
+    "PORT_QOS_MAP": {
+        {% if port_names_downlink and port_names_downlink.strip() %}
+        {{ generate_port_qos_map_per_sku(port_names_downlink, 'downlink') }}{% if port_names_uplink and port_names_uplink.strip() %},{% endif %}
+        {% endif %}
+        {% if port_names_uplink and port_names_uplink.strip() %}
+        {{ generate_port_qos_map_per_sku(port_names_uplink, 'uplink') }}
+        {% endif %}
+    },
 {% else %}
     "PORT_QOS_MAP": {
 {% if generate_global_dscp_to_tc_map is defined %}
@@ -456,6 +493,17 @@
         "{{ system_port }}|6": {
             "scheduler": "scheduler.0"
         }{% if not loop.last %},{% endif %}
+{% endfor %}
+    }
+{% elif generate_direction_based_queue_per_sku is defined %}
+    "QUEUE": {
+{% for port in PORT_DOWNLINK %}
+    {{ generate_direction_based_queue_per_sku(port, 'downlink') }}
+    {%- if not loop.last or PORT_UPLINK|length > 0 -%},{% endif %}
+{% endfor %}
+{% for port in PORT_UPLINK %}
+    {{ generate_direction_based_queue_per_sku(port, 'uplink') }}
+        {%- if not loop.last -%},{% endif %}
 {% endfor %}
     }
 {% elif generate_single_queue_per_sku is defined %}

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -64,11 +64,12 @@
 {%- set PORT_ACTIVE = PORT_ACTIVE | reject('in', PORT_QOS_BYPASS) | list %}
 {%- if PORT_ACTIVE | sort_by_port_index %}{% endif %}
 
+{# Generate uplink and downlink port lists based on router type and neighbors #}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined %}
-    {%- if 'type' in DEVICE_METADATA['localhost'] %}
+    {%- if 'type' in DEVICE_METADATA['localhost'] and DEVICE_NEIGHBOR is defined %}
         {%- set local_router_type = DEVICE_METADATA['localhost']['type'] %}
         {%- for port in PORT_ACTIVE %}
-            {%- if DEVICE_NEIGHBOR.get(port) and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA %}
+            {%- if DEVICE_NEIGHBOR.get(port) and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA %}
                 {%- set neighbor_info = DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name] %}
                 {%- if local_router_type == 'LeafRouter' %}
                     {%- if neighbor_info.type == 'ToRRouter' %}
@@ -366,7 +367,7 @@
 {% endif %}
 {% if (generate_port_qos_map is defined) %}
     {{- generate_port_qos_map(port_names_active) }}
-{% elif (generate_port_qos_map_per_sku is defined) %}
+{% elif (generate_port_qos_map_per_sku is defined) and (PORT_DOWNLINK|length > 0 or PORT_UPLINK|length > 0) %}
     "PORT_QOS_MAP": {
         {% if port_names_downlink and port_names_downlink.strip() %}
         {{ generate_port_qos_map_per_sku(port_names_downlink, 'downlink') }}{% if port_names_uplink and port_names_uplink.strip() %},{% endif %}
@@ -496,7 +497,7 @@
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     }
-{% elif generate_direction_based_queue_per_sku is defined %}
+{% elif generate_direction_based_queue_per_sku is defined and (PORT_DOWNLINK|length > 0 or PORT_UPLINK|length > 0) %}
     "QUEUE": {
 {% for port in PORT_DOWNLINK %}
     {{ generate_direction_based_queue_per_sku(port, 'downlink') }}

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -64,21 +64,22 @@
 {%- set PORT_ACTIVE = PORT_ACTIVE | reject('in', PORT_QOS_BYPASS) | list %}
 {%- if PORT_ACTIVE | sort_by_port_index %}{% endif %}
 
-{# Generate uplink and downlink port lists based on router type and neighbors #}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined %}
     {%- if 'type' in DEVICE_METADATA['localhost'] %}
+        {%- set local_router_type = DEVICE_METADATA['localhost']['type'] %}
         {%- for port in PORT_ACTIVE %}
-            {%- if DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA %}
-                {%- if DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
-                    {%- if DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'ToRRouter' %}
+            {%- if DEVICE_NEIGHBOR.get(port) and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA %}
+                {%- set neighbor_info = DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name] %}
+                {%- if local_router_type == 'LeafRouter' %}
+                    {%- if neighbor_info.type == 'ToRRouter' %}
                         {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
-                    {%- elif DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'SpineRouter' %}
+                    {%- elif neighbor_info.type == 'SpineRouter' %}
                         {%- if PORT_UPLINK.append(port) %}{%- endif %}
                     {%- endif %}
-                {%- elif DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
-                    {%- if DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'LeafRouter' %}
+                {%- elif local_router_type == 'ToRRouter' %}
+                    {%- if neighbor_info.type == 'LeafRouter' %}
                         {%- if PORT_UPLINK.append(port) %}{%- endif %}
-                    {%- elif DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'Server' %}
+                    {%- elif neighbor_info.type == 'Server' %}
                         {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
                     {%- endif %}
                 {%- endif %}

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -472,6 +472,8 @@ def main():
     if args.template_dir:
         paths.append(os.path.abspath(args.template_dir))
 
+    paths.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../files/build_templates')))
+
     if args.template:
         for template_file, _ in args.template:
             paths.append(os.path.dirname(os.path.abspath(template_file)))


### PR DESCRIPTION
Add per queue direction priority config.

#### Why I did it
It would provide flexibility in the configurations and fine tuning of QoS Parameters for Fairwater Project.

#### How I did it
Enabling Per-Queue, Per-Prio, Per-Direction QoS for BUFFER_QUEUE, QUEUE, SCHEDULER, WRED_PROFILE, BUFFER_PROFILE and related configs.
Remove egress lossless config.
Enable wred for Q1-3, disable wred for Q4 and Q5.

#### How to verify it
Verify with config qos reload, and check related json files, and SDK config.

#### Which release branch to backport (provide reason below if selected)
- [x] 202412
- [x] 202505

#### Tested branch (Please provide the tested image version)
202412_RC.100-526c8c6a0_Internal