### PR TITLE
[reboot-cause] Fix reboot cause timezone on new image first reboot

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -1024,6 +1024,7 @@ sudo LANG=C cp $SCRIPTS_DIR/bmp.sh $FILESYSTEM_ROOT/usr/local/bin/bmp.sh
 sudo LANG=C cp $SCRIPTS_DIR/mgmt-framework.sh $FILESYSTEM_ROOT/usr/local/bin/mgmt-framework.sh
 sudo LANG=C cp $SCRIPTS_DIR/asic_status.sh $FILESYSTEM_ROOT/usr/local/bin/asic_status.sh
 sudo LANG=C cp $SCRIPTS_DIR/asic_status.py $FILESYSTEM_ROOT/usr/local/bin/asic_status.py
+sudo LANG=C cp $SCRIPTS_DIR/upgrade_hook_script.py $FILESYSTEM_ROOT/usr/local/bin/upgrade_hook_script.py
 sudo LANG=C cp $SCRIPTS_DIR/startup_tsa_tsb.py $FILESYSTEM_ROOT/usr/local/bin/startup_tsa_tsb.py
 sudo LANG=C cp $SCRIPTS_DIR/sonic-dpu-mgmt-traffic.sh $FILESYSTEM_ROOT/usr/local/bin/sonic-dpu-mgmt-traffic.sh
 sudo LANG=C cp $SCRIPTS_DIR/dash-ha.sh $FILESYSTEM_ROOT/usr/local/bin/dash-ha.sh

--- a/files/scripts/upgrade_hook_script.py
+++ b/files/scripts/upgrade_hook_script.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+import argparse
+import click
+import subprocess
+import os
+from sonic_py_common import logger
+
+
+SYSLOG_IDENTIFIER = "upgrade_hook_script"
+LOG_ERR = logger.Logger.LOG_PRIORITY_ERROR
+LOG_WARN = logger.Logger.LOG_PRIORITY_WARNING
+LOG_NOTICE = logger.Logger.LOG_PRIORITY_NOTICE
+# Global logger instance
+log = logger.Logger(SYSLOG_IDENTIFIER)
+
+
+class UpgradeHookException(Exception):
+    """ Runtime Exception class used to report upgrade hook script related errors
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.notes = []
+
+    def __str__(self):
+        msg = super().__str__()
+        if self.notes:
+            msg += "\n" + "\n".join(self.notes)
+        return msg
+
+    def add_note(self, note):
+        self.notes.append(note)
+
+
+def echo_and_log(msg, priority=LOG_NOTICE, fg=None):
+    if priority == LOG_ERR:
+        # Print to stderr if priority is error
+        click.secho(msg, fg=fg, err=True)
+    else:
+        click.secho(msg, fg=fg)
+    log.log(priority, msg, False)
+
+
+def run_command_or_raise(command_args, raise_exception=True):
+    """ Run bash command and return output, raise if it fails
+    """
+    echo_and_log(f"Command: {command_args}")
+    proc = subprocess.Popen(command_args, text=True, stdout=subprocess.PIPE)
+    out, err = proc.communicate()
+    if proc.returncode != 0:
+        sre = UpgradeHookException("Failed to run command '{0}'".format(command_args))
+        if out:
+            sre.add_note("\nSTDOUT:\n{}".format(out.rstrip("\n")))
+        if err:
+            sre.add_note("\nSTDERR:\n{}".format(err.rstrip("\n")))
+        echo_and_log(str(sre), LOG_WARN)
+        if raise_exception:
+            raise sre
+    return out.rstrip("\n")
+
+
+def update_localtime(new_image_dir):
+    """ Update copy the symlink of /etc/localtime to the new image
+        to synchronize localtime on the new image with the current time
+    """
+    LOCALTIME = "/etc/localtime"
+    # Check if mounted fs is rw
+    stat = os.statvfs(new_image_dir)
+    if bool(stat.f_flag & os.ST_RDONLY):
+        echo_and_log("Cannot set localtime, new image filesystem is read only", LOG_WARN)
+        return
+    full_path = os.path.join(os.path.dirname(LOCALTIME), os.readlink(LOCALTIME))
+    if os.path.exists(new_image_dir + full_path):
+        run_command_or_raise(["cp", "-af", LOCALTIME, os.path.join(new_image_dir, "etc", "localtime")], raise_exception=False)
+    else:
+        echo_and_log("The localtime file does not exist on new image", LOG_WARN)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser('Script to perform upon image upgrade')
+    parser.add_argument('--update-localtime', action='store_true',
+                        help='Copy /etc/localtime into the mounted fs of the next image')
+    parser.add_argument('--image-dir',
+                        help='A path to a mounted rw fs of the next image')
+    return parser.parse_args()
+
+
+def main():
+    echo_and_log("Executing upgrade hook script")
+    args = parse_args()
+    if args.update_localtime:
+        # If image_dir is not given we do nothing
+        image_dir = args.image_dir
+        if image_dir:
+            update_localtime(image_dir)
+        else:
+            echo_and_log("Image mount directory not given", LOG_WARN)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        echo_and_log(str(e), LOG_ERR)
+        exit(1)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Dependent PR: https://github.com/sonic-net/sonic-utilities/pull/3932

#### Why I did it
Newly installed SONIC images default the localtime to UTC even when the current image uses a different timezone.
This causes incorrect timestamps in reboot-cause after rebooting on the new image
(until the user reconfigures the timezone via config clock timezone <timezone_name>).
Besides fixing the specific issue, we also added a framework for image upgrade,
which can be extended in the future for different purposes.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
I added an upgrade_hook_script.py (standalone script) that copies the current /etc/localtime symlink
into the new image's filesystem during installation.
This ensures the timezone is preserved after rebooting into the new image.

#### How to verify it
- Use an image that includes the fix.
- Set a non-UTC timezone on the current image: config clock timezone Asia/Jerusalem
(sudo timedatectl set-timezone Asia/Jerusalem).
- Run sonic-installer install <image> for a new image that is not already installed and includes the fix.
- Reboot for using the new image.
- Reboot again on the new image.
- Verify timedatectl/date and show reboot-cause reflect the expected timezone.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

