### PR TITLE
[dhcp_server] Fix dhcp_server show info issue

### DIFF
--- a/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli-plugin-tests/test_show_dhcp_server.py
@@ -221,6 +221,17 @@ class TestShowDHCPServer(object):
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
         assert result.stdout == expected_stdout
 
+        expected_stdout = """\
++-------------+--------+-----------+---------------+-----------------+----------+----------------------+
+| Interface   | Mode   | Gateway   | Netmask       |   Lease Time(s) | State    | Customized Options   |
++=============+========+===========+===============+=================+==========+======================+
+| Vlan300     | PORT   | 100.1.1.1 | 255.255.255.0 |            3600 | disabled |                      |
++-------------+--------+-----------+---------------+-----------------+----------+----------------------+
+"""
+        result = runner.invoke(show_dhcp_server.dhcp_server.commands["ipv4"].commands["info"], ["Vlan300", "--with_customized_options"], obj=db)
+        assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+        assert result.stdout == expected_stdout
+
     def test_show_dhcp_server_ipv4_option_without_name(self, mock_db):
         expected_stdout = """\
 +---------------+-------------+-------------+--------+

--- a/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
+++ b/dockers/docker-dhcp-server/cli/show/plugins/show_dhcp_server.py
@@ -112,7 +112,7 @@ def info(db, dhcp_interface, with_customized_options):
         interface = key.split("|")[1]
         table.append([interface, entry["mode"], entry["gateway"], entry["netmask"], entry["lease_time"], entry["state"]])
         if with_customized_options:
-            table[-1].append(entry["customized_options@"])
+            table[-1].append(entry["customized_options@"] if "customized_options@" in entry else "")
     click.echo(tabulate(table, headers=headers, tablefmt="grid"))
 
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
If there are not customized options bound to Vlan, show info with customized options would raise exception
```
admin@sonic:~$ show dhcp_server ipv4 info --with_customized_options Vlan1000
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/show/plugins/dhcp-server.py", line 115, in info
    table[-1].append(entry["customized_options@"])
                     ~~~~~^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'customized_options@'
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add empty if there is not customized option bound to vlan and update UT

#### How to verify it
1. UT passed
2. Manually test
```
admin@sonic:~$ show dhcp_server ipv4 info --with_customized_options Vlan1000
+-------------+--------+-------------+---------------+-----------------+----------+----------------------+
| Interface   | Mode   | Gateway     | Netmask       |   Lease Time(s) | State    | Customized Options   |
+=============+========+=============+===============+=================+==========+======================+
| Vlan1000    | PORT   | 192.168.0.1 | 255.255.255.0 |             900 | disabled |                      |
+-------------+--------+-------------+---------------+-----------------+----------+----------------------+
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

