### PR TITLE
Enable impacted area based PR testing in sonic-buildimage repo

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,114 +165,204 @@ stages:
         testResultsFiles: '**/tr.xml'
         testRunTitle: vstest
 
-  - job: t0_elastictest
-    pool: sonic-ubuntu-1c
-    displayName: "kvmtest-t0 by Elastictest"
+  - job: get_impacted_area
+    displayName: "Get impacted area"
     timeoutInMinutes: 240
     continueOnError: false
+    pool: sonic-ubuntu-1c
     steps:
-    - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
-      parameters:
-        TOPOLOGY: t0
-        MIN_WORKER: $(T0_INSTANCE_NUM)
-        MAX_WORKER: $(T0_INSTANCE_NUM)
-        MGMT_BRANCH: $(BUILD_BRANCH)
+      - template: .azure-pipelines/impacted_area_testing/get-impacted-area.yml@sonic-mgmt
+        parameters:
+          BUILD_BRANCH: $(BUILD_BRANCH)
 
-  - job: t0_2vlans_elastictest
-    pool: sonic-ubuntu-1c
-    displayName: "kvmtest-t0-2vlans by Elastictest"
+  - job: impacted_area_t0_elastictest
+    displayName: "impacted-area-kvmtest-t0 by Elastictest"
+    dependsOn:
+      - get_impacted_area
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0_checker')
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
     timeoutInMinutes: 240
     continueOnError: false
+    pool: sonic-ubuntu-1c
     steps:
-    - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
-      parameters:
-        TOPOLOGY: t0
-        TEST_SET: t0-2vlans
-        MIN_WORKER: $(T0_2VLANS_INSTANCE_NUM)
-        MAX_WORKER: $(T0_2VLANS_INSTANCE_NUM)
-        MGMT_BRANCH: $(BUILD_BRANCH)
-        DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
+      - template: .azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml@sonic-mgmt
+        parameters:
+          TOPOLOGY: t0
+          BUILD_BRANCH: $(BUILD_BRANCH)
 
-  - job: t1_lag_elastictest
-    pool: sonic-ubuntu-1c
-    displayName: "kvmtest-t1-lag by Elastictest"
-    timeoutInMinutes: 240
-    continueOnError: false
-    steps:
-    - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
-      parameters:
-        TOPOLOGY: t1-lag
-        MIN_WORKER: $(T1_LAG_INSTANCE_NUM)
-        MAX_WORKER: $(T1_LAG_INSTANCE_NUM)
-        MGMT_BRANCH: $(BUILD_BRANCH)
-
-  - job: multi_asic_elastictest
-    displayName: "kvmtest-multi-asic-t1-lag by Elastictest"
-    pool: sonic-ubuntu-1c
-    timeoutInMinutes: 240
-    continueOnError: false
-    steps:
       - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
         parameters:
-          TOPOLOGY: t1-8-lag
-          TEST_SET: multi-asic-t1-lag
-          MIN_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
-          MAX_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
-          NUM_ASIC: 4
+          TOPOLOGY: t0
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
           MGMT_BRANCH: $(BUILD_BRANCH)
 
-  - job: dualtor_elastictest
-    pool: sonic-ubuntu-1c
-    displayName: "kvmtest-dualtor-t0 by Elastictest"
+  - job: impacted_area_t0_2vlans_elastictest
+    displayName: "impacted-area-kvmtest-t0-2vlans by Elastictest"
+    dependsOn:
+      - get_impacted_area
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-2vlans_checker')
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
     timeoutInMinutes: 240
     continueOnError: false
+    pool: sonic-ubuntu-1c
     steps:
