### PR TITLE
BGP Template change to ensure SELECTIVE_ROUTE_DOWNLOAD config is only available on upstream LC

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
@@ -14,7 +14,7 @@
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
-{% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' %}
+{% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC' %}
     table-map SELECTIVE_ROUTE_DOWNLOAD_V4
 {% endif %}
   exit-address-family
@@ -29,7 +29,7 @@
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
-{% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' %}
+{% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC' %}
     table-map SELECTIVE_ROUTE_DOWNLOAD_V6
 {% endif %}
   exit-address-family

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
@@ -14,7 +14,7 @@
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
-{% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC' %}
+{% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' %}
     table-map SELECTIVE_ROUTE_DOWNLOAD_V4
 {% endif %}
   exit-address-family
@@ -29,7 +29,7 @@
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
-{% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC' %}
+{% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' %}
     table-map SELECTIVE_ROUTE_DOWNLOAD_V6
 {% endif %}
   exit-address-family

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
@@ -101,7 +101,7 @@ route-map CHECK_IDF_ISOLATION permit 10
 !
 !
 {% if CONFIG_DB__DEVICE_METADATA and 'localhost' in CONFIG_DB__DEVICE_METADATA and 'type' in CONFIG_DB__DEVICE_METADATA['localhost'] and 'subtype' in CONFIG_DB__DEVICE_METADATA['localhost'] %}
-{% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC' %}
+{% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' %}
 bgp community-list standard ANCHOR_ROUTE_COMMUNITY permit {{ constants.bgp.anchor_route_community }}
 bgp community-list standard LOCAL_ANCHOR_ROUTE_COMMUNITY permit {{ constants.bgp.local_anchor_route_community }}
 bgp community-list standard ANCHOR_CONTRIBUTING_ROUTE_COMMUNITY permit {{ constants.bgp.anchor_contributing_route_community }}

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
@@ -119,20 +119,20 @@ route-map SELECTIVE_ROUTE_DOWNLOAD_V6 permit 1000
 route-map TAG_ANCHOR_COMMUNITY permit 10
   set community {{ constants.bgp.local_anchor_route_community }} {{ constants.bgp.anchor_route_community }} additive
 !
-route-map TO_BGP_PEER_V6 permit 30
+route-map TO_BGP_PEER_V6 permit 50
   match ipv6 address prefix-list ANCHOR_CONTRIBUTING_ROUTES
   set community {{ constants.bgp.anchor_contributing_route_community }} additive
   on-match next
 !
-route-map TO_BGP_PEER_V6 permit 40
+route-map TO_BGP_PEER_V6 permit 60
   set comm-list LOCAL_ANCHOR_ROUTE_COMMUNITY delete
 !
-route-map TO_BGP_PEER_V4 permit 30
-  match ipv6 address prefix-list ANCHOR_CONTRIBUTING_ROUTES
+route-map TO_BGP_PEER_V4 permit 50
+  match ip address prefix-list ANCHOR_CONTRIBUTING_ROUTES
   set community {{ constants.bgp.anchor_contributing_route_community }} additive
   on-match next
 !
-route-map TO_BGP_PEER_V4 permit 40
+route-map TO_BGP_PEER_V4 permit 60
   set comm-list LOCAL_ANCHOR_ROUTE_COMMUNITY delete
 !
 {% endif %}

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/param_UpperSpineRouter.json
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/param_UpperSpineRouter.json
@@ -1,0 +1,7 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "type": "UpperSpineRouter"
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/param_downstream_lc.json
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/param_downstream_lc.json
@@ -1,0 +1,8 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "type": "SpineRouter",
+            "subtype": "DownstreamLC"
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/param_spine_no_subtype.json
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/param_spine_no_subtype.json
@@ -1,0 +1,7 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "type": "SpineRouter"
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/param_upstream_lc.json
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/param_upstream_lc.json
@@ -1,0 +1,8 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "type": "SpineRouter",
+            "subtype": "UpstreamLC"
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_UpperSpineRouter.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_UpperSpineRouter.conf
@@ -1,0 +1,20 @@
+!
+! template: bgpd/templates/general/peer-group.conf.j2
+!
+  neighbor PEER_V4 peer-group
+  neighbor PEER_V6 peer-group
+  address-family ipv4
+    neighbor PEER_V4 soft-reconfiguration inbound
+    neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+    table-map SELECTIVE_ROUTE_DOWNLOAD_V4
+  exit-address-family
+  address-family ipv6
+    neighbor PEER_V6 soft-reconfiguration inbound
+    neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+    table-map SELECTIVE_ROUTE_DOWNLOAD_V6
+  exit-address-family
+!
+! end of template: bgpd/templates/general/peer-group.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_downstream_lc.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_downstream_lc.conf
@@ -1,0 +1,18 @@
+!
+! template: bgpd/templates/general/peer-group.conf.j2
+!
+  neighbor PEER_V4 peer-group
+  neighbor PEER_V6 peer-group
+  address-family ipv4
+    neighbor PEER_V4 soft-reconfiguration inbound
+    neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+  exit-address-family
+  address-family ipv6
+    neighbor PEER_V6 soft-reconfiguration inbound
+    neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+  exit-address-family
+!
+! end of template: bgpd/templates/general/peer-group.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_spine_no_subtype.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_spine_no_subtype.conf
@@ -1,0 +1,18 @@
+!
+! template: bgpd/templates/general/peer-group.conf.j2
+!
+  neighbor PEER_V4 peer-group
+  neighbor PEER_V6 peer-group
+  address-family ipv4
+    neighbor PEER_V4 soft-reconfiguration inbound
+    neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+  exit-address-family
+  address-family ipv6
+    neighbor PEER_V6 soft-reconfiguration inbound
+    neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+  exit-address-family
+!
+! end of template: bgpd/templates/general/peer-group.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_upstream_lc.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_upstream_lc.conf
@@ -1,0 +1,20 @@
+!
+! template: bgpd/templates/general/peer-group.conf.j2
+!
+  neighbor PEER_V4 peer-group
+  neighbor PEER_V6 peer-group
+  address-family ipv4
+    neighbor PEER_V4 soft-reconfiguration inbound
+    neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+    table-map SELECTIVE_ROUTE_DOWNLOAD_V4
+  exit-address-family
+  address-family ipv6
+    neighbor PEER_V6 soft-reconfiguration inbound
+    neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+    table-map SELECTIVE_ROUTE_DOWNLOAD_V6
+  exit-address-family
+!
+! end of template: bgpd/templates/general/peer-group.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all_chassis_pkt.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all_chassis_pkt.conf
@@ -90,20 +90,20 @@ route-map SELECTIVE_ROUTE_DOWNLOAD_V6 permit 1000
 route-map TAG_ANCHOR_COMMUNITY permit 10
   set community 12345:555 12345:666 additive
 !
-route-map TO_BGP_PEER_V6 permit 30
+route-map TO_BGP_PEER_V6 permit 50
   match ipv6 address prefix-list ANCHOR_CONTRIBUTING_ROUTES
   set community 12345:777 additive
   on-match next
 !
-route-map TO_BGP_PEER_V6 permit 40
+route-map TO_BGP_PEER_V6 permit 60
   set comm-list LOCAL_ANCHOR_ROUTE_COMMUNITY delete
 !
-route-map TO_BGP_PEER_V4 permit 30
-  match ipv6 address prefix-list ANCHOR_CONTRIBUTING_ROUTES
+route-map TO_BGP_PEER_V4 permit 50
+  match ip address prefix-list ANCHOR_CONTRIBUTING_ROUTES
   set community 12345:777 additive
   on-match next
 !
-route-map TO_BGP_PEER_V4 permit 40
+route-map TO_BGP_PEER_V4 permit 60
   set comm-list LOCAL_ANCHOR_ROUTE_COMMUNITY delete
 !
 ! end of template: bgpd/templates/general/policies.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all_voq.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all_voq.conf
@@ -90,20 +90,20 @@ route-map SELECTIVE_ROUTE_DOWNLOAD_V6 permit 1000
 route-map TAG_ANCHOR_COMMUNITY permit 10
   set community 12345:555 12345:666 additive
 !
-route-map TO_BGP_PEER_V6 permit 30
+route-map TO_BGP_PEER_V6 permit 50
   match ipv6 address prefix-list ANCHOR_CONTRIBUTING_ROUTES
   set community 12345:777 additive
   on-match next
 !
-route-map TO_BGP_PEER_V6 permit 40
+route-map TO_BGP_PEER_V6 permit 60
   set comm-list LOCAL_ANCHOR_ROUTE_COMMUNITY delete
 !
-route-map TO_BGP_PEER_V4 permit 30
-  match ipv6 address prefix-list ANCHOR_CONTRIBUTING_ROUTES
+route-map TO_BGP_PEER_V4 permit 50
+  match ip address prefix-list ANCHOR_CONTRIBUTING_ROUTES
   set community 12345:777 additive
   on-match next
 !
-route-map TO_BGP_PEER_V4 permit 40
+route-map TO_BGP_PEER_V4 permit 60
   set comm-list LOCAL_ANCHOR_ROUTE_COMMUNITY delete
 !
 ! end of template: bgpd/templates/general/policies.conf.j2


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes issue https://github.com/sonic-net/sonic-buildimage/issues/22953 and https://github.com/sonic-net/sonic-buildimage/issues/23324
##### Work item tracking
- Microsoft ADO **(number only)**:
33812223
#### How I did it
Updated BGP templates to ensure SELECTIVE_ROUTE_DOWNLOAD config is only available on upstream LC.
Fixed the Radian route-map sequence numbers to avoid conflicts with TSA seq numbers
#### How to verify it
Ran newly written tests and verified table-map config is not present on downstream LC
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)
master
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

