### PR TITLE
[Arista] Update sensor.conf for 7060X6-64PE-B

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/sensors.conf
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/sensors.conf
@@ -1,6 +1,6 @@
-bus "i2c-27" "SCD 0000:08:00.0 SMBus master 1 bus 0"
-bus "i2c-30" "SCD 0000:08:00.0 SMBus master 1 bus 3"
-bus "i2c-31" "SCD 0000:08:00.0 SMBus master 1 bus 4"
+bus "i2c-27" "SCD 0000:05:00.0 SMBus master 1 bus 0"
+bus "i2c-30" "SCD 0000:05:00.0 SMBus master 1 bus 3"
+bus "i2c-31" "SCD 0000:05:00.0 SMBus master 1 bus 4"
 
 chip "max6581-i2c-27-4d"
     ignore temp5
@@ -22,5 +22,13 @@ chip "pmbus-i2c-30-58"
     ignore fan4
 
 chip "pmbus-i2c-31-58"
+    ignore fan3
+    ignore fan4
+
+chip "dps800-i2c-30-58"
+    ignore fan3
+    ignore fan4
+
+chip "dps800-i2c-31-58"
     ignore fan3
     ignore fan4


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Update sensor.conf SCD address with value from 'i2cdetect -l'. 
Add chip name and fan ignore to sensor.conf.
This will stop `ALERT pmon#sensord: Sensor alarm: Chip dps800-i2c-30-58: fan3: -1 RPM [ALARM]`

#### How to verify it
Confirmed that it stopped the log alert on Quicksilver 512 dut.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] msft_202412
- [x] msft_202503

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

