### PR TITLE
PDDF: Fix xcvr reset

### DIFF
--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
@@ -245,23 +245,16 @@ class PddfSfp(SfpOptoeBase):
         status = False
         device = 'PORT{}'.format(self.port_index)
         path = self.pddf_obj.get_path(device, 'xcvr_reset')
-
         if path:
             try:
-                f = open(path, 'r+')
-            except IOError as e:
-                return False
-
-            try:
-                f.seek(0)
-                f.write('1')
-                time.sleep(1)
-                f.seek(0)
-                f.write('0')
-
-                f.close()
-                status = True
-            except IOError as e:
+                with open(path, 'r+') as f:
+                    f.seek(0)
+                    f.write('1')
+                    time.sleep(1)
+                    f.seek(0)
+                    f.write('0')
+                    status = True
+            except (IOError, OSError):
                 status = False
         else:
             # Use common SfpOptoeBase implementation for reset


### PR DESCRIPTION
<!-- Please provide the following information: -->

#### Why I did it
xcvr reset using sfputil reset is not working for pddf. `ff` is meant to be cleared and show `00`
```
admin@sonic:~$ sudo sfputil read-eeprom -p Ethernet305 -n 0x13 -o 183  -s 1
        000000b7 ff                                               |.|

root@sonic:/home/admin# sudo sfputil reset Ethernet305
Resetting port Ethernet305 ... OK

admin@sonic:~$ sudo sfputil read-eeprom -p Ethernet305 -n 0x13 -o 183  -s 1
        000000b7 ff
```

#### How I did it
The code was missing `f.flush()` to write `1` to the sysfs file. I used a context manager instead, which ensures the file is properly flushed and closed.

#### How to verify it
```
root@sonic:/home/admin# sudo sfputil read-eeprom -p Ethernet8 -n 0x13 -o 183 -s 1
        000000b7 ff                                               |.|
root@sonic:/home/admin# sfputil reset Ethernet8
Resetting port Ethernet8 ... OK
root@sonic:/home/admin# sudo sfputil read-eeprom -p Ethernet8 -n 0x13 -o 183 -s 1
        000000b7 00
```
#### Which release branch to backport (provide reason below if selected)
NA

#### Tested branch (Please provide the tested image version)
- [master] <!-- image version 1 -->

#### Description for the changelog
fix sfputil reset for pddf