### PR TITLE
[202505] Update sai_stats_support_mask from 0x80 to 0x480 to mask off PFC pause frames

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/th5-a7060x6-64pe.config.bcm
@@ -3362,7 +3362,7 @@ bcm_device:
     0:
         global:
             ftem_mem_entries: 65536
-            sai_stats_support_mask: 0x80
+            sai_stats_support_mask: 0x480
             global_flexctr_ing_action_num_reserved: 20
             global_flexctr_ing_pool_num_reserved: 8
             global_flexctr_ing_op_profile_num_reserved: 20

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
@@ -3377,7 +3377,7 @@ bcm_device:
     0:
         global:
             ftem_mem_entries: 65536
-            sai_stats_support_mask: 0x80
+            sai_stats_support_mask: 0x480
             global_flexctr_ing_action_num_reserved: 20
             global_flexctr_ing_pool_num_reserved: 8
             global_flexctr_ing_op_profile_num_reserved: 20

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
@@ -1382,7 +1382,7 @@ bcm_device:
         global:
             ftem_mem_entries: 65536
             #enable port queue drop stats
-            sai_stats_support_mask: 0x80
+            sai_stats_support_mask: 0x480
             #disable vxlan tunnel stats
             sai_stats_disable_mask: 0x200
             #For PPIU Mode, Set resources for counters in global mode counters like ACL, etc

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128S2/th5-a7060x6-64pe.config.bcm
@@ -1397,7 +1397,7 @@ bcm_device:
     0:
         global:
             ftem_mem_entries: 65536
-            sai_stats_support_mask: 0x80
+            sai_stats_support_mask: 0x480
             global_flexctr_ing_action_num_reserved: 20
             global_flexctr_ing_pool_num_reserved: 8
             global_flexctr_ing_op_profile_num_reserved: 20

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/th5-a7060x6-64pe.config.bcm
@@ -1263,7 +1263,7 @@ bcm_device:
     0:
         global:
             ftem_mem_entries: 65536
-            sai_stats_support_mask: 0x80
+            sai_stats_support_mask: 0x480
             #disable vxlan tunnel stats
             sai_stats_disable_mask: 0x200
             #For PPIU Mode, Set resources for counters in global mode counters like ACL, etc

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P64/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P64/th5-a7060x6-64pe.config.bcm
@@ -1128,7 +1128,7 @@ bcm_device:
     0:
         global:
             ftem_mem_entries: 65536
-            sai_stats_support_mask: 0x80
+            sai_stats_support_mask: 0x480
             #disable vxlan tunnel stats
             sai_stats_disable_mask: 0x200
             global_flexctr_ing_action_num_reserved: 20


### PR DESCRIPTION
Cherry-pick from https://github.com/sonic-net/sonic-buildimage/pull/23772

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR is to set `sai_stats_support_mask` to `0x880` for a series of Arista HWSKUs.

##### Work item tracking
- Microsoft ADO **34515971**:
- CSP **CS00012419125**

#### How I did it
Update config.bcm

#### How to verify it
The change is verified by running PFCWD test on a physical testbed.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 202503
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Set `sai_stats_support_mask` to `0x480` for a series of Arista HWSKUs.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