+      - template: .azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml@sonic-mgmt
+        parameters:
+          TOPOLOGY: t0-2vlans
+          BUILD_BRANCH: $(BUILD_BRANCH)
+
+      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
+        parameters:
+          TOPOLOGY: t0
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
+          DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+          MGMT_BRANCH: $(BUILD_BRANCH)
+
+  - job: impacted_area_t1_lag_elastictest
+    displayName: "impacted-area-kvmtest-t1-lag by Elastictest"
+    dependsOn:
+      - get_impacted_area
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker')
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+    timeoutInMinutes: 240
+    continueOnError: false
+    pool: sonic-ubuntu-1c
+    steps:
+      - template: .azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml@sonic-mgmt
+        parameters:
+          TOPOLOGY: t1
+          BUILD_BRANCH: $(BUILD_BRANCH)
+          # 40 mins for preparing testbed, 10 mins for pre-test and post-test
+          PREPARE_TIME: 50
+
+      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
+        parameters:
+          TOPOLOGY: t1-lag
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+          MGMT_BRANCH: $(BUILD_BRANCH)
+
+  - job: impacted_area_dualtor_elastictest
+    displayName: "impacted-area-kvmtest-dualtor by Elastictest"
+    dependsOn:
+      - get_impacted_area
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dualtor_checker')
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+    timeoutInMinutes: 240
+    continueOnError: false
+    pool: sonic-ubuntu-1c
+    steps:
+      - template: .azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml@sonic-mgmt
+        parameters:
+          TOPOLOGY: dualtor
+          BUILD_BRANCH: $(BUILD_BRANCH)
+          # 30 mins for preparing testbed, 30 mins for pre-test and 20 mins for post-test
+          PREPARE_TIME: 80
+
       - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
         parameters:
           TOPOLOGY: dualtor
-          MIN_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
-          MAX_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
-          MGMT_BRANCH: $(BUILD_BRANCH)
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
           COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+          MGMT_BRANCH: $(BUILD_BRANCH)
 
-  - job: sonic_t0_elastictest
-    displayName: "kvmtest-t0-sonic by Elastictest"
-    pool: sonic-ubuntu-1c
+  - job: impacted_area_multi_asic_elastictest
+    displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest"
+    dependsOn:
+      - get_impacted_area
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1-multi-asic_checker')
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
     timeoutInMinutes: 240
     continueOnError: false
+    pool: sonic-ubuntu-1c
     steps:
+      - template: .azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml@sonic-mgmt
+        parameters:
+          TOPOLOGY: t1-multi-asic
+          BUILD_BRANCH: $(BUILD_BRANCH)
+
+      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
+        parameters:
+          TOPOLOGY: t1-8-lag
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
+          NUM_ASIC: 4
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+          MGMT_BRANCH: $(BUILD_BRANCH)
+
+  - job: impacted_area_t0_sonic_elastictest
+    displayName: "impacted-area-kvmtest-t0-sonic by Elastictest"
+    dependsOn:
+      - get_impacted_area
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-sonic_checker')
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+    timeoutInMinutes: 240
+    continueOnError: false
+    pool: sonic-ubuntu-1c
+    steps:
+      - template: .azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml@sonic-mgmt
+        parameters:
+          TOPOLOGY: t0-sonic
+          BUILD_BRANCH: $(BUILD_BRANCH)
+          PREPARE_TIME: 40
+
       - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
         parameters:
           TOPOLOGY: t0-64-32
-          MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
-          MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
-          TEST_SET: t0-sonic
-          MGMT_BRANCH: $(BUILD_BRANCH)
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
           COMMON_EXTRA_PARAMS: "--neighbor_type=sonic "
           VM_TYPE: vsonic
