### PR TITLE
Update Arista7280DR3A variants to ignore psu fans 3 and 4

### DIFF
--- a/device/arista/x86_64-arista_7280dr3a_36/sensors.conf
+++ b/device/arista/x86_64-arista_7280dr3a_36/sensors.conf
@@ -1,3 +1,6 @@
+bus "i2c-21" "SCD 0000:01:00.0 SMBus master 0 bus 0"
+bus "i2c-22" "SCD 0000:01:00.0 SMBus master 0 bus 1"
+
 chip "nvme-pci-0500"
     ignore temp2
     ignore temp3
@@ -5,3 +8,20 @@ chip "nvme-pci-0500"
     ignore temp5
     ignore temp6
     ignore temp7
+
+chip "dps800-i2c-21-58"
+    label temp1 "Power supply 1 inlet temp sensor"
+    label temp2 "Power supply 1 secondary hotspot sensor"
+    label temp3 "Power supply 1 primary hotspot temp sensor"
+
+    ignore fan3
+    ignore fan4
+
+chip "dps800-i2c-22-58"
+    label temp1 "Power supply 2 inlet temp sensor"
+    label temp2 "Power supply 2 secondary hotspot sensor"
+    label temp3 "Power supply 2 primary hotspot temp sensor"
+
+    ignore fan3
+    ignore fan4
+

--- a/device/arista/x86_64-arista_7280dr3ak_36/sensors.conf
+++ b/device/arista/x86_64-arista_7280dr3ak_36/sensors.conf
@@ -1,7 +1,1 @@
-chip "nvme-pci-0500"
-    ignore temp2
-    ignore temp3
-    ignore temp4
-    ignore temp5
-    ignore temp6
-    ignore temp7
+../x86_64-arista_7280dr3a_36/sensors.conf

--- a/device/arista/x86_64-arista_7280dr3ak_36s/sensors.conf
+++ b/device/arista/x86_64-arista_7280dr3ak_36s/sensors.conf
@@ -1,7 +1,1 @@
-chip "nvme-pci-0500"
-    ignore temp2
-    ignore temp3
-    ignore temp4
-    ignore temp5
-    ignore temp6
-    ignore temp7
+../x86_64-arista_7280dr3a_36/sensors.conf

--- a/device/arista/x86_64-arista_7280dr3am_36/sensors.conf
+++ b/device/arista/x86_64-arista_7280dr3am_36/sensors.conf
@@ -1,7 +1,1 @@
-chip "nvme-pci-0500"
-    ignore temp2
-    ignore temp3
-    ignore temp4
-    ignore temp5
-    ignore temp6
-    ignore temp7
+../x86_64-arista_7280dr3a_36/sensors.conf


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
These errors appear on Arista 72800DR3A SKUs. Pmon expects psu fan3 and fan4 to be readable but this particular model only has two psu fans, the rest need to be ignored.

Fixes #23188 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modify sensors.conf to ignore these PSU fans.

#### How to verify it
Rebooted the DUT with the change and verified that the messages no longer appear.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202503

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] msft-202503

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Ignore PSU fans 3 and 4 on Arista 72800DR3A SKUs

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
NA

#### A picture of a cute animal (not mandatory but encouraged)
![image](https://github.com/user-attachments/assets/0cb91709-826c-4bad-823b-2807bba43612)

