### PR TITLE
Modified platform to support MtFuji rev 2 board and bug fixes

### DIFF
--- a/files/dsc/dpu.init
+++ b/files/dsc/dpu.init
@@ -60,6 +60,8 @@ function start_polaris()
     echo $IMAGE_NAME:$TAG > $DPU_DOCKER_INFO_DIR/image
     /usr/sbin/ethtool -K Ethernet0 tx off sg off tso off rx off
 
+    echo 50 > $HOST_DIR_POLARIS/data/free_mem_threshold
+
     docker ps -a --format "{{.ID}}\t{{.Image}}" | grep "$IMAGE_NAME:$TAG" | awk '{print $1}' | xargs -I {} docker rm {}
 
     docker run -v $HOST_DIR_POLARIS/update:/update -v $HOST_DIR_POLARIS/sysconfig/config0:/sysconfig/config0 -v $HOST_DIR_POLARIS/sysconfig/config1:/sysconfig/config1 -v $HOST_DIR_POLARIS/obfl/a:/obfl -v $HOST_DIR_POLARIS/obfl:/var/log/obfl -v $HOST_DIR_POLARIS/data:/data -v $HOST_DIR_POLARIS/share:/share -v $HOST_DIR_POLARIS/external:/external -v $HOST_DIR_POLARIS/mnt/a:/ro -v /dev:/dev -v /sys:/sys --net=host --name=$CONTAINER_NAME_POLARIS --privileged $IMAGE_NAME:$TAG &

--- a/platform/pensando/sonic-platform-modules-dpu/dpu/utils/dpu_pensando_util.py
+++ b/platform/pensando/sonic-platform-modules-dpu/dpu/utils/dpu_pensando_util.py
@@ -12,6 +12,10 @@ from sonic_py_common import syslogger
 
 QSFP_STAT_CTRL_CPLD_ADDR = "0x2"
 apiHelper = APIHelper()
+LOCALHOST = "127.0.0.1"
+REDIS_PORT = 6379
+CHSSIS_DB = 4
+DISABLE_CONTAINER_LIST = ["snmp", "dhcp_relay", "mgmt_framework"]
 
 SYSLOG_IDENTIFIER = 'dpu_pensando_util'
 logger_instance = syslogger.SysLogger(SYSLOG_IDENTIFIER)
@@ -84,6 +88,19 @@ def setup_platform_components_json(slot_id):
     except Exception as e:
         log_err("failed to setup platform_components.json due to {}".format(e))
 
+def disable_unused_containers():
+    try:
+        import redis
+
+        r = redis.StrictRedis(host=LOCALHOST, port=REDIS_PORT, db=CHSSIS_DB, decode_responses=True)
+
+        for feature in DISABLE_CONTAINER_LIST:
+            key = f"FEATURE|{feature}"
+            if r.exists(key):
+                r.hset(key, "state", "disabled")
+    except Exception as e:
+        log_err("failed to disable state of unused container due to {}".format(e))
+
 def config_setup():
     try:
         from sonic_platform.chassis import Chassis
@@ -98,6 +115,7 @@ def config_setup():
         log_err("failed to set Ethernet0 ip due to {}".format(e))
 
     setup_platform_components_json(slot_id)
+    disable_unused_containers()
 
     try:
         run_cmd("mkdir -p /host/images")

--- a/platform/pensando/sonic-platform-modules-dpu/sonic_platform/chassis.py
+++ b/platform/pensando/sonic-platform-modules-dpu/sonic_platform/chassis.py
@@ -22,8 +22,8 @@ except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 NUM_THERMAL = 2
-NUM_VOLTAGE_SENSORS = 6
-NUM_CURRENT_SENSORS = 6
+NUM_VOLTAGE_SENSORS = 0
+NUM_CURRENT_SENSORS = 0
 HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 HOST_CHK_CMD = "docker > /dev/null 2>&1"
@@ -31,6 +31,7 @@ REBOOT_CAUSE_SOFTWARE = "Software causes"
 REBOOT_CAUSE_EXTERNAL = "External causes"
 RESET_CAUSE_PATH = "/sys/firmware/pensando/rstcause/this_cause"
 DOCKER_HWSKU_PATH = '/usr/share/sonic/platform'
