### PR TITLE
Add components to platform_components.json for Arista 7280DR3 SKUs

### DIFF
--- a/device/arista/x86_64-arista_7280dr3a_36/platform_components.json
+++ b/device/arista/x86_64-arista_7280dr3a_36/platform_components.json
@@ -2,6 +2,12 @@
    "chassis": {
       "DCS-7280DR3A-36": {
          "component": {
+             "Aboot()": {},
+             "Scd(addr=0000:00:18.7)": {},
+             "Adm1266(addr=10-004f)": {},
+             "Ucd90320(addr=14-0011)": {},
+             "Scd(addr=0000:01:00.0)": {},
+             "CormorantSysCpld(addr=13-0023)": {}
          }
       }
    }

--- a/device/arista/x86_64-arista_7280dr3ak_36/platform_components.json
+++ b/device/arista/x86_64-arista_7280dr3ak_36/platform_components.json
@@ -2,6 +2,12 @@
    "chassis": {
       "DCS-7280DR3AK-36": {
          "component": {
+             "Aboot()": {},
+             "Scd(addr=0000:00:18.7)": {},
+             "Adm1266(addr=10-004f)": {},
+             "Ucd90320(addr=14-0011)": {},
+             "Scd(addr=0000:01:00.0)": {},
+             "CormorantSysCpld(addr=13-0023)": {}
          }
       }
    }

--- a/device/arista/x86_64-arista_7280dr3ak_36s/platform_components.json
+++ b/device/arista/x86_64-arista_7280dr3ak_36s/platform_components.json
@@ -2,6 +2,12 @@
    "chassis": {
       "DCS-7280DR3AK-36S": {
          "component": {
+             "Aboot()": {},
+             "Scd(addr=0000:00:18.7)": {},
+             "Adm1266(addr=10-004f)": {},
+             "Ucd90320(addr=14-0011)": {},
+             "Scd(addr=0000:01:00.0)": {},
+             "CormorantSysCpld(addr=13-0023)": {}
          }
       }
    }

--- a/device/arista/x86_64-arista_7280dr3am_36/platform_components.json
+++ b/device/arista/x86_64-arista_7280dr3am_36/platform_components.json
@@ -2,6 +2,12 @@
    "chassis": {
       "DCS-7280DR3AM-36": {
          "component": {
+             "Aboot()": {},
+             "Scd(addr=0000:00:18.7)": {},
+             "Adm1266(addr=10-004f)": {},
+             "Ucd90320(addr=14-0011)": {},
+             "Scd(addr=0000:01:00.0)": {},
+             "CormorantSysCpld(addr=13-0023)": {}
          }
       }
    }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The platform_components.json file is used for firmware upgrades via `fwutil`. One such application is to upgrade SCD firmware on the device.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Populated the platform_components.json for all the Arista 7280DR3 SKUs listed below:
- x86_64-arista_7280dr3a_36
- x86_64-arista_7280dr3ak_36
- x86_64-arista_7280dr3ak_36s
- x86_64-arista_7280dr3am_36

#### How to verify it
Run `fwutil show updates` and verify that no errors are reported

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] msft-202503

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] msft-202503

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

This change populates the platform_components.json with the physical components so that they can be accessed for firmware upgrade via fwutils.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
<img width="1999" height="1124" alt="image" src="https://github.com/user-attachments/assets/a579766a-d278-4935-ab45-c7add8755c1e" />

