### PR TITLE
[docker-orchagent]: Increase ndppd route-ttl option in ndppd.conf.j2 unconditionally 

### DIFF
--- a/dockers/docker-orchagent/ndppd.conf.j2
+++ b/dockers/docker-orchagent/ndppd.conf.j2
@@ -6,6 +6,7 @@
 {% endblock banner %}
 # Config file for ndppd, the NDP Proxy Daemon
 # See man page for ndppd.conf.5 for descriptions of all available options
+route-ttl 2147483647
 {%  if VLAN_INTERFACE and VLAN_INTERFACE|pfx_filter|length > 0%}
 {#      Get all VLAN interfaces that have proxy_arp enabled #}
 {%      set proxy_interfaces = {} %}
@@ -21,7 +22,6 @@
 {%              set _x = proxy_interfaces[intf].append(prefix) %}
 {%          endif %}
 {%      endfor -%}
-route-ttl 2147483647
 {%      for intf, prefix_list in proxy_interfaces.items() %}
 {%          if prefix_list %}
 

--- a/src/sonic-config-engine/tests/data/ndppd/empty_vlan_interfaces.json
+++ b/src/sonic-config-engine/tests/data/ndppd/empty_vlan_interfaces.json
@@ -1,0 +1,3 @@
+{
+    "VLAN_INTERFACE": {}
+}

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -806,6 +806,19 @@ class TestJ2Files(TestCase):
         self.run_script(argument, output_file=self.output_file)
         assert utils.cmp(expected, self.output_file), self.run_diff(expected, self.output_file)
 
+    def test_ndppd_conf_no_vlan_interfaces(self):
+        """Test ndppd.conf generation when no VLAN interfaces exist"""
+        conf_template = os.path.join(self.test_dir, "ndppd.conf.j2")
+        empty_json = os.path.join(self.test_dir, "data", "ndppd", "empty_vlan_interfaces.json")
+        
+        argument = ['-j', empty_json, '-t', conf_template]
+        self.run_script(argument, output_file=self.output_file)
+        
+        # Verify route-ttl is still generated even without VLAN interfaces
+        with open(self.output_file, 'r') as f:
+            content = f.read()
+            assert 'route-ttl 2147483647' in content
+
     def test_ntp_conf(self):
         conf_template = os.path.join(self.test_dir, "chrony.conf.j2")
         config_db_ntp_json = os.path.join(self.test_dir, "data", "ntp", "ntp_interfaces.json")


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

`route-ttl` option in `ndppd` is a global option, but the `ndppd.conf.j2` template adds it conditional on vlan interfaces with prefix length > 0 being present. This causes `route-ttl` to not get set on POC setups without VLAN interfaces, causing ndppd to keep spinning reading route table in case of route scale. Keeping this option out of the `if VLAN_INTERFACE` block in jinja template.

fixes #23765

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

take `route-ttl` knob out of the `if VLAN_INTERFACE` block to set it unconditionally.

#### How to verify it

Have a very large number of routes (~500k used in our testing) with no VLAN_INTERFACE in config_db. ndppd does not show up spinning at 100% anymore.

Before:

```
admin@sonic:~$ sonic-db-cli ASIC_DB keys "*ROUTE_ENTRY*" | wc -l
506841

top inside swss container:

top - 01:15:01 up  3:05,  4 users,  load average: 1.46, 1.37, 1.50
Tasks: 439 total,   2 running, 424 sleeping,   0 stopped,  13 zombie
%Cpu(s):  1.1 us,  7.0 sy,  0.0 ni, 91.9 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
MiB Mem :  31905.2 total,  18852.7 free,   7100.6 used,   6758.9 buff/cache
MiB Swap:      0.0 total,      0.0 free,      0.0 used.  24804.6 avail Mem

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
  12865 root      20   0   49744  47412   3280 R 100.0   0.1 118:54.07 ndppd
  10372 root      20   0 4416380   1.5g 530956 S  10.0   4.8  54:07.61 syncd
   7566 tss       20   0  706904 329344   9092 S   7.0   1.0  34:45.71 redis-server
```

After:

```
admin@sonic:~$ sonic-db-cli ASIC_DB keys "*ROUTE_ENTRY*" | wc -l
500012

admin@gold157:~$ sonic-db-cli APPL_DB keys "*ROUTE_TABLE*" | wc -l
500004
admin@gold157:~$

top inside swss container:

Tasks:  23 total,   1 running,  22 sleeping,   0 stopped,   0 zombie
%Cpu(s): 19.9 us,  2.9 sy,  0.0 ni, 77.1 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
MiB Mem :  31905.2 total,  15919.4 free,   9908.2 used,   6887.4 buff/cache
MiB Swap:      0.0 total,      0.0 free,      0.0 used.  21997.0 avail Mem

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
      1 root      20   0   42008  36684  10440 S   0.0   0.1   0:27.13 supervisord
     42 root      20   0  130984  32620  17140 S   0.0   0.1   0:03.65 python3
     45 root      20   0  221836   6912   3444 S   0.0   0.0   3:21.87 rsyslogd
     50 root      20   0   88208   6260   5640 S   0.0   0.0   0:02.87 portsyncd
     55 root      20   0  865364 627232  21600 S   0.0   1.9  24:39.90 orchagent
     88 root      20   0   88500   7760   6976 S   0.0   0.0   0:02.83 coppmgrd                                                                                                                                                                                                     115 root      20   0    4436   3280   2904 S   0.0   0.0   0:03.49 arp_update
    116 root      20   0   88360   7664   6796 S   0.0   0.0   0:01.42 neighsyncd                                                                                                                                                                                                   120 root      20   0   88508   7992   7204 S   0.0   0.0   0:02.86 vlanmgrd
    122 root      20   0   88652   7988   7128 S   0.0   0.0   0:03.03 intfmgrd
    123 root      20   0   88344   6516   5888 S   0.0   0.0   0:02.69 fabricmgrd
    125 root      20   0   88584   7992   7156 S   0.0   0.0   0:02.93 portmgrd
    129 root      20   0   88708   7828   6992 S   0.0   0.0   0:15.42 buffermgrd
    140 root      20   0   88476   7864   7056 S   0.0   0.0   0:02.79 vrfmgrd
    150 root      20   0   88384   6372   5744 S   0.0   0.0   0:02.76 nbrmgrd
    156 root      20   0   88516   7880   7120 S   0.0   0.0   0:02.82 vxlanmgrd
    167 root      20   0   88240   6368   5744 S   0.0   0.0   0:01.39 fdbsyncd
    171 root      20   0   88468   7660   6920 S   0.0   0.0   0:02.84 tunnelmgrd
   1972 root      20   0    5788   1968   1796 S   0.0   0.0   0:01.12 ndppd
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

