### PR TITLE
Updated cable length configuration for upperspinerouter to lowerspinerouter

### DIFF
--- a/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/buffers_defaults_t2.j2
@@ -5,6 +5,7 @@
         'leafrouter_torrouter'   : '300m',
         'spinerouter_leafrouter' : '2000m',
         'upperspinerouter_spinerouter' : '50m',
+        'upperspinerouter_lowerspinerouter' : '50m',
         'regionalhub_upperspinerouter': '120000m',
         'aznghub_upperspinerouter'    : '120000m',
         'regionalhub_spinerouter': '120000m',

--- a/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/1/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/1/buffers_defaults_t2.j2
@@ -5,6 +5,7 @@
         'leafrouter_torrouter'   : '300m',
         'spinerouter_leafrouter' : '2000m',
         'upperspinerouter_spinerouter' : '50m',
+        'upperspinerouter_lowerspinerouter' : '50m',
         'regionalhub_upperspinerouter': '120000m',
         'aznghub_upperspinerouter'    : '120000m',
         'regionalhub_spinerouter': '120000m',

--- a/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/0/buffers_defaults_t2.j2
+++ b/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/0/buffers_defaults_t2.j2
@@ -5,6 +5,7 @@
         'leafrouter_torrouter'   : '300m',
         'spinerouter_leafrouter' : '2000m',
         'upperspinerouter_spinerouter' : '50m',
+        'upperspinerouter_lowerspinerouter' : '50m',
         'regionalhub_upperspinerouter': '120000m',
         'aznghub_upperspinerouter'    : '120000m',
         'regionalhub_spinerouter': '120000m',

--- a/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/1/buffers_defaults_t2.j2
+++ b/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/1/buffers_defaults_t2.j2
@@ -5,6 +5,7 @@
         'leafrouter_torrouter'   : '300m',
         'spinerouter_leafrouter' : '2000m',
         'upperspinerouter_spinerouter' : '50m',
+        'upperspinerouter_lowerspinerouter' : '50m',
         'regionalhub_upperspinerouter': '120000m',
         'aznghub_upperspinerouter'    : '120000m',
         'regionalhub_spinerouter': '120000m',

--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -60,6 +60,7 @@ def
             'torrouter_server'       : '5m',
             'leafrouter_torrouter'   : '40m',
             'upperspinerouter_spinerouter' : '50m',
+            'upperspinerouter_lowerspinerouter' : '50m',
             'spinerouter_leafrouter' : '300m',
             'regionalhub_upperspinerouter': '80000m',
             'regionalhub_spinerouter': '80000m',


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To update cable settings between upperspinerouter and lowerspinerouter. As name spinerouter would be changed to lowerspinerouter in future.

##### Work item tracking
- Microsoft ADO **([33881573])**:

#### How I did it
Updated buffer config and template file with additional changes.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

