### PR TITLE
[smartswitch][config-engine] Skip enabling chrony server on smartswitch DPU

### DIFF
--- a/files/image_config/chrony/chrony.conf.j2
+++ b/files/image_config/chrony/chrony.conf.j2
@@ -55,7 +55,7 @@ confdir /etc/chrony/conf.d
 {% endfor -%}
 
 {# Enable the NTP server configuration only if the switch type is smartswitch -#}
-{% if device_metadata.subtype == 'SmartSwitch' -%}
+{% if device_metadata.subtype == 'SmartSwitch' and device_metadata.type != 'SmartSwitchDPU' -%}
 {# Enable NTP server functionality if server_role is enabled or DHCP configuration is enabled -#}
 {% if global.server_role == 'enabled' or global.dhcp == 'enabled' -%}
 allow

--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -193,6 +193,16 @@ def generate_t1_smartswitch_dpu_sample_config(data, ss_config):
         }
     }
 
+    data['NTP'] = {
+        "global": {
+            "admin_state": "enabled",
+            "authentication": "enabled",
+            "dhcp": "enabled",
+            "server_role": "disabled",
+            "vrf": "default"
+        }
+    }
+
     return data
 
 def generate_t1_smartswitch_sample_config(data):

--- a/src/sonic-config-engine/tests/data/ntp/ntp_smartswitch_dpu_interfaces.json
+++ b/src/sonic-config-engine/tests/data/ntp/ntp_smartswitch_dpu_interfaces.json
@@ -1,0 +1,40 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "type": "SmartSwitchDPU",
+            "subtype": "SmartSwitch"
+        }
+    },
+
+    "NTP_SERVER": {
+        "169.254.200.254": {
+            "iburst": "on"
+        }
+    },
+    "NTP": {
+        "global": {
+            "admin_state": "enabled",
+            "authentication": "enabled",
+            "dhcp": "enabled",
+            "server_role": "disabled",
+            "vrf": "default"
+        }
+    },
+    "NTP_KEY": {
+        "1": {
+            "type": "md5",
+            "trusted": "no",
+            "value": "blabla"
+        },
+        "42": {
+            "type": "sha1",
+            "trusted": "yes",
+            "value": "the_answer"
+        }
+    },
+    "INTERFACE": {
+        "Ethernet0": {},
+        "Ethernet0|10.0.0.0/31": {},
+        "Ethernet0|192.168.0.122/24": {}
+    }
+}

--- a/src/sonic-config-engine/tests/sample_output/py3/chrony_smartswitch_dpu.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/chrony_smartswitch_dpu.conf
@@ -1,0 +1,67 @@
+###############################################################################
+# This file was AUTOMATICALLY GENERATED. DO NOT MODIFY.
+# Controlled by chrony-config.sh
+###############################################################################
+
+# Welcome to the chrony configuration file. See chrony.conf(5) for more
+# information about usable directives.
+
+# Include configuration files found in /etc/chrony/conf.d.
+confdir /etc/chrony/conf.d
+
+server 169.254.200.254 iburst
+
+
+
+
+# Use time sources from DHCP.
+sourcedir /run/chrony-dhcp
+
+# Use NTP sources found in /etc/chrony/sources.d.
+sourcedir /etc/chrony/sources.d
+
+# This directive specify the location of the file containing ID/key pairs for
+# NTP authentication.
+keyfile /etc/chrony/chrony.keys
+
+# This directive specify the file into which chronyd will store the rate
+# information.
+driftfile /var/lib/chrony/chrony.drift
+
+# Save NTS keys and cookies.
+ntsdumpdir /var/lib/chrony
+
+# Uncomment the following line to turn logging on.
+#log tracking measurements statistics
+
+# Log files location.
+logdir /var/log/chrony
+
+# Stop bad estimates upsetting machine clock.
+maxupdateskew 100.0
+
+# This directive enables kernel synchronisation (every 11 minutes) of the
+# real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
+#rtcsync
+
+# Instead of having the kernel manage the real-time clock, have chrony do this
+# instead. The reason for this is that if the system time and the real-time clock
+# are signficantly different from the actual time, then the system time must be
+# slewed, while the real-time clock can be stepped to the actual time. That way,
+# when the device next reboots (whether it be cold, warm, or fast), it will come
+# up with the actual time from the real-time clock.
+rtcfile /var/lib/chrony/rtc
+hwclockfile /etc/adjtime
+rtconutc
+rtcautotrim 15
+
+# Step the system clock instead of slewing it if the adjustment is larger than
+# one second, but only in the first three clock updates.
+#
+# Disabled because we don't want chrony to do any clock steps; it should only slew
+#makestep 1 3
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+# This directive must be commented out when using time sources serving
+# leap-smeared time.
+leapsectz right/UTC

--- a/src/sonic-config-engine/tests/sample_output/t1-smartswitch-dpu.json
+++ b/src/sonic-config-engine/tests/sample_output/t1-smartswitch-dpu.json
@@ -78,6 +78,16 @@
             "dash_ipv6_acl_rule_high_threshold": "85"
         }
     },
+    "NTP": {
+        "global": {
+            "admin_state": "enabled",
+            "authentication": "disabled",
+            "dhcp": "enabled",
+            "server_role": "disabled",
+            "src_intf": "eth0",
+            "vrf": "default"
+        }
+    },
     "NTP_SERVER": {
         "169.254.200.254": {
             "iburst": "on"

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -824,6 +824,15 @@ class TestJ2Files(TestCase):
         self.run_script(argument, output_file=self.output_file)
         assert utils.cmp(expected, self.output_file), self.run_diff(expected, self.output_file)
 
+    def test_ntp_smartswitch_dpu_conf(self):
+        conf_template = os.path.join(self.test_dir, "chrony.conf.j2")
+        config_db_ntp_json = os.path.join(self.test_dir, "data", "ntp", "ntp_smartswitch_dpu_interfaces.json")
+        expected = os.path.join(self.test_dir, "sample_output", utils.PYvX_DIR, "chrony_smartswitch_dpu.conf")
+
+        argument = ['-j', config_db_ntp_json, '-t', conf_template]
+        self.run_script(argument, output_file=self.output_file)
+        assert utils.cmp(expected, self.output_file), self.run_diff(expected, self.output_file)
+
     def test_ntp_keys(self):
         conf_template = os.path.join(self.test_dir, "chrony.keys.j2")
         config_db_ntp_json = os.path.join(self.test_dir, "data", "ntp", "ntp_interfaces.json")


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
This PR enhances NTP configuration support for SmartSwitch DPUs in the SONiC config engine by:
- Updating the `chrony.conf.j2` template to skip NTP server bindings on `SmartSwitchDPU` type
- Adding NTP config generation logic and test data for SmartSwitch DPU
- Adding new sample input/output test files for validation
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

