### PR TITLE
[202411][Smartswitch] Fix SN4280 SKU pmon daemon control to skip chassisd 

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../../x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/pmon_daemon_control.json
+../Mellanox-SN4280-O28/pmon_daemon_control.json


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently chassisd is enabled for some SKUs even though it is not required for 202411 for SN4280. So we are setting the pmon_daemon_control.json to skip the chassisd for this particular SKU

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Change link for `Mellanox-SN4280-O8C40` SKU pmon_daemon_control.json from `Mellanox-SN4700-O8C48` to `Mellanox-SN4280-O28` which has `skip_chassisd` set to True

#### How to verify it
Tested manually to see that there is no chassisd process in pmon container. Built the image to see that there are no issues 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)
202411

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

