### PR TITLE
Fix process_audit rule in auditd

### DIFF
--- a/dockers/docker-auditd-watchdog/watchdog/src/main.rs
+++ b/dockers/docker-auditd-watchdog/watchdog/src/main.rs
@@ -7,8 +7,8 @@ static NSENTER_CMD: &str = "nsenter --target 1 --pid --mount --uts --ipc --net";
 
 // Expected hash values
 static AUDITD_CONF_HASH: &str = "7cdbd1450570c7c12bdc67115b46d9ae778cbd76";
-static AUDITD_RULES_HASH_DEFAULT: &str = "3042c67383dccff079755c5f3daa2820e2ca392a";
-static AUDITD_RULES_HASH_NOKIA: &str = "fffb00199104c493d04a621b257c579c48d77225";
+static AUDITD_RULES_HASH_DEFAULT: &str = "99bf4b5a80ac2b8d03fa69d1b8e7f7b2a1423ba8";
+static AUDITD_RULES_HASH_NOKIA: &str = "6002dcd7ef2cbeabc7a60925bd603ebe901d58be";
 
 // Helper to run commands
 fn run_command(cmd: &str) -> Result<String, String> {

--- a/dockers/docker-auditd/auditd_config_files/30-audisp-tacplus.rules
+++ b/dockers/docker-auditd/auditd_config_files/30-audisp-tacplus.rules
@@ -22,8 +22,8 @@
 # We assume here that user 1000 is the first local user, and therefore
 # should not be looked up for tacacs.  You may need to change this for
 # your local configuration
--a always,exit -F arch=b32 -S execve -S exit -S exit_group -F auid>1000 -F auid!=4294967295 -k tacplus
--a always,exit -F arch=b64 -S execve -S exit -S exit_group -F auid>1000 -F auid!=4294967295 -k tacplus
+-a always,exit -F arch=b32 -S exit -S exit_group -F auid>1000 -F auid!=4294967295 -k tacplus
+-a always,exit -F arch=b64 -S exit -S exit_group -F auid>1000 -F auid!=4294967295 -k tacplus
 
 # In newer distributions (such as debian jessie), a number of auditing events
 # are logged by default even after the -D initialization.  If you are using

--- a/dockers/docker-auditd/auditd_config_files/31-process_audit.rules
+++ b/dockers/docker-auditd/auditd_config_files/31-process_audit.rules
@@ -1,2 +1,2 @@
--a always,exit -F arch=b64 -S execve -F auid>=1000 -F auid!=4294967295 -F key=process_audit
--a always,exit -F arch=b32 -S execve -F auid>=1000 -F auid!=4294967295 -F key=process_audit
+-a always,exit -F arch=b64 -S execve -F auid>=1000 -F auid!=4294967295 -F key=process_audit -F key=tacplus
+-a always,exit -F arch=b32 -S execve -F auid>=1000 -F auid!=4294967295 -F key=process_audit -F key=tacplus

--- a/dockers/docker-auditd/auditd_config_files/32bit/30-audisp-tacplus.rules
+++ b/dockers/docker-auditd/auditd_config_files/32bit/30-audisp-tacplus.rules
@@ -22,7 +22,7 @@
 # We assume here that user 1000 is the first local user, and therefore
 # should not be looked up for tacacs.  You may need to change this for
 # your local configuration
--a always,exit -F arch=b32 -S execve -S exit -S exit_group -F auid>1000 -F auid!=4294967295 -k tacplus
+-a always,exit -F arch=b32 -S exit -S exit_group -F auid>1000 -F auid!=4294967295 -k tacplus
 # No 64bit support -a always,exit -F arch=b64 -S execve -S exit -S exit_group -F auid>1000 -F auid!=4294967295 -k tacplus
 
 # In newer distributions (such as debian jessie), a number of auditing events

--- a/dockers/docker-auditd/auditd_config_files/32bit/31-process_audit.rules
+++ b/dockers/docker-auditd/auditd_config_files/32bit/31-process_audit.rules
@@ -1,1 +1,1 @@
--a always,exit -F arch=b32 -S execve -F auid>=1000 -F auid!=4294967295 -F key=process_audit
+-a always,exit -F arch=b32 -S execve -F auid>=1000 -F auid!=4294967295 -F key=process_audit -F key=tacplus

--- a/dockers/docker-auditd/config_checker.py
+++ b/dockers/docker-auditd/config_checker.py
@@ -18,8 +18,8 @@ CONFIG_FILES = "/usr/share/sonic/auditd_config_files/"
 # Expected hash values
 CONFIG_HASHES = {
     "rules": {
-        "default": "3042c67383dccff079755c5f3daa2820e2ca392a",
-        "nokia": "fffb00199104c493d04a621b257c579c48d77225"
+        "default": "99bf4b5a80ac2b8d03fa69d1b8e7f7b2a1423ba8",
+        "nokia": "6002dcd7ef2cbeabc7a60925bd603ebe901d58be"
     },
     "auditd_conf": "7cdbd1450570c7c12bdc67115b46d9ae778cbd76"
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

