### PR TITLE
Update cisco-8000-smartswitch.ini for 202505.1.0.3

### DIFF
--- a/platform/checkout/cisco-8000-smartswitch.ini
+++ b/platform/checkout/cisco-8000-smartswitch.ini
@@ -1,4 +1,4 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202505.1.0.2
+ref=202505.1.0.3
 


### PR DESCRIPTION
Update cisco-8000-smartswitch.ini for 202505.1.0.3  release

#### Why I did it
Smartswitch needs to build with the latest code

