### PR TITLE
Change incorrect component name for Arista-7060-CX32S platform

### DIFF
--- a/device/arista/x86_64-arista_7060_cx32s/platform.json
+++ b/device/arista/x86_64-arista_7060_cx32s/platform.json
@@ -15,7 +15,7 @@
                 "name": "Ucd90120A(addr=8-004e)"
             },
             {
-                "name": "CrowSysCpld(addr=2-0023)"
+                "name": "KoiSysCpld(addr=2-0023)"
             }
         ],
         "fans": [],


### PR DESCRIPTION
#### Why I did it
platform_tests/api/test_component.py was failing due to the hard coded component name in the corresponding platform.json file not matching the component name retrieved from the Arista platform information API.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Changed the component name in the platform.json file to match our platform information API.

#### How to verify it
Ran the test with and without the change, confirmed that it passes with the change.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

