### PR TITLE
[202405] Enable gnmi/telemetry user authorization by config_db (#21363)

### DIFF
--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -3,6 +3,11 @@
 EXIT_TELEMETRY_VARS_FILE_NOT_FOUND=1
 INCORRECT_TELEMETRY_VALUE=2
 TELEMETRY_VARS_FILE=/usr/share/sonic/templates/telemetry_vars.j2
+ESCAPE_QUOTE="'\''"
+
+extract_field() {
+    echo $(echo $1 | jq -r $2)
+}
 
 if [ ! -f "$TELEMETRY_VARS_FILE" ]; then
     echo "Telemetry vars template file not found"
@@ -21,30 +26,29 @@ TELEMETRY_ARGS=" -logtostderr"
 export CVL_SCHEMA_PATH=/usr/sbin/schema
 
 if [ -n "$CERTS" ]; then
-    SERVER_CRT=$(echo $CERTS | jq -r '.server_crt')
-    SERVER_KEY=$(echo $CERTS | jq -r '.server_key')
+    SERVER_CRT=$(extract_field "$CERTS" '.server_crt')
+    SERVER_KEY=$(extract_field "$CERTS" '.server_key')
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
         TELEMETRY_ARGS+=" --insecure"
     else
         TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
     fi
 
-    CA_CRT=$(echo $CERTS | jq -r '.ca_crt')
+    CA_CRT=$(extract_field "$CERTS" '.ca_crt')
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
 
-    TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
 elif [ -n "$X509" ]; then
-    SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
-    SERVER_KEY=$(echo $X509 | jq -r '.server_key')
+    SERVER_CRT=$(extract_field "$X509" '.server_crt')
+    SERVER_KEY=$(extract_field "$X509" '.server_key')
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
         TELEMETRY_ARGS+=" --insecure"
     else
         TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
     fi
 
-    CA_CRT=$(echo $X509 | jq -r '.ca_crt')
+    CA_CRT=$(extract_field "$X509" '.ca_crt')
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
@@ -56,16 +60,21 @@ fi
 if [ -z "$GNMI" ]; then
     PORT=8080
 else
-    PORT=$(echo $GNMI | jq -r '.port')
+    PORT=$(extract_field "$GNMI" '.port')
+    if ! [[ $PORT =~ ^[0-9]+$ ]]; then
+        echo "Incorrect port value ${PORT}, expecting positive integers" >&2
+        exit $INCORRECT_TELEMETRY_VALUE
+    fi
 fi
+
 TELEMETRY_ARGS+=" --port $PORT"
 
-CLIENT_AUTH=$(echo $GNMI | jq -r '.client_auth')
+CLIENT_AUTH=$(extract_field "$GNMI" '.client_auth')
 if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then
     TELEMETRY_ARGS+=" --allow_no_client_auth"
 fi
 
-LOG_LEVEL=$(echo $GNMI | jq -r '.log_level')
+LOG_LEVEL=$(extract_field "$GNMI" '.log_level')
 if [[ $LOG_LEVEL =~ ^[0-9]+$ ]]; then
     TELEMETRY_ARGS+=" -v=$LOG_LEVEL"
 else
@@ -79,7 +88,7 @@ if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
 fi
 
 # Server will handle threshold connections consecutively
-THRESHOLD_CONNECTIONS=$(echo $GNMI | jq -r '.threshold')
+THRESHOLD_CONNECTIONS=$(extract_field "$GNMI" '.threshold')
 if [[ $THRESHOLD_CONNECTIONS =~ ^[0-9]+$ ]]; then
     TELEMETRY_ARGS+=" --threshold $THRESHOLD_CONNECTIONS"
 else
@@ -92,7 +101,7 @@ else
 fi
 
 # Close idle connections after certain duration (in seconds)
-IDLE_CONN_DURATION=$(echo $GNMI | jq -r '.idle_conn_duration')
+IDLE_CONN_DURATION=$(extract_field "$GNMI" '.idle_conn_duration')
 if [[ $IDLE_CONN_DURATION =~ ^[0-9]+$ ]]; then
     TELEMETRY_ARGS+=" --idle_conn_duration $IDLE_CONN_DURATION"
 else
@@ -104,4 +113,24 @@ else
     fi
 fi
 
+USER_AUTH=$(extract_field "$GNMI" '.user_auth')
+if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
+    TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
+
+    if [ $USER_AUTH == "cert" ]; then
+        TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
+
+        ENABLE_CRL=$(echo $GNMI | jq -r '.enable_crl')
+        if [ $ENABLE_CRL == "true" ]; then
+            TELEMETRY_ARGS+=" --enable_crl"
+        fi
+
+        CRL_EXPIRE_DURATION=$(extract_field "$GNMI" '.crl_expire_duration')
+        if [ ! -z "$CRL_EXPIRE_DURATION" ] && [ $CRL_EXPIRE_DURATION != "null" ]; then
+            TELEMETRY_ARGS+=" --crl_expire_duration $CRL_EXPIRE_DURATION"
+        fi
+    fi
+fi
+
+echo "gnmi args: $TELEMETRY_ARGS"
 exec /usr/sbin/telemetry ${TELEMETRY_ARGS}

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -3,6 +3,11 @@
 EXIT_TELEMETRY_VARS_FILE_NOT_FOUND=1
 INCORRECT_TELEMETRY_VALUE=2
 TELEMETRY_VARS_FILE=/usr/share/sonic/templates/telemetry_vars.j2
+ESCAPE_QUOTE="'\''"
+
+extract_field() {
+    echo $(echo $1 | jq -r $2)
+}
 
 if [ ! -f "$TELEMETRY_VARS_FILE" ]; then
     echo "Telemetry vars template file not found"
@@ -22,31 +27,28 @@ export CVL_SCHEMA_PATH=/usr/sbin/schema
 export GOTRACEBACK=crash
 
 if [ -n "$CERTS" ]; then
-    SERVER_CRT=$(echo $CERTS | jq -r '.server_crt')
-    SERVER_KEY=$(echo $CERTS | jq -r '.server_key')
+    SERVER_CRT=$(extract_field "$CERTS" '.server_crt')
+    SERVER_KEY=$(extract_field "$CERTS" '.server_key')
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
         TELEMETRY_ARGS+=" --insecure"
     else
         TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
     fi
 
-    CA_CRT=$(echo $CERTS | jq -r '.ca_crt')
+    CA_CRT=$(extract_field "$CERTS" '.ca_crt')
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
-
-    # Reuse GNMI_CLIENT_CERT for telemetry service
-    TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
 elif [ -n "$X509" ]; then
-    SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
-    SERVER_KEY=$(echo $X509 | jq -r '.server_key')
+    SERVER_CRT=$(extract_field "$X509" '.server_crt')
+    SERVER_KEY=$(extract_field "$X509" '.server_key')
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
         TELEMETRY_ARGS+=" --insecure"
     else
         TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
     fi
 
-    CA_CRT=$(echo $X509 | jq -r '.ca_crt')
+    CA_CRT=$(extract_field "$X509" '.ca_crt')
     if [ ! -z $CA_CRT ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
@@ -58,16 +60,20 @@ fi
 if [ -z "$GNMI" ]; then
     PORT=8080
 else
-    PORT=$(echo $GNMI | jq -r '.port')
+    PORT=$(extract_field "$GNMI" '.port')
+    if ! [[ $PORT =~ ^[0-9]+$ ]]; then
+        echo "Incorrect port value ${PORT}, expecting positive integers" >&2
+        exit $INCORRECT_TELEMETRY_VALUE
+    fi
 fi
 TELEMETRY_ARGS+=" --port $PORT"
 
-CLIENT_AUTH=$(echo $GNMI | jq -r '.client_auth')
+CLIENT_AUTH=$(extract_field "$GNMI" '.client_auth')
 if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then
     TELEMETRY_ARGS+=" --allow_no_client_auth"
 fi
 
-LOG_LEVEL=$(echo $GNMI | jq -r '.log_level')
+LOG_LEVEL=$(extract_field "$GNMI" '.log_level')
 if [[ $LOG_LEVEL =~ ^[0-9]+$ ]]; then
     TELEMETRY_ARGS+=" -v=$LOG_LEVEL"
 else
@@ -83,7 +89,7 @@ if [ ! -z "$SAVE_ON_SET" ]; then
 fi
 
 # Server will handle threshold connections consecutively
-THRESHOLD_CONNECTIONS=$(echo $GNMI | jq -r '.threshold')
+THRESHOLD_CONNECTIONS=$(extract_field "$GNMI" '.threshold')
 if [[ $THRESHOLD_CONNECTIONS =~ ^[0-9]+$ ]]; then
     TELEMETRY_ARGS+=" --threshold $THRESHOLD_CONNECTIONS"
 else
@@ -96,7 +102,7 @@ else
 fi
 
 # Close idle connections after certain duration (in seconds)
-IDLE_CONN_DURATION=$(echo $GNMI | jq -r '.idle_conn_duration')
+IDLE_CONN_DURATION=$(extract_field "$GNMI" '.idle_conn_duration')
 if [[ $IDLE_CONN_DURATION =~ ^[0-9]+$ ]]; then
     TELEMETRY_ARGS+=" --idle_conn_duration $IDLE_CONN_DURATION"
 else
@@ -109,4 +115,25 @@ else
 fi
 TELEMETRY_ARGS+=" -gnmi_native_write=false"
 
+USER_AUTH=$(extract_field "$GNMI" '.user_auth')
+if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
+    TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
+
+    if [ $USER_AUTH == "cert" ]; then
+        # Reuse GNMI_CLIENT_CERT for telemetry service
+        TELEMETRY_ARGS+=" --config_table_name GNMI_CLIENT_CERT"
+
+        ENABLE_CRL=$(echo $GNMI | jq -r '.enable_crl')
+        if [ $ENABLE_CRL == "true" ]; then
+            TELEMETRY_ARGS+=" --enable_crl"
+        fi
+
+        CRL_EXPIRE_DURATION=$(extract_field "$GNMI" '.crl_expire_duration')
+        if [ ! -z "$CRL_EXPIRE_DURATION" ] && [ $CRL_EXPIRE_DURATION != "null" ]; then
+            TELEMETRY_ARGS+=" --crl_expire_duration $CRL_EXPIRE_DURATION"
+        fi
+    fi
+fi
+
+echo "telemetry args: $TELEMETRY_ARGS"
 exec /usr/sbin/telemetry ${TELEMETRY_ARGS}

--- a/src/sonic-yang-models/yang-models/sonic-gnmi.yang
+++ b/src/sonic-yang-models/yang-models/sonic-gnmi.yang
@@ -71,6 +71,12 @@ module sonic-gnmi {
                     description "Port gnmi runs on.";
                 }
 
+                leaf user_auth {
+                    type string {
+                        pattern 'password|jwt|cert';
+                    }
+                    description "GNMI service user authorization type.";
+                }
             }
         }
 
@@ -78,7 +84,6 @@ module sonic-gnmi {
             description "GNMI client cert list";
 
             list GNMI_CLIENT_CERT_LIST {
-                max-elements 8;
                 key "cert_cname";
 
                 leaf cert_cname {

--- a/src/sonic-yang-models/yang-models/sonic-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-telemetry.yang
@@ -71,6 +71,12 @@ module sonic-telemetry {
                     description "Port gnmi runs on.";
                 }
 
+                leaf user_auth {
+                    type string {
+                        pattern 'password|jwt|cert';
+                    }
+                    description "Telemetry service user authorization type.";
+                }
             }
 
         }


### PR DESCRIPTION
Enable gnmi/telemetry user authorization by config_db.

Why I did it
gnmi/telemetry user authorization flag not used in SONiC and can't config by config_db

How I did it
Update Yang model and update gnmi/telemetry start script.

How to verify it
Pass all UT.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

