### PR TITLE
[202505] Add stat_custom_receive0_management_mode to the Broadcom config file of TH5 platforms

### DIFF
--- a/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2-COPPER-LAB/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2-COPPER-LAB/th5-a7060x6-16pe-384c.config.bcm
@@ -43,6 +43,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2-FANOUT/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2-FANOUT/th5-a7060x6-16pe-384c.config.bcm
@@ -43,6 +43,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2-LAB/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2-LAB/th5-a7060x6-16pe-384c.config.bcm
@@ -43,6 +43,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2/th5-a7060x6-16pe-384c.config.bcm
@@ -43,6 +43,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-O128S2-COPPER-LAB/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-O128S2-COPPER-LAB/th5-a7060x6-16pe-384c.config.bcm
@@ -42,6 +42,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-O128S2-LAB/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-O128S2-LAB/th5-a7060x6-16pe-384c.config.bcm
@@ -42,6 +42,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-O128S2/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-O128S2/th5-a7060x6-16pe-384c.config.bcm
@@ -43,6 +43,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-256x200G/th5-a7060x6-64de.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-256x200G/th5-a7060x6-64de.config.bcm
@@ -42,6 +42,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-O128S2/th5-a7060x6-64de.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-O128S2/th5-a7060x6-64de.config.bcm
@@ -42,6 +42,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE/th5-a7060x6-64de.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE/th5-a7060x6-64de.config.bcm
@@ -42,6 +42,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-256x200G/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-256x200G/th5-a7060x6-64pe.config.bcm
@@ -42,6 +42,7 @@ bcm_device:
             mmu_init_config: "\"TH5-MSFT-PROD\""
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-64x400G/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-64x400G/th5-a7060x6-64pe.config.bcm
@@ -42,6 +42,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C224O8/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C224O8/th5-a7060x6-64pe.config.bcm
@@ -42,6 +42,7 @@ bcm_device:
             mmu_init_config: "\"TH5-MSFT-PROD\""
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C256S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C256S2/th5-a7060x6-64pe.config.bcm
@@ -42,6 +42,7 @@ bcm_device:
             mmu_init_config: "\"TH5-MSFT-PROD\""
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-O128S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-O128S2/th5-a7060x6-64pe.config.bcm
@@ -43,6 +43,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-P32O64/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-P32O64/th5-a7060x6-64pe.config.bcm
@@ -42,6 +42,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE/th5-a7060x6-64pe.config.bcm
@@ -42,6 +42,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/th5-a7060x6-64pe.config.bcm
@@ -42,6 +42,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
@@ -42,6 +42,7 @@ bcm_device:
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
+            stat_custom_receive0_management_mode: 1
 ---
 device:
     0:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cherry pick changes from https://github.com/sonic-net/sonic-buildimage/pull/22825

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

