### PR TITLE
Update user_auth for gnmi and telemetry yang models

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/gnmi.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/gnmi.json
@@ -24,5 +24,8 @@
     },
     "GNMI_CLIENT_CERT_LIST_TABLE_WITH_VALID_CONFIG": {
         "desc": "TABLE WITH VALID CONFIG."
+    },
+    "GNMI_TABLE_WITH_VALID_USER_AUTH": {
+        "desc": "TABLE WITH VALID USER_AUTH."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/telemetry.json
@@ -17,5 +17,8 @@
     },
     "TELEMETRY_TABLE_WITH_VALID_CONFIG": {
         "desc": "TABLE WITH VALID CONFIG."
+    },
+    "TELEMETRY_TABLE_WITH_VALID_USER_AUTH": {
+        "desc": "TABLE WITH VALID USER_AUTH."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/gnmi.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/gnmi.json
@@ -121,5 +121,22 @@
                 ]
             }
         }
+    },
+    "GNMI_TABLE_WITH_VALID_USER_AUTH": {
+        "sonic-gnmi:sonic-gnmi": {
+            "sonic-gnmi:GNMI": {
+                "certs": {
+                    "ca_crt": "/etc/sonic/credentials/dsmsroot.cer",
+                    "server_crt": "/etc/sonic/credentials/server.cer",
+                    "server_key": "/etc/sonic/credentials/server.key"
+                },
+                "gnmi": {
+                    "client_auth": "true",
+                    "user_auth": "none",
+                    "log_level": "2",
+                    "port": "50052"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/telemetry.json
@@ -90,5 +90,22 @@
                 }
             }
         }
+    },
+    "TELEMETRY_TABLE_WITH_VALID_USER_AUTH": {
+        "sonic-telemetry:sonic-telemetry": {
+            "sonic-telemetry:TELEMETRY": {
+                "certs": {
+                    "ca_crt": "/etc/sonic/telemetry/dsmsroot.cer",
+                    "server_crt": "/etc/sonic/telemetry/streamingtelemetryserver.cer",
+                    "server_key": "/etc/sonic/telemetry/streamingtelemetryserver.key"
+                },
+                "gnmi": {
+                    "client_auth": "true",
+                    "user_auth": "none",
+                    "log_level": "2",
+                    "port": "50051"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-gnmi.yang
+++ b/src/sonic-yang-models/yang-models/sonic-gnmi.yang
@@ -88,7 +88,7 @@ module sonic-gnmi {
 
                 leaf user_auth {
                     type string {
-                        pattern 'password|jwt|cert';
+                        pattern 'password|jwt|cert|none';
                     }
                     description "GNMI service user authorization type.";
                 }

--- a/src/sonic-yang-models/yang-models/sonic-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-telemetry.yang
@@ -88,7 +88,7 @@ module sonic-telemetry {
 
                 leaf user_auth {
                     type string {
-                        pattern 'password|jwt|cert';
+                        pattern 'password|jwt|cert|none';
                     }
                     description "Telemetry service user authorization type.";
                 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
user_auth can be none, but current yang models do not have this mode.

##### Work item tracking
- Microsoft ADO **(number only)**:33257886

#### How I did it
Update sonic-gnmi.yang and sonic-telemetry.yang to add new user_auth value.

#### How to verify it
Run sonic-yang unit test.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