+SLOT_ID_MASK = 0x7
 
 #cpld masks for system led
 SYSTEM_LED_GREEN   = 0x7
@@ -141,6 +142,8 @@ class Chassis(ChassisBase):
         board_id = self._api_helper.get_board_id()
         if board_id == self._api_helper.mtfuji_board_id:
             NUM_THERMAL = 8
+            if self.get_revision() == self._api_helper.mtfuji_rev_v2:
+                NUM_THERMAL = 6
         if Thermal._thermals_available():
             for index in range(0, NUM_THERMAL):
                 thermal = Thermal(index)
@@ -174,6 +177,11 @@ class Chassis(ChassisBase):
 
     def __initialize_voltage_sensors(self):
         from sonic_platform.sensor import VoltageSensor
+        board_id = self._api_helper.get_board_id()
+        if board_id == self._api_helper.mtfuji_board_id:
+            NUM_VOLTAGE_SENSORS = 6
+            if self.get_revision() == self._api_helper.mtfuji_rev_v2:
+                NUM_VOLTAGE_SENSORS = 4
         if VoltageSensor._validate_voltage_sensors():
             for index in range(0, NUM_VOLTAGE_SENSORS):
                 voltage = VoltageSensor(index)
@@ -207,6 +215,11 @@ class Chassis(ChassisBase):
 
     def __initialize_current_sensors(self):
         from sonic_platform.sensor import CurrentSensor
+        board_id = self._api_helper.get_board_id()
+        if board_id == self._api_helper.mtfuji_board_id:
+            NUM_CURRENT_SENSORS = 6
+            if self.get_revision() == self._api_helper.mtfuji_rev_v2:
+                NUM_CURRENT_SENSORS = 4
         if CurrentSensor._validate_current_sensors():
             for index in range(0, NUM_CURRENT_SENSORS):
                 current = CurrentSensor(index)
@@ -361,12 +374,12 @@ class Chassis(ChassisBase):
         try:
             if self._api_helper.is_host():
                 slot_id = self._api_helper.run_docker_cmd(cmd)
-                return int(slot_id,16)
+                return int(slot_id,16) & SLOT_ID_MASK
             else:
                 slot_id_file = DOCKER_HWSKU_PATH + "/dpu_slot_id"
                 slot_id_hex = open(slot_id_file, "r").read()
                 if slot_id_hex:
-                    slot_id = int(slot_id_hex, 16)
+                    slot_id = int(slot_id_hex, 16) & SLOT_ID_MASK
                     return slot_id
             return -1
         except:
