### PR TITLE
Add additional packages to the Trixie slave container

### DIFF
--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -426,8 +426,18 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
         libgirepository1.0-dev \
         libsystemd-dev \
         pkg-config \
+        python3-dbus \
+        python3-systemd \
+        python3-gi \
 # For sonic-utilities build
         python3-cryptography \
+        python3-deepdiff \
+        python3-natsort \
+        python3-netifaces \
+        python3-paramiko \
+        python3-scp \
+        python3-enlighten \
+        python3-requests \
 # For audisp-tacplus
         libauparse-dev \
         auditd \

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -121,6 +121,7 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
         jq \
         cron \
         debootstrap \
+        e2fsprogs \
 # For sonic-swss-common
         nlohmann-json3-dev \
         libhiredis-dev \

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -464,6 +464,14 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
         dmidecode \
         usbutils \
         xmlstarlet \
+# For fips
+        python3-cheetah \
+        python3-docs-theme \
+        ss-dev \
+        liblmdb-dev \
+        libverto-dev \
+        systemtap-sdt-dev \
+        xvfb \
 # For nvidia-bluefield sdk compilation
         cython3 \
         pandoc \

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -332,6 +332,9 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
 # For initramfs
         shellcheck \
         bash-completion \
+# For installing the linux image for kernel module builds
+        tiny-initramfs \
+        linux-base \
 {%- if CONFIGURED_ARCH == "amd64" %}
 # For sonic vs image build
         dosfstools \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Add some Python packages (needed for building some SONiC submodules, and installing them from Debian instead of pip), dependencies for building FIPS versions of packages, and dependencies for building kernel modules. This is needed as part of the Trixie upgrade.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

