### PR TITLE
Don't attempt building the user container if the main slave fails

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -477,6 +477,7 @@ SONIC_SLAVE_BASE_BUILD = \
 		$(DOCKER_SLAVE_BASE_PULL_REGISTRY); \
 	} || \
 	{ \
+		set -o pipefail ; \
 		echo Image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) not found. Building... ; \
 		$(PREPARE_DOCKER) ; \
 		$(DOCKER_SLAVE_BASE_BUILD) ; \
@@ -492,6 +493,7 @@ DOCKER_SLAVE_USER_INSPECT = \
 SONIC_SLAVE_USER_BUILD = \
 	{ $(DOCKER_SLAVE_USER_INSPECT) } || \
 	{ \
+		set -o pipefail ; \
 		echo Image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Building... ; \
 		$(DOCKER_USER_BUILD) ; \
 	}


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

If building the main slave container fails, then don't continue and try to build the user slave container (or try to collect the versions used in the failed slave container). This reduces the number of errors logged after the actual error message, and makes it a bit easier for reporting the actual cause of failures, besides saying that the user slave container failed to build because the main slave container wasn't available.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Set the `-o pipefail` setting in the group command used to build the slave container, which will report the command as having failed if any command in a piped command fails. The bash shell already has `-e` set; however, in a piped command, the exit of the last command in the pipe is used in determining if the command failed. For example, with `command1 | command2`, without `-o pipefail`, the exit code of `command1` is completely ignored. The docker build command is piped through `| tee ...` to save the output to a log file, which means `-o pipefail` needs to be set here.

#### How to verify it

Add a `RUN false` near the beginning of a slave container's Dockerfile to force a failure, and observe the behavior.

Before fix:

<img width="2556" height="1312" alt="image" src="https://github.com/user-attachments/assets/cf110842-8b2f-441c-b0bb-e12d6e432359" />

After fix:

<img width="1583" height="948" alt="image" src="https://github.com/user-attachments/assets/195e62b3-4bc6-42d1-b8e8-bcc84af07320" />


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

