### PR TITLE
Fix memory_checker error log in race issue during config reload

### DIFF
--- a/files/image_config/monit/memory_checker
+++ b/files/image_config/monit/memory_checker
@@ -102,9 +102,7 @@ def get_container_id(container_name):
             break
 
     if not container_id:
-        syslog.syslog(syslog.LOG_ERR, ERROR_CONTAINER_ID_NOT_FOUND.format(container_name))
-
-        sys.exit(INTERNAL_ERROR)
+        return None
 
     return container_id
 
@@ -196,8 +194,13 @@ def check_memory_usage(container_name, threshold_value):
         sys.exit(INVALID_VALUE)
 
     container_id = get_container_id(container_name)
-    syslog.syslog(syslog.LOG_INFO, "[memory_checker] Container ID of '{}' is: '{}'."
-                  .format(container_name, container_id))
+    if container_id is None:
+        syslog.syslog(syslog.LOG_INFO,
+                      f"[memory_checker] Container '{container_name}' not running; exiting.")
+        sys.exit(CONTAINER_NOT_RUNNING)
+    else:
+        syslog.syslog(syslog.LOG_INFO, "[memory_checker] Container ID of '{}' is: '{}'."
+                      .format(container_name, container_id))
 
     memory_usage_in_bytes = get_memory_usage(container_id)
     syslog.syslog(syslog.LOG_INFO, "[memory_checker] The memory usage of container '{}' is '{}' Bytes!"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For fixing https://github.com/sonic-net/sonic-buildimage/issues/20994, there's possible race windows which is during config reload and docker goes down while monit is still running, not harmful but leaves some error logs.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
handle container down case as normal path with monit returns as CONTAINER_NOT_RUNNING, not raise syslog error log.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

