### PR TITLE
[PDDF][xcvr] Add support for optoe3

### DIFF
--- a/platform/pddf/i2c/modules/xcvr/pddf_xcvr_module.c
+++ b/platform/pddf/i2c/modules/xcvr/pddf_xcvr_module.c
@@ -141,7 +141,9 @@ static ssize_t do_device_operation(struct device *dev, struct device_attribute *
                 goto free_data;
             }
         }
-        else if((strcmp(cdata->dev_type, "optoe1")==0) || (strcmp(cdata->dev_type, "optoe2")==0)) 
+        else if((strcmp(cdata->dev_type, "optoe1")==0) ||
+                (strcmp(cdata->dev_type, "optoe2")==0) ||
+                (strcmp(cdata->dev_type, "optoe3")==0))
         {
 
             adapter = i2c_get_adapter(cdata->parent_bus);

--- a/platform/pddf/i2c/utils/pddfparse.py
+++ b/platform/pddf/i2c/utils/pddfparse.py
@@ -1107,7 +1107,7 @@ class PddfParse():
 
 
     def validate_xcvr_device(self, dev, ops):
-        devtype_list = ['optoe1', 'optoe2']
+        devtype_list = ['optoe1', 'optoe2', 'optoe3']
         dev_attribs = ['xcvr_present', 'xcvr_reset', 'xcvr_intr_status', 'xcvr_lpmode']
         ret_val = "xcvr validation failed"
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add support for optoe3 in pddfparse.py and pddf xcvr module.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added device type comparison check for optoe3.

#### How to verify it
Verified using marvell-teralynx OSFP board which uses optoe3 for parsing eeprom.

[   20.991100] PDDF_CLIENT	add_device_table: Adding ptr 0x0000000013c2df9e to the hash table
[   20.992017] optoe 93-0050: 32896 byte optoe3 EEPROM, read/write
[   20.992046] i2c i2c-93: new_device: Instantiated device optoe3 at 0x50
[   21.026281] xcvr 93-0066: chip found
[   21.026334] xcvr 93-0066: hwmon68: xcvr 'pddf_xcvr'
[   21.026363] PDDF_XCVR	Created a PORT64-CTRL client: 0x00000000805cb9f5

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

