### PR TITLE
[Mellanox] Thermal algorithm module enhancement

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -862,9 +862,6 @@ class SFP(NvidiaSFPCommon):
         """
         try:
             sw_control = self.is_sw_control()
-            if not sw_control:
-                return sw_control, None, None, None
-
             sn_changed = self.reinit_if_sn_changed()
             # software control, read from EEPROM
             temperature = super().get_temperature()

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
@@ -123,8 +123,6 @@ class ThermalUpdater:
             pre_presence = self._sfp_status.get(sfp.sdk_index)
             if presence:
                 sw_control, temperature, warning_thresh, critical_thresh = sfp.get_temperature_info()
-                if not sw_control:
-                    return
                 fault = ERROR_READ_THERMAL_DATA if (temperature is None or warning_thresh is None or critical_thresh is None) else 0
                 temperature = 0 if temperature is None else temperature * SFP_TEMPERATURE_SCALE
                 warning_thresh = 0 if warning_thresh is None else warning_thresh * SFP_TEMPERATURE_SCALE


### PR DESCRIPTION
Enhance smart switch thermal updater for FW mode

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- Avoid multiple entities reading module temperature over I2C.
- Reduce CPU utilization by eliminating redundant sensor reads.
- Centralize thermal data collection in FW mode through Sonic.

#### How I did it
1. Modified SmartswitchThermalUpdater.start() to check DPU presence and mode:
   - If no DPU present: Run thermal updater regardless of mode
   - If DPU present in FW mode: Start thermal updater for SDK data collection
   - If DPU present in SW mode: Use original timer-based logic

2. Updated SmartswitchThermalUpdater.stop() with similar logic for proper cleanup

3. Enhanced SmartswitchThermalUpdater.update_dpu() to handle different modes:
   - FW mode: Call super().update_thermal() to read SDK and update hw-management/thermal
   - SW mode: Update DPU thermal data using original logic

#### How to verify it
1. Test SW mode (SAI_INDEPENDENT_MODULE_MODE != 1):
   - Verify DPU thermal data is updated via original logic

2. Test FW mode (SAI_INDEPENDENT_MODULE_MODE = 1):
   - Verify thermal updater runs and reads SDK data
   - Check hw-management/thermal files are updated

3. Test no DPU scenario:
   - Verify thermal updater runs for smart switch

4. Verify no regression in existing functionality

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 202505

#### Tested branch (Please provide the tested image version)
TBD, test in ENV and UT
