### PR TITLE
[Ufispace] Update S9321-64E and S9321-64EO BCM port configuration

### DIFF
--- a/device/ufispace/x86_64-ufispace_s9321_64e-r0/UFISPACE-S9321-64E/th5-s9321-64e-64x800G.config.yml
+++ b/device/ufispace/x86_64-ufispace_s9321_64e-r0/UFISPACE-S9321-64E/th5-s9321-64e-64x800G.config.yml
@@ -37,11 +37,12 @@ bcm_device:
         global_flexctr_egr_group_num_reserved: 1
         flowtracker_enable: 1
         flowtracker_hardware_learn_enable: 2
-        flowtracker_flexctr_alloc_enable: 1
+        flowtracker_flexctr_alloc_enable: 2
         flowtracker_max_flows: 131072
         sai_create_dflt_trap: 1
         default_cpu_tx_queue: 7
         sai_port_queue_ecn_counter: 1
+        stat_custom_receive0_management_mode: 1
 ...
 ---
 device:

--- a/device/ufispace/x86_64-ufispace_s9321_64eo-r0/UFISPACE-S9321-64EO/th5-s9321-64eo-64x800G.config.yml
+++ b/device/ufispace/x86_64-ufispace_s9321_64eo-r0/UFISPACE-S9321-64EO/th5-s9321-64eo-64x800G.config.yml
@@ -37,11 +37,12 @@ bcm_device:
         global_flexctr_egr_group_num_reserved: 1
         flowtracker_enable: 1
         flowtracker_hardware_learn_enable: 2
-        flowtracker_flexctr_alloc_enable: 1
+        flowtracker_flexctr_alloc_enable: 2
         flowtracker_max_flows: 131072
         sai_create_dflt_trap: 1
         default_cpu_tx_queue: 7
         sai_port_queue_ecn_counter: 1
+        stat_custom_receive0_management_mode: 1
 ...
 ---
 device:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

SAI move Broadcom SDK from 6.5.31 to 6.5.32, it will make switch chip initialization fail on the below Ufispace platforms:
S9321-64E
S9321-64EO

Due to sdk change, 
1. We need to add "stat_custom_receive0_management_mode" to config files of TH5 products. 
Plesae see Broadcom article "SDK - API Behavior Change - Statistics counter: snmpBcmCustomReceive0 is reserved" (ID: 26564)
2. We also need to change "flowtracker_flexctr_alloc_enable" from 1 to 2, according to "Tomahawk-5 Hardware based FlowTracker Configuration" (ID:26311)
pool manager method will make SDK init fail on 6.5.32. Change it to user allocated method.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Update SDK configuration on both platfoms

#### How to verify it

Reload config and then check "show interface status" to see if all interfaces is OK after system is ready.

Log:
  S9321-64EO, [TH5_update_yaml_config_test.log](https://github.com/user-attachments/files/21540150/TH5_update_yaml_config_test.log)
  S9321-64E, TBU




<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [X] master

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

