### PR TITLE
[FRR]Fixing BGP performance issues with BMP enabled

### DIFF
--- a/src/sonic-frr/patch/0060-bgpd-Convert-bmp-path_info-tracking-from-hash-to-rbt.patch
+++ b/src/sonic-frr/patch/0060-bgpd-Convert-bmp-path_info-tracking-from-hash-to-rbt.patch
@@ -1,0 +1,99 @@
+From da81e60f5852eee8f0f4b8d21bafd8931ffbebb4 Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Wed, 10 Sep 2025 11:04:10 -0400
+Subject: [PATCH] bgpd: Convert bmp path_info tracking from hash to rbtree
+
+The current implementation has this cycle:
+
+a) As path_info comes in, bmp_process is called, this generates
+an item on a hash.  This typesafe hash was automatically growing
+as more path info's were received.
+b) This generation of items on the hash eventually causes pullwr_run
+to happen, which pulls items off the hash, encodes them and sends them
+to a peer.  This causes the hash to automatically shrink.
+
+Now imagine a scenario where you have a large number of paths being
+brought in upon initial startup.  Run time starts to be dominated by
+the hash_grow and hash_shrink functions because it involves reallocs
+and memory manipulation:
+
++   99.17%     0.00%  bgpd     bgpd               [.] _start
++   99.17%     0.00%  bgpd     libc.so.6          [.] __libc_start_main
++   99.17%     0.00%  bgpd     libc.so.6          [.] 0x00007f0188f2d249
++   99.17%     0.00%  bgpd     bgpd               [.] main
++   99.17%     0.00%  bgpd     libfrr.so.0.0.0    [.] frr_run
++   99.10%     0.01%  bgpd     libfrr.so.0.0.0    [.] event_call
++   64.01%     0.01%  bgpd     bgpd               [.] bgp_process_packet
++   63.95%     0.01%  bgpd     bgpd               [.] bgp_update_receive
++   63.92%     0.01%  bgpd     bgpd               [.] bgp_nlri_parse_ip
++   63.90%     0.04%  bgpd     bgpd               [.] bgp_update
++   63.62%     0.00%  bgpd     bgpd               [.] hook_call_bgp_process (inlined)
++   63.62%     0.00%  bgpd     bgpd_bmp.so        [.] bmp_process
++   63.61%     0.00%  bgpd     bgpd_bmp.so        [.] bmp_process_one (inlined)
++   63.61%     0.00%  bgpd     bgpd_bmp.so        [.] bmp_qhash_add (inlined)
++   63.59%    57.66%  bgpd     libfrr.so.0.0.0    [.] typesafe_hash_grow
++   34.63%     0.00%  bgpd     libfrr.so.0.0.0    [.] pullwr_run
++   34.39%     0.01%  bgpd     bgpd_bmp.so        [.] bmp_wrfill
++   34.39%     0.00%  bgpd     bgpd_bmp.so        [.] bmp_wrqueue (inlined)
++   34.17%     0.00%  bgpd     bgpd_bmp.so        [.] bmp_pull (inlined)
++   34.17%     0.00%  bgpd     bgpd_bmp.so        [.] bmp_pull_from_queue
++   34.17%     0.00%  bgpd     bgpd_bmp.so        [.] bmp_qhash_del (inlined)
++   34.17%    32.71%  bgpd     libfrr.so.0.0.0    [.] typesafe_hash_shrink
+
+As you can see run time is spending 57.66 + 32.71% of the time in
+grow/shrink cycles as each side of the event system gets to run.
+
+Let's just convert the system to use a RB Tree to avoid this problem.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+
+diff --git a/bgpd/bgp_bmp.c b/bgpd/bgp_bmp.c
+index 1de48a072a..0fb43f501f 100644
+--- a/bgpd/bgp_bmp.c
++++ b/bgpd/bgp_bmp.c
+@@ -174,28 +174,7 @@ static int bmp_qhash_cmp(const struct bmp_queue_entry *a,
+ 	return ret;
+ }
+ 
+-static uint32_t bmp_qhash_hkey(const struct bmp_queue_entry *e)
+-{
+-	uint32_t key;
+-
+-	key = prefix_hash_key((void *)&e->p);
+-	key = jhash(&e->peerid,
+-		    offsetof(struct bmp_queue_entry, refcount)
+-			    - offsetof(struct bmp_queue_entry, peerid),
+-		    key);
+-	if ((e->afi == AFI_L2VPN && e->safi == SAFI_EVPN) ||
+-	    (e->safi == SAFI_MPLS_VPN))
+-		key = jhash(&e->rd,
+-			    offsetof(struct bmp_queue_entry, rd)
+-				    - offsetof(struct bmp_queue_entry, refcount)
+-				    + PSIZE(e->rd.prefixlen),
+-			    key);
+-
+-	return key;
+-}
+-
+-DECLARE_HASH(bmp_qhash, struct bmp_queue_entry, bhi,
+-		bmp_qhash_cmp, bmp_qhash_hkey);
++DECLARE_RBTREE_UNIQ(bmp_qhash, struct bmp_queue_entry, bhi, bmp_qhash_cmp);
+ 
+ static int bmp_active_cmp(const struct bmp_active *a,
+ 		const struct bmp_active *b)
+diff --git a/bgpd/bgp_bmp.h b/bgpd/bgp_bmp.h
+index dadd99eb6d..f4d82392d8 100644
+--- a/bgpd/bgp_bmp.h
++++ b/bgpd/bgp_bmp.h
+@@ -54,7 +54,7 @@
+  */
+ 
+ PREDECL_DLIST(bmp_qlist);
+-PREDECL_HASH(bmp_qhash);
++PREDECL_RBTREE_UNIQ(bmp_qhash);
+ 
+ struct bmp_queue_entry {
+ 	struct bmp_qlist_item bli;
+-- 
+2.50.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -57,3 +57,4 @@
 0057-mgmtd-remove-bogus-hedge-code-which-corrupted-active.patch
 0058-mgmtd-normalize-argument-order-to-copy-dst-src.patch
 0059-zebra-Ensure-that-the-dplane-can-send-the-full-packe.patch
+0060-bgpd-Convert-bmp-path_info-tracking-from-hash-to-rbt.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixing BGP performance issues when running with BMP enabled


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Ported fix https://github.com/FRRouting/frr/pull/19548 from FRR community

#### How to verify it
Running bgp convergence with the test and confirming it improves the performance.  Previously the time to learn 6k IPv6 routes was 30-40 seconds and after this fix it is less than 10 seconds.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

