### PR TITLE
Add support for use-route-replace in sonic dataplane provider

### DIFF
--- a/dockers/docker-fpm-frr/frr/zebra/zebra.conf.j2
+++ b/dockers/docker-fpm-frr/frr/zebra/zebra.conf.j2
@@ -15,6 +15,13 @@ fpm use-next-hop-groups
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 {% endif %}
+{% if ( ('localhost' in DEVICE_METADATA) and ('route_replace' in  DEVICE_METADATA['localhost']) and
+        (DEVICE_METADATA['localhost']['route_replace'] == 'enabled') ) %}
+! enable route replace semantics
+fpm use-route-replace
+{% else %}
+no fpm use-route-replace
+{% endif %}
 !
 fpm address 127.0.0.1
 {% endblock fpm %}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/zebra.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/zebra.conf
@@ -6,6 +6,7 @@
 !
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
+no fpm use-route-replace
 !
 fpm address 127.0.0.1
 zebra nexthop-group keep 1

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-vni-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-vni-zebra.conf
@@ -6,6 +6,7 @@
 !
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
+no fpm use-route-replace
 !
 fpm address 127.0.0.1
 zebra nexthop-group keep 1

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-zebra.conf
@@ -6,6 +6,7 @@
 !
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
+no fpm use-route-replace
 !
 fpm address 127.0.0.1
 zebra nexthop-group keep 1

--- a/src/sonic-config-engine/tests/sample_output/py2/zebra_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/zebra_frr_dualtor.conf
@@ -6,6 +6,7 @@
 !
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
+no fpm use-route-replace
 !
 fpm address 127.0.0.1
 zebra nexthop-group keep 1

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-vni-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-vni-zebra.conf
@@ -6,6 +6,7 @@
 !
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
+no fpm use-route-replace
 !
 fpm address 127.0.0.1
 zebra nexthop-group keep 1

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-zebra.conf
@@ -6,6 +6,7 @@
 !
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
+no fpm use-route-replace
 !
 fpm address 127.0.0.1
 zebra nexthop-group keep 1

--- a/src/sonic-config-engine/tests/sample_output/py3/zebra_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/zebra_frr.conf
@@ -6,6 +6,7 @@
 !
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
+no fpm use-route-replace
 !
 fpm address 127.0.0.1
 zebra nexthop-group keep 1

--- a/src/sonic-config-engine/tests/sample_output/py3/zebra_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/zebra_frr_dualtor.conf
@@ -6,6 +6,7 @@
 !
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
+no fpm use-route-replace
 !
 fpm address 127.0.0.1
 zebra nexthop-group keep 1

--- a/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
+++ b/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
@@ -18,6 +18,13 @@ fpm use-next-hop-groups
 ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
 no fpm use-next-hop-groups
 {% endif %}
+{% if ( ('localhost' in DEVICE_METADATA) and ('route_replace' in  DEVICE_METADATA['localhost']) and
+        (DEVICE_METADATA['localhost']['route_replace'] == 'enabled') ) %}
+! enable route replace semantics
+fpm use-route-replace
+{% else %}
+no fpm use-route-replace
+{% endif %}
 !
 ! Add fpm address for zebra
 fpm address 127.0.0.1

--- a/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
+++ b/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
@@ -45,6 +45,7 @@
 #include "lib/network.h"
 #include "lib/ns.h"
 #include "lib/frr_pthread.h"
+#include "lib/termtable.h"
 #include "zebra/debug.h"
 #include "zebra/interface.h"
 #include "zebra/zebra_dplane.h"
@@ -176,6 +177,7 @@ struct fpm_nl_ctx {
 	bool disabled;
 	bool connecting;
 	bool use_nhg;
+	bool use_route_replace;
 	struct sockaddr_storage addr;
 
 	/* data plane buffers. */
@@ -298,6 +300,24 @@ static void fpm_rmac_reset(struct event *t);
  * CLI.
  */
 #define FPM_STR "Forwarding Plane Manager configuration\n"
+DEFUN(fpm_use_route_replace, fpm_use_route_replace_cmd,
+      "fpm use-route-replace",
+      FPM_STR
+      "Use netlink route replace semantics\n")
+{
+	gfnc->use_route_replace = true;
+	return CMD_SUCCESS;
+}
+
+DEFUN(no_fpm_use_route_replace, no_fpm_use_route_replace_cmd,
+      "no fpm use-route-replace",
+      NO_STR
+      FPM_STR
+      "Use netlink route replace semantics\n")
+{
+	gfnc->use_route_replace = false;
+	return CMD_SUCCESS;
+}
 
 DEFUN(fpm_set_address, fpm_set_address_cmd,
       "fpm address <A.B.C.D|X:X::X:X> [port (1-65535)]",
@@ -407,6 +427,78 @@ DEFUN(fpm_reset_counters, fpm_reset_counters_cmd,
 {
 	event_add_event(gfnc->fthread->master, fpm_process_event, gfnc,
 			 FNE_RESET_COUNTERS, &gfnc->t_event);
+	return CMD_SUCCESS;
+}
+
+DEFUN(fpm_show_status,
+      fpm_show_status_cmd,
+      "show fpm status [json]$json",
+      SHOW_STR FPM_STR "FPM status\n" JSON_STR)
+{
+	struct json_object *j;
+	bool connected;
+	uint16_t port;
+	struct sockaddr_in *sin;
+	struct sockaddr_in6 *sin6;
+	char buf[BUFSIZ];
+
+	bool json = false;
+	if (argc == 4 && !strcmp(argv[3]->arg, "json")) {
+		json = true;
+	}
+	connected = gfnc->socket > 0 ? true : false;
+
+	switch (gfnc->addr.ss_family) {
+	case AF_INET:
+		sin = (struct sockaddr_in *)&gfnc->addr;
+		snprintfrr(buf, sizeof(buf), "%pI4", &sin->sin_addr);
+		port = ntohs(sin->sin_port);
+		break;
+	case AF_INET6:
+		sin6 = (struct sockaddr_in6 *)&gfnc->addr;
+		snprintfrr(buf, sizeof(buf), "%pI6", &sin6->sin6_addr);
+		port = ntohs(sin6->sin6_port);
+		break;
+	default:
+		strlcpy(buf, "Unknown", sizeof(buf));
+		port = FPM_DEFAULT_PORT;
+		break;
+	}
+
+	if (json) {
+		j = json_object_new_object();
+
+		json_object_boolean_add(j, "connected", connected);
+		json_object_boolean_add(j, "useNHG", gfnc->use_nhg);
+		json_object_boolean_add(j, "useRouteReplace",
+					gfnc->use_route_replace);
+		json_object_boolean_add(j, "disabled", gfnc->disabled);
+		json_object_string_add(j, "address", buf);
+		json_object_int_add(j, "port", port);
+
+		vty_json(vty, j);
+	} else {
+		struct ttable *table = ttable_new(&ttable_styles[TTSTYLE_BLANK]);
+		char *out;
+
+		ttable_rowseps(table, 0, BOTTOM, true, '-');
+		ttable_add_row(table, "Address to connect to|%s", buf);
+		ttable_add_row(table, "Port|%u", port);
+		ttable_add_row(table, "Connected|%s", connected ? "Yes" : "No");
+		ttable_add_row(table, "Use Nexthop Groups|%s",
+			       gfnc->use_nhg ? "Yes" : "No");
+		ttable_add_row(table, "Use Route Replace Semantics|%s",
+			       gfnc->use_route_replace ? "Yes" : "No");
+		ttable_add_row(table, "Disabled|%s",
+			       gfnc->disabled ? "Yes" : "No");
+
+		out = ttable_dump(table, "\n");
+		vty_out(vty, "%s\n", out);
+		XFREE(MTYPE_TMP_TTABLE, out);
+
+		ttable_del(table);
+	}
+
 	return CMD_SUCCESS;
 }
 
@@ -520,6 +612,11 @@ static int fpm_write_config(struct vty *vty)
 
 	if (!gfnc->use_nhg) {
 		vty_out(vty, "no fpm use-next-hop-groups\n");
+		written = 1;
+	}
+
+	if (!gfnc->use_route_replace) {
+		vty_out(vty, "no fpm use-route-replace\n");
 		written = 1;
 	}
 
@@ -2207,6 +2304,20 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 
 	nl_buf_len = 0;
 
+	/*
+	 * If route replace is enabled then directly encode the install which
+	 * is going to use `NLM_F_REPLACE` (instead of delete/add operations).
+	 */
+	if (fnc->use_route_replace && op == DPLANE_OP_ROUTE_UPDATE) {
+		nexthop = dplane_ctx_get_ng(ctx)->nexthop;
+		if (nexthop && nexthop->nh_srv6) {
+			// Dont change op for srv6 yet. Not sure if update
+			// semantics will work or not
+		} else {
+			op = DPLANE_OP_ROUTE_INSTALL;
+		}
+	}
+
 	switch (op) {
 	case DPLANE_OP_ROUTE_UPDATE:
 	case DPLANE_OP_ROUTE_DELETE:
@@ -2255,7 +2366,8 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 		} else {
 			rv = netlink_route_multipath_msg_encode(
 				RTM_NEWROUTE, ctx, &nl_buf[nl_buf_len],
-				sizeof(nl_buf) - nl_buf_len, true, fnc->use_nhg, false);
+				sizeof(nl_buf) - nl_buf_len, true, fnc->use_nhg,
+				fnc->use_route_replace);
 			if (rv <= 0) {
 				zlog_err(
 					"%s: netlink_route_multipath_msg_encode failed",
@@ -2974,6 +3086,7 @@ static int fpm_nl_start(struct zebra_dplane_provider *prov)
 
 	/* Set default values. */
 	fnc->use_nhg = true;
+	fnc->use_route_replace = false;
 
 	return 0;
 }
@@ -3132,6 +3245,7 @@ static int fpm_nl_new(struct event_loop *tm)
 		zlog_debug("%s register status: %d", prov_name, rv);
 
 	install_node(&fpm_node);
+	install_element(ENABLE_NODE, &fpm_show_status_cmd);
 	install_element(ENABLE_NODE, &fpm_show_counters_cmd);
 	install_element(ENABLE_NODE, &fpm_show_counters_json_cmd);
 	install_element(ENABLE_NODE, &fpm_reset_counters_cmd);
@@ -3139,6 +3253,8 @@ static int fpm_nl_new(struct event_loop *tm)
 	install_element(CONFIG_NODE, &no_fpm_set_address_cmd);
 	install_element(CONFIG_NODE, &fpm_use_nhg_cmd);
 	install_element(CONFIG_NODE, &no_fpm_use_nhg_cmd);
+	install_element(CONFIG_NODE, &fpm_use_route_replace_cmd);
+	install_element(CONFIG_NODE, &no_fpm_use_route_replace_cmd);
 
 	return 0;
 }

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -289,6 +289,15 @@ module sonic-device_metadata {
                     default disabled;
                 }
 
+                leaf route_replace {
+                    description "Enable or disable Route replace semantics.";
+                    type enumeration {
+                        enum enabled;
+                        enum disabled;
+                    }
+                    default disabled;
+                }
+
                 leaf ring_thread_enabled {
                     type boolean;
                     description "Enable gRingMode of OrchDaemon, which would set up its ring thread to accelerate task execution.";


### PR DESCRIPTION
The FRR's zebra has two dataplane providers. One of them programs routes into the kernel, while the other one sends routes towards sonic. This one sends routes to fpmsyncd. Currently, this sonic dataplane provider does not make use of the route replace semantics. This means that any change to an existing route is first sent as a delete and then a new add notification is sent later. 
The sonic dataplane provider code currently sends a RTM_DELROUTE followed by a RTM_NEWROUTE for an update operation as well. This will lead to churn even when the ECMP set is growing.
This PR enables the "fpm use-route-replace" configuration in zebra. Additionally it also fixes the "show fpm status [json]" show cli.

Refer to the corresponding PR in fpmsyncd to be able to accept this https://github.com/sonic-net/sonic-swss/pull/3872

#### Why I did it

This will allow zebra to be configured with "fpm use-route-replace", which will cause it to update a route instead of delete followed by new.  This also helps when there are ECMP changes (ecmp growth or shrink) and allows for zero traffic drops. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added support for route replace semantics in zebra's sonic dataplane provider.

#### How to verify it
Verified with ECMP routes with growth or shrink of ECMP.


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Add support for use-route-replace in sonic dataplane provider


#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

