### PR TITLE
Add ipmi device for pmon container

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -714,6 +714,7 @@ start() {
 {%- endif %}
 {%- if docker_container_name == "pmon" %}
     -v /usr/share/sonic/firmware:/usr/share/sonic/firmware:rw \
+    $(if [ -e "/dev/ipmi0" ]; then echo "--device=/dev/ipmi0:/dev/ipmi0"; fi) \
     $(if [ -e "/dev/watchdog" ]; then echo "--device=/dev/watchdog:/dev/watchdog"; fi) \
     $(for watchdog in /sys/class/watchdog/*; do if [ -d "$watchdog" ]; then device_name=$(basename "$watchdog"); dev_file="/dev/$device_name"; if [ -e "$dev_file" ]; then echo "--device=$dev_file:$dev_file"; fi; fi; done) \
 {%- endif %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
On platforms using the IPMI interface, the current pmon is broken.
```
root@sonic:~# show logging "Could not open device"
2025 Sep 18 02:18:30.578482 sonic INFO pmon#supervisord: psud Could not open device at /dev/ipmi0 or /dev/ipmi/0 or /dev/ipmidev/0: No such file or directory
2025 Sep 18 02:18:31.689267 sonic INFO pmon#supervisord: psud Could not open device at /dev/ipmi0 or /dev/ipmi/0 or /dev/ipmidev/0: No such file or directory
2025 Sep 18 02:21:55.434346 sonic INFO pmon#supervisord: psud Could not open device at /dev/ipmi0 or /dev/ipmi/0 or /dev/ipmidev/0: No such file or directory
2025 Sep 18 02:21:57.355865 sonic INFO pmon#supervisord: psud Could not open device at /dev/ipmi0 or /dev/ipmi/0 or /dev/ipmidev/0: No such file or directory
2025 Sep 18 02:21:57.355865 sonic INFO pmon#supervisord: thermalctld Could not open device at /dev/ipmi0 or /dev/ipmi/0 or /dev/ipmidev/0: No such file or directory
2025 Sep 18 02:21:58.653110 sonic INFO pmon#supervisord: psud Could not open device at /dev/ipmi0 or /dev/ipmi/0 or /dev/ipmidev/0: No such file or directory
root@sonic:~# docker exec -it pmon bash -c "ls /dev/ipmi*"
ls: cannot access '/dev/ipmi*': No such file or directory
root@sonic:~# show platform psustatus 
Error: Failed to get PSU status
Error: failed to get PSU status from state DB
root@sonic:~# show platform temperature 
Thermal Not detected
root@sonic:~# 
```

After this fix
```
root@sonic:~# show logging "Could not open device"
root@sonic:~# docker exec -it pmon bash -c "ls /dev/ipmi*"
/dev/ipmi0
root@sonic:~# show platform psustatus 
PSU    Model       Serial               HW Rev      Voltage (V)    Current (A)    Power (W)  Status    LED
-----  ----------  -------------------  --------  -------------  -------------  -----------  --------  -----
PSU1   YNEE0750EM  F7510AS90580X020027  N/A                0.00           0.00         0.00  NOT OK    green
PSU2   YNEE0750EM  F7510AS90580X020024  N/A               12.12          10.00       121.20  OK        green
root@sonic:~# show platform temperature 
          Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
----------------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
      PSU1_TEMP1             32        N/A       N/A             N/A            N/A      False  20250918 02:07:24
      PSU2_TEMP1             32        N/A       N/A             N/A            N/A      False  20250918 02:07:24
    TEMP_ENV_BMC             37       75.0       N/A            80.0            N/A      False  20250918 02:07:23
TEMP_ENV_MACCASE             40       75.0       N/A            80.0            N/A      False  20250918 02:07:23
TEMP_ENV_PSUCASE             32       57.0       N/A            62.0            N/A      False  20250918 02:07:23
TEMP_ENV_SSDCASE             42       75.0       N/A            80.0            N/A      False  20250918 02:07:23
        TEMP_MAC             41       95.0       N/A           105.0            N/A      False  20250918 02:07:22
 TEMP_PSU0_TEMP1             32        N/A       N/A            70.0            N/A      False  20250918 02:07:23
 TEMP_PSU1_TEMP1             32        N/A       N/A            70.0            N/A      False  20250918 02:07:24
root@sonic:~# 
```
This regression was introduced by https://github.com/sonic-net/sonic-buildimage/pull/23457

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

