### PR TITLE
[Mellanox] Add CPO support and new sensor

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -30,6 +30,7 @@ try:
     from sonic_py_common import device_info
     from functools import reduce
     from .utils import extract_RJ45_ports_index
+    from .utils import extract_cpo_ports_index
     from . import module_host_mgmt_initializer
     from . import utils
     from .device_data import DeviceDataManager
@@ -120,6 +121,10 @@ class Chassis(ChassisBase):
         self._RJ45_port_inited = False
         self._RJ45_port_list = None
 
+        # Build the CPO port list from platform.json and hwsku.json
+        self._cpo_port_inited = False
+        self._cpo_port_list = None
+
         Chassis.chassis_instance = self
 
         self.module_host_mgmt_initializer = module_host_mgmt_initializer.ModuleHostMgmtInitializer()
@@ -139,6 +144,13 @@ class Chassis(ChassisBase):
             self._RJ45_port_inited = True
         return self._RJ45_port_list
 
+    @property
+    def cpo_port_list(self):
+        if not self._cpo_port_inited:
+            self._cpo_port_list = extract_cpo_ports_index()
+            self._cpo_port_inited = True
+        return self._cpo_port_list
+
     ##############################################
     # PSU methods
     ##############################################
@@ -147,6 +159,9 @@ class Chassis(ChassisBase):
         if not self._psu_list:
             from .psu import Psu, FixedPsu
             psu_count = DeviceDataManager.get_psu_count()
+            if psu_count == 0:
+                # For system with no PSU, for example, PDU system.
+                return
             hot_swapable = DeviceDataManager.is_psu_hotswapable()
 
             # Initialize PSU list
@@ -202,9 +217,11 @@ class Chassis(ChassisBase):
         if not self._fan_drawer_list:
             from .fan import Fan
             from .fan_drawer import RealDrawer, VirtualDrawer
-
-            hot_swapable = DeviceDataManager.is_fan_hotswapable()
             drawer_num = DeviceDataManager.get_fan_drawer_count()
+            if drawer_num == 0:
+                # For system with no fan, for example, liquid cooling system.
+                return
+            hot_swapable = DeviceDataManager.is_fan_hotswapable()
             fan_num = DeviceDataManager.get_fan_count()
             fan_num_per_drawer = fan_num // drawer_num
             drawer_ctor = RealDrawer if hot_swapable else VirtualDrawer
@@ -277,6 +294,8 @@ class Chassis(ChassisBase):
                         sfp_module = self._import_sfp_module()
                         if self.RJ45_port_list and index in self.RJ45_port_list:
                             self._sfp_list[index] = sfp_module.RJ45Port(index)
+                        elif self.cpo_port_list and index in self.cpo_port_list:
+                            self._sfp_list[index] = sfp_module.CpoPort(index)
                         else:
                             self._sfp_list[index] = sfp_module.SFP(index)
                         self.sfp_initialized_count += 1
@@ -294,6 +313,8 @@ class Chassis(ChassisBase):
                         for index in range(sfp_count):
                             if self.RJ45_port_list and index in self.RJ45_port_list:
                                 sfp_object = sfp_module.RJ45Port(index)
+                            elif self.cpo_port_list and index in self.cpo_port_list:
+                                sfp_object = sfp_module.CpoPort(index)
                             else:
                                 sfp_object = sfp_module.SFP(index)
                             self._sfp_list.append(sfp_object)
@@ -304,6 +325,8 @@ class Chassis(ChassisBase):
                             if self._sfp_list[index] is None:
                                 if self.RJ45_port_list and index in self.RJ45_port_list:
                                     self._sfp_list[index] = sfp_module.RJ45Port(index)
+                                elif self.cpo_port_list and index in self.cpo_port_list:
+                                    self._sfp_list[index] = sfp_module.CpoPort(index)
                                 else:
                                     self._sfp_list[index] = sfp_module.SFP(index)
                         self.sfp_initialized_count = len(self._sfp_list)
