### PR TITLE
[202505][frr]: Force disable next hop group support 

### DIFF
--- a/dockers/docker-fpm-frr/docker_init.sh
+++ b/dockers/docker-fpm-frr/docker_init.sh
@@ -49,6 +49,10 @@ write_default_zebra_config()
         echo "no fpm use-next-hop-groups" >> $FILE_NAME
         echo "fpm address 127.0.0.1" >> $FILE_NAME
     }
+
+    grep -q '^no zebra nexthop kernel enable' $FILE_NAME || {
+        echo "no zebra nexthop kernel enable" >> $FILE_NAME
+    }
 }
 
 if [[ ! -z "$NAMESPACE_ID" ]]; then

--- a/dockers/docker-fpm-frr/frr/zebra/zebra.conf.j2
+++ b/dockers/docker-fpm-frr/frr/zebra/zebra.conf.j2
@@ -7,6 +7,8 @@
 {% endblock banner %}
 !
 {% block fpm %}
+! Force disable next hop group support
+no zebra nexthop kernel enable
 {% if ( ('localhost' in DEVICE_METADATA) and ('nexthop_group' in  DEVICE_METADATA['localhost']) and
         (DEVICE_METADATA['localhost']['nexthop_group'] == 'enabled') ) %}
 ! enable next hop group support

--- a/platform/vs/docker-sonic-vs/frr/zebra.conf
+++ b/platform/vs/docker-sonic-vs/frr/zebra.conf
@@ -1,5 +1,4 @@
+no zebra nexthop kernel enable
 no fpm use-next-hop-groups
-
 fpm address 127.0.0.1
 zebra nexthop-group keep 1
-

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/zebra.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/zebra.conf
@@ -4,6 +4,8 @@
 ! file: zebra.conf
 !
 !
+! Force disable next hop group support
+no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-vni-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-vni-zebra.conf
@@ -4,6 +4,8 @@
 ! file: zebra.conf
 !
 !
+! Force disable next hop group support
+no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-zebra.conf
@@ -4,6 +4,8 @@
 ! file: zebra.conf
 !
 !
+! Force disable next hop group support
+no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/zebra_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/zebra_frr.conf
@@ -4,6 +4,8 @@
 ! file: zebra.conf
 !
 !
+! Force disable next hop group support
+no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/zebra_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/zebra_frr_dualtor.conf
@@ -4,6 +4,8 @@
 ! file: zebra.conf
 !
 !
+! Force disable next hop group support
+no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-vni-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-vni-zebra.conf
@@ -4,6 +4,8 @@
 ! file: zebra.conf
 !
 !
+! Force disable next hop group support
+no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-zebra.conf
@@ -4,6 +4,8 @@
 ! file: zebra.conf
 !
 !
+! Force disable next hop group support
+no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/zebra_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/zebra_frr.conf
@@ -4,6 +4,8 @@
 ! file: zebra.conf
 !
 !
+! Force disable next hop group support
+no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/zebra_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/zebra_frr_dualtor.conf
@@ -4,6 +4,8 @@
 ! file: zebra.conf
 !
 !
+! Force disable next hop group support
+no zebra nexthop kernel enable
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 !


### PR DESCRIPTION
[202411][frr]: Force disable next hop group support

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Pick https://github.com/sonic-net/sonic-buildimage/pull/23292

##### Work item tracking
- Microsoft ADO **(number only)**:
33406776

#### How I did it
Pick https://github.com/sonic-net/sonic-buildimage/pull/23292

#### How to verify it
Run the BGP cases for the image with PR on 2700 T0 and T1 
https://elastictest.org/scheduler/testplan/687d9fb346be15d7ecfaf76b
https://elastictest.org/scheduler/testplan/687d9f2c46be15d7ecfaf768

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

