### PR TITLE
TH5-512 ingress and egress lossy queue buffer size change

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t0.j2
@@ -10,7 +10,7 @@
             "mode": "dynamic"
         },
         "egress_lossy_pool": {
-            "size": "165307264",
+            "size": "161999982",
             "type": "egress",
             "mode": "dynamic"
         }

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t0.j2
@@ -5,12 +5,12 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossy_pool": {
-            "size": "161999982",
+            "size": "163593526",
             "type": "ingress",
             "mode": "dynamic"
         },
         "egress_lossy_pool": {
-            "size": "161999982",
+            "size": "163593526",
             "type": "egress",
             "mode": "dynamic"
         }

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t0.j2
@@ -5,7 +5,7 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossy_pool": {
-            "size": "165307264",
+            "size": "161999982",
             "type": "ingress",
             "mode": "dynamic"
         },

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t1.j2
@@ -10,7 +10,7 @@
             "mode": "dynamic"
         },
         "egress_lossy_pool": {
-            "size": "165307264",
+            "size": "161999982",
             "type": "egress",
             "mode": "dynamic"
         }

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t1.j2
@@ -5,12 +5,12 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossy_pool": {
-            "size": "161999982",
+            "size": "163593526",
             "type": "ingress",
             "mode": "dynamic"
         },
         "egress_lossy_pool": {
-            "size": "161999982",
+            "size": "163593526",
             "type": "egress",
             "mode": "dynamic"
         }

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t1.j2
@@ -5,7 +5,7 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossy_pool": {
-            "size": "165307264",
+            "size": "161999982",
             "type": "ingress",
             "mode": "dynamic"
         },


### PR DESCRIPTION
#### Why I did it

BRCM SAI 13.2.1 increases the pkt trim buffer pool to 1.7MB, leading to the reduction of available lossy queue buffer.

Without this change, there will be a syncd crash on default buffer profile pairing with SAI 13.2.1.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Reduce default ingress and egress lossy buffer size from 165307264 with 161999982

#### How to verify it

Verified on Arista-7060X6-64PE-B-C512S2

#### Which release branch to backport (provide reason below if selected)

- [x] 202412

#### Tested branch (Please provide the tested image version)

- [x] 202412.b27 

#### Description for the changelog

BRCM SAI 13.2.1 increases the pkt trim buffer pool to 1.7MB, available lossy queue buffer size to be reduced accordingly. 

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

