### PR TITLE
YANG: Route Map allow match_interface on Loopback

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
@@ -15,6 +15,9 @@
     "ROUTE_MAP_VALID": {
         "desc": "Configure route map table."
     },
+    "ROUTE_MAP_MATCH_INTERFACE_LOOPBACK": {
+        "desc": "Allow match on loopback interface"
+    },
     "ROUTE_MAP_INVALID_STMT": {
         "desc": "Configure route map table with wrong value for stmt_name.",
         "eStrKey": "InvalidValue",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
@@ -195,6 +195,29 @@
             }
         }
     },
+    "ROUTE_MAP_MATCH_INTERFACE_LOOPBACK": {
+        "sonic-loopback-interface:sonic-loopback-interface": {
+            "sonic-loopback-interface:LOOPBACK_INTERFACE": {
+                "LOOPBACK_INTERFACE_LIST": [
+                    {
+                        "name": "Loopback0"
+                    }
+                ]
+            }
+        },
+        "sonic-route-map:sonic-route-map": {
+            "sonic-route-map:ROUTE_MAP": {
+                "ROUTE_MAP_LIST": [
+                {
+                    "name": "map1",
+                    "stmt_name": 1,
+                    "route_operation": "permit",
+                    "match_interface": "Loopback0"
+                }
+                ]
+            }
+        }
+    },
     "ROUTE_MAP_INVALID_STMT": {
         "sonic-route-map:sonic-route-map":{
             "sonic-route-map:ROUTE_MAP": {

--- a/src/sonic-yang-models/yang-models/sonic-route-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-route-map.yang
@@ -27,6 +27,10 @@ module sonic-route-map {
         prefix vrf;
     }
 
+    import sonic-loopback-interface {
+        prefix loopback;
+    }
+
     organization
         "SONiC";
 
@@ -48,6 +52,9 @@ module sonic-route-map {
             }
             type leafref {
                 path "/lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name";
+            }
+            type leafref {
+                path "/loopback:sonic-loopback-interface/loopback:LOOPBACK_INTERFACE/loopback:LOOPBACK_INTERFACE_LIST/loopback:name";
             }
             // Comment VLAN leaf reference here until libyang back-links issue is resolved and use VLAN string pattern
             //type leafref {


### PR DESCRIPTION
#### Why I did it

When using BGP Unnumbered for an underlay network its often desirable to only advertise the loopback interface IP address.  The implementation allows it but the YANG model did not.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Add yang model adjustments and  adds a test to ensure it doesn't regress.

#### How to verify it
 Run test case.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

master as of 20250608

#### Description for the changelog
YANG: Route Map allow match_interface on Loopback

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)

Fixes https://github.com/sonic-net/sonic-buildimage/issues/22899
Signed-off-by : Brad House <bhouse@nexthop.ai>
