### PR TITLE
Expose label_revision in pddf_eeprom

### DIFF
--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_eeprom.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_eeprom.py
@@ -128,6 +128,13 @@ class PddfEeprom(eeprom_tlvinfo.TlvInfoDecoder):
 
         return results[2].decode('ascii')
 
+    def label_revision_str(self):
+        (is_valid, results) = self.get_tlv_field(self.eeprom_data, self._TLV_CODE_LABEL_REVISION)
+        if not is_valid:
+            return "N/A"
+
+        return results[2].decode('ascii')
+
     def system_eeprom_info(self):
         """
         Returns a dictionary, where keys are the type code defined in


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Label Revision is a supported TLV code in the eeprom, but there is no getter for it in the pddf_eeprom. 
This PR adds it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

