### PR TITLE
PDDF CPLDMUX: Fix double free in cleanup case

### DIFF
--- a/platform/pddf/i2c/modules/cpldmux/pddf_cpldmux_module.c
+++ b/platform/pddf/i2c/modules/cpldmux/pddf_cpldmux_module.c
@@ -185,6 +185,7 @@ free_data:
     {
         printk(KERN_ERR "%s: Unable to register a cpldmux device. Freeing the platform data\n", __FUNCTION__);
         kfree(cpldmux_platform_data);
+        plat_dev->dev.platform_data = NULL;
     }
 
     /* Put the platform device structure */


### PR DESCRIPTION
If we free this chunk of memory but don't set it to NULL, platform_device_put will try to free it later and panic the kernel.

By setting it to NULL, the other code won't free it.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

If we don't set this field to NULL, platform_dev_put() will free the dangling pointer which has already been free'd. This will result in a kernel panic.

Fixes #23682 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Set the pointer field in the struct to NULL after free'ing it.

#### How to verify it

Run on a system with missing CPLDMUX hardware and observe no kernel panic.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

