### PR TITLE
[ci] Update repd build upgrade version pipeline.

### DIFF
--- a/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
+++ b/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
@@ -71,7 +71,7 @@ stages:
   - template: azure-pipelines-build.yml
     parameters:
       jobFilters: ${{ parameters.jobFilters }}
-      buildOptions: '${{ variables.VERSION_CONTROL_OPTIONS }} ENABLE_DOCKER_BASE_PULL=n SONIC_BUILD_JOBS=$(nproc) ENABLE_IMAGE_SIGNATURE=y'
+      buildOptions: '${{ variables.VERSION_CONTROL_OPTIONS }} ENABLE_DOCKER_BASE_PULL=n SONIC_BUILD_JOBS=$(nproc) ENABLE_IMAGE_SIGNATURE=y NOBUSTER=1 NOBULLSEYE=1'
       preSteps:
       - template: .azure-pipelines/template-clean-sonic-slave.yml@buildimage
       - checkout: self

--- a/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
+++ b/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
@@ -34,9 +34,6 @@ parameters:
   default:
   - vs
   - broadcom
-  - centec
-  - centec-arm64
-  - generic
   - marvell-prestera-armhf
   - marvell-prestera-arm64
   - mellanox

--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -73,23 +73,6 @@ jobs:
             docker_syncd_rpc_image: yes
             platform_rpc: brcm
 
-        - name: centec
-          variables:
-            dbg_image: yes
-            docker_syncd_rpc_image: yes
-            platform_rpc: centec
-
-        - name: centec-arm64
-          ${{ if not(parameters.qemuOrCrossBuild) }}:
-            pool: sonicbld-arm64
-          timeoutInMinutes: 2880
-          variables:
-            PLATFORM_ARCH: arm64
-
-        - name: generic
-          variables:
-            dbg_image: yes
-
         - name: marvell-teralynx
           variables:
             dbg_image: yes
@@ -97,7 +80,6 @@ jobs:
         - name: marvell-prestera-armhf
           ${{ if not(parameters.qemuOrCrossBuild) }}:
             pool: sonicbld-armhf
-          timeoutInMinutes: 2880
           variables:
             PLATFORM_NAME: marvell-prestera
             PLATFORM_ARCH: armhf
@@ -105,7 +87,6 @@ jobs:
         - name: marvell-prestera-arm64
           ${{ if not(parameters.qemuOrCrossBuild) }}:
             pool: sonicbld-arm64
-          timeoutInMinutes: 2880
           variables:
             PLATFORM_NAME: marvell-prestera
             PLATFORM_ARCH: arm64


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. centec is still using debian:bullseye as base image. debian bullseye-backports is deprecated on Jun 21.
It blocks docker-base-bullseye build. Stop supporting centec reproducible build.
2. Generic build is not neccessary. Remove it.
3. armhf/arm64 build don't run on amd64 host. Remove special timeout config.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

