### PR TITLE
Solve the error problem when the MTU configuration exceeds 9100

### DIFF
--- a/device/micas/x86_64-micas_m2-w6520-24dc8qc-r0/platform_env.conf
+++ b/device/micas/x86_64-micas_m2-w6520-24dc8qc-r0/platform_env.conf
@@ -1,2 +1,3 @@
 is_ltsw_chip=1
 SYNCD_SHM_SIZE=1g
+rx_buffer_size=9238

--- a/device/micas/x86_64-micas_m2-w6520-48c8qc-r0/platform_env.conf
+++ b/device/micas/x86_64-micas_m2-w6520-48c8qc-r0/platform_env.conf
@@ -1,2 +1,3 @@
 is_ltsw_chip=1
 SYNCD_SHM_SIZE=1g
+rx_buffer_size=9238

--- a/device/micas/x86_64-micas_m2-w6930-64qc-r0/platform_env.conf
+++ b/device/micas/x86_64-micas_m2-w6930-64qc-r0/platform_env.conf
@@ -1,2 +1,3 @@
 is_ltsw_chip=1
 SYNCD_SHM_SIZE=1g
+rx_buffer_size=9238

--- a/device/micas/x86_64-micas_m2-w6940-128qc-r0/platform_env.conf
+++ b/device/micas/x86_64-micas_m2-w6940-128qc-r0/platform_env.conf
@@ -1,2 +1,3 @@
 is_ltsw_chip=1
 SYNCD_SHM_SIZE=1g
+rx_buffer_size=9238

--- a/device/micas/x86_64-micas_m2-w6940-64oc-r0/platform_env.conf
+++ b/device/micas/x86_64-micas_m2-w6940-64oc-r0/platform_env.conf
@@ -1,2 +1,3 @@
 is_ltsw_chip=1
 SYNCD_SHM_SIZE=1g
+rx_buffer_size=9238

--- a/platform/broadcom/saibcm-modules/debian/opennsl-modules.init
+++ b/platform/broadcom/saibcm-modules/debian/opennsl-modules.init
@@ -47,7 +47,7 @@ function load_kernel_modules()
     if [[ $is_ltsw_chip -eq 1 ]]; then
         modprobe psample
         modprobe linux_ngbde
-        modprobe linux_ngknet
+        modprobe linux_ngknet rx_buffer_size=$rx_buffer_size
         modprobe linux_ngknetcb
     else
         modprobe linux-kernel-bde dmasize=$dmasize maxpayload=128 debug=4 dma_debug=1 usemsi=$usemsi
@@ -93,6 +93,7 @@ function load_platform_env()
     dmasize=32M
     usemsi=0
     is_ltsw_chip=0
+    rx_buffer_size=9216
 
     # Source the platform env file
     env_file="/usr/share/sonic/device/$platform/platform_env.conf"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
 As described in this issue : https://github.com/sonic-net/sonic-buildimage/issues/23045
The broadcom TH4/TH5 chip can not config MTU over 9100

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modify the knet configuration file to enable the MTU to be greater than 9100

#### How to verify it
The MTU can be configured to be greater than 9100.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!--SONiC.master-23008.879672-df6f4ebc5 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
![image](https://github.com/user-attachments/assets/ddb3e524-2304-468f-9021-0aa990650095)

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

