### PR TITLE
Extend MACsec show command to support FIPS POST status option.

### DIFF
--- a/dockers/docker-macsec/cli-plugin-tests/test_show_macsec.py
+++ b/dockers/docker-macsec/cli-plugin-tests/test_show_macsec.py
@@ -1,5 +1,5 @@
 import sys
-from unittest import mock
+from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
@@ -9,7 +9,7 @@ import show_macsec
 
 class TestShowMACsec(object):
     def test_plugin_registration(self):
-        cli = mock.MagicMock()
+        cli = MagicMock()
         show_macsec.register(cli)
         cli.add_command.assert_called_once_with(show_macsec.macsec)
 
@@ -27,3 +27,85 @@ class TestShowMACsec(object):
         runner = CliRunner()
         result = runner.invoke(show_macsec.macsec,["--profile"])
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+
+    @patch('show_macsec.SonicV2Connector')
+    def test_post_status_success(self, mock_connector):
+        """Test --post-status command with successful data"""
+        # Mock the database connection and data
+        mock_db = MagicMock()
+        mock_connector.return_value = mock_db
+
+        # Mock keys method to return test modules
+        mock_db.keys.return_value = [
+            "FIPS_MACSEC_POST_TABLE|crypto",
+            "FIPS_MACSEC_POST_TABLE|sai"
+        ]
+
+        # Mock get_all method to return test data
+        def mock_get_all(db_name, key):
+            if key == "FIPS_MACSEC_POST_TABLE|crypto":
+                return {
+                    'status': 'pass',
+                    'timestamp': '2025-09-15 10:30:00 UTC',
+                }
+            elif key == "FIPS_MACSEC_POST_TABLE|sai":
+                return {
+                    'status': 'pass',
+                    'timestamp': '2025-09-15 10:30:00 UTC',
+                }
+            return {}
+
+        mock_db.get_all.side_effect = mock_get_all
+
+        runner = CliRunner()
+        result = runner.invoke(show_macsec.macsec, ["--post-status"])
+
+        assert result.exit_code == 0
+        assert "Module      : crypto" in result.output
+        assert "Status      : pass" in result.output
+        assert "Timestamp   : 2025-09-15 10:30:00 UTC" in result.output
+        assert "Module      : sai" in result.output
+
+    @patch('show_macsec.SonicV2Connector')
+    def test_post_status_no_entries(self, mock_connector):
+        """Test --post-status command when no POST entries exist"""
+        # Mock the database connection
+        mock_db = MagicMock()
+        mock_connector.return_value = mock_db
+
+        # Mock keys method to return empty list
+        mock_db.keys.return_value = []
+
+        runner = CliRunner()
+        result = runner.invoke(show_macsec.macsec, ["--post-status"])
+
+        assert result.exit_code == 0
+        assert "No entries found" in result.output
+
+    def test_post_status_mutual_exclusivity(self):
+        """Test that --post-status and other option/argument are mutually exclusive"""
+        runner = CliRunner()
+        result = runner.invoke(show_macsec.macsec, ["Ethernet0", "--post-status"])
+
+        assert result.exit_code == 0
+        assert "POST status is not valid with other options/arguments" in result.output
+
+        result = runner.invoke(show_macsec.macsec, ["--profile", "--post-status"])
+
+        assert result.exit_code == 0
+        assert "POST status is not valid with other options/arguments" in result.output
+
+        result = runner.invoke(show_macsec.macsec, ["--dump-file", "--post-status"])
+
+        assert result.exit_code == 0
+        assert "POST status is not valid with other options/arguments" in result.output
+
+        result = runner.invoke(show_macsec.macsec, ["--profile", "--post-status"])
+
+        assert result.exit_code == 0
+        assert "POST status is not valid with other options/arguments" in result.output
+
+        result = runner.invoke(show_macsec.macsec, ["Ethernet0", "--profile", "--post-status"])
+
+        assert result.exit_code == 0
+        assert "POST status is not valid with other options/arguments" in result.output


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Extended the MACsec show command to display FIPS POST (Power-On Self-Test) status, enabling network operators to verify cryptographic module compliance and operational readiness in FIPS  enabled deployments.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Added `--post-status` option to existing `show macsec` command
- Read and display information from `FIPS_MACSEC_POST_TABLE|<module>` keys
- Added unit tests to verify the changes.

Updated macsec show command structure
show macsec [--profile/--dump-file/**--post-status**] [interface_name]

#### How to verify it
```bash
show macsec --post-status
```

Sample Outputs
```bash
admin@sonic:~$ show macsec --post-status
POST Status:
===========
Module    : crypto
Status    : pass
Timestamp : 2025-09-16 12:09:11 UTC
```

```bash
admin@sonic:~$ show macsec --post-status
POST Status
===========
No entries found
```

Unit Testing
```bash
cd dockers/docker-macsec/cli-plugin-tests/
python3 -m pytest test_show_macsec.py -v
```

Specific POST-related tests
```bash
python3 -m pytest test_show_macsec.py::TestShowMACsec::test_post_status_success -v
python3 -m pytest test_show_macsec.py::TestShowMACsec::test_post_status_no_entries -v  
python3 -m pytest test_show_macsec.py::TestShowMACsec::test_post_status_mutual_exclusivity -v
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

