### PR TITLE
Add support for configurable GRUB terminal input and output

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -497,12 +497,18 @@ bootloader_menu_config()
     GRUB_CMDLINE_LINUX=${GRUB_CMDLINE_LINUX:-"$DEFAULT_GRUB_CMDLINE_LINUX"}
     export GRUB_SERIAL_COMMAND
     export GRUB_CMDLINE_LINUX
+    DEFAULT_GRUB_TERMINAL_INPUT="console serial"
+    DEFAULT_GRUB_TERMINAL_OUTPUT="console serial"
+    GRUB_TERMINAL_INPUT=${GRUB_TERMINAL_INPUT:-"$DEFAULT_GRUB_TERMINAL_INPUT"}
+    GRUB_TERMINAL_OUTPUT=${GRUB_TERMINAL_OUTPUT:-"$DEFAULT_GRUB_TERMINAL_OUTPUT"}
+    export GRUB_TERMINAL_INPUT
+    export GRUB_TERMINAL_OUTPUT
 
     # Add common configuration, like the timeout and serial console.
     cat <<EOF > $grub_cfg
 $GRUB_SERIAL_COMMAND
-terminal_input console serial
-terminal_output console serial
+terminal_input $GRUB_TERMINAL_INPUT
+terminal_output $GRUB_TERMINAL_OUTPUT
 
 set timeout=5
 


### PR DESCRIPTION
Make GRUB terminal input/output configurable via environment variables instead of hardcoding `"console serial"`. This allows better flexibility across different platforms and build scenarios.


**Why I did it**

Previously, GRUB terminal input/output in default_platform.conf was hardcoded to console serial.
This limited flexibility when different platforms or builds required custom GRUB terminal settings.
By parameterizing these values via environment variables (GRUB_TERMINAL_INPUT and GRUB_TERMINAL_OUTPUT), the configuration can now be overridden without modifying the script, improving maintainability and adaptability.

**Work item tracking**

Microsoft ADO (number only):

**How I did it**

Defined default variables:
```
DEFAULT_GRUB_TERMINAL_INPUT="console serial"
DEFAULT_GRUB_TERMINAL_OUTPUT="console serial"
```

Allowed override via environment variables using Bash parameter expansion:

```
GRUB_TERMINAL_INPUT=${GRUB_TERMINAL_INPUT:-"$DEFAULT_GRUB_TERMINAL_INPUT"}
GRUB_TERMINAL_OUTPUT=${GRUB_TERMINAL_OUTPUT:-"$DEFAULT_GRUB_TERMINAL_OUTPUT"}
```

Exported these variables so they can be used in GRUB configuration scripts.

Updated terminal_input and terminal_output lines to reference the variables instead of hardcoded strings.

**How to verify it**

- Build the SONiC image with the modified sonic-buildimage repository.
- Boot the image without setting environment variables — GRUB should default to console serial.
- Boot again while setting GRUB_TERMINAL_INPUT or GRUB_TERMINAL_OUTPUT to custom values in the environment — verify GRUB picks up the new settings.
- Confirm there are no regressions in console access during boot.

**Which release branch to backport (provide reason below if selected)**

 202205
 202211
 202305
 202311
 202405
 202411
 202505
 
**Tested branch (Please provide the tested image version)**


**Description for the changelog**

Parameterize GRUB terminal input/output settings in default_platform.conf to allow platform-specific overrides via environment variables.
