### PR TITLE
libyang3-py3: test crash seen in Trixie

### DIFF
--- a/src/libyang3-py3/patch/0004-pr141-test-crash.patch
+++ b/src/libyang3-py3/patch/0004-pr141-test-crash.patch
@@ -1,0 +1,70 @@
+From 2d8dcdfb3ac67389b61f46130c27815b47c0e7e7 Mon Sep 17 00:00:00 2001
+From: Brad House <brad@brad-house.com>
+Date: Sun, 6 Jul 2025 16:42:00 -0400
+Subject: [PATCH] tests: test_iffeature_state crash fix
+
+As observed on Debian Trixie RC2, test_iffeature_state crashes due
+to an internal pointer being invalidated.  This invalidation appears
+to be due to a call to lys_set_implemented() possibly causing a
+full recompile of the ctx.
+
+This simply reorders the caching of the path pointers so they are
+not invalidated when used.
+
+Signed-off-by: Brad House <brad@brad-house.com>
+---
+ tests/test_schema.py | 19 ++++++++-----------
+ 1 file changed, 8 insertions(+), 11 deletions(-)
+
+diff --git a/tests/test_schema.py b/tests/test_schema.py
+index a310aad..4578f84 100644
+--- a/tests/test_schema.py
++++ b/tests/test_schema.py
+@@ -197,18 +197,8 @@ def feature_disable_only(feature):
+                     continue
+                 self.mod.feature_enable(f.name())
+ 
+-        leaf_simple = next(self.ctx.find_path("/yolo-system:conf/yolo-system:speed"))
+-
+-        self.mod.feature_disable_all()
+-        leaf_not = next(self.ctx.find_path("/yolo-system:conf/yolo-system:offline"))
+-        self.mod.feature_enable_all()
+-
+-        leaf_and = next(self.ctx.find_path("/yolo-system:conf/yolo-system:full"))
+-        leaf_or = next(
+-            self.ctx.find_path("/yolo-system:conf/yolo-system:isolation-level")
+-        )
+-
+         # if-feature is just a feature
++        leaf_simple = next(self.ctx.find_path("/yolo-system:conf/yolo-system:speed"))
+         tree = next(leaf_simple.if_features()).tree()
+         self.mod.feature_enable_all()
+         self.assertEqual(tree.state(), True)
+@@ -216,6 +206,8 @@ def feature_disable_only(feature):
+         self.assertEqual(tree.state(), False)
+ 
+         # if-feature is "NOT networking"
++        self.mod.feature_disable_all()
++        leaf_not = next(self.ctx.find_path("/yolo-system:conf/yolo-system:offline"))
+         tree = next(leaf_not.if_features()).tree()
+         self.mod.feature_enable_all()
+         self.assertEqual(tree.state(), False)
+@@ -223,6 +215,8 @@ def feature_disable_only(feature):
+         self.assertEqual(tree.state(), True)
+ 
+         # if-feature is "turbo-boost AND networking"
++        self.mod.feature_enable_all()
++        leaf_and = next(self.ctx.find_path("/yolo-system:conf/yolo-system:full"))
+         tree = next(leaf_and.if_features()).tree()
+         self.mod.feature_enable_all()
+         self.assertEqual(tree.state(), True)
+@@ -234,6 +228,9 @@ def feature_disable_only(feature):
+         self.assertEqual(tree.state(), False)
+ 
+         # if-feature is "turbo-boost OR networking"
++        leaf_or = next(
++            self.ctx.find_path("/yolo-system:conf/yolo-system:isolation-level")
++        )
+         tree = next(leaf_or.if_features()).tree()
+         self.mod.feature_enable_all()
+         self.assertEqual(tree.state(), True)

--- a/src/libyang3-py3/patch/series
+++ b/src/libyang3-py3/patch/series
@@ -1,3 +1,4 @@
 0001-debian.patch
 0002-pr134-json-string-datatypes.patch
 0003-pr132-backlinks.patch
+0004-pr141-test-crash.patch


### PR DESCRIPTION
#### Why I did it
Issue #23147 noted test case failures of the recent libyang3-py3 code test cases during compilation when using Trixie.

There is an internal Python CFFI pointer that gets invalidated in a test case due to the internal object being mutated.  This test case appears to be malformed and makes incorrect assumptions.

Nothing here in particular appears to be actually related to Trixie so it isn't clear why it shows up. The feature being tested is also in a code path that is not used at all by SONiC.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Triaged underlying issue and submitted upstream PR https://github.com/CESNET/libyang-python/pull/141 to fix the issue

#### How to verify it

Build SONiC with Trixie and observe libyang3-py3 compiles as expected.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

master as of 20250706

#### Description for the changelog
libyang3-py3: test crash seen in Trixie

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)

Fixes #23147
Signed-off-by: Brad House <brad@brad-house.com>
