### PR TITLE
[Mellanox][Smartswitch] Add Force power indication in the status for dpuctl

### DIFF
--- a/platform/mellanox/mlnx-platform-api/smart_switch/dpuctl/main.py
+++ b/platform/mellanox/mlnx-platform-api/smart_switch/dpuctl/main.py
@@ -1,6 +1,7 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
-# Apache-2.0
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/platform/mellanox/mlnx-platform-api/smart_switch/dpuctl/main.py
+++ b/platform/mellanox/mlnx-platform-api/smart_switch/dpuctl/main.py
@@ -181,9 +181,10 @@ def dpuctl_get_status(ctx, all_dpus=False, dpu_names=None):
                 dpu_status_list = [dpu_name,
                                    dpu_obj.dpu_ready_indication,
                                    dpu_obj.dpu_shtdn_ready_indication,
-                                   dpu_obj.boot_prog_indication]
+                                   dpu_obj.boot_prog_indication,
+                                   dpu_obj.dpu_force_pwr_indication]
                 status_list.append(dpu_status_list)
-        header = ['DPU', 'dpu ready', 'dpu shutdown ready', 'boot progress']
+        header = ['DPU', 'dpu ready', 'dpu shutdown ready', 'boot progress', 'Force Power Required']
         click.echo(tabulate(status_list, header))
     except Exception as error:
         print(f"An error occurred: {type(error).__name__} - {error}")

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -102,6 +102,7 @@ class DpuCtlPlat():
         self.boot_prog_state = None
         self.shtdn_state = None
         self.dpu_ready_state = None
+        self.dpu_force_pwr_state = None
         self.setup_logger()
         self.pci_dev_path = []
         self.verbosity = False
@@ -373,12 +374,22 @@ class DpuCtlPlat():
             self.log_error(f"Could not update dpu_shtdn_ready for DPU")
             raise e
 
+    def dpu_force_pwr_update(self):
+        """Monitor and read changes to dpu_shtdn_ready sysfs file and map it to corresponding indication"""
+        try:
+            self.dpu_force_pwr_state = self.read_force_power_path()
+            self.dpu_force_pwr_indication = f"{False if self.dpu_force_pwr_state == 1 else True if self.dpu_force_pwr_state == 0 else str(self.dpu_force_pwr_state)+' - N/A'}"
+        except Exception as e:
+            self.log_error(f"Could not update dpu_force_pwr_state for DPU")
+            raise e
+
     def dpu_status_update(self):
         """Update status for all the three relevant sysfs files for DPU monitoring"""
         try:
             self.dpu_boot_prog_update()
             self.dpu_ready_update()
             self.dpu_shtdn_ready_update()
+            self.dpu_force_pwr_update()
         except Exception as e:
             self.log_error(f"Could not obtain status of DPU")
             raise e

--- a/platform/mellanox/mlnx-platform-api/tests/dpuctl_inputs/dpuctl_test_inputs.py
+++ b/platform/mellanox/mlnx-platform-api/tests/dpuctl_inputs/dpuctl_test_inputs.py
@@ -1,6 +1,7 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
-# Apache-2.0
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/platform/mellanox/mlnx-platform-api/tests/dpuctl_inputs/dpuctl_test_inputs.py
+++ b/platform/mellanox/mlnx-platform-api/tests/dpuctl_inputs/dpuctl_test_inputs.py
@@ -113,31 +113,31 @@ testData = {
                      },
 }
 
-status_output = ["""DPU    dpu ready    dpu shutdown ready    boot progress
------  -----------  --------------------  -----------------
-dpu0   True         False                 5 - OS is running
-dpu1   True         False                 5 - OS is running
-dpu2   True         False                 5 - OS is running
-dpu3   True         False                 5 - OS is running
+status_output = ["""DPU    dpu ready    dpu shutdown ready    boot progress      Force Power Required
+-----  -----------  --------------------  -----------------  ----------------------
+dpu0   True         False                 5 - OS is running  False
+dpu1   True         False                 5 - OS is running  False
+dpu2   True         False                 5 - OS is running  False
+dpu3   True         False                 5 - OS is running  False
 """,
-                 """DPU    dpu ready    dpu shutdown ready    boot progress
------  -----------  --------------------  -----------------
-dpu1   True         False                 5 - OS is running
+                 """DPU    dpu ready    dpu shutdown ready    boot progress      Force Power Required
+-----  -----------  --------------------  -----------------  ----------------------
+dpu1   True         False                 5 - OS is running  False
 """,
-                 """DPU    dpu ready    dpu shutdown ready    boot progress
------  -----------  --------------------  -----------------
-dpu0   True         False                 5 - OS is running
+                 """DPU    dpu ready    dpu shutdown ready    boot progress      Force Power Required
+-----  -----------  --------------------  -----------------  ----------------------
+dpu0   True         False                 5 - OS is running  False
 """,
                  """An error occurred: AssertionError - Invalid Arguments provided!dpu5 does not exist!
 """,
                  """An error occurred: AssertionError - Invalid Arguments provided!dpu10 does not exist!
 """,
-                 """DPU    dpu ready    dpu shutdown ready    boot progress
------  -----------  --------------------  ------------------
-dpu0   False        True                  0 - Reset/Boot-ROM
-dpu1   False        True                  0 - Reset/Boot-ROM
-dpu2   False        True                  0 - Reset/Boot-ROM
-dpu3   False        True                  0 - Reset/Boot-ROM
+                 """DPU    dpu ready    dpu shutdown ready    boot progress       Force Power Required
+-----  -----------  --------------------  ------------------  ----------------------
+dpu0   False        True                  0 - Reset/Boot-ROM  False
+dpu1   False        True                  0 - Reset/Boot-ROM  False
+dpu2   False        True                  0 - Reset/Boot-ROM  False
+dpu3   False        True                  0 - Reset/Boot-ROM  False
 """,
-                 ["dpu1", "True", "False"],
+                 ["dpu1", "True", "False", "False"],
                  ]

