### PR TITLE
[T2][Arista 7808]: Remove empty port_config.ini files for arista supervisors

### DIFF
--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/0/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/0/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/1/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/1/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/10/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/10/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/11/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/11/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/2/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/2/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/3/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/3/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/4/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/4/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/5/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/5/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/6/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/6/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/7/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/7/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/8/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/8/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/9/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/9/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/0/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/0/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/1/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/1/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/10/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/10/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/11/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/11/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/12/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/12/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/13/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/13/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/14/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/14/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/15/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/15/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/16/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/16/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/17/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/17/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/2/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/2/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/3/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/3/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/4/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/4/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/5/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/5/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/6/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/6/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/7/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/7/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/8/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/8/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/9/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/9/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/0/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/0/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/1/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/1/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/10/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/10/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/11/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/11/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/2/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/2/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/3/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/3/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/4/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/4/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/5/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/5/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/6/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/6/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/7/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/7/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/8/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/8/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/9/port_config.ini
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/9/port_config.ini
@@ -1,1 +1,0 @@
-# name         lanes                     alias        index  speed


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Port config files are not required for arista supervisors

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
remove the empty files

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [x ] 202405
- [x ] 202411
- [x ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Remove empty port_config.ini files for arista supervisors
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

