### PR TITLE
Update QoS when disable HBA

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_defaults_objects.j2
@@ -137,7 +137,7 @@
             {% endif %}
             "pool": "egress_lossy_pool",
             "size": "0",
-            "dynamic_th": "0"
+            "dynamic_th": "-7"
         },
         "queue2_downlink_lossy_profile": {
             {% if traffic_config.traffic_classification_enable %}
@@ -145,7 +145,7 @@
             {% endif %}
             "pool": "egress_lossy_pool",
             "size": "0",
-            "dynamic_th": "0"
+            "dynamic_th": "-7"
         },
         "queue3_downlink_lossy_profile": {
             {% if traffic_config.traffic_classification_enable %}
@@ -153,12 +153,12 @@
             {% endif %}
             "pool": "egress_lossy_pool",
             "size": "0",
-            "dynamic_th": "0"
+            "dynamic_th": "-7"
         },
         "queue4_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "0",
-            "dynamic_th": "7"
+            "dynamic_th": "0"
         },
         "queue5_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
@@ -181,7 +181,7 @@
             {% endif %}
             "pool": "egress_lossy_pool",
             "size": "0",
-            "dynamic_th": "0"
+            "dynamic_th": "-7"
         },
         "queue2_uplink_lossy_profile": {
             {% if traffic_config.traffic_classification_enable %}
@@ -189,7 +189,7 @@
             {% endif %}
             "pool": "egress_lossy_pool",
             "size": "0",
-            "dynamic_th": "0"
+            "dynamic_th": "-7"
         },
         "queue3_uplink_lossy_profile": {
             {% if traffic_config.traffic_classification_enable %}
@@ -197,12 +197,12 @@
             {% endif %}
             "pool": "egress_lossy_pool",
             "size": "0",
-            "dynamic_th": "0"
+            "dynamic_th": "-7"
         },
         "queue4_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "0",
-            "dynamic_th": "7"
+            "dynamic_th": "0"
         },
         "queue5_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",


### PR DESCRIPTION
Update alpha when HBA is disabled.

#### Why I did it
Need update alpha when HBA is disabled.

#### How I did it
Update alpha for each queue.

#### How to verify it
Disable HBA, and config qos reload.

#### Which release branch to backport (provide reason below if selected)
- [x] 202412
- [x] 202505

#### Tested branch (Please provide the tested image version)
202412