### PR TITLE
Fix the scd address in platform.json for Arista_7060x6_64pe_b

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/platform.json
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/platform.json
@@ -9,10 +9,10 @@
                 "name": "Scd(addr=0000:03:00.0)"
             },
             {
-                "name": "RedstartSysCpld(addr=13-0023)"
+                "name": "Scd(addr=0000:05:00.0)"
             },
             {
-                "name": "Scd(addr=0000:05:00.0)"
+                "name": "RedstartSysCpld(addr=13-0023)"
             }
         ],
         "fans": [],

--- a/device/arista/x86_64-arista_7060x6_64pe_b/platform_components.json
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/platform_components.json
@@ -4,8 +4,8 @@
          "component": {
             "Aboot()": {},
             "Scd(addr=0000:03:00.0)": {},
-            "RedstartSysCpld(addr=13-0023)": {},
-            "Scd(addr=0000:05:00.0)": {}
+            "Scd(addr=0000:05:00.0)": {},
+            "RedstartSysCpld(addr=13-0023)": {}
          }
       }
    }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix https://github.com/aristanetworks/sonic-qual.msft/issues/596

##### Work item tracking
- Microsoft ADO **(number only)**: 33592288

#### How I did it
Correct the order of scd addresses in platform.json for x86_64-arista_7060x6_64pe_b.

#### How to verify it
Run platform_tests/api/test_component.py::TestComponentApi::test_get_name on a th5 DUT and the case passed.
```
platform_tests/api/test_component.py::TestComponentApi::test_get_name[str5-7060x6-512-3] PASSED     [100%]
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 202412
- [x] 202505

Signed-off-by: zitingguo-ms <zitingguo@mcirosoft.com>
