### PR TITLE
[Arista-7060X6-64PE-B, Arista-7060X6-16PE-384C-B]: Scale Up NHG on 202505

### DIFF
--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-FANOUT/sai.profile
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-FANOUT/sai.profile
@@ -1,2 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-16pe-384c.config.bcm
 SAI_NUM_ECMP_MEMBERS=128
+SAI_NHG_HIERARCHICAL_NEXTHOP=false

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-FANOUT/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-FANOUT/th5-a7060x6-16pe-384c.config.bcm
@@ -39,9 +39,9 @@ bcm_device:
             pfc_deadlock_seq_control : 1
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
-            l3_ecmp_member_first_lkup_mem_size: 12288
+            l3_ecmp_member_first_lkup_mem_size: 0
             l3_alpm_large_vrf_mode: 1
-            l3_ecmp_member_secondary_mem_size: 4096
+            l3_ecmp_member_secondary_mem_size: 0
             sai_mmu_custom_config: 1
             stat_custom_receive0_management_mode: 1
 ---

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-LAB/sai.profile
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-LAB/sai.profile
@@ -1,2 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-16pe-384c.config.bcm
 SAI_NUM_ECMP_MEMBERS=128
+SAI_NHG_HIERARCHICAL_NEXTHOP=false

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-LAB/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-LAB/th5-a7060x6-16pe-384c.config.bcm
@@ -39,9 +39,9 @@ bcm_device:
             pfc_deadlock_seq_control : 1
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
-            l3_ecmp_member_first_lkup_mem_size: 12288
+            l3_ecmp_member_first_lkup_mem_size: 0
             l3_alpm_large_vrf_mode: 1
-            l3_ecmp_member_secondary_mem_size: 4096
+            l3_ecmp_member_secondary_mem_size: 0
             sai_mmu_custom_config: 1
             stat_custom_receive0_management_mode: 1
 ---

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/sai.profile
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/sai.profile
@@ -1,2 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-16pe-384c.config.bcm
 SAI_NUM_ECMP_MEMBERS=128
+SAI_NHG_HIERARCHICAL_NEXTHOP=false

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/th5-a7060x6-16pe-384c.config.bcm
@@ -39,9 +39,9 @@ bcm_device:
             pfc_deadlock_seq_control : 1
             sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
-            l3_ecmp_member_first_lkup_mem_size: 12288
+            l3_ecmp_member_first_lkup_mem_size: 0
             l3_alpm_large_vrf_mode: 1
-            l3_ecmp_member_secondary_mem_size: 4096
+            l3_ecmp_member_secondary_mem_size: 0
             sai_mmu_custom_config: 1
             stat_custom_receive0_management_mode: 1
 ---

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/sai.profile
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/sai.profile
@@ -1,2 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-64pe.config.bcm
 SAI_NUM_ECMP_MEMBERS=512
+SAI_NHG_HIERARCHICAL_NEXTHOP=false

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/th5-a7060x6-64pe.config.bcm
@@ -41,7 +41,8 @@ bcm_device:
             pfc_deadlock_seq_control : 1
             sai_tunnel_support: 0x12
             bcm_tunnel_term_compatible_mode: 1
-            l3_ecmp_member_first_lkup_mem_size: 12288
+            l3_ecmp_member_first_lkup_mem_size: 0
+            l3_ecmp_member_secondary_mem_size: 0
             stat_custom_receive0_management_mode: 1
 ---
 device:

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/sai.profile
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/sai.profile
@@ -1,2 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-64pe.config.bcm
 SAI_NUM_ECMP_MEMBERS=512
+SAI_NHG_HIERARCHICAL_NEXTHOP=false

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
@@ -41,7 +41,8 @@ bcm_device:
             pfc_deadlock_seq_control : 1
             sai_tunnel_support: 0x12
             bcm_tunnel_term_compatible_mode: 1
-            l3_ecmp_member_first_lkup_mem_size: 12288
+            l3_ecmp_member_first_lkup_mem_size: 0
+            l3_ecmp_member_secondary_mem_size: 0
             stat_custom_receive0_management_mode: 1
 ---
 device:

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/sai.profile
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/sai.profile
@@ -1,2 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-64pe.config.bcm
 SAI_NUM_ECMP_MEMBERS=128
