### PR TITLE
Fallback recovery from minigraph.xml if config_db.json is missing

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -404,4 +404,11 @@ if [ -f /var/log/fsck.log.gz ]; then
     rm -f /var/log/fsck.log.gz
 fi
 
+# Fallback recovery from minigraph.xml if config_db.json is missing
+if [ ! -s /etc/sonic/config_db.json ] && [ -f /etc/sonic/minigraph.xml ]; then
+    logger "rc.local: config_db.json missing. Attempting recovery using minigraph.xml"
+    config load_minigraph -y
+    config save -y
+fi
+
 exit 0


### PR DESCRIPTION
Fallback recovery from minigraph.xml if config_db.json is missing

#### Why I did it
The pilot buildout workflow  removes the config_db.json and leaves only the minigraph.xml
`Start with smartswitch running 20241110.24 version
Install image 20241110.25 using sonic-installer install <>
Verify that /etc/sonic/config_db.json exists and /etc/sonic/minigraph.xml exists and also /host/old_config/minigraph.xml exists
Now remove /host/old_config/config_db.json using rm -f /host/old_config/config_db.json
sudo reboot`
Since there is no "config_db.json" the "reboot" command that is issued immediately after it creates the default config_db.json which misses the management IP etc.
So this fall back mechanism will restore the config_db.json from the minigraph.xml and save it.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added the conditional fallback recovery using "config load_minigraph -y" and "config save -y"  in rc.local

#### How to verify it
Follow the steps in "Why I did it" to recreate the problem and the problem should not be seen.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [x ] 202405
- [ x] 202411
- [ x] 202505
- [ x] 202506

#### Description for the changelog


