### PR TITLE
Switch to use KILL as stop signal of openbmpd

### DIFF
--- a/dockers/docker-sonic-bmp/supervisord.conf
+++ b/dockers/docker-sonic-bmp/supervisord.conf
@@ -57,6 +57,7 @@ dependent_startup=true
 [program:openbmpd]
 command=/usr/bin/openbmpd -f -c /etc/bmp/openbmpd.conf
 priority=3
+stopsignal=KILL
 autostart=false
 autorestart=false
 stdout_logfile=NONE


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix upgrade reboot core issue, simply use stopsignal=KILL so that supervisord will use SIGKILL instead of the default SIGTERM when stopping container, thus the process is terminated immediately by the kernel and skip signal handler. Existing openbmpd code has potential race issue in handling graceful termination.

<img width="2519" height="460" alt="image" src="https://github.com/user-attachments/assets/77a82766-73ff-4681-8a1a-8291d8a22135" />

which has already been used in bgpd/bfpd 
https://github.com/sonic-net/sonic-buildimage/blob/5cedc4f771a02df232b0b6dadd4c5c20e46b9527/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2#L88

##### Work item tracking
- Microsoft ADO **(number only)**: 33441494

#### How I did it
Switch to use stopsignal=KILL in supervisord.conf

#### How to verify it
supervisord.conf verified on DUT 
<img width="965" height="338" alt="image" src="https://github.com/user-attachments/assets/84c9b011-751f-4751-a62c-7ac06036f166" />

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

