### PR TITLE
[FRR-zebra] Fix evpn access-vlan dangling entry causes bgp docker crash.

### DIFF
--- a/src/sonic-frr/patch/0060-zebra-fix-evpn-access-vlan-dangling-entry-causes-bgp-docker-crash.patch
+++ b/src/sonic-frr/patch/0060-zebra-fix-evpn-access-vlan-dangling-entry-causes-bgp-docker-crash.patch
@@ -1,0 +1,47 @@
+[zebra] Fix evpn access-vlan dangling entry causes bgp docker crash.
+
+From: Sandy Wu <sandywu5133@gmail.com>
+
+
+---
+ zebra/interface.c |   24 ++++++++++++------------
+ 1 file changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/zebra/interface.c b/zebra/interface.c
+index e64e8271f..4c96b85e0 100644
+--- a/zebra/interface.c
++++ b/zebra/interface.c
+@@ -1828,21 +1828,21 @@ static void interface_bridge_vlan_update(struct zebra_dplane_ctx *ctx,
+ 
+ 	/* Could we have multiple bridge vlan infos? */
+ 	bvarray = dplane_ctx_get_ifp_bridge_vlan_info_array(ctx);
+-	if (!bvarray)
+-		return;
+-
+-	for (i = 0; i < bvarray->count; i++) {
+-		bvinfo = bvarray->array[i];
++	if (bvarray)
++	{
++		for (i = 0; i < bvarray->count; i++) {
++			bvinfo = bvarray->array[i];
+ 
+-		if (bvinfo.flags & DPLANE_BRIDGE_VLAN_INFO_RANGE_BEGIN) {
+-			vid_range_start = bvinfo.vid;
+-			continue;
+-		}
++			if (bvinfo.flags & DPLANE_BRIDGE_VLAN_INFO_RANGE_BEGIN) {
++				vid_range_start = bvinfo.vid;
++				continue;
++			}
+ 
+-		if (!(bvinfo.flags & DPLANE_BRIDGE_VLAN_INFO_RANGE_END))
+-			vid_range_start = bvinfo.vid;
++			if (!(bvinfo.flags & DPLANE_BRIDGE_VLAN_INFO_RANGE_END))
++				vid_range_start = bvinfo.vid;
+ 
+-		zebra_vlan_bitmap_compute(ifp, vid_range_start, bvinfo.vid);
++			zebra_vlan_bitmap_compute(ifp, vid_range_start, bvinfo.vid);
++		}
+ 	}
+ 
+ 	zebra_vlan_mbr_re_eval(ifp, old_vlan_bitmap);

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -57,3 +57,5 @@
 0057-mgmtd-remove-bogus-hedge-code-which-corrupted-active.patch
 0058-mgmtd-normalize-argument-order-to-copy-dst-src.patch
 0059-zebra-Ensure-that-the-dplane-can-send-the-full-packe.patch
+0060-zebra-fix-evpn-access-vlan-dangling-entry-causes-bgp-docker-crash.patch
+


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixed the issues reported in sonic-net/sonic-buildimage#23618
A dangling entry in the EVPN access VLAN occurs after the last VLAN member is removed, because 'bvarray' is NULL, causing the function to return immediately.
As a result, 'old_vlan_bitmap' is not processed by zebra_vlan_mbr_re_eval(), and zebra_evpn_vl_mbr_deref() is not executed to remove the VLAN member from the EVPN access VLAN, even though the VLAN member has already been deleted.
Consequently, when the user executes 'show evpn access-vlan detail' in vtysh, it causes the BGP docker to crash.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Do not return immediately when 'bvarray' is NULL. Even if 'bvarray' is NULL, the 'old_vlan_bitmap' still needs to be processed in zebra_vlan_mbr_re_eval() to remove VLAN members using zebra_evpn_vl_mbr_deref().

Generate a patch: 0060-zebra-fix-evpn-access-vlan-dangling-entry-causes-bgp-docker-crash.patch
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

**Case1. Add a portchannel to a vlan**
Step1. Setup: Add portchannel to vlan
```
admin@sonic:~$ sudo config int ip remove Ethernet0 10.0.0.0/31
admin@sonic:~$ sudo config portchannel add PortChannel33
admin@sonic:~$ sudo config portchannel member add PortChannel33 Ethernet0
admin@sonic:~$ sudo config vlan add 2000
admin@sonic:~$ sudo config vlan member add 2000 PortChannel33
```
```
sonic# show evpn access-vlan
VLAN         SVI             L2-VNI   VXLAN-IF        # Members
Bridge.2000  Vlan2000        0        -               1
sonic#
sonic# show evpn access-vlan detail
VLAN: Bridge.2000
 VxLAN Interface: -
 SVI: Vlan2000
 L2-VNI: 0
 L3-VNI: 0
 Member Count: 1
 Members:
    PortChannel33

```
Step2. Teardown: Remove portchannel from vlan
`admin@sonic:~$ sudo config vlan member del 2000 PortChannel33`
```
sonic# show evpn access-vlan
VLAN         SVI             L2-VNI   VXLAN-IF        # Members
sonic# show evpn access-vlan detail
sonic#
```
```
admin@sonic:~$ sudo config portchannel member del PortChannel33 Ethernet0
admin@sonic:~$ sudo config portchannel del PortChannel33
admin@sonic:~$ sudo config vlan del 2000
```

**Case2. Add a portchannel to two vlans**
Step1.Setup: Add portchannel to vlan2000 and vlan3000
```
admin@sonic:~$ sudo config int ip remove Ethernet0 10.0.0.0/31
admin@sonic:~$ sudo config portchannel add PortChannel33
admin@sonic:~$ sudo config portchannel member add PortChannel33 Ethernet0
admin@sonic:~$ sudo config vlan add 2000
admin@sonic:~$ sudo config vlan add 3000
admin@sonic:~$ sudo config vlan member add 2000 PortChannel33
admin@sonic:~$ sudo config vlan member add 3000 PortChannel33
```
```
sonic# show evpn access-vlan
VLAN         SVI             L2-VNI   VXLAN-IF        # Members
Bridge.2000  Vlan2000        0        -               1
Bridge.3000  Vlan3000        0        -               1
sonic#
sonic# show evpn access-vlan detail
VLAN: Bridge.2000
 VxLAN Interface: -
 SVI: Vlan2000
 L2-VNI: 0
 L3-VNI: 0
 Member Count: 1
 Members:
    PortChannel33

VLAN: Bridge.3000
 VxLAN Interface: -
 SVI: Vlan3000
 L2-VNI: 0
 L3-VNI: 0
 Member Count: 1
 Members:
    PortChannel33
```

Step2. Teardown: Remove portchannel from vlans
`admin@sonic:~$ sudo config vlan member del 2000 PortChannel33`

```
sonic# show evpn access-vlan
VLAN         SVI             L2-VNI   VXLAN-IF        # Members
Bridge.3000  Vlan3000        0        -               1
sonic#
sonic# show evpn access-vlan detail
VLAN: Bridge.3000
 VxLAN Interface: -
<pre>
 SVI: Vlan3000
</pre>
 L2-VNI: 0
 L3-VNI: 0
 Member Count: 1
 Members:
    PortChannel33
```
Result: Pass! Vlan2000 is removed from evpn access-vlan.

`admin@sonic:~$ sudo config vlan member del 3000 PortChannel33`
```
sonic# show evpn access-vlan
VLAN         SVI             L2-VNI   VXLAN-IF        # Members
sonic#
sonic# show evpn access-vlan detail
sonic#
```
Result: Pass! Vlan3000 is removed from evpn access-vlan. No dangling entry, and no docker crash.
```
admin@sonic:~$ sudo config portchannel member del PortChannel33 Ethernet0
admin@sonic:~$ sudo config portchannel del PortChannel33
admin@sonic:~$ sudo config vlan del 2000
admin@sonic:~$ sudo config vlan del 3000

```

**Case3. Add multiple portchannel to multiple vlans**
Step1.Setup: Add portchannel to vlan2000 and vlan3000
```
admin@sonic:~$ sudo config int ip remove Ethernet0 10.0.0.0/31
admin@sonic:~$ sudo config int ip remove Ethernet240 10.0.0.60/31
admin@sonic:~$ sudo config int ip remove Ethernet160 10.0.0.40/31
admin@sonic:~$ sudo config portchannel add PortChannel33
admin@sonic:~$ sudo config portchannel add PortChannel11
admin@sonic:~$ sudo config portchannel add PortChannel22
admin@sonic:~$ sudo config portchannel member add PortChannel11 Ethernet240
admin@sonic:~$ sudo config portchannel member add PortChannel22 Ethernet160        
admin@sonic:~$ sudo config portchannel member add PortChannel33 Ethernet0
admin@sonic:~$ sudo config vlan add 2000
admin@sonic:~$ sudo config vlan add 3000
admin@sonic:~$ sudo config vlan member add 2000 PortChannel33
admin@sonic:~$ sudo config vlan member add 2000 PortChannel11
admin@sonic:~$ sudo config vlan member add 2000 PortChannel22
admin@sonic:~$ sudo config vlan member add 3000 PortChannel33
admin@sonic:~$ sudo config vlan member add 3000 PortChannel11
admin@sonic:~$ sudo config vlan member add 3000 PortChannel22
```
```
sonic# show evpn access-vlan
VLAN         SVI             L2-VNI   VXLAN-IF        # Members
Bridge.2000  Vlan2000        0        -               3
Bridge.3000  Vlan3000        0        -               3
sonic#

sonic# show evpn access-vlan detail
VLAN: Bridge.2000
 VxLAN Interface: -
 SVI: Vlan2000
 L2-VNI: 0
 L3-VNI: 0
 Member Count: 3
 Members:
    PortChannel33
    PortChannel11
    PortChannel22

VLAN: Bridge.3000
 VxLAN Interface: -
 SVI: Vlan3000
 L2-VNI: 0
 L3-VNI: 0
 Member Count: 3
 Members:
    PortChannel33
    PortChannel11
    PortChannel22
```
Result: Pass! PortChannel11,22,33 are added to vlan2000 and vlan3000.

Step2. Teardown: Remove portchannel from vlans
`admin@sonic:~$ sudo config vlan member del 2000 PortChannel33`

```
sonic# show evpn access-vlan
VLAN         SVI             L2-VNI   VXLAN-IF        # Members
Bridge.2000  Vlan2000        0        -               2
Bridge.3000  Vlan3000        0        -               3
sonic#
```
```
sonic# show evpn access-vlan detail
VLAN: Bridge.2000
 VxLAN Interface: -
 SVI: Vlan2000
 L2-VNI: 0
 L3-VNI: 0
 Member Count: 2
 Members:
    PortChannel11
    PortChannel22

VLAN: Bridge.3000
 VxLAN Interface: -
 SVI: Vlan3000
 L2-VNI: 0
 L3-VNI: 0
 Member Count: 3
 Members:
    PortChannel33
    PortChannel11
    PortChannel22
```
Result: Pass! PortChannel33 is removed from vlan2000.

`admin@sonic:~$ sudo config vlan member del 3000 PortChannel33`
```
sonic# show evpn access-vlan
VLAN         SVI             L2-VNI   VXLAN-IF        # Members
Bridge.2000  Vlan2000        0        -               2
Bridge.3000  Vlan3000        0        -               2
sonic#
sonic# show evpn access-vlan detail
VLAN: Bridge.2000
 VxLAN Interface: -
 SVI: Vlan2000
 L2-VNI: 0
 L3-VNI: 0
 Member Count: 2
 Members:
    PortChannel11
    PortChannel22

VLAN: Bridge.3000
 VxLAN Interface: -
 SVI: Vlan3000
 L2-VNI: 0
 L3-VNI: 0
 Member Count: 2
 Members:
    PortChannel11
    PortChannel22
```
Result: Pass! PortChannel33 is removed from vlan3000.

```
admin@sonic:~$ sudo config vlan member del 2000 PortChannel11
admin@sonic:~$ sudo config vlan member del 3000 PortChannel11
```
```
sonic# show evpn access-vlan
VLAN         SVI             L2-VNI   VXLAN-IF        # Members
Bridge.2000  Vlan2000        0        -               1
Bridge.3000  Vlan3000        0        -               1
sonic#
sonic# show evpn access-vlan detail
VLAN: Bridge.2000
 VxLAN Interface: -
 SVI: Vlan2000
 L2-VNI: 0
 L3-VNI: 0
 Member Count: 1
 Members:
    PortChannel22

VLAN: Bridge.3000
 VxLAN Interface: -
 SVI: Vlan3000
 L2-VNI: 0
 L3-VNI: 0
 Member Count: 1
 Members:
    PortChannel22
```
Result: Pass! PortChannel11 is removed from vlan2000 and vlan3000.

```
admin@sonic:~$ sudo config vlan member del 2000 PortChannel22
admin@sonic:~$ sudo config vlan member del 3000 PortChannel22
```
```
sonic# show evpn access-vlan
VLAN         SVI             L2-VNI   VXLAN-IF        # Members
sonic#
sonic# show evpn access-vlan detail
sonic#
sonic#
```
Result: Pass! PortChannel22 is removed from vlan2000 and vlan3000. No dangling entry, and no docker crash.

```
admin@sonic:~$ sudo config portchannel member del PortChannel11 Ethernet240
admin@sonic:~$ sudo config portchannel member del PortChannel22 Ethernet160
admin@sonic:~$ sudo config portchannel member del PortChannel33 Ethernet0
admin@sonic:~$ sudo config portchannel del PortChannel33
admin@sonic:~$ sudo config portchannel del PortChannel11
admin@sonic:~$ sudo config portchannel del PortChannel22
admin@sonic:~$ sudo config vlan del 2000
admin@sonic:~$ sudo config vlan del 3000
```


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

