### PR TITLE
[CI][202405]update pr test pipeline default timeout to 8 hours to mitigate timeout issues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,11 @@ resources:
     endpoint: sonic-net
     ref: master
 
+parameters:
+- name: TIMEOUT_IN_MINUTES_PR_TEST
+  type: number
+  default: 360
+
 variables:
 - template: .azure-pipelines/azure-pipelines-repd-build-variables.yml@buildimage
 - template: .azure-pipelines/template-variables.yml@buildimage
@@ -166,7 +171,7 @@ stages:
   - job: t0_elastictest
     pool: sonic-ubuntu-1c
     displayName: "kvmtest-t0 by Elastictest"
-    timeoutInMinutes: 240
+    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     steps:
     - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
@@ -180,7 +185,7 @@ stages:
   - job: t0_2vlans_elastictest
     pool: sonic-ubuntu-1c
     displayName: "kvmtest-t0-2vlans by Elastictest"
-    timeoutInMinutes: 240
+    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     steps:
     - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
@@ -196,7 +201,7 @@ stages:
   - job: t1_lag_elastictest
     pool: sonic-ubuntu-1c
     displayName: "kvmtest-t1-lag by Elastictest"
-    timeoutInMinutes: 240
+    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     steps:
     - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
@@ -210,7 +215,7 @@ stages:
   - job: multi_asic_elastictest
     displayName: "kvmtest-multi-asic-t1-lag by Elastictest"
     pool: sonic-ubuntu-1c
-    timeoutInMinutes: 240
+    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     steps:
       - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
@@ -226,7 +231,7 @@ stages:
   - job: dualtor_elastictest
     pool: sonic-ubuntu-1c
     displayName: "kvmtest-dualtor-t0 by Elastictest"
-    timeoutInMinutes: 240
+    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     steps:
       - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
@@ -241,7 +246,7 @@ stages:
   - job: sonic_t0_elastictest
     displayName: "kvmtest-t0-sonic by Elastictest"
     pool: sonic-ubuntu-1c
-    timeoutInMinutes: 240
+    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     steps:
       - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
@@ -257,7 +262,7 @@ stages:
 
   - job: dpu_elastictest
     displayName: "kvmtest-dpu by Elastictest"
-    timeoutInMinutes: 240
+    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
@@ -268,16 +273,3 @@ stages:
           MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
           MGMT_BRANCH: $(BUILD_BRANCH)
           PTF_IMAGE_TAG: $(BUILD_BRANCH)
-
-#  - job: wan_elastictest
-#    displayName: "kvmtest-wan by Elastictest"
-#    pool: sonic-ubuntu-1c
-#    timeoutInMinutes: 240
-#    continueOnError: false
-#    steps:
-#      - template: .azure-pipelines/run-test-scheduler-template.yml
-#        parameters:
-#          TOPOLOGY: wan-pub
-#          MIN_WORKER: $(WAN_INSTANCE_NUM)
-#          MAX_WORKER: $(WAN_INSTANCE_NUM)
-#          COMMON_EXTRA_PARAMS: "--skip_sanity "

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
 parameters:
 - name: TIMEOUT_IN_MINUTES_PR_TEST
   type: number
-  default: 360
+  default: 480
 
 variables:
 - template: .azure-pipelines/azure-pipelines-repd-build-variables.yml@buildimage


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

reference: https://github.com/sonic-net/sonic-buildimage/pull/22969

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

