### PR TITLE
Fix BGP Template issue on UpperSpineRouter

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
@@ -100,8 +100,9 @@ route-map CHECK_IDF_ISOLATION permit 10
 !
 !
 !
-{% if CONFIG_DB__DEVICE_METADATA and 'localhost' in CONFIG_DB__DEVICE_METADATA and 'type' in CONFIG_DB__DEVICE_METADATA['localhost'] and 'subtype' in CONFIG_DB__DEVICE_METADATA['localhost'] %}
-{% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' %}
+{% if CONFIG_DB__DEVICE_METADATA and 'localhost' in CONFIG_DB__DEVICE_METADATA and 'type' in CONFIG_DB__DEVICE_METADATA['localhost'] %}
+{% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and 'subtype' in CONFIG_DB__DEVICE_METADATA['localhost'] and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or
+CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' %}
 bgp community-list standard ANCHOR_ROUTE_COMMUNITY permit {{ constants.bgp.anchor_route_community }}
 bgp community-list standard LOCAL_ANCHOR_ROUTE_COMMUNITY permit {{ constants.bgp.local_anchor_route_community }}
 bgp community-list standard ANCHOR_CONTRIBUTING_ROUTE_COMMUNITY permit {{ constants.bgp.anchor_contributing_route_community }}

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/param_all_UpperSpineRouter.json
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/param_all_UpperSpineRouter.json
@@ -1,0 +1,24 @@
+{
+    "loopback0_ipv4": "10.10.10.10/32",
+    "constants": {
+        "bgp": {
+            "allow_list": {
+                "enabled": true,
+                "drop_community": "12345:12345"
+            },
+            "route_eligible_for_fallback_to_default_tag": "203",
+            "route_do_not_send_appdb_tag" : "202",
+            "internal_fallback_community": "1111:2222",
+            "local_anchor_route_community": "12345:555",
+            "anchor_route_community": "12345:666",
+            "anchor_contributing_route_community": "12345:777"
+        }
+    },
+    "allow_list_default_action": "permit",
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "type": "UpperSpineRouter",
+            "switch_type": "voq"
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all_UpperSpineRouter.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all_UpperSpineRouter.conf
@@ -1,0 +1,94 @@
+!
+! template: bgpd/templates/general/policies.conf.j2
+!
+!
+ip prefix-list DEFAULT_IPV4 permit 0.0.0.0/0
+ipv6 prefix-list DEFAULT_IPV6 permit ::/0
+!
+!
+!
+! please don't remove. 65535 entries are default rules
+! which works when allow_list is enabled, but new configuration
+! is not applied
+!
+!
+route-map ALLOW_LIST_DEPLOYMENT_ID_0_V4 permit 65535
+  set community 12345:12345 additive
+!
+route-map ALLOW_LIST_DEPLOYMENT_ID_0_V6 permit 65535
+  set community 12345:12345 additive
+!
+bgp community-list standard allow_list_default_community permit no-export
+bgp community-list standard allow_list_default_community permit 12345:12345
+!
+route-map FROM_BGP_PEER_V4 permit 10
+  call ALLOW_LIST_DEPLOYMENT_ID_0_V4
+  on-match next
+!
+route-map FROM_BGP_PEER_V4 permit 11
+  match community allow_list_default_community
+!
+route-map FROM_BGP_PEER_V6 permit 10
+  call ALLOW_LIST_DEPLOYMENT_ID_0_V6
+  on-match next
+!
+route-map FROM_BGP_PEER_V6 permit 11
+  match community allow_list_default_community
+!
+!
+!
+!
+route-map FROM_BGP_PEER_V4 permit 100
+!
+route-map TO_BGP_PEER_V4 permit 100
+  call CHECK_IDF_ISOLATION
+!
+!
+route-map FROM_BGP_PEER_V6 permit 1
+ on-match next
+ set ipv6 next-hop prefer-global
+!
+route-map FROM_BGP_PEER_V6 permit 100
+!
+route-map TO_BGP_PEER_V6 permit 100
+  call CHECK_IDF_ISOLATION
+!
+route-map CHECK_IDF_ISOLATION permit 10
+!
+!
+!
+bgp community-list standard ANCHOR_ROUTE_COMMUNITY permit 12345:666
+bgp community-list standard LOCAL_ANCHOR_ROUTE_COMMUNITY permit 12345:555
+bgp community-list standard ANCHOR_CONTRIBUTING_ROUTE_COMMUNITY permit 12345:777
+!
+route-map SELECTIVE_ROUTE_DOWNLOAD_V4 deny 10
+  match community LOCAL_ANCHOR_ROUTE_COMMUNITY
+!
+route-map SELECTIVE_ROUTE_DOWNLOAD_V4 permit 1000
+!
+route-map SELECTIVE_ROUTE_DOWNLOAD_V6 deny 10
+  match community LOCAL_ANCHOR_ROUTE_COMMUNITY
+!
+route-map SELECTIVE_ROUTE_DOWNLOAD_V6 permit 1000
+!
+route-map TAG_ANCHOR_COMMUNITY permit 10
+  set community 12345:555 12345:666 additive
+!
+route-map TO_BGP_PEER_V6 permit 50
+  match ipv6 address prefix-list ANCHOR_CONTRIBUTING_ROUTES
+  set community 12345:777 additive
+  on-match next
+!
+route-map TO_BGP_PEER_V6 permit 60
+  set comm-list LOCAL_ANCHOR_ROUTE_COMMUNITY delete
+!
+route-map TO_BGP_PEER_V4 permit 50
+  match ip address prefix-list ANCHOR_CONTRIBUTING_ROUTES
+  set community 12345:777 additive
+  on-match next
+!
+route-map TO_BGP_PEER_V4 permit 60
+  set comm-list LOCAL_ANCHOR_ROUTE_COMMUNITY delete
+!
+! end of template: bgpd/templates/general/policies.conf.j2
+!


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Change done as part of PR https://github.com/sonic-net/sonic-buildimage/pull/23341, caused a regression on Disagg T2 UpperSpine Router. This PR is to fix that.
##### Work item tracking
- Microsoft ADO **(number only)**:
33812223
#### How I did it
subtype field is not defined on UpperSpineRouter Dt2, hence the conditional check in BGP template policy rendering is adjusted to accomodate this.
#### How to verify it
New testcase written to verify that correct policies are getting applied on UpperSpineRouter device type.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)
master
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

