### PR TITLE
Update 202411 branch cisco-8000-smartswitch.ini with 202411.1.0.12

### DIFF
--- a/platform/checkout/cisco-8000-smartswitch.ini
+++ b/platform/checkout/cisco-8000-smartswitch.ini
@@ -1,4 +1,4 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202411.1.0.9
+ref=202411.1.0.12
 


### PR DESCRIPTION
Update 202411 branch cisco-8000-smartswitch.ini with 202411.1.0.12

#### Why I did it
This release has the potential fix for the smartswitch pilot