@@ -416,4 +429,7 @@ class Chassis(ChassisBase):
             bool: True if it is replaceable.
         """
         return False
+
+    def get_revision(self):
+        return self._api_helper.get_board_rev()
 

--- a/platform/pensando/sonic-platform-modules-dpu/sonic_platform/component.py
+++ b/platform/pensando/sonic-platform-modules-dpu/sonic_platform/component.py
@@ -53,7 +53,7 @@ def fetch_version_info(apiHelper):
         from sonic_installer.bootloader import get_bootloader
         bootloader = get_bootloader()
         curimage = bootloader.get_current_image()
-        curimage = curimage.split('-')[-1]
+        curimage = curimage.split('SONiC-OS-')[-1]
         fwupdate_version_list = []
         try:
             dpu_docker_name = apiHelper.get_dpu_docker_container_name()

--- a/platform/pensando/sonic-platform-modules-dpu/sonic_platform/helper.py
+++ b/platform/pensando/sonic-platform-modules-dpu/sonic_platform/helper.py
@@ -21,10 +21,14 @@ QSFP_STAT_CTRL_CPLD_ADDR = "0x2"
 DPU_DOCKER_IMAGE_NAME_FILE="/host/dpu-docker-info/image"
 DPU_DOCKER_CONTAINER_NAME_FILE = "/host/dpu-docker-info/name"
 DOCKER_HWSKU_PATH = '/usr/share/sonic/platform'
+CPLD_REV_MASK = 0x7
+CPLD_REV_SHIFT = 4
 
 class APIHelper():
 
     mtfuji_board_id = 130
+    mtfuji_rev_v1 = "V1"
+    mtfuji_rev_v2 = "V2"
 
     def __init__(self):
         pass
@@ -136,6 +140,25 @@ class APIHelper():
         except Exception as e:
             print(f"Failed to get board id due to {e}")
             return 0
+
+    def get_board_rev(self):
+        cmd = "cpldapp -r 0xA"
+        slot_id = 0
+        try:
+            if self.is_host():
+                slot_id = self.run_docker_cmd(cmd)
+            else:
+                slot_id_file = DOCKER_HWSKU_PATH + "/dpu_slot_id"
+                slot_id = open(slot_id_file, "r").read()
+            if self.get_board_id() == self.mtfuji_board_id:
+                rev = (int(slot_id, 16) >> CPLD_REV_SHIFT) & CPLD_REV_MASK
+                if rev == 0x2:
+                    return self.mtfuji_rev_v2
+                else:
+                    return self.mtfuji_rev_v1
+            return "N/A"
+        except:
+            return "N/A"
 
     def readline_txt_file(self, path):
         try:

--- a/platform/pensando/sonic-platform-modules-dpu/sonic_platform/thermal.py
+++ b/platform/pensando/sonic-platform-modules-dpu/sonic_platform/thermal.py
@@ -17,6 +17,7 @@ except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 g_board_id = None
+g_board_rev = None
 
 class Thermal(ThermalBase):
     """Pensando-specific Thermal class"""
@@ -28,7 +29,7 @@ class Thermal(ThermalBase):
     ]
 
     # [ Sensor-Name, sysfs, low_threshold, high_threshold, critical_low, critical_high]
-    SENSOR_MAPPING_MTFUJI = [
+    SENSOR_MAPPING_MTFUJI_V1 = [
         ["Die temperature", "/sys/class/hwmon/hwmon0/temp2_input", 1, 110, -10, 130],
         ["Board temperature", "/sys/class/hwmon/hwmon0/temp1_input", 1, 110, -10, 130],
         ["VP0P85_VDD_DDR_DPU0", "/sys/bus/i2c/devices/0-0044/hwmon/hwmon2/temp2_input", 1, 110, -10, 130],
@@ -39,12 +40,24 @@ class Thermal(ThermalBase):
         ["VP0P85_VDD_ARM_DPU0", "/sys/bus/i2c/devices/0-0066/hwmon/hwmon0/temp3_input", 1, 110, -10, 130],
     ]
 
+    # [ Sensor-Name, sysfs, low_threshold, high_threshold, critical_low, critical_high]
+    SENSOR_MAPPING_MTFUJI_V2 = [
+        ["Die temperature", "/sys/class/hwmon/hwmon0/temp2_input", 1, 110, -10, 130],
+        ["Board temperature", "/sys/class/hwmon/hwmon0/temp1_input", 1, 110, -10, 130],
+        ["VP0P85_VDD_DDR_DPU0", "/sys/bus/i2c/devices/0-0072/hwmon/hwmon0/temp1_input", 1, 110, -10, 130],
+        ["VP1P2_DDR_VDDQ_DPU0", "/sys/bus/i2c/devices/0-0072/hwmon/hwmon0/temp2_input", 1, 110, -10, 130],
+        ["VP0P75_VDD_CORE_DPU0", "/sys/bus/i2c/devices/0-0062/hwmon/hwmon1/temp1_input", 1, 110, -10, 130],
+        ["VP0P85_VDD_ARM_DPU0", "/sys/bus/i2c/devices/0-0062/hwmon/hwmon1/temp2_input", 1, 110, -10, 130],
+    ]
+
     @classmethod
     def _thermals_available(cls):
         global g_board_id
+        global g_board_rev
         from sonic_platform.helper import APIHelper
         apiHelper = APIHelper()
         g_board_id = apiHelper.get_board_id()
+        g_board_rev = apiHelper.get_board_rev()
         temp_hwmon = '/sys/bus/i2c/devices/i2c-0/0-004c/hwmon'
         if g_board_id == apiHelper.mtfuji_board_id:
             temp_hwmon = '/sys/class/hwmon/hwmon0/temp1_input'
@@ -58,11 +71,18 @@ class Thermal(ThermalBase):
         self._api_helper = APIHelper()
         self.index = thermal_index + 1
         self.board_id = g_board_id
+        self.board_rev = g_board_rev
+        self.sensor_mapping = self.SENSOR_MAPPING
         if self.board_id != self._api_helper.mtfuji_board_id:
             temp_hwmon = '/sys/bus/i2c/devices/i2c-0/0-004c/hwmon'
             self.temp_dir = None
             if os.path.exists(temp_hwmon):
                 self.temp_dir = temp_hwmon + '/' + os.listdir(temp_hwmon)[0]
+        else:
+            if self.board_rev == self._api_helper.mtfuji_rev_v1:
+                self.sensor_mapping = self.SENSOR_MAPPING_MTFUJI_V1
+            if self.board_rev == self._api_helper.mtfuji_rev_v2:
+                self.sensor_mapping = self.SENSOR_MAPPING_MTFUJI_V2
 
     def get_name(self):
         """