@@ -315,13 +338,22 @@ class Chassis(ChassisBase):
         Returns:
             An integer, the number of sfps available on this chassis
         """
+        num_sfps = 0
         if not self._RJ45_port_inited:
             self._RJ45_port_list = extract_RJ45_ports_index()
             self._RJ45_port_inited = True
+        
+        if not self._cpo_port_inited:
+            self._cpo_port_list = extract_cpo_ports_index()
+            self._cpo_port_inited = True
+        
+        num_sfps = DeviceDataManager.get_sfp_count()
         if self._RJ45_port_list is not None:
-            return DeviceDataManager.get_sfp_count() + len(self._RJ45_port_list)
-        else:
-            return DeviceDataManager.get_sfp_count()
+            num_sfps += len(self._RJ45_port_list)
+        if self._cpo_port_list is not None:
+            num_sfps += len(self._cpo_port_list)
+        
+        return num_sfps
 
     def get_all_sfps(self):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -229,13 +229,22 @@ class DeviceDataManager:
         version = check_output_pipe(["lspci", "-vv"], ["grep", "SimX"])
         parsed_version = re.search("([0-9]+\\.[0-9]+-[0-9]+)", version)
         return parsed_version.group(1) if parsed_version else "N/A"
+    
+    @classmethod
+    @utils.read_only_cache()
+    def get_fan_drawer_sysfs_count(cls):
+        return len(glob.glob('/run/hw-management/thermal/fan*_status'))
 
     @classmethod
     @utils.read_only_cache()
     def get_fan_drawer_count(cls):
         # Here we don't read from /run/hw-management/config/hotplug_fans because the value in it is not
         # always correct.
-        return len(glob.glob('/run/hw-management/thermal/fan*_status')) if cls.is_fan_hotswapable() else 1
+        fan_status_count = cls.get_fan_drawer_sysfs_count()
+        if fan_status_count == 0:
+            # For system with no fan, for example, liquid cooling system.
+            return 0
+        return fan_status_count if cls.is_fan_hotswapable() else 1
 
     @classmethod
     @utils.read_only_cache()

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -36,7 +36,11 @@ try:
     from .device_data import DeviceDataManager
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
     from sonic_platform_base.sonic_xcvr.fields import consts
-    from sonic_platform_base.sonic_xcvr.api.public import cmis, sff8636, sff8436
+    from sonic_platform_base.sonic_xcvr.api.public import sff8636, sff8436
+
+    from sonic_platform_base.sonic_xcvr.api.public import cmis as cmis_api
+    from sonic_platform_base.sonic_xcvr.codes.public import cmis as cmis_codes
+    from sonic_platform_base.sonic_xcvr.mem_maps.public import cmis as cmis_mem
 
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
@@ -72,6 +76,7 @@ QSFP_DD_TYPE_CODE_LIST = [
 ]
 
 RJ45_TYPE = "RJ45"
+CPO_TYPE = "CPO"
 
 #variables for sdk
 REGISTER_NUM = 1
@@ -461,10 +466,10 @@ class SFP(NvidiaSFPCommon):
         for s in not_ready_list:
             logger.log_error(f'SFP {s.sdk_index} eeprom is not ready')
 
-    # read eeprom specfic bytes beginning from offset with size as num_bytes
+    # read eeprom specific bytes beginning from offset with size as num_bytes
     def read_eeprom(self, offset, num_bytes):
         """
-        Read eeprom specfic bytes beginning from a random offset with size as num_bytes
+        Read eeprom specific bytes beginning from a random offset with size as num_bytes
         Returns:
             bytearray, if raw sequence of bytes are read correctly from the offset of size num_bytes
             None, if the read_eeprom fails
@@ -472,7 +477,7 @@ class SFP(NvidiaSFPCommon):
         return self._read_eeprom(offset, num_bytes)
 
     def _read_eeprom(self, offset, num_bytes, log_on_error=True):
-        """Read eeprom specfic bytes beginning from a random offset with size as num_bytes
+        """Read eeprom specific bytes beginning from a random offset with size as num_bytes
 
         Args:
             offset (int): read offset
@@ -520,10 +525,10 @@ class SFP(NvidiaSFPCommon):
 
         return bytearray(result)
 
