### PR TITLE
Fix for MIGSMSFT-1038 "Config on device gets wiped out when upgrading from Cisco factory image to Microsoft golden image on Smartswitch"

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -404,4 +404,12 @@ if [ -f /var/log/fsck.log.gz ]; then
     rm -f /var/log/fsck.log.gz
 fi
 
+# Restore config_db.json if present in /host/old_config 
+if [ ! -f /etc/sonic/config_db.json ] && [ -f /host/old_config/config_db.json ]; then
+    echo "[rc.local] Restoring config_db.json from /host/old_config/"
+    cp /host/old_config/config_db.json /etc/sonic/config_db.json
+    chown root:root /etc/sonic/config_db.json
+    chmod 644 /etc/sonic/config_db.json
+fi
+
 exit 0


### PR DESCRIPTION
Fix for config wipeout issue during pilot. There is a corresponding fix in sonic-utilities.  Restores the saved config from /host/old_config

Fixes: #[MIGSMSFT-1038](https://migsonic.atlassian.net/browse/MIGSMSFT-1038)

#### Why I did it
Config on device gets wiped out when upgrading from Cisco factory image to Microsoft golden image on Smartswitch.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Reproduced the problem by issuing the "sonic-installer install" CLI more than once on the same installed image.  Then identified the root cause to be that the second installation takes a different code path and doesn't store and restore the the config file.  Moreover the during the second instance of the CLI on the same image the file system clean up happens wiping out all config files in "/etc/sonic"

#### How to verify it
Patch the  PRs  on the following two files and issue "sonic-installer install <img>" two or more times on the same image.
Before issuing the second instance of the CLI change the hostname and see the change is persisted.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ x] 202405
- [ x] 202411
- [ x] 202505

#### Tested branch (Please provide the tested image version)
- [ x] 202505

#### Description for the changelog
There is a corresponding fix in grub.py in sonic-utilities