+          MGMT_BRANCH: $(BUILD_BRANCH)
+          SPECIFIC_PARAM: '[
+            {"name": "bgp/test_bgp_fact.py", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"},
+            {"name": "macsec", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"}
+            ]'
 
-  - job: dpu_elastictest
-    displayName: "kvmtest-dpu by Elastictest"
+  - job: impacted_area_dpu_elastictest
+    displayName: "impacted-area-kvmtest-dpu by Elastictest"
+    dependsOn:
+      - get_impacted_area
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dpu_checker')
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
     timeoutInMinutes: 240
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
+      - template: .azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml@sonic-mgmt
+        parameters:
+          TOPOLOGY: dpu
+          BUILD_BRANCH: $(BUILD_BRANCH)
+
       - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
         parameters:
           TOPOLOGY: dpu
-          MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
-          MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
           MGMT_BRANCH: $(BUILD_BRANCH)
-
-#  - job: wan_elastictest
-#    displayName: "kvmtest-wan by Elastictest"
-#    pool: sonic-ubuntu-1c
-#    timeoutInMinutes: 240
-#    continueOnError: false
-#    steps:
-#      - template: .azure-pipelines/run-test-scheduler-template.yml
-#        parameters:
-#          TOPOLOGY: wan-pub
-#          MIN_WORKER: $(WAN_INSTANCE_NUM)
-#          MAX_WORKER: $(WAN_INSTANCE_NUM)
-#          COMMON_EXTRA_PARAMS: "--skip_sanity "
+          SPECIFIC_PARAM: '[
+            {"name": "dash/test_dash_vnet.py", "param": "--skip_dataplane_checking"}
+            ]'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -187,6 +187,7 @@ stages:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
+      - checkout: sonic-mgmt
       - template: .azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml@sonic-mgmt
         parameters:
           TOPOLOGY: t0
@@ -212,6 +213,7 @@ stages:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
+      - checkout: sonic-mgmt
       - template: .azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml@sonic-mgmt
         parameters:
           TOPOLOGY: t0-2vlans
@@ -238,6 +240,7 @@ stages:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
+      - checkout: sonic-mgmt
       - template: .azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml@sonic-mgmt
         parameters:
           TOPOLOGY: t1
@@ -265,6 +268,7 @@ stages:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
+      - checkout: sonic-mgmt
       - template: .azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml@sonic-mgmt
         parameters:
           TOPOLOGY: dualtor
@@ -293,6 +297,7 @@ stages:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
+      - checkout: sonic-mgmt
       - template: .azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml@sonic-mgmt
         parameters:
           TOPOLOGY: t1-multi-asic
@@ -319,6 +324,7 @@ stages:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
+      - checkout: sonic-mgmt
       - template: .azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml@sonic-mgmt
         parameters:
           TOPOLOGY: t0-sonic
@@ -351,6 +357,7 @@ stages:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
+      - checkout: sonic-mgmt
       - template: .azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml@sonic-mgmt
         parameters:
           TOPOLOGY: dpu

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,7 +171,8 @@ stages:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
-      - template: .azure-pipelines/impacted_area_testing/get-impacted-area.yml@sonic-mgmt
+      - checkout: sonic-mgmt
+      - template: .azure-pipelines/impacted_area_testing/get-impacted-area.yml
         parameters:
           BUILD_BRANCH: $(BUILD_BRANCH)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,7 +172,7 @@ stages:
     pool: sonic-ubuntu-1c
     steps:
       - checkout: sonic-mgmt
-      - template: .azure-pipelines/impacted_area_testing/get-impacted-area.yml
+      - template: .azure-pipelines/impacted_area_testing/get-impacted-area.yml@sonic-mgmt
         parameters:
           BUILD_BRANCH: $(BUILD_BRANCH)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
At the beginning of this year, we transitioned the PR testing approach in the sonic-mgmt repository from a classical model to an impacted area-based model. This new approach enables automatic collection of relevant test cases, eliminating the need for the previously hardcoded `pr_test_scripts.yaml` list, and we no longer maintain it.

However, the sonic-buildimage repository has continued to use the classical PR testing model. As a result, any new test cases added in the sonic-mgmt repository are not picked up during PR testing in sonic-buildimage.

This PR updates the sonic-buildimage repository to adopt the impacted area-based PR testing model. With this change, all relevant test cases—including newly added ones—will be properly included in the PR testing workflow.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
This PR updates the sonic-buildimage repository to adopt the impacted area-based PR testing model. With this change, all relevant test cases—including newly added ones—will be properly included in the PR testing workflow.

#### How to verify it
Test by pipeline itself, we can see that, the PR testing adopts the impacted area-based model and collect all relvent test cases.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