+SAI_NHG_HIERARCHICAL_NEXTHOP=false

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
@@ -38,9 +38,9 @@ bcm_device:
             pfc_deadlock_seq_control : 1
             sai_tunnel_support: 0x12
             bcm_tunnel_term_compatible_mode: 1
-            l3_ecmp_member_first_lkup_mem_size: 12288
+            l3_ecmp_member_first_lkup_mem_size: 0
             l3_alpm_large_vrf_mode: 1
-            l3_ecmp_member_secondary_mem_size: 4096
+            l3_ecmp_member_secondary_mem_size: 0
             sai_mmu_custom_config: 1
             stat_custom_receive0_management_mode: 1
 ---

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128S2/sai.profile
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128S2/sai.profile
@@ -1,2 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-64pe.config.bcm
 SAI_NUM_ECMP_MEMBERS=128
+SAI_NHG_HIERARCHICAL_NEXTHOP=false

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128S2/th5-a7060x6-64pe.config.bcm
@@ -41,7 +41,8 @@ bcm_device:
             pfc_deadlock_seq_control : 1
             sai_tunnel_support: 0x12
             bcm_tunnel_term_compatible_mode: 1
-            l3_ecmp_member_first_lkup_mem_size: 12288
+            l3_ecmp_member_first_lkup_mem_size: 0
+            l3_ecmp_member_secondary_mem_size: 0
             stat_custom_receive0_management_mode: 1
 ---
 device:

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/sai.profile
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/sai.profile
@@ -1,2 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-64pe.config.bcm
 SAI_NUM_ECMP_MEMBERS=96
+SAI_NHG_HIERARCHICAL_NEXTHOP=false

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/th5-a7060x6-64pe.config.bcm
@@ -41,10 +41,10 @@ bcm_device:
             pfc_deadlock_seq_control : 1
             sai_tunnel_support: 0x12
             bcm_tunnel_term_compatible_mode: 1
-            l3_ecmp_member_first_lkup_mem_size: 12288
+            l3_ecmp_member_first_lkup_mem_size: 0
             stat_custom_receive0_management_mode: 1
             l3_alpm_large_vrf_mode: 1
-            l3_ecmp_member_secondary_mem_size: 4096
+            l3_ecmp_member_secondary_mem_size: 0
             sai_mmu_custom_config: 1
 ---
 device:

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P64/sai.profile
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P64/sai.profile
@@ -1,2 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-64pe.config.bcm
 SAI_NUM_ECMP_MEMBERS=64
+SAI_NHG_HIERARCHICAL_NEXTHOP=false

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P64/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P64/th5-a7060x6-64pe.config.bcm
@@ -41,10 +41,10 @@ bcm_device:
             pfc_deadlock_seq_control : 1
             sai_tunnel_support: 0x12
             bcm_tunnel_term_compatible_mode: 1
-            l3_ecmp_member_first_lkup_mem_size: 12288
+            l3_ecmp_member_first_lkup_mem_size: 0
             stat_custom_receive0_management_mode: 1
             l3_alpm_large_vrf_mode: 1
-            l3_ecmp_member_secondary_mem_size: 4096
+            l3_ecmp_member_secondary_mem_size: 0
             sai_mmu_custom_config: 1
 ---
 device:


### PR DESCRIPTION
#### Why I did it
Fix failure to create NHG on TH5 with 512 BGP sessions.

This is a manual cherry-pick to 202505 for original PR: https://github.com/sonic-net/sonic-buildimage/pull/23722

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Set the following fields in the Broadcom configure for the ___ HWSKUs:
`l3_ecmp_member_first_lkup_mem_size: 0`
`l3_ecmp_member_secondary_mem_size: 0`

Also, disable hierarchical nexthop group via sai.profile:
`SAI_NHG_HIERARCHICAL_NEXTHOP=false`

#### How to verify it
Run pre-test checks and confirm they pass.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)
202412

#### Description for the changelog
Scale up NHG, Disable Hierarchical Nexthop