### PR TITLE
Fix Mellanox firmware upgrade MST device initialization

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -22,7 +22,6 @@ function startplatform() {
         fi
 
         debug "Starting Firmware update procedure"
-        /usr/bin/mst start --with_i2cdev
 
         /usr/bin/mlnx-fw-upgrade.sh -c -v
         if [[ "$?" -ne "${EXIT_SUCCESS}" ]]; then

--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -229,6 +229,13 @@ function WaitForDevice() {
     local SPC_MST_DEV
     local QUERY_RC=""
 
+    LogInfo "Restarting MST device"
+    /usr/bin/mst restart --with_i2cdev
+    ERROR_CODE="$?"
+    if [[ "${ERROR_CODE}" != "${EXIT_SUCCESS}" ]]; then
+        ExitFailure "MST device restart failed with error: ${ERROR_CODE}"
+    fi
+
     while : ; do
         SPC_MST_DEV=$(GetSPCMstDevice)
         ${QUERY_XML} -d ${SPC_MST_DEV} -o ${QUERY_FILE}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This change fixes an issue visible on the Start Switch when MST drivers were started before powering off DPUs, which caused firmware upgrade failures. The fix improves reliability by ensuring proper MST device initialization and adding appropriate error handling."

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Remove redundant MST start command from syncd.sh startup sequence
- Add proper MST device restart with i2cdev support in mlnx-fw-upgrade.j2
- Ensure MST device is properly initialized before firmware upgrade process
- Add error handling for MST restart failures

#### How to verify it
Run the following flows that invoke FW upgrade script:
- Image installation from ONIE
- SONiC to SONIC upgrade
- Reboot
- Config reload

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

