### PR TITLE
[Arista] Add HwSkus for x86_64-arista_7050cx3_32c

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32c/Arista-7050CX3-32C-C28S16
+++ b/device/arista/x86_64-arista_7050cx3_32c/Arista-7050CX3-32C-C28S16
@@ -1,0 +1,1 @@
+../x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C28S16

--- a/device/arista/x86_64-arista_7050cx3_32c/Arista-7050CX3-32C-C28S4
+++ b/device/arista/x86_64-arista_7050cx3_32c/Arista-7050CX3-32C-C28S4
@@ -1,0 +1,1 @@
+../x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C28S4

--- a/device/arista/x86_64-arista_7050cx3_32c/Arista-7050CX3-32C-C6S104
+++ b/device/arista/x86_64-arista_7050cx3_32c/Arista-7050CX3-32C-C6S104
@@ -1,0 +1,1 @@
+../x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C6S104

--- a/device/arista/x86_64-arista_7050cx3_32c/Arista-7050CX3-32C-D48C8
+++ b/device/arista/x86_64-arista_7050cx3_32c/Arista-7050CX3-32C-D48C8
@@ -1,0 +1,1 @@
+../x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8

--- a/device/arista/x86_64-arista_7050cx3_32c/Arista-7050CX3-32C-S128
+++ b/device/arista/x86_64-arista_7050cx3_32c/Arista-7050CX3-32C-S128
@@ -1,0 +1,1 @@
+../x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-S128


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add HwSkus for x86_64-arista_7050cx3_32c. They are symbolic links to existing HwSkus of x86_64-arista_7050cx3_32s

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it


#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

