### PR TITLE
Set psu fan speed and thermal controllable to false on Arista 7280DR3A variants

### DIFF
--- a/device/arista/x86_64-arista_7280dr3a_36/platform.json
+++ b/device/arista/x86_64-arista_7280dr3a_36/platform.json
@@ -88,6 +88,9 @@
                         "name": "psu1/1",
                         "status_led": {
                             "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
                         }
                     }
                 ]
@@ -99,6 +102,9 @@
                         "name": "psu2/1",
                         "status_led": {
                             "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
                         }
                     }
                 ]
@@ -106,28 +112,36 @@
         ],
         "thermals": [
             {
-                "name": "CPU"
+                "name": "CPU",
+                "controllable": false
             },
             {
-                "name": "CPU board"
+                "name": "CPU board",
+                "controllable": false
             },
             {
-                "name": "Back-panel"
+                "name": "Back-panel",
+                "controllable": false
             },
             {
-                "name": "JE0 Front Side"
+                "name": "JE0 Front Side",
+                "controllable": false
             },
             {
-                "name": "Air Inlet"
+                "name": "Air Inlet",
+                "controllable": false
             },
             {
-                "name": "Board Temp"
+                "name": "Board Temp",
+                "controllable": false
             },
             {
-                "name": "JE1_C Diode"
+                "name": "JE1_C Diode",
+                "controllable": false
             },
             {
-                "name": "JE0_C Diode"
+                "name": "JE0_C Diode",
+                "controllable": false
             }
         ],
         "sfps": [

--- a/device/arista/x86_64-arista_7280dr3ak_36/platform.json
+++ b/device/arista/x86_64-arista_7280dr3ak_36/platform.json
@@ -88,6 +88,9 @@
                         "name": "psu1/1",
                         "status_led": {
                             "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
                         }
                     }
                 ]
@@ -99,6 +102,9 @@
                         "name": "psu2/1",
                         "status_led": {
                             "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
                         }
                     }
                 ]
@@ -106,28 +112,36 @@
         ],
         "thermals": [
             {
-                "name": "CPU"
+                "name": "CPU",
+                "controllable": false
             },
             {
-                "name": "CPU board"
+                "name": "CPU board",
+                "controllable": false
             },
             {
-                "name": "Back-panel"
+                "name": "Back-panel",
+                "controllable": false
             },
             {
-                "name": "JE0 Front Side"
+                "name": "JE0 Front Side",
+                "controllable": false
             },
             {
-                "name": "Air Inlet"
+                "name": "Air Inlet",
+                "controllable": false
             },
             {
-                "name": "Board Temp"
+                "name": "Board Temp",
+                "controllable": false
             },
             {
-                "name": "JE1_C Diode"
+                "name": "JE1_C Diode",
+                "controllable": false
             },
             {
-                "name": "JE0_C Diode"
+                "name": "JE0_C Diode",
+                "controllable": false
             }
         ],
         "sfps": [

--- a/device/arista/x86_64-arista_7280dr3ak_36s/platform.json
+++ b/device/arista/x86_64-arista_7280dr3ak_36s/platform.json
@@ -88,6 +88,9 @@
                         "name": "psu1/1",
                         "status_led": {
                             "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
                         }
                     }
                 ]
@@ -99,6 +102,9 @@
                         "name": "psu2/1",
                         "status_led": {
                             "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
                         }
                     }
                 ]
@@ -106,28 +112,36 @@
         ],
         "thermals": [
             {
-                "name": "CPU"
+                "name": "CPU",
+                "controllable": false
             },
             {
-                "name": "CPU board"
+                "name": "CPU board",
+                "controllable": false
             },
             {
-                "name": "Back-panel"
+                "name": "Back-panel",
+                "controllable": false
             },
             {
-                "name": "JE0 Front Side"
+                "name": "JE0 Front Side",
+                "controllable": false
             },
             {
-                "name": "Air Inlet"
+                "name": "Air Inlet",
+                "controllable": false
             },
             {
-                "name": "Board Temp"
+                "name": "Board Temp",
+                "controllable": false
             },
             {
-                "name": "JE1_C Diode"
+                "name": "JE1_C Diode",
+                "controllable": false
             },
             {
-                "name": "JE0_C Diode"
+                "name": "JE0_C Diode",
+                "controllable": false
             }
         ],
         "sfps": [

--- a/device/arista/x86_64-arista_7280dr3am_36/platform.json
+++ b/device/arista/x86_64-arista_7280dr3am_36/platform.json
@@ -88,6 +88,9 @@
                         "name": "psu1/1",
                         "status_led": {
                             "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
                         }
                     }
                 ]
@@ -99,6 +102,9 @@
                         "name": "psu2/1",
                         "status_led": {
                             "controllable": false
+                        },
+                        "speed": {
+                            "controllable": false
                         }
                     }
                 ]
@@ -106,28 +112,36 @@
         ],
         "thermals": [
             {
-                "name": "CPU"
+                "name": "CPU",
+                "controllable": false
             },
             {
-                "name": "CPU board"
+                "name": "CPU board",
+                "controllable": false
             },
             {
-                "name": "Back-panel"
+                "name": "Back-panel",
+                "controllable": false
             },
             {
-                "name": "JE0 Front Side"
+                "name": "JE0 Front Side",
+                "controllable": false
             },
             {
-                "name": "Air Inlet"
+                "name": "Air Inlet",
+                "controllable": false
             },
             {
-                "name": "Board Temp"
+                "name": "Board Temp",
+                "controllable": false
             },
             {
-                "name": "JE1_C Diode"
+                "name": "JE1_C Diode",
+                "controllable": false
             },
             {
-                "name": "JE0_C Diode"
+                "name": "JE0_C Diode",
+                "controllable": false
             }
         ],
         "sfps": [


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Arista 7280DR3A SKUs don't support controlling thermal and psu fan speed. This makes some platform_tests under sonic-mgmt fail since they assume they are controllable by default.

Tests affected by this:

`platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_speed`
`platform_tests/api/test_thermal.py::TestThermalApi::test_set_low_threshold`
`platform_tests/api/test_thermal.py::TestThermalApi::test_set_high_threshold`

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modify `platform.json` to explicity mention that psu fan speed and thermal sensors are not controllable

#### How to verify it
Reran the above-mentioned tests and verified that they are skipped.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202503 (For Disagg T2)

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->
- [x] msft-202503

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
![image](https://github.com/user-attachments/assets/6984acbe-0e5d-480c-923c-7f20a4e8731e)

