### PR TITLE
Remove unused `sai_postinit_cmd_file` soc property for `x86_64-arista_7280dr3a_36`

### DIFF
--- a/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/jr2p-a7280dra3-36-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/jr2p-a7280dra3-36-36x400G.config.bcm
@@ -3,7 +3,6 @@ system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 programmability_ucode_relative_path.BCM8885X=pemla/ucode/standard_1/jer2pemla/u_code_db2pem.txt
-sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 ####################################################
 ##Reference applications related properties - Start
 ####################################################

--- a/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/1/jr2p-a7280dra3-36-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/1/jr2p-a7280dra3-36-36x400G.config.bcm
@@ -3,7 +3,6 @@ system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 programmability_ucode_relative_path.BCM8885X=pemla/ucode/standard_1/jer2pemla/u_code_db2pem.txt
-
 ####################################################
 ##Reference applications related properties - Start
 ####################################################


### PR DESCRIPTION
This soc property was causing an ERR to be generated
`ERR syncd0#syncd: [09:00.0] SAI_API_SWITCH:platform_rcload_file:457 Failed to open RC file, errno = 2.`
Causing some sonic-mgmt tests to fail in LogAnalyzer

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] msft-202503
