### PR TITLE
Add startup_tsa configuration file for 7280dr3 devices

### DIFF
--- a/device/arista/x86_64-arista_7280dr3a_36/services.conf
+++ b/device/arista/x86_64-arista_7280dr3a_36/services.conf
@@ -1,0 +1,1 @@
+startup_tsa_tsb.service

--- a/device/arista/x86_64-arista_7280dr3a_36/startup-tsa-tsb.conf
+++ b/device/arista/x86_64-arista_7280dr3a_36/startup-tsa-tsb.conf
@@ -1,0 +1,1 @@
+../x86_64-arista_7800r3a_36d2_lc/startup-tsa-tsb.conf

--- a/device/arista/x86_64-arista_7280dr3a_36/startup-tsa-tsb.conf
+++ b/device/arista/x86_64-arista_7280dr3a_36/startup-tsa-tsb.conf
@@ -1,1 +1,1 @@
-../x86_64-arista_7800r3a_36d2_lc/startup-tsa-tsb.conf
+STARTUP_TSB_TIMER=900

--- a/device/arista/x86_64-arista_7280dr3ak_36/services.conf
+++ b/device/arista/x86_64-arista_7280dr3ak_36/services.conf
@@ -1,0 +1,1 @@
+startup_tsa_tsb.service

--- a/device/arista/x86_64-arista_7280dr3ak_36/startup-tsa-tsb.conf
+++ b/device/arista/x86_64-arista_7280dr3ak_36/startup-tsa-tsb.conf
@@ -1,0 +1,1 @@
+../x86_64-arista_7800r3a_36d2_lc/startup-tsa-tsb.conf

--- a/device/arista/x86_64-arista_7280dr3ak_36/startup-tsa-tsb.conf
+++ b/device/arista/x86_64-arista_7280dr3ak_36/startup-tsa-tsb.conf
@@ -1,1 +1,1 @@
-../x86_64-arista_7800r3a_36d2_lc/startup-tsa-tsb.conf
+STARTUP_TSB_TIMER=900

--- a/device/arista/x86_64-arista_7280dr3ak_36s/services.conf
+++ b/device/arista/x86_64-arista_7280dr3ak_36s/services.conf
@@ -1,0 +1,1 @@
+startup_tsa_tsb.service

--- a/device/arista/x86_64-arista_7280dr3ak_36s/startup-tsa-tsb.conf
+++ b/device/arista/x86_64-arista_7280dr3ak_36s/startup-tsa-tsb.conf
@@ -1,0 +1,1 @@
+../x86_64-arista_7800r3a_36d2_lc/startup-tsa-tsb.conf

--- a/device/arista/x86_64-arista_7280dr3ak_36s/startup-tsa-tsb.conf
+++ b/device/arista/x86_64-arista_7280dr3ak_36s/startup-tsa-tsb.conf
@@ -1,1 +1,1 @@
-../x86_64-arista_7800r3a_36d2_lc/startup-tsa-tsb.conf
+STARTUP_TSB_TIMER=900

--- a/device/arista/x86_64-arista_7280dr3am_36/services.conf
+++ b/device/arista/x86_64-arista_7280dr3am_36/services.conf
@@ -1,0 +1,1 @@
+startup_tsa_tsb.service

--- a/device/arista/x86_64-arista_7280dr3am_36/startup-tsa-tsb.conf
+++ b/device/arista/x86_64-arista_7280dr3am_36/startup-tsa-tsb.conf
@@ -1,0 +1,1 @@
+../x86_64-arista_7800r3a_36d2_lc/startup-tsa-tsb.conf

--- a/device/arista/x86_64-arista_7280dr3am_36/startup-tsa-tsb.conf
+++ b/device/arista/x86_64-arista_7280dr3am_36/startup-tsa-tsb.conf
@@ -1,1 +1,1 @@
-../x86_64-arista_7800r3a_36d2_lc/startup-tsa-tsb.conf
+STARTUP_TSB_TIMER=900


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Startup TSA configuration file is required to enable startup-tsa service on the device to automatically TSA after unplanned reboot. 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add conf file to all supported platform SKUs

#### How to verify it
Reboot device and confirm that the device remains in TSA for the configured time

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

