### PR TITLE
Nokia D4 platform - QoS buffer pool configurations

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7220_d4-r0/Nokia-IXR7220-D4-36D/buffers_defaults_t0.j2
+++ b/device/nokia/x86_64-nokia_ixr7220_d4-r0/Nokia-IXR7220-D4-36D/buffers_defaults_t0.j2
@@ -5,7 +5,7 @@
 {%- macro generate_buffer_pool_and_profiles() %}
    "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "61293228",
+            "size": "84219120",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "20325220"

--- a/device/nokia/x86_64-nokia_ixr7220_d4-r0/Nokia-IXR7220-D4-36D/buffers_defaults_t1.j2
+++ b/device/nokia/x86_64-nokia_ixr7220_d4-r0/Nokia-IXR7220-D4-36D/buffers_defaults_t1.j2
@@ -5,7 +5,7 @@
 {%- macro generate_buffer_pool_and_profiles() %}
    "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "61293228",
+            "size": "84219120",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "20325220"


### PR DESCRIPTION
Why I did it
Nokia D4 platform QoS profiles - buffers, PFC profiles, egress queuesfor the newly introduced Nokia-IXR7220-D4-36D platform https://github.com/sonic-net/sonic-buildimage/pull/21853

How I did it
Updated buffers_defaults_t0.j2/t1.j2 file under the device/nokia/x86_64-nokia_ixr7220_d4-r0/Nokia-IXR7220-D4-36D

How to verify it
QoS SAI test OC suite used to verify buffer pools, profiles and various use cases as per dataplane tests.

Which release branch to backport (provide reason below if selected)
- [x] 202505
