### PR TITLE
[202505]: Changed pciesvc driver compilation methods to support linux 6.1.123

### DIFF
--- a/platform/checkout/pensando.ini
+++ b/platform/checkout/pensando.ini
@@ -1,4 +1,4 @@
 [module]
 repo=git@github.com:pensando/pensando-sonic-artifacts.git
-ref=1.87.0-SS-14-release
+ref=1.87.0-SS-15-release
 path=platform/pensando/pensando-sonic-artifacts

--- a/platform/pensando/dsc-drivers/debian/rules
+++ b/platform/pensando/dsc-drivers/debian/rules
@@ -26,11 +26,11 @@ clean:
 	dh_testroot
 	dh_clean
 	ARCH=aarch64 KSRC=/lib/modules/$(KVERSION)/build KMOD_OUT_DIR=$(CURDIR)/src/drivers/linux/build KMOD_SRC_DIR=$(CURDIR)/src/drivers/linux make -C $(CURDIR)/src/drivers/linux clean
-	ARCH=aarch64 KSRC=/lib/modules/$(KVERSION)/build KMOD_OUT_DIR=$(CURDIR)/src/drivers/linux/build KMOD_SRC_DIR=$(CURDIR)/src/drivers/linux/pciesvc make -C $(CURDIR)/src/drivers/linux/pciesvc clean
+	ARCH=aarch64 KMOD_OUT_DIR=$(CURDIR)/src/drivers/linux/build KMOD_SRC_DIR=$(CURDIR)/src/drivers/linux/pciesvc make -C $(CURDIR)/src/drivers/linux/pciesvc clean
 
 build:
 	ARCH=aarch64 KSRC=/lib/modules/$(KVERSION)/build KMOD_OUT_DIR=$(CURDIR)/src/drivers/linux/build KMOD_SRC_DIR=$(CURDIR)/src/drivers/linux/ make -C $(CURDIR)/src/drivers/linux
-	ARCH=aarch64 KSRC=/lib/modules/$(KVERSION)/build KMOD_OUT_DIR=$(CURDIR)/src/drivers/linux/build KMOD_SRC_DIR=$(CURDIR)/src/drivers/linux/pciesvc make -C $(CURDIR)/src/drivers/linux/pciesvc
+	ARCH=aarch64 KMOD_OUT_DIR=$(CURDIR)/src/drivers/linux/build KMOD_SRC_DIR=$(CURDIR)/src/drivers/linux/pciesvc make -C $(CURDIR)/src/drivers/linux/pciesvc
 
 binary: binary-arch binary-indep
 	# Nothing to do

--- a/platform/pensando/dsc-drivers/src/drivers/linux/pciesvc/Makefile
+++ b/platform/pensando/dsc-drivers/src/drivers/linux/pciesvc/Makefile
@@ -16,14 +16,13 @@ kpci += $(pciesvc-obj)
 INCLUDES = -I/sonic/platform/pensando/dsc-drivers/src/drivers/linux/pciesvc \
 	   -I/sonic/platform/pensando/dsc-drivers/src/drivers/linux/pciesvc/pciesvc/include \
 	   -I/sonic/platform/pensando/dsc-drivers/src/drivers/linux/pciesvc/pciesvc/src \
-	   -I/sonic/src/sonic-linux-kernel/linux-6.1.94/include/linux
+	   -I/usr/src/linux-headers-$(shell echo $(KVERSION) | sed 's/-arm64//')-common/include/linux
 	   #-I/usr/include \
-	   #-I$(PWD) \
-	   #-I/sonic/src/sonic-linux-kernel/linux-6.1.94/debian/build/build_arm64_none_arm64
+	   #-I$(PWD)
 $(MODNAME)-y := $(kpci) kpci_get_entry.o kpcimgr_module.o kpcinterface.o \
 	     kpci_entry.o kpci_kexec.o kpci_test.o pciesvc_end.o
 
-KDIR := /sonic/src/sonic-linux-kernel/linux-6.1.94/debian/build/build_arm64_none_arm64
+KDIR := /lib/modules/$(KVERSION)/build
 PWD := $(shell pwd)
 UTS := X$(shell grep UTS_RELEASE $(KDIR)/include/generated/utsrelease.h)
 REL := $(shell echo $(UTS) | awk '{ print $$3 }' | sed -e 's/"//g')
@@ -46,7 +45,7 @@ cc-option = $(shell set -e;		\
 	fi)
 
 KCFLAGS = -fno-jump-tables -fno-stack-protector -fno-function-sections -fno-dse -ffreestanding -fno-builtin
