### PR TITLE
Update telemetry docker entry flow to detect FEATURE table

### DIFF
--- a/dockers/docker-sonic-telemetry/Dockerfile.j2
+++ b/dockers/docker-sonic-telemetry/Dockerfile.j2
@@ -26,6 +26,7 @@ COPY ["start.sh", "telemetry.sh", "dialout.sh", "/usr/bin/"]
 COPY ["telemetry_vars.j2", "/usr/share/sonic/templates/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["critical_processes", "/etc/supervisor"]
+COPY ["docker-telemetry-entry.sh", "/usr/local/bin/"]
 
 FROM $BASE
 
@@ -37,4 +38,5 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Pass the image_version to container
 ENV IMAGE_VERSION=$image_version
 
-ENTRYPOINT ["/usr/local/bin/supervisord"]
+RUN chmod +x /usr/local/bin/docker-telemetry-entry.sh
+ENTRYPOINT ["/usr/local/bin/docker-telemetry-entry.sh"]

--- a/dockers/docker-sonic-telemetry/docker-telemetry-entry.sh
+++ b/dockers/docker-sonic-telemetry/docker-telemetry-entry.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+while true; do
+  STATE=$(redis-cli -n 4 HGET "FEATURE|telemetry" state)
+  if [ "$STATE" == "enabled" ]; then
+    echo "Telemetry is enabled. Starting service..."
+    break
+  else
+    echo "Telemetry is disabled. Entering idle..."
+    sleep 10
+  fi
+done
+
+exec /usr/local/bin/supervisord


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:34506301

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

