### PR TITLE
[Fix]: Allow empty object lists in high-frequency-telemetry YANG model

### DIFF
--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -62,6 +62,7 @@ yang_files = [
     'sonic-feature.yang',
     'sonic-fips.yang',
     'sonic-hash.yang',
+    'sonic-high-frequency-telemetry.yang',
     'sonic-trimming.yang',
     'sonic-system-defaults.yang',
     'sonic-interface.yang',
@@ -146,7 +147,6 @@ yang_files = [
     'sonic-smart-switch.yang',
     'sonic-spanning-tree.yang',
     'sonic-srv6.yang',
-    'sonic-high-frequency-telemetry.yang',
 ]
 
 class my_build_py(build_py):

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -146,6 +146,7 @@ yang_files = [
     'sonic-smart-switch.yang',
     'sonic-spanning-tree.yang',
     'sonic-srv6.yang',
+    'sonic-high-frequency-telemetry.yang',
 ]
 
 class my_build_py(build_py):

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -3110,6 +3110,29 @@
         "DEBUG_COUNTER_DROP_REASON": {
             "DEBUG_4|DIP_LINK_LOCAL": {},
             "DEBUG_4|SIP_LINK_LOCAL": {}
+        },
+        "HIGH_FREQUENCY_TELEMETRY_PROFILE": {
+            "dummy": {
+                "stream_state": "disabled",
+                "poll_interval": "100000"
+            },
+            "hft_profile": {
+                "stream_state": "enabled",
+                "poll_interval": "100000"
+            }
+        },
+        "HIGH_FREQUENCY_TELEMETRY_GROUP": {
+            "dummy|PORT": {},
+            "hft_profile|PORT": {
+                "object_names": [
+                    "Ethernet0",
+                    "Ethernet4"
+                ],
+                "object_counters": [
+                    "IF_IN_OCTETS",
+                    "OUT_CURR_OCCUPANCY_BYTES"
+                ]
+            }
         }
     },
     "SAMPLE_CONFIG_DB_UNKNOWN": {

--- a/src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py
+++ b/src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py
@@ -50,6 +50,7 @@ class Test_yang_models:
             'MaxElements': ['Too many'],
             'UnknownElement': ['Unknown element'],
             'Missing': ['Missing required element'],
+            "InvalidJSON": ['Invalid JSON data'],
             'None': [],
 # New keys are needed for libyang3's messages which are different.  Go
 # ahead and add them now with the libyang1 values (which are duplicates

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
@@ -1,5 +1,13 @@
 {
     "HIGH_FREQUENCY_TELEMETRY_VALID_CASE": {
         "desc": "Valid high frequency telemetry configuration."
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_PORT": {
+        "desc": "Invalid port.",
+        "eStrKey": "Must"
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_STATS": {
+        "desc": "Invalid stats.",
+        "eStrKey": "Must"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
@@ -9,5 +9,13 @@
     "HIGH_FREQUENCY_TELEMETRY_INVALID_STATS": {
         "desc": "Invalid stats.",
         "eStrKey": "Must"
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_DUMMY_TABLE1": {
+        "desc": "Invalid dummy table1.",
+        "eStrKey": "InvalidJSON"
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_DUMMY_TABLE2": {
+        "desc": "Invalid dummy table2.",
+        "eStrKey": "InvalidJSON"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
@@ -69,6 +69,16 @@
                         "name": "high_frequency_counters",
                         "stream_state": "enabled",
                         "poll_interval": 100
+                    },
+                    {
+                        "name": "partial_objects",
+                        "stream_state": "disabled",
+                        "poll_interval": 100000
+                    },
+                    {
+                        "name": "dummy_profile",
+                        "stream_state": "disabled",
+                        "poll_interval": 100000
                     }
                 ]
             },
@@ -119,6 +129,110 @@
                         "object_counters": [
                             "CURR_OCCUPANCY_BYTES",
                             "XOFF_ROOM_WATERMARK_BYTES"
+                        ]
+                    },
+                    {
+                        "profile_name": "partial_objects",
+                        "group_name": "PORT",
+                        "object_names": [
+                            "Ethernet0"
+                        ],
+                        "object_counters": [
+                            "IF_IN_OCTETS",
+                            "OUT_CURR_OCCUPANCY_BYTES"
+                        ]
+                    },
+                    {
+                        "profile_name": "dummy_profile",
+                        "group_name": "PORT"
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_PORT": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet0",
+                        "lanes": "0",
+                        "speed": 25000
+                    },
+                    {
+                        "name": "Ethernet4",
+                        "lanes": "4",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_PROFILE": {
+                "HIGH_FREQUENCY_TELEMETRY_PROFILE_LIST": [
+                    {
+                        "name": "invalid_port",
+                        "stream_state": "enabled",
+                        "poll_interval": 100
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_GROUP": {
+                "HIGH_FREQUENCY_TELEMETRY_GROUP_LIST": [
+                    {
+                        "profile_name": "invalid_port",
+                        "group_name": "PORT",
+                        "object_names": [
+                            "Ethernet1"
+                        ],
+                        "object_counters": [
+                            "IF_IN_OCTETS",
+                            "OUT_CURR_OCCUPANCY_BYTES"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_STATS": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet0",
+                        "lanes": "0",
+                        "speed": 25000
+                    },
+                    {
+                        "name": "Ethernet4",
+                        "lanes": "4",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_PROFILE": {
+                "HIGH_FREQUENCY_TELEMETRY_PROFILE_LIST": [
+                    {
+                        "name": "invalid_stats",
+                        "stream_state": "enabled",
+                        "poll_interval": 100
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_GROUP": {
+                "HIGH_FREQUENCY_TELEMETRY_GROUP_LIST": [
+                    {
+                        "profile_name": "invalid_stats",
+                        "group_name": "PORT",
+                        "object_names": [
+                            "Ethernet0"
+                        ],
+                        "object_counters": [
+                            "IF_IN_OCTETS",
+                            "OUT_CURR_OCCUPANCY_BYTES",
+                            "INVALID_STAT"
                         ]
                     }
                 ]

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
@@ -238,5 +238,51 @@
                 ]
             }
         }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_DUMMY_TABLE1": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_PROFILE": {
+                "HIGH_FREQUENCY_TELEMETRY_PROFILE_LIST": [
+                    {
+                        "name": "invalid_dummy",
+                        "stream_state": "disabled",
+                        "poll_interval": 100
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_GROUP": {
+                "HIGH_FREQUENCY_TELEMETRY_GROUP_LIST": [
+                    {
+                        "profile_name": "invalid_dummy",
+                        "group_name": "BUFFER_POOL",
+                        "object_names": "",
+                        "object_counters": ""
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_DUMMY_TABLE2": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_PROFILE": {
+                "HIGH_FREQUENCY_TELEMETRY_PROFILE_LIST": [
+                    {
+                        "name": "invalid_dummy",
+                        "stream_state": "disabled",
+                        "poll_interval": 100
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_GROUP": {
+                "HIGH_FREQUENCY_TELEMETRY_GROUP_LIST": [
+                    {
+                        "profile_name": "invalid_dummy",
+                        "group_name": "PORT",
+                        "object_names": [],
+                        "object_counters": []
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
@@ -93,8 +93,6 @@ module sonic-high-frequency-telemetry {
                         + " or ( ../group_name = 'QUEUE' and substring-before(current(), '|') = /bql:sonic-buffer-queue/bql:BUFFER_QUEUE/bql:BUFFER_QUEUE_LIST/bql:port and re-match(substring-after(current(), '|'), '[0-9]+') )";
                 }
 
-                must "count(object_names) > 0";
-
                 leaf-list object_counters {
                     type string;
                     must "( ../group_name = 'PORT' and re-match(current(), 'IF_IN_OCTETS|IF_IN_UCAST_PKTS|IF_IN_DISCARDS|IF_IN_ERRORS|IN_CURR_OCCUPANCY_BYTES|IF_OUT_OCTETS|IF_OUT_DISCARDS|IF_OUT_ERRORS|IF_OUT_UCAST_PKTS|OUT_CURR_OCCUPANCY_BYTES|TRIM_PACKETS') )"


### PR DESCRIPTION
#### Why I did it
We must have a dummy HFT table to support dynamically configuring HFT. This Yang model change is to support the dummy table.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Remove mandatory constraint for object_names list
- Add test cases for empty lists and validation scenarios
- Include high-frequency telemetry model
- 
#### How to verify it

Check Azp status. This PR includes its test.

#### Which release branch to backport (provide reason below if selected)

- [x] 202412

#### Tested branch (Please provide the tested image version)

master
