### PR TITLE
Revert "Improve monit_gnmi.2 to support smartswitch"

### DIFF
--- a/dockers/docker-sonic-gnmi/Dockerfile.j2
+++ b/dockers/docker-sonic-gnmi/Dockerfile.j2
@@ -12,12 +12,6 @@ ENV IMAGE_VERSION=$image_version
 
 RUN apt-get update
 
-# Unit test for monit_gnmi.j2
-COPY ["base_image_files/monit_gnmi.j2", "/tmp/monit_gnmi.j2"]
-RUN SMARTSWITCH=1 j2 -f env /tmp/monit_gnmi.j2 | grep "gnmi 1073741824"
-RUN j2 -f env /tmp/monit_gnmi.j2 | grep "gnmi 419430400"
-RUN rm -f /tmp/monit_gnmi.j2
-
 {% if docker_sonic_gnmi_debs.strip() -%}
 # Copy locally-built Debian package dependencies
 {{ copy_files("debs/", docker_sonic_gnmi_debs.split(' '), "/debs/") }}

--- a/dockers/docker-sonic-gnmi/base_image_files/monit_gnmi.j2
+++ b/dockers/docker-sonic-gnmi/base_image_files/monit_gnmi.j2
@@ -1,9 +1,9 @@
 ###############################################################################
 ## Monit configuration for telemetry container
 ###############################################################################
-{%- if SMARTSWITCH is defined and SMARTSWITCH == "1" %}
+{% if SMARTSWITCH is defined and SMARTSWITCH == 1 %}
 check program container_memory_gnmi with path "/usr/bin/memory_checker gnmi 1073741824"
-{%- else %}
+{% else %}
 check program container_memory_gnmi with path "/usr/bin/memory_checker gnmi 419430400"
-{%- endif %}
+{% endif %}
     if status == 3 for 10 times within 20 cycles then exec "/usr/bin/restart_service gnmi" repeat every 2 cycles


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#22702

The correct way to fix this would be to read the memory limit from CONFIG_DB or somehow determine based on runtime.