### PR TITLE
 [DPU] Update BFSoC to 4.12.0, SDK to 25.7-RC10

### DIFF
--- a/platform/nvidia-bluefield/recipes/bluefield-soc.mk
+++ b/platform/nvidia-bluefield/recipes/bluefield-soc.mk
@@ -16,8 +16,8 @@
 #
 
 # Bluefied Software Distribution Version
-BFSOC_VERSION = 4.11.0
-BFSOC_REVISION = 13611
+BFSOC_VERSION = 4.12.0
+BFSOC_REVISION = 13720
 BFB_IMG_TYPE = prod
 BFSOC_BUILD_DATE =
 

--- a/platform/nvidia-bluefield/recipes/sdk.mk
+++ b/platform/nvidia-bluefield/recipes/sdk.mk
@@ -19,7 +19,7 @@ SDK_BASE_PATH = $(PLATFORM_PATH)/sdk-src/sonic-bluefield-packages/bin
 
 # Place here URL where SDK sources exist
 SDK_SOURCE_BASE_URL =
-SDK_VERSION = 25.7-RC7
+SDK_VERSION = 25.7-RC10
 
 SDK_COLLECTX_URL = https://linux.mellanox.com/public/repo/doca/1.5.2/debian12/aarch64/
 

--- a/platform/nvidia-bluefield/recipes/sdk.mk
+++ b/platform/nvidia-bluefield/recipes/sdk.mk
@@ -19,7 +19,7 @@ SDK_BASE_PATH = $(PLATFORM_PATH)/sdk-src/sonic-bluefield-packages/bin
 
 # Place here URL where SDK sources exist
 SDK_SOURCE_BASE_URL =
-SDK_VERSION = 25.7-RC6
+SDK_VERSION = 25.7-RC7
 
 SDK_COLLECTX_URL = https://linux.mellanox.com/public/repo/doca/1.5.2/debian12/aarch64/
 


### PR DESCRIPTION
#### Why I did it

To include latest fixes and new functionality

#### How I did it

* SDK_VERSION_DPU 25.7-RC6 -> 25.7-RC10
* BFSOC_VERSION 4.11.0 -> 4.12.0


#### How to verify it
Build an image and run tests from "sonic-mgmt".

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog

#### A picture of a cute animal (not mandatory but encouraged)