-    # write eeprom specfic bytes beginning from offset with size as num_bytes
+    # write eeprom specific bytes beginning from offset with size as num_bytes
     def write_eeprom(self, offset, num_bytes, write_buffer):
         """
-        write eeprom specfic bytes beginning from a random offset with size as num_bytes
+        write eeprom specific bytes beginning from a random offset with size as num_bytes
         and write_buffer as the required bytes
         Returns:
             Boolean, true if the write succeeded and false if it did not succeed.
@@ -1086,7 +1091,7 @@ class SFP(NvidiaSFPCommon):
         Returns:
             bool: True if the api is of type CMIS
         """
-        return isinstance(xcvr_api, cmis.CmisApi)
+        return isinstance(xcvr_api, cmis_api.CmisApi)
 
     def is_sff_api(self, xcvr_api):
         """Check if the api type is SFF
@@ -1811,3 +1816,159 @@ class RJ45Port(NvidiaSFPCommon):
         """
         status = super().get_module_status()
         return SFP_STATUS_REMOVED if status == SFP_STATUS_UNKNOWN else status
+
+
+class CpoPort(NvidiaSFPCommon):
+    """class derived from SFP, representing CPO ports"""
+
+    def __init__(self, sfp_index):
+        super(CpoPort, self).__init__(sfp_index)
+        self._sfp_type_str = None
+        self.sfp_type = CPO_TYPE
+
+    def get_transceiver_info(self):
+        transceiver_info_dict = super().get_transceiver_info()
+        transceiver_info_dict['type'] = self.sfp_type
+        return transceiver_info_dict
+
+    def get_xcvr_api(self):
+        if self._xcvr_api is None:
+            self._xcvr_api = self._xcvr_api_factory._create_api(cmis_codes.CmisCodes, cmis_mem.CmisMemMap, cmis_api.CmisApi)
+        return self._xcvr_api
+
+    def get_presence(self):
+        file_path = SFP_SDK_MODULE_SYSFS_ROOT_TEMPLATE.format(self.sdk_index) + SFP_SYSFS_PRESENT
+        present = utils.read_int_from_file(file_path)
+        return present == 1
+
+    def reinit(self):
+        """
+        Nothing to do for cpo. Just provide it to avoid exception
+        :return:
+        """
+        return
+
+    def read_eeprom(self, offset, num_bytes):
+        """
+        Read eeprom specific bytes beginning from a random offset with size as num_bytes
+        Returns:
+            bytearray, if raw sequence of bytes are read correctly from the offset of size num_bytes
+            None, if the read_eeprom fails
+        """
+        return self._read_eeprom(offset, num_bytes)
+
+    def _read_eeprom(self, offset, num_bytes, log_on_error=True):
+        """Read eeprom specific bytes beginning from a random offset with size as num_bytes
+
+        Args:
+            offset (int): read offset
+            num_bytes (int): read size
+            log_on_error (bool, optional): whether log error when exception occurs. Defaults to True.
+
+        Returns:
+            bytearray: the content of EEPROM
+        """
+        result = bytearray(0)
+        while num_bytes > 0:
+            _, page, page_offset = self._get_page_and_page_offset(offset)
+            if not page:
+                return None
+
+            try:
+                with open(page, mode='rb', buffering=0) as f:
+                    f.seek(page_offset)
+                    content = f.read(num_bytes)
+                    if not result:
+                        result = content
+                    else:
+                        result += content
+                    read_length = len(content)
+                    if read_length == 0:
+                        logger.log_error(f'SFP {self.sdk_index}: EEPROM page {page} is empty, no data retrieved')
+                        return None
+                    num_bytes -= read_length
+                    if num_bytes > 0:
+                        page_size = f.seek(0, os.SEEK_END)
+                        if page_offset + read_length == page_size:
+                            offset += read_length
+                        else:
+                            # Indicate read finished
+                            num_bytes = 0
+                    if ctypes.get_errno() != 0:
+                        raise IOError(f'errno = {os.strerror(ctypes.get_errno())}')
+                    logger.log_debug(f'read EEPROM sfp={self.sdk_index}, page={page}, page_offset={page_offset}, '\
+                        f'size={read_length}, data={content}')
+            except (OSError, IOError) as e:
+                if log_on_error:
+                    logger.log_warning(f'Failed to read sfp={self.sdk_index} EEPROM page={page}, page_offset={page_offset}, '\
+                        f'size={num_bytes}, offset={offset}, error = {e}')
+                return None
+
+        return bytearray(result)
+
+    def _get_eeprom_path(self):
+        return SFP_EEPROM_ROOT_TEMPLATE.format(self.sdk_index)
+
+    def _get_page_and_page_offset(self, overall_offset):
+        """Get EEPROM page and page offset according to overall offset
+
+        Args:
+            overall_offset (int): Overall read offset
+
+        Returns:
+            tuple: (<page_num>, <page_path>, <page_offset>)
+        """
+        eeprom_path = self._get_eeprom_path()
+        if not os.path.exists(eeprom_path):
+            logger.log_error(f'EEPROM file path for sfp {self.sdk_index} does not exist')
+            return None, None, None
+
+        if overall_offset < SFP_PAGE_SIZE:
+            return 0, os.path.join(eeprom_path, SFP_PAGE0_PATH), overall_offset
+
+        if self._get_sfp_type_str(eeprom_path) == SFP_TYPE_SFF8472:
+            page1h_start = SFP_PAGE_SIZE * 2
+            if overall_offset < page1h_start:
+                return -1, os.path.join(eeprom_path, SFP_A2H_PAGE0_PATH), overall_offset - SFP_PAGE_SIZE
+        else:
+            page1h_start = SFP_PAGE_SIZE
+
+        page_num = (overall_offset - page1h_start) // SFP_UPPER_PAGE_OFFSET + 1
+        page = f'{page_num}/data'
+        offset = (overall_offset - page1h_start) % SFP_UPPER_PAGE_OFFSET
+        return page_num, os.path.join(eeprom_path, page), offset
+
+    def _get_sfp_type_str(self, eeprom_path):
+        """Get SFP type by reading first byte of EEPROM
+
+        Args:
+            eeprom_path (str): EEPROM path
+
+        Returns:
+            str: SFP type in string
+        """
+        if self._sfp_type_str is None:
+            page = os.path.join(eeprom_path, SFP_PAGE0_PATH)
+            try:
+                with open(page, mode='rb', buffering=0) as f:
+                    id_byte_raw = bytearray(f.read(1))
+                    id = id_byte_raw[0]
+                    if id == 0x18 or id == 0x19 or id == 0x1e:
+                        self._sfp_type_str = SFP_TYPE_CMIS
+                    elif id == 0x11 or id == 0x0D:
+                        # in sonic-platform-common, 0x0D is treated as sff8436,
+                        # but it shared the same implementation on Nvidia platforms,
+                        # so, we treat it as sff8636 here.
+                        self._sfp_type_str = SFP_TYPE_SFF8636
+                    elif id == 0x03:
+                        self._sfp_type_str = SFP_TYPE_SFF8472
+                    else:
+                        logger.log_error(f'Unsupported sfp type {id}')
+            except (OSError, IOError) as e:
+                # SFP_EEPROM_NOT_AVAILABLE usually indicates SFP is not present, no need
+                # print such error information to log
+                if SFP_EEPROM_NOT_AVAILABLE not in str(e):
+                    logger.log_error(f'Failed to get SFP type, index={self.sdk_index}, error={e}')
+                return None
+        return self._sfp_type_str
+

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -85,11 +85,13 @@ THERMAL_NAMING_RULE = {
         },
         {
             "name": "Ambient Port Side Temp",
-            "temperature": "port_amb"
+            "temperature": "port_amb",
+            "default_present": True
         },
         {
             "name": "Ambient Fan Side Temp",
-            "temperature": "fan_amb"
+            "temperature": "fan_amb",
+            "default_present": True
         },
         {
             "name": "Ambient COMEX Temp",
@@ -138,6 +140,15 @@ THERMAL_NAMING_RULE = {
             "high_critical_threshold": "sodimm{}_temp_crit",
             "search_pattern": '/run/hw-management/thermal/sodimm*_temp_input',
             'index_pattern': r'sodimm(\d+)_temp_input',
+            "type": "discrete",
+        },
+        {
+            "name": "PMIC {} Temp",
+            "temperature": "voltmon{}_temp1_input",
+            "high_threshold": "voltmon{}_temp1_max",
+            "high_critical_threshold": "voltmon{}_temp1_crit",
+            "search_pattern": '/run/hw-management/thermal/voltmon*_temp1_input',
+            'index_pattern': r'voltmon(\d+)_temp1_input',
             "type": "discrete",
         }
     ],

