### PR TITLE
[DASH] Add support to enable Metering counters

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -36,7 +36,7 @@ def enable_rates():
 def enable_counters():
     db = swsscommon.ConfigDBConnector()
     db.connect()
-    dpu_counters = ["ENI"]
+    dpu_counters = ["ENI","DASH_METER"]
 
     platform_info = device_info.get_platform_info(db)
     if platform_info.get('switch_type') == 'dpu':

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1553,6 +1553,10 @@
                 "FLEX_COUNTER_STATUS": "enable",
                 "POLL_INTERVAL": "10000"
             },
+            "DASH_METER": {
+                "FLEX_COUNTER_STATUS": "enable",
+                "POLL_INTERVAL": "10000"
+            },
             "SRV6": {
                 "FLEX_COUNTER_STATUS": "enable",
                 "POLL_INTERVAL": "10000"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
@@ -13,6 +13,10 @@
                     "FLEX_COUNTER_STATUS": "enable",
                     "POLL_INTERVAL": 10000
                 },
+                "DASH_METER": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
+                },
                 "PFCWD": {
                     "FLEX_COUNTER_STATUS": "enable"
                 },

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -92,6 +92,19 @@ module sonic-flex_counter {
                 }
             }
 
+            container DASH_METER {
+                /* METER_STAT_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+                leaf POLL_INTERVAL {
+                    type poll_interval;
+                }
+            }
+
             container PFCWD {
                 /* PFC_WD_FLEX_COUNTER_GROUP */
                 leaf FLEX_COUNTER_STATUS {


### PR DESCRIPTION
What I did
This PR enables Sonic-buildimage support for DASH Metering counters.

Related to the following PR's:
https://github.com/sonic-net/sonic-swss/pull/3631

Why I did it
To enable support for metering counters .
