### PR TITLE
Use uniform mode for IPinIP packet decap on cisco devices

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -8,6 +8,12 @@
   {% set is_broadcom = true %}
 {% endif %}
 
+{# Check if the hwsku is Cisco #}
+{% set is_cisco = false %}
+{% if "cisco" in DEVICE_METADATA['localhost']['hwsku']|lower %}
+  {% set is_cisco = true %}
+{% endif %}
+
 {% set ipv4_addresses = [] %}
 {% set ipv6_addresses = [] %}
 {% set ipv4_vlan_addresses = [] %}
@@ -79,7 +85,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_SUBNET" : {
             "tunnel_type":"IPINIP",
-{% if is_broadcom %}
+{% if is_broadcom or is_cisco %}
             "dscp_mode":"uniform",
 {% else %}
             "dscp_mode":"pipe",
@@ -105,7 +111,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-{% if is_broadcom %}
+{% if is_broadcom or is_cisco %}
             "dscp_mode":"uniform",
 {% else %}
             "dscp_mode":"pipe",
@@ -138,7 +144,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_SUBNET_V6" : {
             "tunnel_type":"IPINIP",
-{% if is_broadcom %}
+{% if is_broadcom or is_cisco %}
             "dscp_mode":"uniform",
 {% else %}
             "dscp_mode":"pipe",
@@ -164,7 +170,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-{% if is_broadcom %}
+{% if is_broadcom or is_cisco %}
             "dscp_mode":"uniform",
 {% else %}
             "dscp_mode":"pipe",


### PR DESCRIPTION
Cisco devices support uniform mode for IPinIP packet decap, doesn't support pipe mode.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
Verified  modified template on a lab device.
```
cisco@light-dut:~$ docker cp ipinip.json.j2 swss:/usr/share/sonic/templates/ipinip.json.j2
                                             Successfully copied 7.68kB to swss:/usr/share/sonic/templates/ipinip.json.j2
cisco@light-dut:~$ sudo config load_minigraph -y


Acquired lock on /etc/sonic/reload.lock
Disabling container and routeCheck monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Running command: config qos reload --no-dynamic-buffer --no-delay
Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-O64S2/buffers.json.j2,/tmp/cfg_buffer.json -t /usr/share/sonic/device/x86_64-8122_64eh_o-r0/Cisco-8122-O64S2/qos.json.j2,/tmp/cfg_qos.json -y /etc/sonic/sonic_version.yml
Running command: /usr/local/bin/sonic-cfggen -j /tmp/cfg_buffer.json -j /tmp/cfg_qos.json --write-to-db
Running command: pfcwd start_default
Restarting SONiC target ...
Enabling container and routeCheck monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon
Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
Released lock on /etc/sonic/reload.lock
cisco@light-dut:~$ 
cisco@light-dut:~$ docker exec -it swss bash
root@light-dut:/# cat /etc/swss/config.d/ipinip.json | grep dscp_mode
            "dscp_mode":"uniform",
            "dscp_mode":"uniform",
root@light-dut:/# cat /etc/swss/config.d/ipinip.json                 


  


[
    {
        "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
            "tunnel_type":"IPINIP",
            "dscp_mode":"uniform",
            "ecn_mode":"copy_from_outer",
            "ttl_mode":"pipe"
        },
        "OP": "SET"
    },
    {
        "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.0.0.56" : {
            "term_type":"P2MP"
        },
        "OP": "SET"
    },
    {
        "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.0.0.58" : {
            "term_type":"P2MP"
        },
        "OP": "SET"
    },
    {
        "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.0.0.60" : {
            "term_type":"P2MP"
        },
        "OP": "SET"
    },
    {
        "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.0.0.62" : {
            "term_type":"P2MP"
        },
        "OP": "SET"
    },
    {
        "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.1.0.32" : {
            "term_type":"P2MP"
        },
        "OP": "SET"
    },
    {
        "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:192.168.0.1" : {
            "term_type":"P2MP"
        },
        "OP": "SET"
    },
    {
        "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
            "tunnel_type":"IPINIP",
            "dscp_mode":"uniform",
            "ecn_mode":"copy_from_outer",
            "ttl_mode":"pipe"
        },
        "OP": "SET"
    },
    {
        "TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL:fc00:1::32" : {
            "term_type":"P2MP"
        },
        "OP": "SET"
    },
    {
        "TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL:fc00::71" : {
            "term_type":"P2MP"
        },
        "OP": "SET"
    },
    {
        "TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL:fc00::75" : {
            "term_type":"P2MP"
        },
        "OP": "SET"
    },
    {
        "TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL:fc00::79" : {
            "term_type":"P2MP"
        },
        "OP": "SET"
    },
    {
        "TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL:fc00::7d" : {
            "term_type":"P2MP"
        },
        "OP": "SET"
    },
    {
        "TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL:fc02:1000::1" : {
            "term_type":"P2MP"
        },
        "OP": "SET"
    }
]
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202505
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