--- a/platform/mellanox/mlnx-platform-api/tests/test_change_event.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_change_event.py
@@ -39,6 +39,7 @@ class TestChangeEvent:
     @mock.patch('sonic_platform.device_data.DeviceDataManager.is_module_host_management_mode', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=1))
     @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.sfp.SFP.get_module_status')
     def test_get_change_event_legacy(self, mock_status, mock_time, mock_create_poll, mock_get_fd):
         c = chassis.Chassis()
@@ -92,6 +93,7 @@ class TestChangeEvent:
     @mock.patch('sonic_platform.device_data.DeviceDataManager.is_module_host_management_mode', mock.MagicMock(return_value=True))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=1))
     @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.module_host_mgmt_initializer.ModuleHostMgmtInitializer.initialize', mock.MagicMock())
     def test_get_change_event_for_module_host_management_mode(self, mock_time, mock_create_poll, mock_get_fd, mock_ready):
         """Test steps:

--- a/platform/mellanox/mlnx-platform-api/tests/test_module_initializer.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_module_initializer.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,9 +60,9 @@ class TestModuleInitializer:
         mock_exists.return_value = False
         initializer.wait_module_ready()
         assert not initializer.initialized
-        
 
     @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=1))
     @mock.patch('sonic_platform.sfp.SFP.initialize_sfp_modules', mock.MagicMock())
     @mock.patch('sonic_platform.module_host_mgmt_initializer.ModuleHostMgmtInitializer.is_initialization_owner')

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -29,7 +29,7 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
-from sonic_platform.sfp import SFP, RJ45Port, SX_PORT_MODULE_STATUS_INITIALIZING, SX_PORT_MODULE_STATUS_PLUGGED, SX_PORT_MODULE_STATUS_UNPLUGGED, SX_PORT_MODULE_STATUS_PLUGGED_WITH_ERROR, SX_PORT_MODULE_STATUS_PLUGGED_DISABLED
+from sonic_platform.sfp import SFP, RJ45Port, CpoPort, CPO_TYPE, cmis_api, SX_PORT_MODULE_STATUS_INITIALIZING, SX_PORT_MODULE_STATUS_PLUGGED, SX_PORT_MODULE_STATUS_UNPLUGGED, SX_PORT_MODULE_STATUS_PLUGGED_WITH_ERROR, SX_PORT_MODULE_STATUS_PLUGGED_DISABLED
 from sonic_platform.chassis import Chassis
 
 
@@ -319,6 +319,18 @@ class TestSfp:
         assert sfp.get_transceiver_threshold_info()
         sfp.reinit()
 
+    @mock.patch('sonic_platform.sfp.CpoPort.read_eeprom')
+    def test_cpo_get_xcvr_api(self, mock_read):
+        sfp = CpoPort(0)
+        api = sfp.get_xcvr_api()
+        assert isinstance(api, cmis_api.CmisApi)
+
+    @mock.patch('sonic_platform.sfp.SfpOptoeBase.get_transceiver_info', return_value={})
+    def test_cpo_get_transceiver_info(self, mock_get_info):
+        sfp = CpoPort(0)
+        info = sfp.get_transceiver_info()
+        assert info['type'] == CPO_TYPE
+
     @mock.patch('os.path.exists')
     @mock.patch('sonic_platform.utils.read_int_from_file')
     def test_get_temperature(self, mock_read, mock_exists):
@@ -507,6 +519,7 @@ class TestSfp:
         assert error_desc is None
 
     @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=1))
     def test_initialize_sfp_modules(self):
         c = Chassis()

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal.py
@@ -40,12 +40,18 @@ class TestThermal:
     @mock.patch('os.path.exists', mock.MagicMock(return_value=True))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_gearbox_count', mock.MagicMock(return_value=2))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_cpu_thermal_count', mock.MagicMock(return_value=2))
-    @mock.patch('sonic_platform.thermal.glob.iglob', mock.MagicMock(
-        return_value=['/run/hw-management/thermal/sodimm1_temp_input',
-                      '/run/hw-management/thermal/sodimm2_temp_input']))
+    @mock.patch('sonic_platform.thermal.glob.iglob')
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_platform_name', mock.MagicMock(return_value='x86_64-mlnx_msn2700-r0'))
-    def test_chassis_thermal(self):
+    def test_chassis_thermal(self, mock_glob):
         from sonic_platform.thermal import THERMAL_NAMING_RULE
+        def mocked_glob(pattern):
+            if 'sodimm' in pattern:
+                return ['/run/hw-management/thermal/sodimm1_temp_input',
+                        '/run/hw-management/thermal/sodimm2_temp_input']
+            elif 'voltmon' in pattern:
+                return ['/run/hw-management/thermal/voltmon1_temp1_input',
+                        '/run/hw-management/thermal/voltmon2_temp1_input']
+        mock_glob.side_effect = mocked_glob
         chassis = Chassis()
         thermal_list = chassis.get_all_thermals()
         assert thermal_list

--- a/platform/mellanox/mlnx-platform-api/tests/test_utils.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_utils.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -160,6 +161,92 @@ class TestUtils:
 
         mock_load_json.side_effect = [platform_json, hwsku_json]
         assert utils.extract_RJ45_ports_index() == [0]
+
+    @pytest.mark.parametrize(
+        "mock_exists_value, platform_json, hwsku_json, expected_result",
+        [
+            # Case 1: hwsku.json file does not exist
+            (False, {}, {}, None),
+
+            # Case 2: file exists, but no CPO ports
+            (
+                True,
+                {
+                    'interfaces': {
+                        "Ethernet0": {
+                            "index": "1",
+                            "lanes": "0",
+                            "breakout_modes": {
+                                "2x400G[200G]": ["etp1a", "etp1b"]
+                            }
+                        }
+                    }
+                },
+                {
+                    'interfaces': {
+                        "Ethernet0": {
+                            "default_brkout_mode": "2x400G[200G]",
+                            "port_type": "SFP"
+                        }
+                    }
+                },
+                None
+            ),
+
+            # Case 3: one CPO port
+            (
+                True,
+                {
+                    'interfaces': {
+                        "Ethernet0": {
+                            "index": "1",
+                            "lanes": "0",
+                            "breakout_modes": {
+                                "2x400G[200G]": ["etp1a", "etp1b"]
+                            }
+                        }
+                    }
+                },
+                {
+                    'interfaces': {
+                        "Ethernet0": {
+                            "default_brkout_mode": "2x400G[200G]",
+                            "port_type": "CPO"
+                        }
+                    }
+                },
+                [0]
+            ),
+
+            # Case 4: multiple CPO ports
+            (
+                True,
+                {
+                    'interfaces': {
+                        "Ethernet0": {"index": "1"},
+                        "Ethernet4": {"index": "5"},
+                        "Ethernet8": {"index": "9"}
+                    }
+                },
+                {
+                    'interfaces': {
+                        "Ethernet0": {"port_type": "CPO"},
+                        "Ethernet4": {"port_type": "CPO"},
+                        "Ethernet8": {"port_type": "CPO"}
+                    }
+                },
+                [0, 4, 8]
+            ),
+        ]
+    )
+    @mock.patch('sonic_py_common.device_info.get_path_to_port_config_file', mock.MagicMock(return_value='platform.json'))
+    @mock.patch('sonic_py_common.device_info.get_path_to_hwsku_dir', mock.MagicMock(return_value='/tmp'))
+    @mock.patch('sonic_platform.utils.load_json_file')
+    @mock.patch('os.path.exists')
+    def test_extract_cpo_ports_index(self, mock_exists, mock_load_json, mock_exists_value, platform_json, hwsku_json, expected_result):
+        mock_exists.return_value = mock_exists_value
+        mock_load_json.side_effect = [platform_json, hwsku_json]
+        assert utils.extract_cpo_ports_index() == expected_result
 
     def test_wait_until(self):
         values = []


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. Add platform API level support for CPO
2. Add new sensors support

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
1. Create a CPO class to represent CPO module
2. Add new sensors support

#### How to verify it
1. Unit test passed
2. Manual test passed

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

