### PR TITLE
Check if len in headers to avoid KeyError in supervisor-proc-exit-listener

### DIFF
--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -181,7 +181,7 @@ def main(argv):
             headers = childutils.get_headers(line)
             # Check if 'len' exists before using it
             if 'len' not in headers:
-                syslog.syslog(syslog.LOG_ERR, "WARNING: Missing 'len' header in: {}".format(headers))
+                syslog.syslog(syslog.LOG_WARNING, "Missing 'len' in headers: {}, line: {}".format(headers, line))
                 continue
             payload = sys.stdin.read(int(headers['len']))
 

--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -179,12 +179,11 @@ def main(argv):
         if len(file_descriptor_list) > 0:
             line = file_descriptor_list[0].readline()
             headers = childutils.get_headers(line)
-            try:
-                payload_length = int(headers['len'])
-                payload = sys.stdin.read(payload_length)
-            except Exception as e:
-                syslog.syslog(syslog.LOG_ERR, "Get invalid headers:'{}': {}".format(headers, e))
+            # Check if 'len' exists before using it
+            if 'len' not in headers:
+                syslog.syslog(syslog.LOG_ERR, "WARNING: Missing 'len' header in: {}".format(headers))
                 continue
+            payload = sys.stdin.read(int(headers['len']))
 
             # Handle the PROCESS_STATE_EXITED event
             if headers['eventname'] == 'PROCESS_STATE_EXITED':

--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -179,7 +179,12 @@ def main(argv):
         if len(file_descriptor_list) > 0:
             line = file_descriptor_list[0].readline()
             headers = childutils.get_headers(line)
-            payload = sys.stdin.read(int(headers['len']))
+            try:
+                payload_length = int(headers['len'])
+                payload = sys.stdin.read(payload_length)
+            except Exception as e:
+                syslog.syslog(syslog.LOG_ERR, "Get invalid headers:'{}': {}".format(headers, e))
+                continue
 
             # Handle the PROCESS_STATE_EXITED event
             if headers['eventname'] == 'PROCESS_STATE_EXITED':
@@ -218,7 +223,7 @@ def main(argv):
                 # update process heart beat time
                 if (process_name in watch_process_list):
                     process_heart_beat_info[process_name]["last_heart_beat"] = time.time()
-            
+
             # Transition from BUSY to ACKNOWLEDGED
             childutils.listener.ok()
 


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
It found the following KeyError in syslog, not only for lldp, but also for snmp and bgp.

```
2025 Jul 19 18:13:00.240397 vlab-01 ERR lldp#supervisor-proc-exit-listener: Exception: 'len', trace: Traceback (most recent call last):
  File "/usr/bin/supervisor-proc-exit-listener", line 249, in <module>
    main(sys.argv[1:])
  File "/usr/bin/supervisor-proc-exit-listener", line 182, in main
    payload = sys.stdin.read(int(headers['len']))
KeyError: 'len'
```

The context syslog is:
```
2025 Jul 19 18:12:59.505711 vlab-01 INFO lldp#supervisord 2025-07-19 18:12:59,504 INFO waiting for supervisor-proc-exit-listener, rsyslogd, lldpd, lldp-syncd, lldpmgrd to die
2025 Jul 19 18:12:59.761223 vlab-01 INFO containerd[684]: time="2025-07-19T18:12:59.759992163Z" level=info msg="shim disconnected" id=cd6e41a2cc82aae25d2d65801984943311b3f025c98ca865ea79be95194abc95
2025 Jul 19 18:12:59.762463 vlab-01 INFO containerd[684]: time="2025-07-19T18:12:59.760103279Z" level=warning msg="cleaning up after shim disconnected" id=cd6e41a2cc82aae25d2d65801984943311b3f025c98ca865ea79be95194abc95 namespace=moby
2025 Jul 19 18:12:59.765745 vlab-01 INFO containerd[684]: time="2025-07-19T18:12:59.760116062Z" level=info msg="cleaning up dead shim"
2025 Jul 19 18:12:59.767134 vlab-01 INFO dockerd[752]: time="2025-07-19T18:12:59.760554606Z" level=info msg="ignoring event" container=cd6e41a2cc82aae25d2d65801984943311b3f025c98ca865ea79be95194abc95 module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
2025 Jul 19 18:12:59.784436 vlab-01 INFO containerd[684]: time="2025-07-19T18:12:59.783563921Z" level=warning msg="cleanup warnings time=\"2025-07-19T18:12:59Z\" level=info msg=\"starting signal loop\" namespace=moby pid=42053 runtime=io.containerd.runc.v2\n"
2025 Jul 19 18:12:59.826676 vlab-01 INFO systemd[1]: var-lib-docker-overlay2-472b96da162023c3bc1e0d4132486ad7c122b23acf07f93d0e5b0a9538d7cebe-merged.mount: Deactivated successfully.
2025 Jul 19 18:12:59.840815 vlab-01 INFO container: docker cmd: wait for teamd
2025 Jul 19 18:12:59.843934 vlab-01 INFO container: docker cmd: stop for teamd
2025 Jul 19 18:12:59.861044 vlab-01 DEBUG container: container_stop: END
2025 Jul 19 18:12:59.906677 vlab-01 NOTICE admin: Stopped teamd service...
2025 Jul 19 18:12:59.938168 vlab-01 INFO systemd[1]: teamd.service: Deactivated successfully.
2025 Jul 19 18:12:59.938548 vlab-01 INFO systemd[1]: Stopped teamd.service - TEAMD container.
2025 Jul 19 18:12:59.939901 vlab-01 NOTICE rsyslog_plugin: :- publish: EVENT_PUBLISHED: {"sonic-events-host:event-stopped-ctr":{"ctr_name":"TEAMD","timestamp":"2025-07-19T18:12:59.939561Z"}}
2025 Jul 19 18:13:00.196745 vlab-01 INFO dockerd[752]: time="2025-07-19T18:13:00.196382391Z" level=info msg="Container failed to exit within 10s of signal 15 - using the force" container=2188a8952aa8d602224b78e325295831aceb8f14d1b6ec8869cc153b7eafef6a
2025 Jul 19 18:13:00.240397 vlab-01 ERR lldp#supervisor-proc-exit-listener: Exception: 'len', trace: Traceback (most recent call last):#012  File "/usr/bin/supervisor-proc-exit-listener", line 249, in <module>#012    main(sys.argv[1:])#012  File "/usr/bin/supervisor-proc-exit-listener", line 182, in main#012    payload = sys.stdin.read(int(headers['len']))#012                                 ~~~~~~~^^^^^^^#012KeyError: 'len'
```

During shutdown, supervisor is sending termination events to the event listener, but the shutdown process is interrupting the event stream.
The container is being forcibly killed (`Container failed to exit within 10s of signal 15 - using the force`), which can interrupt the supervisor event protocol mid-stream.

Supervisor starts sending an event header
Before it can complete sending the full header (including len: field), the process gets interrupted
The listener receives a partial/malformed header without the len field

##### Work item tracking
- Microsoft ADO **33409727**:

#### How I did it
Check if 'len' exists before using it, if there is no len, it can't process the further steps.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->
Master image
- [ ] SONiC.master.903923-5879963b4
- [ ] SONiC.master.903791-260dff5a1

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

