### PR TITLE
fix issue in logger

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -466,7 +466,7 @@ echo "copp-config.service" | sudo tee -a $GENERATED_SERVICE_FILE
 
 sudo cp $IMAGE_CONFIGS/dhcp_dos_logger/dhcp_dos_logger.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
 sudo cp $IMAGE_CONFIGS/dhcp_dos_logger/dhcp_dos_logger.py $FILESYSTEM_ROOT/usr/bin/
-#sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/dhcp_dos_logger.py
+sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/dhcp_dos_logger.py
 echo "dhcp_dos_logger.service" | sudo tee -a $GENERATED_SERVICE_FILE
 
 # Copy dhcp client configuration template and create an initial configuration

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -464,6 +464,11 @@ sudo cp $IMAGE_CONFIGS/copp/copp-config.sh $FILESYSTEM_ROOT/usr/bin/
 sudo cp $IMAGE_CONFIGS/copp/copp_cfg.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
 echo "copp-config.service" | sudo tee -a $GENERATED_SERVICE_FILE
 
+sudo cp $IMAGE_CONFIGS/dhcp_dos_logger/dhcp_dos_logger.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
+sudo cp $IMAGE_CONFIGS/dhcp_dos_logger/dhcp_dos_logger.py $FILESYSTEM_ROOT/usr/bin/
+sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/dhcp_dos_logger.py
+echo "dhcp_dos_logger.service" | sudo tee -a $GENERATED_SERVICE_FILE
+
 # Copy dhcp client configuration template and create an initial configuration
 sudo cp files/dhcp/dhclient.conf.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
 j2 files/dhcp/dhclient.conf.j2 | sudo tee $FILESYSTEM_ROOT/etc/dhcp/dhclient.conf

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -466,7 +466,7 @@ echo "copp-config.service" | sudo tee -a $GENERATED_SERVICE_FILE
 
 sudo cp $IMAGE_CONFIGS/dhcp_dos_logger/dhcp_dos_logger.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
 sudo cp $IMAGE_CONFIGS/dhcp_dos_logger/dhcp_dos_logger.py $FILESYSTEM_ROOT/usr/bin/
-sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/dhcp_dos_logger.py
+#sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/dhcp_dos_logger.py
 echo "dhcp_dos_logger.service" | sudo tee -a $GENERATED_SERVICE_FILE
 
 # Copy dhcp client configuration template and create an initial configuration

--- a/files/image_config/dhcp_dos_logger/dhcp_dos_logger.py
+++ b/files/image_config/dhcp_dos_logger/dhcp_dos_logger.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import re
+import os
+import subprocess
+import time
+from sonic_py_common.logger import Logger
+from swsscommon.swsscommon import ConfigDBConnector
+
+SYSLOG_IDENTIFIER = os.path.basename(__file__)
+logger = Logger(SYSLOG_IDENTIFIER)
+logger.log_info("Starting DHCP DoS logger...")
+
+config_db = ConfigDBConnector()
+config_db.connect()
+
+ports = config_db.get_table('PORT').keys()
+logger.log_info(f"Monitoring ports: {list(ports)}")
+drop_pkts = {port: 0 for port in ports}
+
+def handler():
+    while True:
+        for port in drop_pkts.keys():
+            try:
+                output = subprocess.run(
+                    ["tc", "-s", "qdisc", "show", "dev", str(port), "handle", "ffff:"],
+                    capture_output=True,
+                    text=True
+                )
+                logger.log_debug(f"TC output for {port}: {output.stdout}")
+                
+                if output.returncode == 0:
+                    match = re.search(r'dropped (\d+)', output.stdout)
+                    if match:
+                        dropped_count = int(match.group(1))
+                        if dropped_count > drop_pkts[port]:
+                            msg = f"Port {port}: DHCP drop counter increased to {dropped_count}"
+                            logger.log_warning(msg)
+                            drop_pkts[port] = dropped_count
+                    else:
+                        logger.log_debug(f"No drops found for port {port}")
+                else:
+                    logger.log_error(f"TC command failed for {port}: {output.stderr}")
+            except Exception as e:
+                logger.log_error(f"Error on port {port}: {str(e)}")
+        time.sleep(10)
+
+if __name__ == "__main__":
+    handler()

--- a/files/image_config/dhcp_dos_logger/dhcp_dos_logger.service
+++ b/files/image_config/dhcp_dos_logger/dhcp_dos_logger.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Log DHCP rate limit violations
+Requires=config-setup.service
+After=config-setup.service
+BindsTo=sonic.target
+After=sonic.target
+After=network.target
+
+[Service]
+Type=simple
+ExecStart= /usr/bin/dhcp_dos_logger.py
+[Install]
+WantedBy=sonic.target


### PR DESCRIPTION
This PR addresses two issues encountered with the dhcp_dos_logger.service in the PR [18947](https://github.com/sonic-net/sonic-buildimage/pull/18947)

    Permission Issue:
        The dhcp_dos_logger.py script was missing execute permissions, service to fail with a Permission denied  error.
        Fixed by ensuring the script has the correct permissions using chmod 755.
    TypeError:
        The script attempted to use a string pattern on a bytes-like object, causing a runtime error.
        Fixed by decoding the bytes object to a string before using it with re.search.


Testing:

    Verified that the service starts correctly and logs DHCP DoS events as expected after applying these changes locally.

Image of Test:
![Screenshot from 2025-06-23 14-35-30](https://github.com/user-attachments/assets/92014733-3d9e-4cfc-89bd-db2e5de91cc8)