### PR TITLE
Yang changes required for oc-system support in UMF 

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -212,5 +212,10 @@
             "admin_state": "enabled",
             "vrf": "default"
         }
+    },
+    "VERSIONS": {
+        "SOFTWARE": {
+            "VERSION": "{{build_version}}"
+        }
     }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1372,6 +1372,9 @@
         "VERSIONS": {
             "DATABASE": {
                 "VERSION": "version_1_0_3"
+            },
+            "SOFTWARE": {
+                "VERSION": "sonic_202411_01_03"
             }
         },
         "TELEMETRY": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/ntp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/ntp.json
@@ -28,7 +28,7 @@
                 ]
             },
             "sonic-ntp:NTP_KEY": {
-                "NTP_KEYS_LIST": [
+                "NTP_KEY_LIST": [
                     {
                         "id": 10,
                         "value": "bHVtb3M="
@@ -422,7 +422,7 @@
     "NTP_KEY_VALID": {
         "sonic-ntp:sonic-ntp": {
             "sonic-ntp:NTP_KEY": {
-                "NTP_KEYS_LIST": [
+                "NTP_KEY_LIST": [
                     {
                         "id": 20,
                         "type": "md5",
@@ -448,7 +448,7 @@
     "NTP_KEY_ID_INVALID": {
         "sonic-ntp:sonic-ntp": {
             "sonic-ntp:NTP_KEY": {
-                "NTP_KEYS_LIST": [
+                "NTP_KEY_LIST": [
                     {
                         "id": 100000
                     }
@@ -459,7 +459,7 @@
     "NTP_KEY_TRUSTED_INVALID": {
         "sonic-ntp:sonic-ntp": {
             "sonic-ntp:NTP_KEY": {
-                "NTP_KEYS_LIST": [
+                "NTP_KEY_LIST": [
                     {
                         "id": 20,
                         "trusted": "nope"
@@ -471,7 +471,7 @@
     "NTP_KEY_TYPE_INVALID": {
         "sonic-ntp:sonic-ntp": {
             "sonic-ntp:NTP_KEY": {
-                "NTP_KEYS_LIST": [
+                "NTP_KEY_LIST": [
                     {
                         "id": 20,
                         "type": "md6"
@@ -483,7 +483,7 @@
     "NTP_KEY_VALUE_INVALID": {
         "sonic-ntp:sonic-ntp": {
             "sonic-ntp:NTP_KEY": {
-                "NTP_KEYS_LIST": [
+                "NTP_KEY_LIST": [
                     {
                         "id": 20,
                         "value": ""

--- a/src/sonic-yang-models/yang-models/sonic-ntp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-ntp.yang
@@ -50,6 +50,11 @@ module sonic-ntp {
             "Add extended configuration options";
     }
 
+    revision 2025-07-21 {
+        description
+            "Corrected NTP_KEY_LIST list name";
+    }
+
     typedef association-type {
         description "NTP server association type";
         type enumeration {
@@ -192,7 +197,7 @@ module sonic-ntp {
                 leaf key {
                     description "NTP server key ID";
                     type leafref {
-                        path /ntp:sonic-ntp/ntp:NTP_KEY/ntp:NTP_KEYS_LIST/ntp:id;
+                        path /ntp:sonic-ntp/ntp:NTP_KEY/ntp:NTP_KEY_LIST/ntp:id;
                     }
                 }
 
@@ -234,7 +239,7 @@ module sonic-ntp {
 
             description "NTP authentication keys inventory";
 
-            list NTP_KEYS_LIST {
+            list NTP_KEY_LIST {
                 description "NTP authentication keys inventory";
                 key "id";
 
@@ -261,7 +266,7 @@ module sonic-ntp {
                     default md5;
                     description "NTP authentication key type";
                 }
-            } /* end of list NTP_KEYS_LIST */
+            } /* end of list NTP_KEY_LIST */
 
         } /* end of container NTP_KEY */
 

--- a/src/sonic-yang-models/yang-models/sonic-versions.yang
+++ b/src/sonic-yang-models/yang-models/sonic-versions.yang
@@ -8,6 +8,10 @@ module sonic-versions {
 
     description "VERSIONS YANG Module for SONiC OS";
 
+    revision 2025-07-21 {
+        description "Added software version support";
+    }
+
     revision 2020-04-10 {
         description "First Revision";
     }
@@ -16,7 +20,7 @@ module sonic-versions {
 
         container VERSIONS {
 
-            description "DATABASE SCHEMA VERSIONS part of config_db.json";
+            description "DATABASE SCHEMA & SOFTWARE VERSIONS part of config_db.json";
 
             container DATABASE {
 
@@ -24,6 +28,16 @@ module sonic-versions {
                     type string {
                         length 1..255;
                         pattern 'version_(([1-9]|[1-9]{1}[0-9]{1})_([0-9]{1,2})_([0-9]{1,2})|([1-9]{1}[0-9]{5})_([0-9]{2}))';
+                    }
+                }
+            }
+            /* end of container DATABASE */
+
+            container SOFTWARE {
+
+                leaf VERSION {
+                    type string {
+                        length 1..255;
                     }
                 }
             }


### PR DESCRIPTION
#### Why I did it
To support openconfig system module in sonic as per HLD : https://github.com/sonic-net/SONiC/pull/1790
Some sonic yang changes are required, which is done under this PR

##### Work item tracking
NA

#### How I did it
- Added leaf in sonic-versions.yang to support SOFTWARE version in DB similar as Database version
- In sonic-ntp.yang, list name was not as per ABNF rule, which was causing cvl errors, fixed the same 
    /ntp:sonic-ntp/ntp:NTP_KEY/ntp:NTP_KEYS_LIST
                         to
    /ntp:sonic-ntp/ntp:NTP_KEY/ntp:NTP_KEY_LIST

#### How to verify it
Ran all test cases in sonic-utilities and sonic-mgmt-common to ensure changes work fine

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

