### PR TITLE
[PDDF] Support Multiple PSU Thermals

### DIFF
--- a/platform/pddf/i2c/modules/include/pddf_psu_defs.h
+++ b/platform/pddf/i2c/modules/include/pddf_psu_defs.h
@@ -71,6 +71,8 @@ typedef struct PSU_DATA
 {
     int idx;    // psu index
     int num_psu_fans;
+    int num_psu_thermals;
+    u32 psu_temp_high_thresh_bitmap;
     PSU_DATA_ATTR psu_attr;
     int len;             // no of valid attributes for this psu client
     PSU_DATA_ATTR psu_attrs[MAX_PSU_ATTRS]; 
@@ -80,6 +82,14 @@ typedef struct PSU_PDATA
 {
     int idx;                    // psu index
     int num_psu_fans;      // num of fans supported by the PSU
+    int num_psu_thermals; // num of thermals supported by the PSU
+    /*
+     * Bitmap of supported thermal thresholds
+     * Bit 0 (LSB) corresponds to thermal sensor 1, bit 1 to sensor 2, etc.
+     * A bit value of 1 means the sensor supports high threshold.
+     * Needed as some PSUs may not support high threshold for all thermal sensors.
+     */
+    u32 psu_temp_high_thresh_bitmap;
     int len;             // no of valid attributes for this psu client
     PSU_DATA_ATTR *psu_attrs; 
 }PSU_PDATA;

--- a/platform/pddf/i2c/modules/include/pddf_psu_driver.h
+++ b/platform/pddf/i2c/modules/include/pddf_psu_driver.h
@@ -35,6 +35,10 @@ enum psu_sysfs_attributes {
     PSU_FAN1_SPEED,
     PSU_TEMP1_INPUT,
     PSU_TEMP1_HIGH_THRESHOLD,
+    PSU_TEMP2_INPUT,
+    PSU_TEMP2_HIGH_THRESHOLD,
+    PSU_TEMP3_INPUT,
+    PSU_TEMP3_HIGH_THRESHOLD,
     PSU_V_IN,
     PSU_I_IN,
 	PSU_P_IN,
@@ -60,6 +64,14 @@ struct psu_data {
 	struct device			*hwmon_dev;
 	u8						index;
 	int						num_psu_fans;
+	int						num_psu_thermals;
+	/*
+	* Bitmap of supported thermal thresholds
+	* Bit 0 (LSB) corresponds to thermal sensor 1, bit 1 to sensor 2, etc.
+	* A bit value of 1 means the sensor supports high threshold.
+	* Needed as some PSUs may not support high threshold for all thermal sensors.
+	*/
+	u32						psu_temp_high_thresh_bitmap;
 	int						num_attr;
 	struct attribute		*psu_attribute_list[MAX_PSU_ATTRS];
 	struct attribute_group	psu_attribute_group;

--- a/platform/pddf/i2c/modules/psu/driver/pddf_psu_api.c
+++ b/platform/pddf/i2c/modules/psu/driver/pddf_psu_api.c
@@ -60,6 +60,12 @@ void get_psu_duplicate_sysfs(int idx, char *str)
         case PSU_TEMP1_INPUT:
             strcpy(str, "temp1_input");
             break;
+        case PSU_TEMP2_INPUT:
+            strcpy(str, "temp2_input");
+            break;
+        case PSU_TEMP3_INPUT:
+            strcpy(str, "temp3_input");
+            break;
         default:
             break;
     }
@@ -241,6 +247,10 @@ ssize_t psu_show_default(struct device *dev, struct device_attribute *da, char *
             break;
         case PSU_TEMP1_INPUT:
         case PSU_TEMP1_HIGH_THRESHOLD:
+        case PSU_TEMP2_INPUT:
+        case PSU_TEMP2_HIGH_THRESHOLD:
+        case PSU_TEMP3_INPUT:
+        case PSU_TEMP3_HIGH_THRESHOLD:
             multiplier = 1000;
             value = sysfs_attr_info->val.shortval;
             exponent = two_complement_to_int(value >> 11, 5, 0x1f);

--- a/platform/pddf/i2c/modules/psu/pddf_psu_module.c
+++ b/platform/pddf/i2c/modules/psu/pddf_psu_module.c
@@ -46,6 +46,9 @@ PSU_DATA psu_data = {0};
 /* PSU CLIENT DATA */
 PDDF_DATA_ATTR(psu_idx, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_INT_DEC, sizeof(int), (void*)&psu_data.idx, NULL);
 PDDF_DATA_ATTR(psu_fans, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_INT_DEC, sizeof(int), (void*)&psu_data.num_psu_fans, NULL);
+PDDF_DATA_ATTR(psu_thermals, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_INT_DEC, sizeof(int), (void*)&psu_data.num_psu_thermals, NULL);
+PDDF_DATA_ATTR(psu_temp_high_thresh_bitmap, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_INT_DEC, sizeof(int), (void*)&psu_data.psu_temp_high_thresh_bitmap, NULL);
+
 
 PDDF_DATA_ATTR(attr_name, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_CHAR, 32, (void*)&psu_data.psu_attr.aname, NULL);
 PDDF_DATA_ATTR(attr_devtype, S_IWUSR|S_IRUGO, show_pddf_data, store_pddf_data, PDDF_CHAR, 8, (void*)&psu_data.psu_attr.devtype, NULL);
@@ -63,6 +66,8 @@ PDDF_DATA_ATTR(dev_ops, S_IWUSR, NULL, do_device_operation, PDDF_CHAR, 8, (void*
 static struct attribute *psu_attributes[] = {
     &attr_psu_idx.dev_attr.attr,
     &attr_psu_fans.dev_attr.attr,
+    &attr_psu_thermals.dev_attr.attr,
+    &attr_psu_temp_high_thresh_bitmap.dev_attr.attr,
 
     &attr_attr_name.dev_attr.attr,
     &attr_attr_devtype.dev_attr.attr,
@@ -121,6 +126,8 @@ struct i2c_board_info *i2c_get_psu_board_info(PSU_DATA *pdata, NEW_DEV_ATTR *cda
 
         psu_platform_data->idx = pdata->idx;
         psu_platform_data->num_psu_fans = pdata->num_psu_fans;
+        psu_platform_data->num_psu_thermals = pdata->num_psu_thermals;
+        psu_platform_data->psu_temp_high_thresh_bitmap = pdata->psu_temp_high_thresh_bitmap;
         psu_platform_data->len = pdata->len;
 
         for (i=0;i<num;i++)

--- a/platform/pddf/i2c/utils/pddfparse.py
+++ b/platform/pddf/i2c/utils/pddfparse.py
@@ -101,6 +101,15 @@ class PddfParse():
 
         return self.data[dev]['dev_attr']['num_psu_fans']
 
+    def get_num_psu_thermals(self, dev):
+        if dev not in self.data.keys():
+            return str(1)
+
+        if 'num_psu_thermals' not in self.data[dev]['dev_attr']:
+            return str(1)
+
+        return self.data[dev]['dev_attr']['num_psu_thermals']
+
     def get_led_path(self):
         return ("pddf/devices/led")
 
@@ -147,6 +156,15 @@ class PddfParse():
             if ret != 0:
                 return create_ret.append(ret)
             cmd = "echo '%s'  > /sys/kernel/pddf/devices/psu/i2c/psu_idx" % (self.get_dev_idx(dev, ops))
+            ret = self.runcmd(cmd)
+            if ret != 0:
+                return create_ret.append(ret)
+            cmd = "echo '%s' > /sys/kernel/pddf/devices/psu/i2c/psu_thermals" % (self.get_num_psu_thermals(dev['dev_info']['virt_parent']))
+            ret = self.runcmd(cmd)
+            if ret != 0:
+                return create_ret.append(ret)
+            cmd = "echo '%s' > /sys/kernel/pddf/devices/psu/i2c/psu_temp_high_thresh_bitmap" % (self.get_psu_temp_high_thresh_bitmap(dev['dev_info']['device_name'],
+                                                                                                    int(self.get_num_psu_thermals(dev['dev_info']['virt_parent']))))
             ret = self.runcmd(cmd)
             if ret != 0:
                 return create_ret.append(ret)
@@ -1827,6 +1845,37 @@ class PddfParse():
         self.populate_pddf_sysfsobj()
         v_ops = {'cmd': 'validate', 'target': 'all', 'attr': 'all'}
         self.dev_parse(self.data['SYSTEM'], v_ops)
+
+    def get_psu_temp_high_thresh_bitmap(self, psu_pmbus_device, num_psu_thermals):
+        """
+        Check which PSU thermal sensors have high threshold support
+
+        Args:
+            psu_pmbus_device (str): PSU PMBUS device name (e.g. "PSU1-PMBUS")
+            num_psu_thermals (int): Number of thermal sensors in the PSU
+
+        Returns:
+            int: Bitmap where each bit represents whether a thermal sensor supports high threshold
+                 Bit 0 (LSB) corresponds to thermal sensor 1, bit 1 to sensor 2, etc.
+                 A bit value of 1 means the sensor supports high threshold, 0 means it doesn't
+        """
+        bitmap = 0
+
+        # Get the set of attribute names for this device (if it exists)
+        attr_names = set()
+        if psu_pmbus_device in self.data:
+            device_data = self.data[psu_pmbus_device]
+            if "i2c" in device_data and "attr_list" in device_data["i2c"]:
+                attr_names = {attr.get("attr_name") for attr in device_data["i2c"]["attr_list"]}
+
+        # Check each thermal sensor's high threshold attribute and set corresponding bit
+        for thermal_idx in range(1, num_psu_thermals + 1):
+            attr_name = f"psu_temp{thermal_idx}_high_threshold"
+            if attr_name in attr_names:
+                # Set the bit corresponding to this thermal sensor (0-indexed)
+                bitmap |= (1 << (thermal_idx - 1))
+
+        return bitmap
 
     ##################################################################################################################
     #   BMC APIs 

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_psu.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_psu.py
@@ -54,7 +54,7 @@ class PddfPsu(PsuBase):
             psu_fan = Fan(0, psu_fan_idx, pddf_data, pddf_plugin_data, True, self.psu_index)
             self._fan_list.append(psu_fan)
 
-        self.num_psu_thermals = 1 # Fixing it 1 for now
+        self.num_psu_thermals = int(self.pddf_obj.get_num_psu_thermals('PSU{}'.format(index+1)))
         for psu_thermal_idx in range(self.num_psu_thermals):
             psu_thermal = Thermal(psu_thermal_idx, pddf_data, pddf_plugin_data, True, self.psu_index)
             self._thermal_list.append(psu_thermal)
@@ -272,7 +272,7 @@ class PddfPsu(PsuBase):
         result, color = self.pddf_obj.get_system_led_color(psu_led_device)
         return (color)
 
-    def get_temperature(self):
+    def get_temperature(self, thermal_index=1):
         """
         Retrieves current temperature reading from PSU
 
@@ -281,7 +281,7 @@ class PddfPsu(PsuBase):
             of one degree Celsius, e.g. 30.125
         """
         device = "PSU{}".format(self.psu_index)
-        output = self.pddf_obj.get_attr_name_output(device, "psu_temp1_input")
+        output = self.pddf_obj.get_attr_name_output(device, "psu_temp{}_input".format(thermal_index))
         if not output:
             return 0.0
 
@@ -341,7 +341,7 @@ class PddfPsu(PsuBase):
         # power is returned in micro watts
         return float(p_in)/1000000
 
-    def get_temperature_high_threshold(self):
+    def get_temperature_high_threshold(self, thermal_index=1):
         """
         Retrieves the high threshold temperature of PSU
         Returns:
@@ -349,7 +349,7 @@ class PddfPsu(PsuBase):
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
         device = "PSU{}".format(self.psu_index)
-        output = self.pddf_obj.get_attr_name_output(device, "psu_temp1_high_threshold")
+        output = self.pddf_obj.get_attr_name_output(device, "psu_temp{}_high_threshold".format(thermal_index))
         if not output:
             return 0.0
 

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_thermal.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_thermal.py
@@ -74,7 +74,7 @@ class PddfThermal(ThermalBase):
     def get_temperature(self):
         if self.is_psu_thermal:
             device = "PSU{}".format(self.thermals_psu_index)
-            output = self.pddf_obj.get_attr_name_output(device, "psu_temp1_input")
+            output = self.pddf_obj.get_attr_name_output(device, "psu_temp{}_input".format(self.thermal_index))
             if not output:
                 return None
 

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
@@ -111,6 +111,15 @@ class PddfApi():
 
         return self.data[dev]['dev_attr']['num_psu_fans']
 
+    def get_num_psu_thermals(self, dev):
+        if dev not in self.data.keys():
+            return str(1)
+
+        if 'num_psu_thermals' not in self.data[dev]['dev_attr']:
+            return str(1)
+
+        return self.data[dev]['dev_attr']['num_psu_thermals']
+
     def get_led_path(self):
         return ("pddf/devices/led")
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add support for up to 3 PSU thermal sensors 
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/23080
HLD changes: https://github.com/sonic-net/SONiC/pull/2022

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- update PSU kernel driver to read and publish two extra PSU temp sensors
- update PDDF python classes to read SysFS for these values and publish to SONiC platform infrastructure

#### How to verify it
Tested on NH-4010 using `show platform temperature`.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