-KCFLAGS += -fno-data-sections -isystem /usr/lib/gcc/aarch64-linux-gnu/12/include
+KCFLAGS += -fno-data-sections
 KCFLAGS += $(call cc-option,-fno-store-merging,)
 KCFLAGS += $(INCLUDES) -DASIC_ELBA -DPCIESVC_SYSTEM_EXTERN
 KOPT = KCFLAGS="$(KCFLAGS)"

--- a/platform/pensando/platform.conf
+++ b/platform/pensando/platform.conf
@@ -25,6 +25,9 @@ ROOT_PARTUUID=C7F48DD2-C265-404B-959D-C64D21D49168
 ROOT_PARTSIZE=24G
 EMMC_MIN_SIZE=32G
 
+# Sonic kernel version
+KVER=6.1.0-29-2-arm64
+
 exec 0< /dev/tty 1> /dev/tty 2> /dev/tty
 
 PKG=""
@@ -190,8 +193,8 @@ cat <<EOF >> $bl_conf_path/$BL_CONF
 default main
 
 label main
-	kernel /$image_dir/boot/vmlinuz-6.1.0-29-2-arm64
-	initrd /$image_dir/boot/initrd.img-6.1.0-29-2-arm64
+	kernel /$image_dir/boot/vmlinuz-$KVER
+	initrd /$image_dir/boot/initrd.img-$KVER
 	devicetree /$image_dir/boot/elba-asic-psci.dtb
 	append softdog.soft_panic=1 FW_NAME=mainfwa root=/dev/mmcblk0p10 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=/$image_dir/fs.squashfs isolcpus=1,2,3,5,6,7,9,10,11,13,14,15 nohz_full=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocbs=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocb_poll irqaffinity=0
 }
@@ -206,8 +209,8 @@ cat <<EOF >> $bl_conf_path/$BL_CONF
 default main
 
 label main
-	kernel /$image_dir/boot/vmlinuz-6.1.0-22-2-arm64
-	initrd /$image_dir/boot/initrd.img-6.1.0-22-2-arm64
+	kernel /$image_dir/boot/vmlinuz-$KVER
+	initrd /$image_dir/boot/initrd.img-$KVER
 	devicetree /$image_dir/boot/elba-asic-psci-mtfuji.dtb
 	append softdog.soft_panic=1 FW_NAME=mainfwa root=/dev/mmcblk0p10 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=/$image_dir/fs.squashfs isolcpus=1,2,3,5,6,7,9,10,11,13,14,15 nohz_full=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocbs=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocb_poll irqaffinity=0
 }
@@ -222,8 +225,8 @@ cat <<EOF >> $bl_conf_path/$BL_CONF
 default main
 
 label main
-	kernel /$image_dir/boot/vmlinuz-6.1.0-22-2-arm64
-	initrd /$image_dir/boot/initrd.img-6.1.0-22-2-arm64
+	kernel /$image_dir/boot/vmlinuz-$KVER
+	initrd /$image_dir/boot/initrd.img-$KVER
 	devicetree /$image_dir/boot/elba-asic-psci-lipari.dtb
 	append softdog.soft_panic=1 FW_NAME=mainfwa root=/dev/mmcblk0p10 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=/$image_dir/fs.squashfs isolcpus=1,2,3,5,6,7,9,10,11,13,14,15 nohz_full=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocbs=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocb_poll irqaffinity=0
 }


### PR DESCRIPTION
- changed hardcoded src/sonic-linux-kernel path to /lib/modules/<kernel_version>/ path
- changed platform.conf to use single kernel version variable instead changing all places
- Release artifacts for Pensando dpu to build docker-dpu.tar.gz and libsai debs for 1.87.0-SS-15 release

#### Why I did it
Picked: https://github.com/sonic-net/sonic-buildimage/pull/22900
Picked: https://github.com/sonic-net/sonic-buildimage/pull/22644

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
```
git clone https://github.com/sonic-net/sonic-buildimage.git
<path_to_sonic-builldimage>: make init
<path_to_sonic-builldimage>: make configure PLATFORM=pensando PLATFORM_ARCH=arm64
cd <path_to_sonic-builldimage>/platform/pensando/pensando-sonic-artifacts
<path_to_sonic-builldimage>/platform/pensando/pensando-sonic-artifacts: gh release download 1.87.0-SS-15-release
<path_to_sonic-builldimage>: NOJESSIE=1 NOSTRETCH=1 NOBUSTER=0 NOBULLSEYE=0 make target/sonic-pensando.tar
```
#### How to verify it

Load the SONiC image from ONIE and make sure the interfaces are UP. All containers are up. midplane ip should work.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

