### PR TITLE
[sonic-package-manager] Use tag to start application

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -744,8 +744,8 @@ start() {
 {%- if docker_container_name == "gbsyncd" %}
         -v /var/run/docker-syncd$DEV:/var/run/sswsyncd \
         "docker-$GBSYNCD_PLATFORM":latest \
-{%- elif docker_image_tag is defined and docker_image_tag is not none %}
-        {{docker_image_tag}} \
+{%- elif docker_image_reference is defined and docker_image_reference is not none %}
+        {{docker_image_reference}} \
 {%- elif docker_image_name is defined %}
         {{docker_image_name}}:latest \
 {%- else %}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -744,6 +744,8 @@ start() {
 {%- if docker_container_name == "gbsyncd" %}
         -v /var/run/docker-syncd$DEV:/var/run/sswsyncd \
         "docker-$GBSYNCD_PLATFORM":latest \
+{%- elif docker_image_tag is defined and docker_image_tag is not none %}
+        {{docker_image_tag}} \
 {%- elif docker_image_name is defined %}
         {{docker_image_name}}:latest \
 {%- else %}


### PR DESCRIPTION
This is done in order to be able to start using tag which will provide a user-friendly identifier when running docker ps.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Needed PR: https://github.com/sonic-net/sonic-utilities/pull/3917
#### Why I did it
To fix https://github.com/sonic-net/sonic-buildimage/issues/22124 while keeping the wanted ability to get real image while using docker ps

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Modified `docker_image_ctl.j2` to add support for using `docker_image_tag` when starting containers
- Added a new condition to check if `docker_image_tag` is defined and not none
- If a tag is specified, it will be used instead of the default `latest` tag

#### How to verify it

1. Install a package using sonic-package-manager
2. Run docker ps to verify that the container is running with the correct tag
3. Check the container configuration to ensure the tag is properly saved

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

