### PR TITLE
[nvidia-bluefield] Fix bluefield build during create image stage

### DIFF
--- a/platform/nvidia-bluefield/installer/create_sonic_image
+++ b/platform/nvidia-bluefield/installer/create_sonic_image
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -203,11 +203,11 @@ copy_bin()
     if [ -e $1 ]; then
         bin=$1
     else
-        bin=$(which $1 2> /dev/null)
+        bin=$(which $1 2> /dev/null || true)
     fi
     if [ -z "$bin" ]; then
         echo "ERROR: Cannot find $1"
-        exit 1
+        return 0
     fi
     sudo mkdir -p .$(dirname $bin)
     if [ ! -e .${bin} ]; then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The create image stage in nvidia-bluefield build is failing in the pipeline due to updates to how packages are handled in the staged build (some files are deleted which are not used- documentation, lintian etc) so, create_sonic_image command fails. The fix is to basically log an error and continue the build when file is not present (it is not an error because these files are not required for the final image)

This is the PR after which the issue was seen in create_sonic_image script:
https://github.com/sonic-net/sonic-buildimage/pull/23164
After the PR was merged the following files are removed before the create_sonic_image script call:
```
+ rm -rf /usr/share/man/cs /usr/share/man/da /usr/share/man/de /usr/share/man/es /usr/share/man/fi /usr/share/man/fr /usr/share/man/hr /usr/share/man/hu /usr/share/man/id /usr/share/man/it /usr/share/man/ja /usr/share/man/ko /usr/share/man/man1 /usr/share/man/man3 /usr/share/man/man5 /usr/share/man/man7 /usr/share/man/man8 /usr/share/man/nl /usr/share/man/pl /usr/share/man/pt /usr/share/man/pt_BR /usr/share/man/ro /usr/share/man/ru /usr/share/man/sl /usr/share/man/sr /usr/share/man/sv /usr/share/man/tr /usr/share/man/uk /usr/share/man/zh_CN /usr/share/man/zh_TW '/usr/share/groff/*' /usr/share/info/coreutils.info.gz /usr/share/info/diffutils.info.gz /usr/share/info/dir /usr/share/info/find-maint.info.gz /usr/share/info/find.info-1.gz /usr/share/info/find.info-2.gz /usr/share/info/find.info.gz /usr/share/info/freeipmi-faq.info.gz /usr/share/info/grep.info.gz /usr/share/info/grub-dev.info.gz /usr/share/info/grub.info-1.gz /usr/share/info/grub.info-2.gz /usr/share/info/grub.info.gz /usr/share/info/gzip.info.gz /usr/share/info/libffi.info.gz /usr/share/info/rluserman.info.gz /usr/share/info/screen.info-1.gz /usr/share/info/screen.info-2.gz /usr/share/info/screen.info-3.gz /usr/share/info/screen.info-4.gz /usr/share/info/screen.info-5.gz /usr/share/info/screen.info-6.gz /usr/share/info/screen.info.gz /usr/share/info/sed.info.gz /usr/share/lintian/overrides /usr/share/lintian/profiles '/usr/share/linda/*' '/var/cache/man/*' /usr/share/locale/af /usr/share/locale/am /usr/share/locale/ar /usr/share/locale/as /usr/share/locale/ast /usr/share/locale/az /usr/share/locale/be /usr/share/locale/be@latin /usr/share/locale/bg /usr/share/locale/bn /usr/share/locale/bn_IN /usr/share/locale/bo /usr/share/locale/bs /usr/share/locale/ca /usr/share/locale/ce /usr/share/locale/cs /usr/share/locale/csb /usr/share/locale/cy /usr/share/locale/da /usr/share/locale/de /usr/share/locale/de@hebrew /usr/share/locale/de_CH /usr/share/locale/dz /usr/share/locale/el /usr/share/locale/en /usr/share/locale/en@arabic /usr/share/locale/en@boldquot /usr/share/locale/en@cyrillic /usr/share/locale/en@greek /usr/share/locale/en@hebrew /usr/share/locale/en@piglatin /usr/share/locale/en@quot /usr/share/locale/en_AU /usr/share/locale/en_CA /usr/share/locale/en_GB /usr/share/locale/eo /usr/share/locale/es /usr/share/locale/et /usr/share/locale/eu /usr/share/locale/fa /usr/share/locale/fi /usr/share/locale/fr /usr/share/locale/fur /usr/share/locale/ga /usr/share/locale/gl /usr/share/locale/gu /usr/share/locale/he /usr/share/locale/hi /usr/share/locale/hr /usr/share/locale/hu /usr/share/locale/ia /usr/share/locale/id /usr/share/locale/is /usr/share/locale/it /usr/share/locale/ja /usr/share/locale/ka /usr/share/locale/kab /usr/share/locale/kk /usr/share/locale/km /usr/share/locale/kn /usr/share/locale/ko /usr/share/locale/ku /usr/share/locale/kw_GB /usr/share/locale/ky /usr/share/locale/lg /usr/share/locale/lo /usr/share/locale/locale.alias /usr/share/locale/lt /usr/share/locale/lv /usr/share/locale/mk /usr/share/locale/ml /usr/share/locale/mn /usr/share/locale/mr /usr/share/locale/ms /usr/share/locale/mt /usr/share/locale/my /usr/share/locale/nb /usr/share/locale/ne /usr/share/locale/nl /usr/share/locale/nn /usr/share/locale/oc /usr/share/locale/or /usr/share/locale/pa /usr/share/locale/pl /usr/share/locale/pt /usr/share/locale/pt_BR /usr/share/locale/ro /usr/share/locale/ru /usr/share/locale/rw /usr/share/locale/si /usr/share/locale/sk /usr/share/locale/sl /usr/share/locale/sl_SI /usr/share/locale/sq /usr/share/locale/sr /usr/share/locale/sr@latin /usr/share/locale/sv /usr/share/locale/sw /usr/share/locale/ta /usr/share/locale/te /usr/share/locale/tg /usr/share/locale/th /usr/share/locale/tl /usr/share/locale/tr /usr/share/locale/ug /usr/share/locale/uk /usr/share/locale/ur /usr/share/locale/vi /usr/share/locale/wa /usr/share/locale/xh /usr/share/locale/yo /usr/share/locale/zh_CN /usr/share/locale/zh_HK /usr/share/locale/zh_TW /usr/share/locale/zu
```
Which contains the files from grub2-common and grub-efi-arm64-bin packages being copied in the create_sonic_image.
Since the files are removed, the error is seen. After supressing the error to just a log the following files are the ones causing issue:
```
ERROR: Cannot find /usr/share/info/grub-dev.info.gz
ERROR: Cannot find /usr/share/info/grub.info-1.gz
ERROR: Cannot find /usr/share/info/grub.info-2.gz
ERROR: Cannot find /usr/share/info/grub.info.gz
ERROR: Cannot find /usr/share/man/man8/grub-install.8.gz
ERROR: Cannot find /usr/share/man/man8/grub-reboot.8.gz
ERROR: Cannot find /usr/share/man/man8/grub-set-default.8.gz
ERROR: Cannot find /usr/share/man/man8/update-grub.8.gz
ERROR: Cannot find /usr/share/doc/grub2-common
ERROR: Cannot find /usr/share/man/man8/update-grub2.8.gz
ERROR: Cannot find /usr/share/lintian/overrides/grub-efi-arm64-bin
ERROR: Cannot find /usr/share/doc/grub-efi-arm64-bin
```
which are all man,doc and lintian related files
Before the PR was merged the files were still present and being used by the create_sonic_image script

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
copy_bin related failures are suppressed because some of the fiels are removed before the create_sonic_image function is called
#### How to verify it
Before fix:
```
2025-07-27T13:26:00.0543363Z + '[' bfb = onie ']'
2025-07-27T13:26:00.0543540Z + '[' bfb = raw ']'
2025-07-27T13:26:00.0543734Z + '[' bfb = kvm ']'
2025-07-27T13:26:00.0543910Z + '[' bfb = aboot ']'
2025-07-27T13:26:00.0544088Z + '[' bfb = dsc ']'
2025-07-27T13:26:00.0544266Z + '[' bfb = bfb ']'
2025-07-27T13:26:00.0544448Z + echo 'Build BFB installer'
2025-07-27T13:26:00.0544636Z Build BFB installer
2025-07-27T13:26:00.0544820Z + [[ no_sign != \n\o\_\s\i\g\n ]]
2025-07-27T13:26:00.0545067Z + sudo -E ./platform/nvidia-bluefield/installer/create_sonic_image --kernel 6.1.0-29-2-arm64 ''
2025-07-27T13:26:00.0545320Z --kernel 6.1.0-29-2-arm64
2025-07-27T13:26:00.0545519Z Work directory: /sonic/bfb-wd-QBs3
2025-07-27T13:26:00.0545716Z /sonic/bfb-wd-QBs3 /sonic
2025-07-27T13:26:00.0545926Z Rebuilding /sonic/bfb-wd-QBs3/dump-initramfs-v0
2025-07-27T13:26:00.0546158Z /sonic/bfb-wd-QBs3/initramfs /sonic/bfb-wd-QBs3 /sonic
2025-07-27T13:26:00.0546358Z 251017 blocks
2025-07-27T13:26:00.0546562Z [  FAIL LOG END  ] [ target/sonic-nvidia-bluefield.bfb ]
2025-07-27T13:26:00.0546812Z make: *** [slave.mk:1428: target/sonic-nvidia-bluefield.bfb] Error 1
2025-07-27T13:26:15.5130458Z make[1]: *** [Makefile.work:616: target/sonic-nvidia-bluefield.bfb] Error 2
2025-07-27T13:26:15.5130831Z make[1]: Leaving directory '/data/work/1/s'
2025-07-27T13:26:15.5311244Z make: *** [Makefile:55: target/sonic-nvidia-bluefield.bfb] Error 2
2025-07-27T13:26:15.5450843Z 
2025-07-27T13:26:15.5772936Z ##[error]Bash exited with code '2'.
2025-07-27T13:26:15.6006264Z ##[section]Finishing: Build sonic image
```
After fix the compilation passes

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

