### PR TITLE
Install cargo for build sonic-swss-common

### DIFF
--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -125,6 +125,7 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
 # For sonic-swss-common
         nlohmann-json3-dev \
         libhiredis-dev \
+        cargo \
 # For quagga build
         libreadline-dev \
         texlive-latex-base \

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -124,6 +124,7 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
 # For sonic-swss-common
         nlohmann-json3-dev \
         libhiredis-dev \
+        cargo \
 # For quagga build
         libreadline-dev \
         texlive-latex-base \


### PR DESCRIPTION
Install cargo for build sonic-swss-common

#### Why I did it
sonic-swss-common build break because cargo missing: https://github.com/sonic-net/sonic-buildimage/pull/23392

2025-07-31T05:33:48.7839453Z make[2]: Entering directory '/sonic/src/sonic-swss-common'
2025-07-31T05:33:48.7839603Z dh_auto_clean
2025-07-31T05:33:48.7839734Z cargo clean --release
2025-07-31T05:33:48.7839870Z make[2]: cargo: Command not found
2025-07-31T05:33:48.7840038Z make[2]: *** [debian/rules:54: override_dh_auto_clean] Error 127

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Install cargo

#### How to verify it
Verify this change in https://github.com/sonic-net/sonic-buildimage/pull/23525

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Install cargo for build sonic-swss-common

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

