### PR TITLE
Updated the YANG model for ERSPAN mirror sessions

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
@@ -23,7 +23,7 @@
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_DST_IP": {
         "desc": "Configuring ERSPAN entry with invalid dst_ip",
-        "eStrKey" : "Pattern"
+        "eStrKey" : "src_ip and dst_ip must have the same IP version."
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_DST_IP_TYPE": {
         "desc": "Configuring ERSPAN entry with invalid dst_ip",
@@ -31,7 +31,7 @@
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_SRC_IP": {
         "desc": "Configuring ERSPAN entry with invalid src_ip",
-        "eStrKey" : "Pattern"
+        "eStrKey" : "src_ip and dst_ip must have the same IP version."
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_SRC_IP_TYPE": {
         "desc": "Configuring ERSPAN entry with invalid src_ip",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
@@ -23,7 +23,7 @@
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_DST_IP": {
         "desc": "Configuring ERSPAN entry with invalid dst_ip",
-        "eStrKey" : "src_ip and dst_ip must have the same IP version."
+        "eStr" : "src_ip and dst_ip must have the same IP version."
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_DST_IP_TYPE": {
         "desc": "Configuring ERSPAN entry with invalid dst_ip",
@@ -31,7 +31,7 @@
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_SRC_IP": {
         "desc": "Configuring ERSPAN entry with invalid src_ip",
-        "eStrKey" : "src_ip and dst_ip must have the same IP version."
+        "eStr" : "src_ip and dst_ip must have the same IP version."
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_SRC_IP_TYPE": {
         "desc": "Configuring ERSPAN entry with invalid src_ip",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
@@ -14,6 +14,9 @@
     "MIRROR_ERSPAN_ENTRY_WITH_VALID_DEC_VALUES_2": {
         "desc": "Configuring ERSPAN entry with valid decimal values."
     },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_IPV6_SRC_AND_DST_IP": {
+        "desc": "Configuring ERSPAN entry with valid IPv6 source and destination IPs."
+    },
     "MIRROR_ERSPAN_ENTRY_WRONG_TYPE": {
         "desc": "Configuring ERSPAN entry with invalid type",
         "eStrKey": "InvalidValue"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
@@ -79,6 +79,25 @@
             }
         }
     },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_IPV6_SRC_AND_DST_IP": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "1001::1",
