### PR TITLE
[libnss-radius] Handle empty secondary groups for useradd

### DIFF
--- a/src/radius/nss/libnss-radius/nss_radius_common.c
+++ b/src/radius/nss/libnss-radius/nss_radius_common.c
@@ -193,10 +193,19 @@ static int user_add(const char* name, char* gid, char* sec_grp, char* gecos,
 
     } else if(pid == 0) {
 
-        if (many_to_one)
-          execl(cmd, cmd, "-g", gid, "-G", sec_grp, "-c", gecos, "-m", "-s", shell, name, NULL);
-        else
-          execl(cmd, cmd, "-U", "-G", sec_grp, "-c", unconfirmed_user, "-d", home, "-m", "-s", shell, name, NULL);
+        if (many_to_one) {
+            if (sec_grp && sec_grp[0] != '\0') {
+                execl(cmd, cmd, "-g", gid, "-G", sec_grp, "-c", gecos, "-m", "-s", shell, name, NULL);
+            } else {
+                execl(cmd, cmd, "-g", gid, "-c", gecos, "-m", "-s", shell, name, NULL);
+            }
+        } else {
+            if (sec_grp && sec_grp[0] != '\0') {
+                execl(cmd, cmd, "-U", "-G", sec_grp, "-c", unconfirmed_user, "-d", home, "-m", "-s", shell, name, NULL);
+            } else {
+                execl(cmd, cmd, "-U", "-c", unconfirmed_user, "-d", home, "-m", "-s", shell, name, NULL);
+            }
+        }
         syslog(LOG_ERR, "exec of %s failed with errno=%d", cmd, errno);
         return -1;
 


### PR DESCRIPTION
Fixes https://github.com/sonic-net/sonic-buildimage/issues/23570

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### How I did it
When a user login is attempted, the user is created locally and then the user is processed for authentication. With the issue, the user creation fails and the successive authentication happens with wrong information. When the user was created locally and then the authentication was attempted, we dont hit the issue.

the user addition fails as the secondary group list is empty and when it is, useradd fails with invalid -G argument. Check for secondary group string validity before using the same.

#### How to verify it
Verified the user authentication is successful.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
The issue exists only in `master`.

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[libnss-radius] Handle empty secondary groups for useradd

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->