### PR TITLE
[PDDF] Add support for PSU thermal sensor in get_high_threshold

### DIFF
--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_thermal.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_thermal.py
@@ -112,7 +112,14 @@ class PddfThermal(ThermalBase):
             else:
                 return (attr_value/float(1000))
         else:
-            raise NotImplementedError
+            device = "PSU{}".format(self.thermals_psu_index)
+            output = self.pddf_obj.get_attr_name_output(device, "psu_temp{}_high_threshold".format(self.thermal_index))
+            if not output:
+                return None
+
+            temp1 = output['status']
+            # temperature returned is in milli celcius
+            return float(temp1)/1000
 
 
     def get_low_threshold(self):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently, `PddfThermal` does not support `get_high_threshold` for PSU thermal sensors

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/23082

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add support to `get_high_threshold` method for PSU thermal sensors.

Retrieve the high threshold value from `psu_temp*_high_threshold` SysFS path.

#### How to verify it
Tested on NH-4010 using `show platform temperature`. 

`High TH` column now displays temperature value instead of `N/A`

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

