### PR TITLE
Fix PSU led controllable status for Arista-7060X6-64PE-B

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/platform.json
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/platform.json
@@ -60,9 +60,15 @@
                         "name": "psu1/1",
                         "speed": {
                             "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
                         }
                     }
-                ]
+                ],
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
                 "name": "psu2",
@@ -73,9 +79,15 @@
                         "name": "psu2/1",
                         "speed": {
                             "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
                         }
                     }
-                ]
+                ],
+                "status_led": {
+                    "controllable": false
+                }
             }
         ],
         "thermals": [


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In the case of Arista-7060X6-64PE-B there is a single aggregate PSU status LED whereas test cases expect individually controllable LEDs. Marking these LEDs as not controllable pending further discussion around driver enhancements.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

