### PR TITLE
Code drop for Smartswitch pilot 202411.1.0.9

### DIFF
--- a/platform/checkout/cisco-8000-smartswitch.ini
+++ b/platform/checkout/cisco-8000-smartswitch.ini
@@ -1,4 +1,4 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202411.1.0.7
+ref=202411.1.0.9
 


### PR DESCRIPTION
Code drop for Smartswitch pilot 202411.1.0.9

#### Why I did it
This is required for pilot FUSE

##### Work item tracking
- Microsoft ADO **(number only)**:

