### PR TITLE
Fix dash-ha smdep.

### DIFF
--- a/rules/dash-ha.dep
+++ b/rules/dash-ha.dep
@@ -1,10 +1,12 @@
 SPATH       := $($(DASH_HA)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/dash-ha.mk rules/dash-ha.dep
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
-SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files))
+SMDEP_FILES := $(SPATH) $(SPATH)/crates/sonic-dash-api-proto/sonic-dash-api
+$(foreach path, $(SMDEP_PATHS), $(eval $(path) :=$(filter-out $(SMDEP_PATHS),$(addprefix $(path)/, \
+					$(shell cd $(path)  && git ls-files | grep -v " ")))))
 
 $(DASH_HA)_CACHE_MODE  := GIT_CONTENT_SHA
 $(DASH_HA)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
 $(DASH_HA)_DEP_FILES   := $(DEP_FILES)
-$(DASH_HA)_SMDEP_FILES := $(SMDEP_FILES)
-$(DASH_HA)_SMDEP_PATHS := $(SPATH)
+$(DASH_HA)_SMDEP_FILES := $(foreach path, $(SMDEP_PATHS), $($(path)))
+$(DASH_HA)_SMDEP_PATHS := $(SMDEP_PATHS)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Build was failing with "fatal: Unable to hash crates/sonic-dash-api-proto/sonic-dash-api" when SONIC_DPKG_CACHE_METHOD=rwcache was set (Issue https://github.com/sonic-net/sonic-buildimage/issues/23900).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added path to newly introduced crates/sonic-dash-api-proto/sonic-dash-api submodule under sonic-dash-ha to SMDEP.

#### How to verify it
Built with SONIC_DPKG_CACHE_METHOD=rwcache flag enabled.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)
Master

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