+                        "src_ip": "2002::2",
+                        "gre_type": "0x1234",
+                        "dscp": "10",
+                        "ttl": "64",
+                        "queue": "0",
+                        "direction": "RX"
+                    }
+                ]
+            }
+        }
+    },
     "MIRROR_ERSPAN_ENTRY_WRONG_TYPE": {
         "sonic-mirror-session:sonic-mirror-session": {
             "MIRROR_SESSION": {

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -82,7 +82,7 @@ module sonic-mirror-session {
 
                 leaf src_ip {
                     when "current()/../type = 'ERSPAN'";
-                    type inet:ipv4-address;
+                    type inet:ip-address;
                     description
                         "ERSPAN source ip. This IP will be set as source ip in
                         outer header of mirrored frame ";
@@ -90,7 +90,7 @@ module sonic-mirror-session {
 
                 leaf dst_ip {
                     when "current()/../type = 'ERSPAN'";
-                    type inet:ipv4-address;
+                    type inet:ip-address;
                     description
                         "ERSPAN destination ip. Mirrored frames will be routed to this destination.
                         This IP will be set as destination ip in outer header of mirrored frame ";

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -82,7 +82,7 @@ module sonic-mirror-session {
 
                 leaf src_ip {
                     when "current()/../type = 'ERSPAN'";
-                    must "(contains(current(), ':') and contains(../dst_ip, ':')) or (contains(current(), '.') and contains(../dst_ip, '.'))" {
+                    must "(contains(current(), ':') and contains(../dst_ip, ':')) or (not(contains(current(), ':')) and not(contains(../dst_ip, ':')))" {
                         error-message "src_ip and dst_ip must have the same IP version.";
                     }
                     type inet:ip-address;
@@ -93,7 +93,7 @@ module sonic-mirror-session {
 
                 leaf dst_ip {
                     when "current()/../type = 'ERSPAN'";
-                    must "(contains(current(), ':') and contains(../src_ip, ':')) or (contains(current(), '.') and contains(../src_ip, '.'))" {
+                    must "(contains(current(), ':') and contains(../src_ip, ':')) or (not(contains(current(), ':')) and not(contains(../src_ip, ':')))" {
                         error-message "src_ip and dst_ip must have the same IP version.";
                     }
                     type inet:ip-address;

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -83,7 +83,7 @@ module sonic-mirror-session {
                 leaf src_ip {
                     when "current()/../type = 'ERSPAN'";
                     must "(contains(current(), ':') and contains(../dst_ip, ':')) or (contains(current(), '.') and contains(../dst_ip, '.'))" {
-                        error-message "src_ip and dst_ip must have the same IP version."
+                        error-message "src_ip and dst_ip must have the same IP version.";
                     }
                     type inet:ip-address;
                     description
@@ -94,7 +94,7 @@ module sonic-mirror-session {
                 leaf dst_ip {
                     when "current()/../type = 'ERSPAN'";
                     must "(contains(current(), ':') and contains(../src_ip, ':')) or (contains(current(), '.') and contains(../src_ip, '.'))" {
-                        error-message "src_ip and dst_ip must have the same IP version."
+                        error-message "src_ip and dst_ip must have the same IP version.";
                     }
                     type inet:ip-address;
                     description

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -82,6 +82,9 @@ module sonic-mirror-session {
 
                 leaf src_ip {
                     when "current()/../type = 'ERSPAN'";
+                    must "(contains(current(), ':') and contains(../dst_ip, ':')) or (contains(current(), '.') and contains(../dst_ip, '.'))" {
+                        error-message "src_ip and dst_ip must have the same IP version."
+                    }
                     type inet:ip-address;
                     description
                         "ERSPAN source ip. This IP will be set as source ip in
@@ -90,6 +93,9 @@ module sonic-mirror-session {
 
                 leaf dst_ip {
                     when "current()/../type = 'ERSPAN'";
+                    must "(contains(current(), ':') and contains(../src_ip, ':')) or (contains(current(), '.') and contains(../src_ip, '.'))" {
+                        error-message "src_ip and dst_ip must have the same IP version."
+                    }
                     type inet:ip-address;
                     description
                         "ERSPAN destination ip. Mirrored frames will be routed to this destination.


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
[PR 3317](https://github.com/sonic-net/sonic-swss/pull/3317) in sonic-swss enables configuration of IPv6 mirror sessions (in which both `src_ip` and `dst_ip` are IPv6 addresses). This PR updates the YANG model for ERSPAN mirror sessions so that IPv6 mirror sessions can be configured using the `config apply-patch` command.

##### Work item tracking
- Microsoft ADO **(number only)**: 33501400

#### How I did it
1. Changed the type of `src_ip` and `dst_ip` for ERSPAN mirror sessions to `ip-address` so that IPv6 addresses are also accepted.
2. Added a condition to ensure that both `src_ip` and `dst_ip` have the same IP version.
3. Added a test to verify that a mirror session with IPv6 `src_ip` and `dst_ip` can be successfully configured.

#### How to verify it
Use `config apply-patch` to configure an ERSPAN mirror session with IPv6 `src_ip` and `dst_ip` addresses. For example:
```
$ cat ./mirror_session.patch
[
        {
                "op": "add",
                "path": "/MIRROR_SESSION",
                "value": {
                        "test_session": {
                                "type": "ERSPAN",
                                "src_ip": "1001::1",
                                "dst_ip": "2002::2",
                                "gre_type": "0x8949",
                                "dscp": "8",
                                "ttl": "64",
                                "queue": "0",
                                "direction": "RX"
                        }
                }
        }
]
$ sudo config apply-patch ./mirror_session.patch
Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: [{"op": "add", "path": "/MIRROR_SESSION", "value": {"test_session": {"type": "ERSPAN", "src_ip": "1001::1", "dst_ip": "2002::2", "gre_type": "0x8949", "dscp": "8", "ttl": "64", "queue": "0", "direction": "RX"}}}]
Patch Applier: localhost getting current config db.
Patch Applier: localhost: simulating the target full config after applying the patch.
Patch Applier: localhost: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: localhost: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
Patch Applier: localhost: sorting patch updates.
Patch Applier: The localhost patch was converted into 1 change:
Patch Applier: localhost: applying 1 change in order:
Patch Applier:   * [{"op": "add", "path": "/MIRROR_SESSION", "value": {"test_session": {"type": "ERSPAN", "src_ip": "1001::1", "dst_ip": "2002::2", "gre_type": "0x8949", "dscp": "8", "ttl": "64", "queue": "0", "direction": "RX"}}}]
Patch Applier: localhost: verifying patch updates are reflected on ConfigDB.
Patch Applier: localhost patch application completed.
Patch applied successfully.
$ show mirror_session
ERSPAN Sessions
Name          Status    SRC IP    DST IP    GRE       DSCP    TTL    Queue  Policer    Monitor Port    SRC Port    Direction
------------  --------  --------  --------  ------  ------  -----  -------  ---------  --------------  ----------  -----------
test_session  active    1001::1   2002::2   0x8949       8     64        0             Ethernet104                 rx
```
If `src_ip` and `dst_ip` have different IP versions, the `apply-patch` command should fail:
```
$ cat ./mirror_session.patch
[
        {
                "op": "add",
                "path": "/MIRROR_SESSION",
                "value": {
                        "invalid_session": {
                                "type": "ERSPAN",
                                "src_ip": "1.1.1.1",
                                "dst_ip": "2002::2",
                                "gre_type": "0x8949",
                                "dscp": "8",
                                "ttl": "64",
                                "queue": "0",
                                "direction": "RX"
                        }
                }
        }
]
$ sudo config apply-patch ./mirror_session.patch
libyang[0]: Must condition "(contains(current(), ':') and contains(../dst_ip, ':')) or (contains(current(), '.') and contains(../dst_ip, '.'))" not satisfied. (path: /sonic-mirror-session:sonic-mirror-session/MIRROR_SESSION/MIRROR_SESSION_LIST[name='invalid_session']/src_ip)
libyang[0]: src_ip and dst_ip must have the same IP version. (path: /sonic-mirror-session:sonic-mirror-session/MIRROR_SESSION/MIRROR_SESSION_LIST[name='invalid_session']/src_ip)
sonic_yang(3):Data Loading Failed:src_ip and dst_ip must have the same IP version.
Failed to apply patch due to: Validate json patch: [{"op": "add", "path": "/MIRROR_SESSION", "value": {"invalid_session": {"type": "ERSPAN", "src_ip": "1.1.1.1", "dst_ip": "2002::2", "gre_type": "0x8949", "dscp": "8", "ttl": "64", "queue": "0", "direction": "RX"}}}] failed due to:Data Loading Failed
src_ip and dst_ip must have the same IP version.
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
Try "config apply-patch -h" for help.

Error: Validate json patch: [{"op": "add", "path": "/MIRROR_SESSION", "value": {"invalid_session": {"type": "ERSPAN", "src_ip": "1.1.1.1", "dst_ip": "2002::2", "gre_type": "0x8949", "dscp": "8", "ttl": "64", "queue": "0", "direction": "RX"}}}] failed due to:Data Loading Failed
src_ip and dst_ip must have the same IP version.
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 20250625.014807

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->
Updated the YANG model for ERSPAN mirror sessions to support IPv6 source and destination addresses.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#acl-and-mirroring
