### PR TITLE
[Arista] Reset switch chip in Aboot for Quicksilver512

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -940,11 +940,27 @@ regular_install() {
     run_hooks post-install
 }
 
+run_quirks() {
+    # only run in Aboot
+    if $in_aboot && [ -f "/etc/cmdline" ]; then
+        if [ "$aboot_machine" = "arista_7060x6_64pe_b" ]; then
+            info "Resetting switch chip"
+            setpci -s 05:00.0 COMMAND=0002
+            devmem 0x80084000 32 0xC
+            sleep 1
+            devmem 0x80084010 32 0x4
+            sleep 1
+            devmem 0x80084010 32 0x8
+        fi
+    fi
+}
+
 secureboot_boot() {
     # boot material is extracted and generated in RAM.
     # SONiC starts as a live OS.
     info "Preparing image for secureboot"
     prepare_image_secureboot
+    run_quirks
     update_next_boot
     run_kexec
 }
@@ -953,6 +969,7 @@ regular_boot() {
     # boot uses the image installed on the flash
     write_regular_configs "$image_path"
     run_hooks pre-kexec
+    run_quirks
     update_next_boot
     run_kexec
 }


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Mitigate for the recent issue that under some unknown initial conditions, the 7060X6-64PE-B device could get into reboot loop. It's been identified so far that the reboot loop is related to the some bad switch chip state. While still trying to figure out the initial trigger, we propose this mitigation that break the reboot loop.

##### Work item tracking

- Microsoft ADO **(number only)**:

#### How I did it
In boot0 script, if the environment is Aboot and the platform is 7060X6-64PE-B, reset the switch chip. 


#### How to verify it
According to our test, this doesn't affect normal booting.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