--- a/platform/mellanox/mlnx-platform-api/tests/test_dpuctl.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_dpuctl.py
@@ -106,8 +106,9 @@ class Testdpuctl:
 
     def test_dpuctl_status(self):
         """Tests for dpuctl click Implementation for Status API"""
-        mock_file_list = ['shtdn_ready', '_ready', 'boot_progress']
-        mock_return_value = [0, 1, 5]
+        mock_file_list = ['shtdn_ready', '_ready', 'boot_progress', 'pwr_force']
+        mock_return_value = [0, 1, 5, 1]
+        assert len(mock_file_list) == len(mock_return_value)
 
         def mock_read_int_from_file(file_path, default=0, raise_exception=False, log_func=None):
             for index, value in enumerate(mock_file_list):
@@ -119,6 +120,7 @@ class Testdpuctl:
             cmd = dpuctl_get_status
             runner = CliRunner()
             result = runner.invoke(cmd, catch_exceptions=False, obj=obj)
+            print(result.output)
             assert result.output == status_output[0]
             result = runner.invoke(cmd, ['dpu1'], catch_exceptions=False, obj=obj)
             assert result.output == status_output[1]
@@ -128,10 +130,10 @@ class Testdpuctl:
             assert result.output == status_output[3]
             result = runner.invoke(cmd, ['dpu10'], catch_exceptions=False, obj=obj)
             assert result.output == status_output[4]
-            mock_return_value = [1, 0, 0]
+            mock_return_value = [1, 0, 0, 1]
             result = runner.invoke(cmd, catch_exceptions=False, obj=obj)
             assert result.output == status_output[5]
-            header = ["DPU", "dpu ready", "dpu shutdown ready", "boot progress"]
+            header = ["DPU", "dpu ready", "dpu shutdown ready", "boot progress", "Force Power Required"]
             boot_prog_map = {
                 0: "Reset/Boot-ROM",
                 1: "BL2 (from ATF image on eMMC partition)",
@@ -148,14 +150,14 @@ class Testdpuctl:
                 15: "Software is inactive"
             }
             for key in boot_prog_map.keys():
-                mock_return_value = [0, 1, key]
+                mock_return_value = [0, 1, key, 1]
                 result = runner.invoke(cmd, ['dpu1'], catch_exceptions=False, obj=obj)
                 expected_value = f"{key} - {boot_prog_map.get(key)}"
-                expected_data = [[status_output[6][0], status_output[6][1], status_output[6][2], expected_value]]
+                expected_data = [[status_output[6][0], status_output[6][1], status_output[6][2], expected_value, status_output[6][3]]]
                 expected_res = tabulate(expected_data, header)
                 assert result.output == expected_res + "\n"
-            mock_return_value = [5, 5, 25]
-            expected_data = [["dpu1", "5 - N/A", "5 - N/A", "25 - N/A"]]
+            mock_return_value = [5, 5, 25, 6]
+            expected_data = [["dpu1", "5 - N/A", "5 - N/A", "25 - N/A", "6 - N/A"]]
             result = runner.invoke(cmd, ['dpu1'], catch_exceptions=False, obj=obj)
             expected_res = tabulate(expected_data, header)
             assert result.output == expected_res + "\n"

--- a/platform/mellanox/mlnx-platform-api/tests/test_dpuctl.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_dpuctl.py
@@ -1,6 +1,7 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
-# Apache-2.0
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The force power sysfs file relevant for the DPU is readable (to check if force power is required or not) This sysfs file is displayed as part of the 
`dpuctl dpu-status` CLI, this helps in debugging for the smartswitch platforms.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
By modifying the main.py file for the dpuctl package to include a function call to the `DpuModule` to read the force power on file for sysfs
#### How to verify it
Unit tests
```
tests/test_dpuctl.py::Testdpuctl::test_dpuctl_power_off PASSED                                                                                                                                                                              [ 24%]
tests/test_dpuctl.py::Testdpuctl::test_dpuctl_power_on PASSED                                                                                                                                                                               [ 25%]
tests/test_dpuctl.py::Testdpuctl::test_dpuctl_reset PASSED                                                                                                                                                                                  [ 25%]
tests/test_dpuctl.py::Testdpuctl::test_dpuctl_status PASSED                                                                                                                                                                                 [ 26%]
```
Tested manually on smartswitch platform

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)
Master branch
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

