### PR TITLE
[202505] Fix subport of Moby backplane ports

### DIFF
--- a/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2/hwsku.json
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2/hwsku.json
@@ -174,61 +174,61 @@
         },
         "Ethernet136": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet140": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet144": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet148": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet152": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet156": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet160": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet164": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet168": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet172": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
@@ -246,61 +246,61 @@
         },
         "Ethernet184": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet188": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet192": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet196": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet200": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet204": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet208": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet212": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet216": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet220": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
@@ -318,61 +318,61 @@
         },
         "Ethernet232": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet236": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet240": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet244": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet248": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet252": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet256": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet260": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet264": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet268": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
@@ -390,61 +390,61 @@
         },
         "Ethernet280": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet284": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet288": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet292": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet296": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet300": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet304": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet308": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet312": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet316": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
@@ -462,61 +462,61 @@
         },
         "Ethernet328": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet332": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet336": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet340": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet344": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet348": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet352": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet356": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet360": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet364": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
@@ -534,61 +534,61 @@
         },
         "Ethernet376": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet380": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet384": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet388": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet392": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet396": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet400": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet404": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet408": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet412": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
@@ -606,61 +606,61 @@
         },
         "Ethernet424": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet428": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet432": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet436": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet440": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet444": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet448": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet452": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet456": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet460": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
@@ -678,61 +678,61 @@
         },
         "Ethernet472": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet476": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet480": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet484": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet488": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet492": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet496": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet500": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet504": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet508": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/hwsku.json
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/hwsku.json
@@ -174,61 +174,61 @@
         },
         "Ethernet136": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet140": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet144": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet148": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet152": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet156": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet160": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet164": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet168": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet172": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
@@ -246,61 +246,61 @@
         },
         "Ethernet184": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet188": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet192": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet196": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet200": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet204": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet208": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet212": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet216": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet220": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
@@ -318,61 +318,61 @@
         },
         "Ethernet232": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet236": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet240": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet244": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet248": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet252": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet256": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet260": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet264": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet268": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
@@ -390,61 +390,61 @@
         },
         "Ethernet280": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet284": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet288": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet292": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet296": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet300": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet304": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet308": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet312": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet316": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
@@ -462,61 +462,61 @@
         },
         "Ethernet328": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet332": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet336": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet340": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet344": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet348": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet352": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet356": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet360": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet364": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
@@ -534,61 +534,61 @@
         },
         "Ethernet376": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet380": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet384": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet388": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet392": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet396": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet400": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet404": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet408": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet412": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
@@ -606,61 +606,61 @@
         },
         "Ethernet424": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet428": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet432": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet436": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet440": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet444": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet448": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet452": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet456": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet460": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
@@ -678,61 +678,61 @@
         },
         "Ethernet472": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "3",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet476": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "4",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet480": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "5",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet484": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "6",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet488": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "7",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet492": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "8",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet496": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "9",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet500": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "10",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet504": {
             "fec": "rs",
-            "subport": "1",
+            "subport": "11",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },
         "Ethernet508": {
             "fec": "rs",
-            "subport": "2",
+            "subport": "12",
             "autoneg": "on",
             "default_brkout_mode": "1x400G"
         },

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -37,7 +37,7 @@ PORT_STR = "Ethernet"
 BRKOUT_MODE = "default_brkout_mode"
 CUR_BRKOUT_MODE = "brkout_mode"
 INTF_KEY = "interfaces"
-OPTIONAL_HWSKU_ATTRIBUTES = ["fec", "autoneg", "role"]
+OPTIONAL_HWSKU_ATTRIBUTES = ["fec", "autoneg", "role", "subport"]
 
 BRKOUT_PATTERN = r'(\d{1,6})x(\d{1,6}G?)(\[(\d{1,6}G?,?)*\])?(\((\d{1,6})\))?'
 BRKOUT_PATTERN_GROUPS = 6

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -375,12 +375,22 @@ class BreakoutCfg(object):
 
                 lanes = self._lanes[lane_id:lane_id + lanes_per_port]
 
+                alias = self._breakout_capabilities[alias_id]
+                # If alias follows new SONiC port naming convention (e.g. et[sX]pY[abcd]),
+                # we can derive subport directly based on the breakout mode. Otherwise,
+                # fallback to the old method.
+                if m := re.match(r"et(s\d+)?p\d+([a-l])?", alias):
+                    breakout = m.groups()[-1]
+                    subport = "0" if not breakout else str(ord(breakout) - ord('a') + 1)
+                else:
+                    subport = "0" if total_num_ports == 1 else str(alias_id + 1)
+
                 ports[interface_name] = {
-                    'alias': self._breakout_capabilities[alias_id],
+                    'alias': alias,
                     'lanes': ','.join(lanes),
                     'speed': str(entry.default_speed),
                     'index': self._indexes[lane_id],
-                    'subport': "0" if total_num_ports == 1 else str(alias_id + 1)
+                    'subport': subport
                 }
 
                 lane_id += lanes_per_port

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
@@ -145,7 +145,7 @@
      "PORT_INVALID_SUBPORT_NUMBER": {
          "desc": "Out of range subport number",
          "eStrKey": "Range",
-         "eStr": "0..8"
+         "eStr": "0..12"
      },
      "PORT_VALID_DOM_POLLING": {
         "desc": "PORT_VALID_DOM_POLLING no failure."

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -655,7 +655,7 @@
                          "alias": "etp1a",
                          "lanes": "60, 61",
                          "speed": 100000,
-                         "subport": 9,
+                         "subport": 13,
                          "mode":"trunk"
                      }
                  ]

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -168,7 +168,7 @@ module sonic-port{
 				leaf subport {
 					description "Logical subport(s) for physical port breakout";
 					type uint8 {
-						range 0..8;
+						range 0..12;
 					}
 				}
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This is a manual cast of changes in https://github.com/sonic-net/sonic-buildimage/pull/23600 to 202505 due to the conficts.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202505

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

