### PR TITLE
[PDDF] Add FAN's get_fault(), fix int overflow in PSU, rm unused var

### DIFF
--- a/platform/pddf/i2c/modules/include/pddf_xcvr_defs.h
+++ b/platform/pddf/i2c/modules/include/pddf_xcvr_defs.h
@@ -29,7 +29,6 @@ typedef struct XCVR_ATTR
     char aname[32];                    // attr name, taken from enum xcvr_sysfs_attributes
     char devtype[32];       // either a 'eeprom' or 'cpld', or 'pmbus' attribute
     char devname[32];       // name of the device from where this sysfs is to be read
-    struct pci_dev *fpga_pci_dev;
     uint32_t devaddr;
     uint32_t offset;
     uint32_t mask;

--- a/platform/pddf/i2c/modules/psu/driver/pddf_psu_api.c
+++ b/platform/pddf/i2c/modules/psu/driver/pddf_psu_api.c
@@ -193,7 +193,7 @@ static u8 psu_get_vout_mode(struct i2c_client *client)
 static long pmbus_linear11_to_int(u16 value, int multiplier)
 {
     s16 exponent;
-    s32 mantissa;
+    s64 mantissa;
 
     exponent = two_complement_to_int(value >> 11, 5, 0x1f);
     mantissa = two_complement_to_int(value & 0x7ff, 11, 0x7ff);


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Multiple improvements in PDDF core code:
1. Implement `PddfFan.get_fault()` to read `fan{idx}_fault` attribute from FAN-CTRL object (if exists), and update `PddfFan.get_status()` to take fault value into account. Value mapping for fault's raw value to boolean should be provided in `pd-plugin.json` (see [here](https://github.com/sonic-net/sonic-buildimage/blob/a80b6cc9e3ca2289961917386986dec4c93eab89/device/nexthop/x86_64-nexthop_4010-r0/pddf/pd-plugin.json#L215-L222) for example).
2. Fix integer overflow when converting pmbus LINEAR11 to int in `pddf_psu_api.c`. The returned value is in microwatts. When PSU has > 2.147kW, it can exceed what 32-bit signed integer (`s32`) can represent. For example, 2.4kW = 2,400,000,000 microwatts.
3. Remove unused variable `fpga_pci_dev` in `XCVR_ATTR`.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

