### PR TITLE
Remove S2 port bcm configs for Arista-7060X6-64PE-B-O128

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
@@ -1331,14 +1331,6 @@ device:
                 PORT_ID: 530
             :
                 PC_PHYS_PORT_ID: 509
-            ?
-                PORT_ID: 118
-            :
-                PC_PHYS_PORT_ID: 513
-            ?
-                PORT_ID: 254
-            :
-                PC_PHYS_PORT_ID: 514
 ...
 ---
 device:
@@ -1382,13 +1374,6 @@ device:
                 SPEED: 400000
                 NUM_LANES: 4
                 FEC_MODE: PC_FEC_RS544_2XN
-                MAX_FRAME_SIZE: 9416
-            ?
-                PORT_ID: [118, 254]
-            :
-                ENABLE: 0
-                SPEED: 10000
-                NUM_LANES: 1
                 MAX_FRAME_SIZE: 9416
 ...
 ---


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Update Arista-7060X6-64PE-B-O128 bcm configs, remove unneeded S2 port configs

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

