### PR TITLE
add loopback&vlan into the ipinip tunnel list for large topo

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -61,10 +61,10 @@
 {% endfor %}
 {%- set ipv4_addresses = ipv4_addresses + ipv4_vlan_addresses %}
 {%- set ipv6_addresses = ipv6_addresses + ipv6_vlan_addresses %}
-{# FIXME: SAI report tunnel TABLE_FULL for large topo. Disable it temporarily if over 128 IPv4/IPv6 tunnels. #}
+{# SAI report tunnel TABLE_FULL for large topo. Only generating for loopback if over 128 routed interfaces.#}
 {% if ipv4_addresses|length + ipv6_addresses|length > 128 %}
-{%- set ipv4_addresses = [] %}
-{%- set ipv6_addresses = [] %}
+{%- set ipv4_addresses = ipv4_loopback_addresses %}
+{%- set ipv6_addresses = ipv6_loopback_addresses %}
 {% endif %}
 
 {# Check if AZURE QoS map exists #}

--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -61,10 +61,10 @@
 {% endfor %}
 {%- set ipv4_addresses = ipv4_addresses + ipv4_vlan_addresses %}
 {%- set ipv6_addresses = ipv6_addresses + ipv6_vlan_addresses %}
-{# SAI report tunnel TABLE_FULL for large topo. Only generating for loopback if over 128 routed interfaces.#}
+{# SAI report tunnel TABLE_FULL for large topo. Only generating for VLAN and loopback if over 128 routed interfaces.#}
 {% if ipv4_addresses|length + ipv6_addresses|length > 128 %}
-{%- set ipv4_addresses = ipv4_loopback_addresses %}
-{%- set ipv6_addresses = ipv6_loopback_addresses %}
+{%- set ipv4_addresses = ipv4_loopback_addresses + ipv4_vlan_addresses %}
+{%- set ipv6_addresses = ipv6_loopback_addresses + ipv6_vlan_addresses %}
 {% endif %}
 
 {# Check if AZURE QoS map exists #}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently there is no tunnel being created when more than 128 addresses in the system. 
This PR enables for loopback addresses in this scenario as it's still needed.

##### Work item tracking
- Microsoft ADO **34827134**:

#### How I did it
Update the tunnel address to include loopback IPv4 and IPv6 addresses.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->
202412

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

