### PR TITLE
[yang] Allow Port or Vlan for port key in sonic_neighbor yang 

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/neigh.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/neigh.json
@@ -3,6 +3,14 @@
         "desc": "Load valid neighbors"
     },
 
+    "NEIGH_VALID_PORT": {
+        "desc": "Load with valid port"
+    },
+
+    "NEIGH_VALID_VLAN": {
+        "desc": "Load with valid Vlan"
+    },
+
     "NEIGH_MISSING_IP": {
         "desc": "Load NEIGH missing IP address",
         "eStr": ["Invalid JSON data"]

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/neigh.json
@@ -28,6 +28,54 @@
         }
     },
 
+    "NEIGH_VALID_PORT": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8"
+                    }
+                ]
+            }
+        },
+        "sonic-neigh:sonic-neigh": {
+            "sonic-neigh:NEIGH": {
+                "NEIGH_LIST": [
+                    {
+                        "port": "Ethernet8",
+                        "neighbor": "100.1.1.3",
+                        "neigh": "00:02:02:03:04:05",
+                        "family": "IPv4"
+                    }
+                ]
+            }
+        }
+    },
+
+    "NEIGH_VALID_VLAN": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan1000"
+                    }
+                ]
+            }
+        },
+        "sonic-neigh:sonic-neigh": {
+            "sonic-neigh:NEIGH": {
+                "NEIGH_LIST": [
+                    {
+                        "port": "Vlan1000",
+                        "neighbor": "100.1.1.3",
+                        "neigh": "00:02:02:03:04:05",
+                        "family": "IPv4"
+                    }
+                ]
+            }
+        }
+    },
+
     "NEIGH_MISSING_IPV4": {
         "sonic-vlan:sonic-vlan": {
             "sonic-vlan:VLAN": {

--- a/src/sonic-yang-models/yang-models/sonic-neigh.yang
+++ b/src/sonic-yang-models/yang-models/sonic-neigh.yang
@@ -14,10 +14,14 @@ module sonic-neigh {
 	import sonic-portchannel {
 		prefix lag;
 	}
-	// TODO: Uncomment the following lines when sonic-vlan.yang is available
-	// import sonic-vlan {
-	// 	prefix svlan;
-	// }
+
+	import sonic-vlan {
+		prefix svlan;
+	}
+
+	import sonic-port {
+		prefix sport;
+	}
 
 	organization "SONiC";
 	contact "SONiC";
@@ -40,13 +44,12 @@ module sonic-neigh {
 						type leafref {
 							path /lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name;
 						}
-						type string {
-							pattern "Vlan[0-9]+";
+						type leafref {
+							path "/svlan:sonic-vlan/svlan:VLAN/svlan:VLAN_LIST/svlan:name";
 						}
-						// TODO: Uncomment the following lines when sonic-vlan.yang is available
-						// type leafref {
-						// 	path "/svlan:sonic-vlan/svlan:VLAN/svlan:VLAN_LIST/svlan:name";
-						// }
+						type leafref {
+							path /sport:sonic-port/sport:PORT/sport:PORT_LIST/sport:name;
+						}
 					}
 				}
 


### PR DESCRIPTION
#### Why I did it
yang validation was failing for valid interface names in the port list.

fixes: https://github.com/sonic-net/sonic-buildimage/issues/22615

##### Work item tracking
- Microsoft ADO **(number only)**: 33384875

#### How I did it
- Added references to sonic-vlan and sonic-port to neigh yang model

#### How to verify it
- build sonic yang models
- added test case for valid Vlan and Port names

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

- [x] master

#### Description for the changelog
Allow for ports in sonic-port:PORT_LIST as name for neighbor interface

#### Link to config_db schema for YANG module changes
https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#neigh
