### PR TITLE
Increase the installer disk size by 1GB and switch to ext2 for KVM

### DIFF
--- a/scripts/build_kvm_image.sh
+++ b/scripts/build_kvm_image.sh
@@ -36,9 +36,9 @@ create_disk()
 
 prepare_installer_disk()
 {
-    fallocate -l 4104M $INSTALLER_DISK
+    fallocate -l 5120M $INSTALLER_DISK
 
-    mkfs.vfat $INSTALLER_DISK
+    mkfs.ext2 $INSTALLER_DISK
 
     tmpdir=$(mktemp -d)
 

--- a/scripts/build_kvm_image.sh
+++ b/scripts/build_kvm_image.sh
@@ -36,7 +36,7 @@ create_disk()
 
 prepare_installer_disk()
 {
-    fallocate -l 4096M $INSTALLER_DISK
+    fallocate -l 4104M $INSTALLER_DISK
 
     mkfs.vfat $INSTALLER_DISK
 


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Following #22199, the debug version of `sonic-vs.bin` file is at 4093MB (to be precise, one particular build was at 4291790831 bytes). This, in theory, should've fit fine in the 4096MB FAT32 installer disk that is created for building the sonic-vs.img QCOW2 image. However, it's short by 5MB. My guess for this reason is because FAT32 itself needs some space for metadata, and so we don't get the full 4096MB. This results in a failure to build the debug KVM image.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

As a fix, increase the installer disk size that we create by 1GB, which should be enough for now, and switch to ext2 filesystem instead of FAT32. This switch is needed because FAT32 only allows files up to 4GB (minus one byte), and the latest debug images are at around 4.1GB.

#### How to verify it

I locally made a loopback file of 4104MB, copied the sonic-vs.bin debug installer file generated in https://dev.azure.com/mssonic/build/_build/results?buildId=900622&view=results into it (which is 4093MB), and verified that it did get copied into there.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

