### PR TITLE
add device type for OpticalCrossConnect (OCS) in yang metadata

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -100,7 +100,7 @@ module sonic-device_metadata {
                 leaf type {
                     type string {
                         length 1..255;
-                        pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC|MgmtToRRouter|MgmtLeafRouter|MgmtSpineRouter|MgmtAccessRouter|SpineRouter|UpperSpineRouter|FabricSpineRouter|LowerSpineRouter|BackEndToRRouter|BackEndLeafRouter|EPMS|MgmtTsToR|BmcMgmtToRRouter|SonicHost|SmartSwitchDPU|not-provisioned";
+                        pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC|MgmtToRRouter|MgmtLeafRouter|MgmtSpineRouter|MgmtAccessRouter|SpineRouter|UpperSpineRouter|FabricSpineRouter|LowerSpineRouter|BackEndToRRouter|BackEndLeafRouter|EPMS|MgmtTsToR|BmcMgmtToRRouter|OpticalCrossConnect|SonicHost|SmartSwitchDPU|not-provisioned";
                     }
                 }
 


### PR DESCRIPTION
Why I did it

NDM/validators reject configs that set DEVICE_METADATA/localhost/type to OpticalCrossConnect because the YANG pattern only allows a fixed set of role strings. This PR expands the allowed roles to include OpticalCrossConnect so SONiC images and off-box config generators can validate and load configs for OCS nodes without errors. See the YANG location and ConfigDB schema docs for context (device metadata table, role/type field). 

https://github.com/sonic-net/sonic-buildimage/issues/9915?

Work item tracking

Microsoft ADO (number only): 

How I did it

Edited: src/sonic-yang-models/yang-models/sonic-device_metadata.yang

In leaf type, appended |OpticalCrossConnect to the existing regex pattern of allowed roles.

No behavior change—this is a schema validation expansion only. (If your deployment also uses neighbor metadata type, a follow-up will mirror the value there.)

Minimal diff (illustrative):

- pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC|MgmtToRRouter|MgmtLeafRouter|MgmtSpineRouter|MgmtAccessRouter|SpineRouter|UpperSpineRouter|FabricSpineRouter|BackEndToRRouter|BackEndLeafRouter|EPMS|MgmtTsToR|BmcMgmtToRRouter|SonicHost|SmartSwitchDPU|not-provisioned";
+ pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC|MgmtToRRouter|MgmtLeafRouter|MgmtSpineRouter|MgmtAccessRouter|SpineRouter|UpperSpineRouter|FabricSpineRouter|BackEndToRRouter|BackEndLeafRouter|EPMS|MgmtTsToR|BmcMgmtToRRouter|SonicHost|SmartSwitchDPU|OpticalCrossConnect|not-provisioned";

How to verify it

Schema parse
Build sonic-yang-models (or run your local YANG validation) and confirm the module compiles with no errors. Guidance + file path for SONiC’s native YANG set: src/sonic-yang-models/yang-models. 
[GitHub](https://github.com/sonic-net/sonic-buildimage?utm_source=chatgpt.com)
[Cisco Live](https://www.ciscolive.com/c/dam/r/ciscolive/global-event/docs/2025/pdf/DEVNET-2990.pdf?utm_source=chatgpt.com)

Config validation (device or container)

Run HwproxyCommand runner for a full config


NDM/config-gen
Run your NDM path that previously failed; expect the YANG rejection of type to disappear (original failure pattern discussed in prior issues around DEVICE_METADATA.type). 
[GitHub](https://github.com/Azure/sonic-buildimage/issues/9915?utm_source=chatgpt.com)

Note: This PR only expands the allowed string; it does not change runtime behavior. Any role-specific logic remains in your templates/automation.

Which release branch to backport (provide reason below if selected)

 202505

Reason: Validation currently blocks OCS deployments on 202505 images/config-gen. This is a minimal schema fix with no functional risk.

Tested branch (Please provide the tested image version)

 <!-- 20250511.14 -->


Description for the changelog

yang: allow OpticalCrossConnect in DEVICE_METADATA.type (schema validation expansion only)

SONiC Configuration / Device Metadata (schema reference):
src/sonic-yang-models/doc/Configuration.md → Device Metadata section.

<img width="309" height="163" alt="image" src="https://github.com/user-attachments/assets/58b7b618-9cc9-4317-aca8-e9e8a159af27" />
