### PR TITLE
Fix missing code signing environment variables

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -728,21 +728,21 @@ if [[ $SECURE_UPGRADE_MODE == 'dev' || $SECURE_UPGRADE_MODE == "prod" ]]; then
             exit 1
         fi
 
-        sudo $sonic_su_prod_signing_tool -a $CONFIGURED_ARCH \
-                                         -r $FILESYSTEM_ROOT \
-                                         -l $LINUX_KERNEL_VERSION \
-                                         -o $OUTPUT_SEC_BOOT_DIR \
-                                         $SECURE_UPGRADE_PROD_TOOL_ARGS
+        sudo -E $sonic_su_prod_signing_tool -a $CONFIGURED_ARCH \
+                                            -r $FILESYSTEM_ROOT \
+                                            -l $LINUX_KERNEL_VERSION \
+                                            -o $OUTPUT_SEC_BOOT_DIR \
+                                            $SECURE_UPGRADE_PROD_TOOL_ARGS
 
         # verifying all EFI files and kernel modules in $OUTPUT_SEC_BOOT_DIR
-        sudo ./scripts/secure_boot_signature_verification.sh -e $OUTPUT_SEC_BOOT_DIR \
-                                                             -c $SECURE_UPGRADE_SIGNING_CERT \
-                                                             -k $FILESYSTEM_ROOT
+        sudo -E ./scripts/secure_boot_signature_verification.sh -e $OUTPUT_SEC_BOOT_DIR \
+                                                                -c $SECURE_UPGRADE_SIGNING_CERT \
+                                                                -k $FILESYSTEM_ROOT
 
         # verifying vmlinuz file.
-        sudo ./scripts/secure_boot_signature_verification.sh -e $FILESYSTEM_ROOT/boot/vmlinuz-${LINUX_KERNEL_VERSION}-${CONFIGURED_ARCH} \
-                                                             -c $SECURE_UPGRADE_SIGNING_CERT \
-                                                             -k $FILESYSTEM_ROOT
+        sudo -E ./scripts/secure_boot_signature_verification.sh -e $FILESYSTEM_ROOT/boot/vmlinuz-${LINUX_KERNEL_VERSION}-${CONFIGURED_ARCH} \
+                                                                -c $SECURE_UPGRADE_SIGNING_CERT \
+                                                                -k $FILESYSTEM_ROOT
     fi
     echo "Secure Boot support build stage: END."
 fi


### PR DESCRIPTION
#### Why I did it

Environmental variables included in the build are currently discarded when invoking signing scripts. This prevents the signing scripts from receiving proper configuration values, tokens, etc.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added the `-E` flag to `sudo` calls to ensure environmental variables are imported into the prod secureboot signing scripts.

#### How to verify it

1. Create a basic prod signing script that outputs the environment (`printenv`). Add logging of the env to [scripts/secure_boot_signature_verification.sh] as well.
2. Perform a "prod" secure boot build of SONiC, and include additional environmental variables with the `SONIC_BUILDER_EXTRA_CMDLINE` build flag. 
3. Confirm the environmental variables are all propagated to the signing script.

```
+ '[' '!' -f /sonic/scripts/signing_secure_boot_prod.sh ']'
+ sudo -E /sonic/scripts/signing_secure_boot_prod.sh -a amd64 -r ./fsroot-cisco-8000 -l 6.1.0-29-2 -o ./fsroot-cisco-8000/boot
+ echo ENV:
ENV:
...
DUMMY_TOKEN=ThisIsASecretToken
--
+ echo '/sonic/scripts/signing_secure_boot_prod.sh signing & verifying EFI files and Kernel Modules DONE'
/sonic/scripts/signing_secure_boot_prod.sh signing & verifying EFI files and Kernel Modules DONE
+ sudo -E ./scripts/secure_boot_signature_verification.sh -e ./fsroot-cisco-8000/boot -c /nobackup/jusherma/azure-sudo-e-fix/sonic-signing/certs/Cisco_Generic_Software_Identity_DEV.pem -k ./fsroot-cisco-8000
ENV:
...
DUMMY_TOKEN=ThisIsASecretToken
--
+ sudo -E ./scripts/secure_boot_signature_verification.sh -e ./fsroot-cisco-8000/boot/vmlinuz-6.1.0-29-2-amd64 -c /nobackup/jusherma/azure-sudo-e-fix/sonic-signing/certs/Cisco_Generic_Software_Identity_DEV.pem -k ./fsroot-cisco-8000
ENV:
...
DUMMY_TOKEN=ThisIsASecretToken
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 202405
- [x] 202411
- [x] 202505

Issues exists in the above branches too

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [00eafe100821f0d80bc506c693e887d702ed6a30]

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix missing environment variables in prod secureboot scripts