@@ -71,8 +91,8 @@ class Thermal(ThermalBase):
             string: The name of the thermal
         """
         if self.board_id == self._api_helper.mtfuji_board_id:
-            return self.SENSOR_MAPPING_MTFUJI[self.index - 1][0]
-        return self.SENSOR_MAPPING[self.index - 1]
+            return self.sensor_mapping[self.index - 1][0]
+        return self.sensor_mapping[self.index - 1]
 
     def get_presence(self):
         """
@@ -119,7 +139,7 @@ class Thermal(ThermalBase):
             try :
                 temp_file = None
                 if self.board_id == self._api_helper.mtfuji_board_id:
-                    temp_file = self.SENSOR_MAPPING_MTFUJI[self.index - 1][1]
+                    temp_file = self.sensor_mapping[self.index - 1][1]
                 else:
                     temp_file = self.temp_dir +'/temp{0}_input'.format(str(self.index))
                 temperature = float(open(temp_file).read()) / 1000.0
@@ -136,7 +156,7 @@ class Thermal(ThermalBase):
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
         if self.board_id == self._api_helper.mtfuji_board_id:
-            return float(self.SENSOR_MAPPING_MTFUJI[self.index - 1][3])
+            return float(self.sensor_mapping[self.index - 1][3])
         raise NotImplementedError
 
     def get_low_threshold(self):
@@ -148,7 +168,7 @@ class Thermal(ThermalBase):
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
         if self.board_id == self._api_helper.mtfuji_board_id:
-            return float(self.SENSOR_MAPPING_MTFUJI[self.index - 1][2])
+            return float(self.sensor_mapping[self.index - 1][2])
         raise NotImplementedError
 
     def get_high_critical_threshold(self):
@@ -167,7 +187,7 @@ class Thermal(ThermalBase):
             except Exception:
                 pass
         else:
-            return float(self.SENSOR_MAPPING_MTFUJI[self.index - 1][5])
+            return float(self.sensor_mapping[self.index - 1][5])
         return float(temperature)
 
     def get_low_critical_threshold(self):
@@ -179,7 +199,7 @@ class Thermal(ThermalBase):
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
         if self.board_id == self._api_helper.mtfuji_board_id:
-            return float(self.SENSOR_MAPPING_MTFUJI[self.index - 1][4])
+            return float(self.sensor_mapping[self.index - 1][4])
         raise NotImplementedError
 
 


### PR DESCRIPTION
- Added get_revision support for mtfuji board types
- Added sensor mapping for mtfuji rev 2
- Fixed fwutil show status output for sonic image version
- Fixed show system-health output for unused containers by disabling state in config_db.json FEATURE table
- Fixed ssh connectivity issue while doing sonic installation via ssh

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

