### PR TITLE
Add Aggregate VOQ counters support for single ASIC linecards

### DIFF
--- a/dockers/docker-database/supervisord.conf.j2
+++ b/dockers/docker-database/supervisord.conf.j2
@@ -35,12 +35,15 @@ dependent_startup=true
 {%- if redis_inst != 'remote_redis' %}
 [program:{{ redis_inst }}]
 {% if redis_items['hostname'] != '127.0.0.1' %}
-{%- set ADDITIONAL_OPTS = '--protected-mode no' %}
 {%- if redis_inst != 'redis_chassis' %}
 {%- set LOOPBACK_IP = '127.0.0.1' -%}
 {%- endif -%}
 {%- else -%}
 {%- set LOOPBACK_IP = '' -%}
+{%- endif -%}
+{%- if not redis_items['is_protected_mode'] %}
+{%- set ADDITIONAL_OPTS = '--protected-mode no' %}
+{%- else %}
 {%- set ADDITIONAL_OPTS = '' %}
 {%- endif -%}
 command=/bin/bash -c "{ [[ -s /var/lib/{{ redis_inst }}/dump.rdb ]] || rm -f /var/lib/{{ redis_inst }}/dump.rdb; } && mkdir -p /var/lib/{{ redis_inst }} && exec /usr/bin/redis-server /etc/redis/redis.conf --bind {{ LOOPBACK_IP }} {{ redis_items['hostname'] }} --port {{ redis_items['port'] }} --unixsocket {{ redis_items['unix_socket_path'] }} --pidfile /var/run/redis/{{ redis_inst }}.pid --dir /var/lib/{{ redis_inst }} {{ ADDITIONAL_OPTS }}"

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -173,6 +173,10 @@ function postStartAction()
 {%- if docker_container_name == "database" %}
     midplane_ip=""
     CHASSISDB_CONF="/usr/share/sonic/device/$PLATFORM/chassisdb.conf"
+    if [[ -f $CHASSISDB_CONF ]]; then
+        slot_id=$(python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); print(platform_chassis.get_my_slot())' 2>/dev/null)
+        supervisor_slot_id=$(python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); print(platform_chassis.get_supervisor_slot())' 2>/dev/null)
+    fi
     [ -f $CHASSISDB_CONF ] && source $CHASSISDB_CONF
     if [[ "$DEV" && $DATABASE_TYPE != "dpudb" ]]; then
         # Enable the forwarding on eth0 interface in namespace.
@@ -187,9 +191,6 @@ function postStartAction()
            # Use /16 for loopback interface
            ip netns exec "$NET_NS" ip addr add 127.0.0.1/16 dev lo
            ip netns exec "$NET_NS" ip addr del 127.0.0.1/8 dev lo
-
-           slot_id=$(python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); print(platform_chassis.get_my_slot())' 2>/dev/null)
-           supervisor_slot_id=$(python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); print(platform_chassis.get_supervisor_slot())' 2>/dev/null)
 
            # Create eth1 in database instance
            if [[ "${slot_id}" == "${supervisor_slot_id}" ]]; then
@@ -235,6 +236,12 @@ function postStartAction()
            fi
        fi
     fi
+
+    # midplane ip for the Linecard database container
+    if [[ -z "$DEV" && "$DATABASE_TYPE" != "dpudb"  && -f $CHASSISDB_CONF && "${slot_id}" != "${supervisor_slot_id}" ]]; then
+        midplane_ip=$(docker exec -i ${DOCKERNAME} ip addr show eth1-midplane | grep 'inet ' | awk '{print $2}' | cut -d'/' -f1)
+    fi
+
     # Setup ebtables configuration
 {%- if sonic_asic_platform != "vs" %}
     ebtables_config
@@ -330,8 +337,8 @@ function postStartAction()
         REDIS_SOCK="/var/run/redis-chassis/redis_chassis.sock"
     fi
     chgrp -f redis $REDIS_SOCK && chmod -f 0760 $REDIS_SOCK
-
-    if [[ $DEV && $midplane_ip ]]; then
+    # Binding the midplane ip to the redisdb
+    if [[ -n "$midplane_ip" ]]; then
         IFS=_ read ip port < <(jq -r '.INSTANCES | [.redis.hostname, .redis.port] | join("_")' /var/run/redis$DEV/sonic-db/database_config.json)
         bound_ips=$(redis-cli --raw -h $ip -p $port config get bind | sed -n '2,2 p')
         redis-cli -h $ip -p $port config set bind "$bound_ips $midplane_ip"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

This feature has been tracked at: https://github.com/sonic-net/SONiC/issues/2020

#### Why I did it
On a linecard, the default namespace database container is only bound to localhost (127.0.0.1).
This prevents other components in the chassis, such as the supervisor card,
from accessing the linecard's default namespace database over the midplane network to aggregate the VOQ counters for Single ASIC Linecards.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Set the protected-mode no and bind the linecard's eth1-midplane IP address to the default namespace  database container, allowing for remote access from the supervisor to collect the VOQ counters.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)
Master
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

