### PR TITLE
[QoS] Disable pfc and pfcwd on service ports

### DIFF
--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/buffers_defaults_t0.j2
@@ -34,3 +34,8 @@
         }
     },
 {%- endmacro %}
+
+{%- macro generate_service_port_list(PORT_SERVICE) -%}
+    {%- if PORT_SERVICE.append("Ethernet512") %}{% endif %}
+    {%- if PORT_SERVICE.append("Ethernet513") %}{% endif %}
+{%- endmacro %}

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/buffers_defaults_t1.j2
@@ -34,3 +34,8 @@
         }
     },
 {%- endmacro %}
+
+{%- macro generate_service_port_list(PORT_SERVICE) -%}
+    {%- if PORT_SERVICE.append("Ethernet512") %}{% endif %}
+    {%- if PORT_SERVICE.append("Ethernet513") %}{% endif %}
+{%- endmacro %}

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -7,18 +7,19 @@
 {%- set PORT_DOWNLINK = [] %}
 {%- set PORT_SERVICE = [] %}
 
-{% import "buffers.json.j2" as buffer_defs %}
-{%- if buffer_defs.default_topo is defined %}
-    {%- set filename_postfix = buffer_defs.default_topo %}
-{%- else %}
-    {%- set filename_postfix = 'def' %}
-{%- endif %}
+{% if template_exists("buffers.json.j2") %}
+    {% import "buffers.json.j2" as buffer_defs %}
+    {%- set filename_postfix = buffer_defs.default_topo | default("def", true) %}
+{% else %}
+    {%- set filename_postfix = "def" %}
+{% endif %}
 
 {# Allow includer to pre-package defs without needing an import #}
-{%- if defs is not defined -%}
+{%- if defs is not defined %}
     {# Import default values from device HWSKU folder #}
-    {%- import 'buffers_defaults_%s.j2' % filename_postfix as defs with context %}
-    {%- set default_cable = defs.default_cable -%}
+    {%- if template_exists('buffers_defaults_%s.j2' % filename_postfix) %}
+        {%- import 'buffers_defaults_%s.j2' % filename_postfix as defs with context %}
+    {%- endif -%}
 {%- endif -%}
 
 {%- set voq_chassis = false %}
@@ -52,7 +53,7 @@
 {%- if generate_qos_bypass_port_list is defined %}
     {%- if generate_qos_bypass_port_list(PORT_QOS_BYPASS) %} {% endif %}
 {%- endif %}
-{%- if defs.generate_service_port_list is defined %}
+{%- if defs is defined and defs.generate_service_port_list is defined %}
     {%- if defs.generate_service_port_list(PORT_SERVICE) %}{% endif %}
 {%- endif %}
 

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -5,6 +5,46 @@
 {%- set PORT_QOS_BYPASS = [] %}
 {%- set PORT_UPLINK = [] %}
 {%- set PORT_DOWNLINK = [] %}
+{%- set PORT_SERVICE = [] %}
+
+{% import "buffers.json.j2" as buffer_defs %}
+{# Determine device topology and filename postfix #}
+{%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost']['type'] is defined %}
+{%-     set switch_role = DEVICE_METADATA['localhost']['type'] %}
+{%  if DEVICE_METADATA['localhost']['subtype'] is defined %}
+{%-     set switch_subrole = DEVICE_METADATA['localhost']['subtype'] %}
+{%- else %}
+{%-     set switch_subrole = '' %}
+{%- endif %}
+{%-     if 'torrouter' in switch_role.lower() and 'mgmt' not in switch_role.lower()%}
+{%-         set filename_postfix = 't0' %}
+{%-     elif 'leafrouter' in switch_role.lower() and 'mgmt' not in switch_role.lower()%}
+{%-         set filename_postfix = 't1' %}
+{%-     elif 'lowerspinerouter' in switch_role.lower() and 'mgmt' not in switch_role.lower()%}
+{%-         set filename_postfix = 'lt2' %}
+{%-     elif 'spinerouter' in switch_role.lower() and 'mgmt' not in switch_role.lower()%}
+    {%-     if 'lowerspinerouter' == switch_subrole.lower() %}
+    {%-         set filename_postfix = 'lt2' %}
+    {%-     elif 'fabricspinerouter' == switch_role.lower() %}
+    {%-         set filename_postfix = 'ft2' %}
+    {%-     else %}
+    {%-         set filename_postfix = 't2' %}
+    {%-     endif -%}
+{%-     else %}
+{%-         set filename_postfix = buffer_defs.default_topo %}
+{%-     endif -%}
+{%- else %}
+{%-         set filename_postfix = buffer_defs.default_topo %}
+{%-         set switch_role      = '' %}
+{%-         set switch_subrole   = '' %}
+{%- endif -%}
+
+{# Allow includer to pre-package defs without needing an import #}
+{%- if defs is not defined -%}
+    {# Import default values from device HWSKU folder #}
+    {%- import 'buffers_defaults_%s.j2' % filename_postfix as defs with context %}
+    {%- set default_cable = defs.default_cable -%}
+{%- endif -%}
 
 {%- set voq_chassis = false %}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost']['switch_type'] is defined and  DEVICE_METADATA['localhost']['switch_type']  == 'voq' %}
@@ -36,6 +76,9 @@
 {%- endif %}
 {%- if generate_qos_bypass_port_list is defined %}
     {%- if generate_qos_bypass_port_list(PORT_QOS_BYPASS) %} {% endif %}
+{%- endif %}
+{%- if defs.generate_service_port_list is defined %}
+    {%- if defs.generate_service_port_list(PORT_SERVICE) %}{% endif %}
 {%- endif %}
 
 {%- if PORT_ALL | sort_by_port_index %}{% endif %}
@@ -426,12 +469,16 @@
 {% endif %}
 {% endif %}
 {% if port not in PORT_DPC %}
-{% if port in port_names_list_extra_queues %}
+{% if port in PORT_SERVICE %}
+            "pfc_enable"      : "",
+            "pfcwd_sw_enable" : "",
+{% elif port in port_names_list_extra_queues %}
             "pfc_enable"      : "2,3,4,6",
+            "pfcwd_sw_enable" : "2,3,4,6",
 {% else %}
             "pfc_enable"      : "{{ LOSSLESS_TC|join(',') }}",
-{% endif %}
             "pfcwd_sw_enable" : "{{ LOSSLESS_TC|join(',') }}",
+{% endif %}
 {% endif %}
 {% if port not in PORT_DPC %}
             "tc_to_pg_map"    : "AZURE",

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -8,36 +8,11 @@
 {%- set PORT_SERVICE = [] %}
 
 {% import "buffers.json.j2" as buffer_defs %}
-{# Determine device topology and filename postfix #}
-{%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost']['type'] is defined %}
-{%-     set switch_role = DEVICE_METADATA['localhost']['type'] %}
-{%  if DEVICE_METADATA['localhost']['subtype'] is defined %}
-{%-     set switch_subrole = DEVICE_METADATA['localhost']['subtype'] %}
+{%- if buffer_defs.default_topo is defined %}
+    {%- set filename_postfix = buffer_defs.default_topo %}
 {%- else %}
-{%-     set switch_subrole = '' %}
+    {%- set filename_postfix = 'def' %}
 {%- endif %}
-{%-     if 'torrouter' in switch_role.lower() and 'mgmt' not in switch_role.lower()%}
-{%-         set filename_postfix = 't0' %}
-{%-     elif 'leafrouter' in switch_role.lower() and 'mgmt' not in switch_role.lower()%}
-{%-         set filename_postfix = 't1' %}
-{%-     elif 'lowerspinerouter' in switch_role.lower() and 'mgmt' not in switch_role.lower()%}
-{%-         set filename_postfix = 'lt2' %}
-{%-     elif 'spinerouter' in switch_role.lower() and 'mgmt' not in switch_role.lower()%}
-    {%-     if 'lowerspinerouter' == switch_subrole.lower() %}
-    {%-         set filename_postfix = 'lt2' %}
-    {%-     elif 'fabricspinerouter' == switch_role.lower() %}
-    {%-         set filename_postfix = 'ft2' %}
-    {%-     else %}
-    {%-         set filename_postfix = 't2' %}
-    {%-     endif -%}
-{%-     else %}
-{%-         set filename_postfix = buffer_defs.default_topo %}
-{%-     endif -%}
-{%- else %}
-{%-         set filename_postfix = buffer_defs.default_topo %}
-{%-         set switch_role      = '' %}
-{%-         set switch_subrole   = '' %}
-{%- endif -%}
 
 {# Allow includer to pre-package defs without needing an import #}
 {%- if defs is not defined -%}
@@ -472,11 +447,12 @@
 {% if port in PORT_SERVICE %}
             "pfc_enable"      : "",
             "pfcwd_sw_enable" : "",
-{% elif port in port_names_list_extra_queues %}
+{% else %}
+{% if port in port_names_list_extra_queues %}
             "pfc_enable"      : "2,3,4,6",
-            "pfcwd_sw_enable" : "2,3,4,6",
 {% else %}
             "pfc_enable"      : "{{ LOSSLESS_TC|join(',') }}",
+{% endif %}
             "pfcwd_sw_enable" : "{{ LOSSLESS_TC|join(',') }}",
 {% endif %}
 {% endif %}
@@ -485,7 +461,11 @@
 {% else %}
             "tc_to_pg_map"    : "AZURE_DPC",
 {% endif %}
+{% if port in PORT_SERVICE %}
+            "pfc_to_queue_map": ""
+{% else %}
             "pfc_to_queue_map": "AZURE"
+{% endif %}
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -301,6 +301,17 @@ def _get_jinja2_env(paths):
     env.filters['b64encode'] = b64encode
     env.filters['b64decode'] = b64decode
 
+    # Introduce a 'template_exists' function to check if a template exists
+    # This is used to conditionally import a template since jinja2 import
+    # statement fails if the template does not exist and does not have native support
+    def template_exists(name):
+        try:
+            loader.get_source(env, name)
+            return True
+        except jinja2.exceptions.TemplateNotFound:
+            return False
+    env.globals['template_exists'] = template_exists
+
     return env
 
 def main():

--- a/src/sonic-config-engine/tests/sample-arista-7060x6-t0-minigraph.xml
+++ b/src/sonic-config-engine/tests/sample-arista-7060x6-t0-minigraph.xml
@@ -1,0 +1,5624 @@
+<DeviceMiniGraph xmlns="Microsoft.Search.Autopilot.Evolution" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <CpgDec>
+    <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    <PeeringSessions>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.1.0</StartPeer>
+        <EndRouter>ARISTA01PT0</EndRouter>
+        <EndPeer>10.0.1.1</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::201</StartPeer>
+        <EndRouter>ARISTA01PT0</EndRouter>
+        <EndPeer>FC00::202</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.0</StartPeer>
+        <EndRouter>ARISTA01T1</EndRouter>
+        <EndPeer>10.0.0.1</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::1</StartPeer>
+        <EndRouter>ARISTA01T1</EndRouter>
+        <EndPeer>FC00::2</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.1.2</StartPeer>
+        <EndRouter>ARISTA02PT0</EndRouter>
+        <EndPeer>10.0.1.3</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::205</StartPeer>
+        <EndRouter>ARISTA02PT0</EndRouter>
+        <EndPeer>FC00::206</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.2</StartPeer>
+        <EndRouter>ARISTA02T1</EndRouter>
+        <EndPeer>10.0.0.3</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::5</StartPeer>
+        <EndRouter>ARISTA02T1</EndRouter>
+        <EndPeer>FC00::6</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.4</StartPeer>
+        <EndRouter>ARISTA03T1</EndRouter>
+        <EndPeer>10.0.0.5</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::9</StartPeer>
+        <EndRouter>ARISTA03T1</EndRouter>
+        <EndPeer>FC00::A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.6</StartPeer>
+        <EndRouter>ARISTA04T1</EndRouter>
+        <EndPeer>10.0.0.7</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::D</StartPeer>
+        <EndRouter>ARISTA04T1</EndRouter>
+        <EndPeer>FC00::E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.8</StartPeer>
+        <EndRouter>ARISTA05T1</EndRouter>
+        <EndPeer>10.0.0.9</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::11</StartPeer>
+        <EndRouter>ARISTA05T1</EndRouter>
+        <EndPeer>FC00::12</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.10</StartPeer>
+        <EndRouter>ARISTA06T1</EndRouter>
+        <EndPeer>10.0.0.11</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::15</StartPeer>
+        <EndRouter>ARISTA06T1</EndRouter>
+        <EndPeer>FC00::16</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.12</StartPeer>
+        <EndRouter>ARISTA07T1</EndRouter>
+        <EndPeer>10.0.0.13</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::19</StartPeer>
+        <EndRouter>ARISTA07T1</EndRouter>
+        <EndPeer>FC00::1A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.14</StartPeer>
+        <EndRouter>ARISTA08T1</EndRouter>
+        <EndPeer>10.0.0.15</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::1D</StartPeer>
+        <EndRouter>ARISTA08T1</EndRouter>
+        <EndPeer>FC00::1E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.16</StartPeer>
+        <EndRouter>ARISTA09T1</EndRouter>
+        <EndPeer>10.0.0.17</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::21</StartPeer>
+        <EndRouter>ARISTA09T1</EndRouter>
+        <EndPeer>FC00::22</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.18</StartPeer>
+        <EndRouter>ARISTA10T1</EndRouter>
+        <EndPeer>10.0.0.19</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::25</StartPeer>
+        <EndRouter>ARISTA10T1</EndRouter>
+        <EndPeer>FC00::26</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.20</StartPeer>
+        <EndRouter>ARISTA11T1</EndRouter>
+        <EndPeer>10.0.0.21</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::29</StartPeer>
+        <EndRouter>ARISTA11T1</EndRouter>
+        <EndPeer>FC00::2A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.22</StartPeer>
+        <EndRouter>ARISTA12T1</EndRouter>
+        <EndPeer>10.0.0.23</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::2D</StartPeer>
+        <EndRouter>ARISTA12T1</EndRouter>
+        <EndPeer>FC00::2E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.24</StartPeer>
+        <EndRouter>ARISTA13T1</EndRouter>
+        <EndPeer>10.0.0.25</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::31</StartPeer>
+        <EndRouter>ARISTA13T1</EndRouter>
+        <EndPeer>FC00::32</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.26</StartPeer>
+        <EndRouter>ARISTA14T1</EndRouter>
+        <EndPeer>10.0.0.27</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::35</StartPeer>
+        <EndRouter>ARISTA14T1</EndRouter>
+        <EndPeer>FC00::36</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.28</StartPeer>
+        <EndRouter>ARISTA15T1</EndRouter>
+        <EndPeer>10.0.0.29</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::39</StartPeer>
+        <EndRouter>ARISTA15T1</EndRouter>
+        <EndPeer>FC00::3A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.30</StartPeer>
+        <EndRouter>ARISTA16T1</EndRouter>
+        <EndPeer>10.0.0.31</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::3D</StartPeer>
+        <EndRouter>ARISTA16T1</EndRouter>
+        <EndPeer>FC00::3E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.32</StartPeer>
+        <EndRouter>ARISTA17T1</EndRouter>
+        <EndPeer>10.0.0.33</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::41</StartPeer>
+        <EndRouter>ARISTA17T1</EndRouter>
+        <EndPeer>FC00::42</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.34</StartPeer>
+        <EndRouter>ARISTA18T1</EndRouter>
+        <EndPeer>10.0.0.35</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::45</StartPeer>
+        <EndRouter>ARISTA18T1</EndRouter>
+        <EndPeer>FC00::46</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.36</StartPeer>
+        <EndRouter>ARISTA19T1</EndRouter>
+        <EndPeer>10.0.0.37</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::49</StartPeer>
+        <EndRouter>ARISTA19T1</EndRouter>
+        <EndPeer>FC00::4A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.38</StartPeer>
+        <EndRouter>ARISTA20T1</EndRouter>
+        <EndPeer>10.0.0.39</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::4D</StartPeer>
+        <EndRouter>ARISTA20T1</EndRouter>
+        <EndPeer>FC00::4E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.40</StartPeer>
+        <EndRouter>ARISTA21T1</EndRouter>
+        <EndPeer>10.0.0.41</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::51</StartPeer>
+        <EndRouter>ARISTA21T1</EndRouter>
+        <EndPeer>FC00::52</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.42</StartPeer>
+        <EndRouter>ARISTA22T1</EndRouter>
+        <EndPeer>10.0.0.43</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::55</StartPeer>
+        <EndRouter>ARISTA22T1</EndRouter>
+        <EndPeer>FC00::56</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.44</StartPeer>
+        <EndRouter>ARISTA23T1</EndRouter>
+        <EndPeer>10.0.0.45</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::59</StartPeer>
+        <EndRouter>ARISTA23T1</EndRouter>
+        <EndPeer>FC00::5A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.46</StartPeer>
+        <EndRouter>ARISTA24T1</EndRouter>
+        <EndPeer>10.0.0.47</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::5D</StartPeer>
+        <EndRouter>ARISTA24T1</EndRouter>
+        <EndPeer>FC00::5E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.48</StartPeer>
+        <EndRouter>ARISTA25T1</EndRouter>
+        <EndPeer>10.0.0.49</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::61</StartPeer>
+        <EndRouter>ARISTA25T1</EndRouter>
+        <EndPeer>FC00::62</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.50</StartPeer>
+        <EndRouter>ARISTA26T1</EndRouter>
+        <EndPeer>10.0.0.51</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::65</StartPeer>
+        <EndRouter>ARISTA26T1</EndRouter>
+        <EndPeer>FC00::66</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.52</StartPeer>
+        <EndRouter>ARISTA27T1</EndRouter>
+        <EndPeer>10.0.0.53</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::69</StartPeer>
+        <EndRouter>ARISTA27T1</EndRouter>
+        <EndPeer>FC00::6A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.54</StartPeer>
+        <EndRouter>ARISTA28T1</EndRouter>
+        <EndPeer>10.0.0.55</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::6D</StartPeer>
+        <EndRouter>ARISTA28T1</EndRouter>
+        <EndPeer>FC00::6E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.56</StartPeer>
+        <EndRouter>ARISTA29T1</EndRouter>
+        <EndPeer>10.0.0.57</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::71</StartPeer>
+        <EndRouter>ARISTA29T1</EndRouter>
+        <EndPeer>FC00::72</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.58</StartPeer>
+        <EndRouter>ARISTA30T1</EndRouter>
+        <EndPeer>10.0.0.59</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::75</StartPeer>
+        <EndRouter>ARISTA30T1</EndRouter>
+        <EndPeer>FC00::76</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.60</StartPeer>
+        <EndRouter>ARISTA31T1</EndRouter>
+        <EndPeer>10.0.0.61</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::79</StartPeer>
+        <EndRouter>ARISTA31T1</EndRouter>
+        <EndPeer>FC00::7A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>10.0.0.62</StartPeer>
+        <EndRouter>ARISTA32T1</EndRouter>
+        <EndPeer>10.0.0.63</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str5-7060x6-moby-512-2</StartRouter>
+        <StartPeer>FC00::7D</StartPeer>
+        <EndRouter>ARISTA32T1</EndRouter>
+        <EndPeer>FC00::7E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+    </PeeringSessions>
+    <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:BGPRouterDeclaration>
+        <a:ASN>65100</a:ASN>
+        <a:Hostname>str5-7060x6-moby-512-2</a:Hostname>
+        <a:Peers>
+          <BGPPeer>
+            <Address>10.0.1.1</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.1</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.1.3</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.3</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.5</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.7</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.9</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.11</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.13</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.15</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.17</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.19</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.21</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.23</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.25</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.27</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.29</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.31</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.33</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.35</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.37</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.39</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.41</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.43</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.45</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.47</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.49</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.51</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.53</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.55</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.57</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.59</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.61</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.63</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer i:type="a:BGPPeerPassive">
+            <ElementType>BGPPeer</ElementType>
+            <Address>10.1.0.32</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+            <a:Name>BGPSLBPassive</a:Name>
+            <a:PeersRange>10.255.0.0/25</a:PeersRange>
+          </BGPPeer>
+          <BGPPeer i:type="a:BGPPeerPassive">
+            <ElementType>BGPPeer</ElementType>
+            <Address>10.1.0.32</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+            <a:Name>BGPVac</a:Name>
+            <a:PeersRange>192.168.0.0/21</a:PeersRange>
+          </BGPPeer>
+        </a:Peers>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65101</a:ASN>
+        <a:Hostname>ARISTA01PT0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA01T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65102</a:ASN>
+        <a:Hostname>ARISTA02PT0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA02T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA03T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA04T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA05T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA06T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA07T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA08T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA09T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA10T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA11T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA12T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA13T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA14T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA15T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA16T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA17T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA18T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA19T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA20T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA21T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA22T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA23T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA24T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA25T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA26T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA27T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA28T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA29T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA30T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA31T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA32T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+    </Routers>
+  </CpgDec>  <DpgDec>
+    <DeviceDataPlaneInfo>
+      <IPSecTunnels/>
+      <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.1.0.32/32</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.1.0.32/32</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FC00:1::32/128</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FC00:1::32/128</a:PrefixStr>
+        </a:LoopbackIPInterface>
+      </LoopbackIPInterfaces>
+      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:ManagementIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.64.247.158/23</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.64.247.158/23</a:PrefixStr>
+        </a:ManagementIPInterface>
+        <a:ManagementIPInterface>
+          <Name>V6HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>2a01:111:e210:b000::a40:f79e/64</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>2a01:111:e210:b000::a40:f79e/64</a:PrefixStr>
+        </a:ManagementIPInterface>
+      </ManagementIPInterfaces>
+      <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+      <MplsInterfaces/>
+      <MplsTeInterfaces/>
+      <RsvpInterfaces/>
+      <Hostname>str5-7060x6-moby-512-2</Hostname>
+      <PortChannelInterfaces>
+      </PortChannelInterfaces>
+      <VlanInterfaces>
+        <VlanInterface>
+          <Name>Vlan1000</Name>
+          <AttachTo>etp17a;etp17b;etp17c;etp17d;etp17e;etp17f;etp17g;etp17h;etp17i;etp17j;etp17k;etp17l;etp18a;etp18b;etp18c;etp18d;etp18e;etp18f;etp18g;etp18h;etp18i;etp18j;etp18k;etp18l;etp19a;etp19b;etp19c;etp19d;etp19e;etp19f;etp19g;etp19h;etp19i;etp19j;etp19k;etp19l;etp20a;etp20b;etp20c;etp20d;etp20e;etp20f;etp20g;etp20h;etp20i;etp20j;etp20k;etp20l;etp21a;etp21b;etp21c;etp21d;etp21e;etp21f;etp21g;etp21h;etp21i;etp21j;etp21k;etp21l;etp22a;etp22b;etp22c;etp22d;etp22e;etp22f;etp22g;etp22h;etp22i;etp22j;etp22k;etp22l;etp23a;etp23b;etp23c;etp23d;etp23e;etp23f;etp23g;etp23h;etp23i;etp23j;etp23k;etp23l;etp24a;etp24b;etp24c;etp24d;etp24e;etp24f;etp24g;etp24h;etp24i;etp24j;etp24k;etp24l</AttachTo>
+          <NoDhcpRelay>False</NoDhcpRelay>
+          <StaticDHCPRelay>0.0.0.0/0</StaticDHCPRelay>
+          <DhcpRelays>192.0.0.1;192.0.0.2;192.0.0.3;192.0.0.4;192.0.0.5;192.0.0.6;192.0.0.7;192.0.0.8;192.0.0.9;192.0.0.10;192.0.0.11;192.0.0.12;192.0.0.13;192.0.0.14;192.0.0.15;192.0.0.16;192.0.0.17;192.0.0.18;192.0.0.19;192.0.0.20;192.0.0.21;192.0.0.22;192.0.0.23;192.0.0.24;192.0.0.25;192.0.0.26;192.0.0.27;192.0.0.28;192.0.0.29;192.0.0.30;192.0.0.31;192.0.0.32;192.0.0.33;192.0.0.34;192.0.0.35;192.0.0.36;192.0.0.37;192.0.0.38;192.0.0.39;192.0.0.40;192.0.0.41;192.0.0.42;192.0.0.43;192.0.0.44;192.0.0.45;192.0.0.46;192.0.0.47;192.0.0.48</DhcpRelays>
+          <Dhcpv6Relays>fc02:2000::1;fc02:2000::2;fc02:2000::3;fc02:2000::4</Dhcpv6Relays>
+          <VlanID>1000</VlanID>
+          <Tag>1000</Tag>
+          <Subnets>192.168.0.0/21</Subnets>
+        </VlanInterface>
+      </VlanInterfaces>
+      <IPInterfaces>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp25a</AttachTo>
+          <Prefix>10.0.1.0/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp25a</AttachTo>
+          <Prefix>FC00::201/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp1a</AttachTo>
+          <Prefix>10.0.0.0/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp1a</AttachTo>
+          <Prefix>FC00::1/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp25b</AttachTo>
+          <Prefix>10.0.1.2/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp25b</AttachTo>
+          <Prefix>FC00::205/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp1b</AttachTo>
+          <Prefix>10.0.0.2/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp1b</AttachTo>
+          <Prefix>FC00::5/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp2a</AttachTo>
+          <Prefix>10.0.0.4/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp2a</AttachTo>
+          <Prefix>FC00::9/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp2b</AttachTo>
+          <Prefix>10.0.0.6/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp2b</AttachTo>
+          <Prefix>FC00::D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp3a</AttachTo>
+          <Prefix>10.0.0.8/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp3a</AttachTo>
+          <Prefix>FC00::11/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp3b</AttachTo>
+          <Prefix>10.0.0.10/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp3b</AttachTo>
+          <Prefix>FC00::15/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp4a</AttachTo>
+          <Prefix>10.0.0.12/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp4a</AttachTo>
+          <Prefix>FC00::19/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp4b</AttachTo>
+          <Prefix>10.0.0.14/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp4b</AttachTo>
+          <Prefix>FC00::1D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp5a</AttachTo>
+          <Prefix>10.0.0.16/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp5a</AttachTo>
+          <Prefix>FC00::21/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp5b</AttachTo>
+          <Prefix>10.0.0.18/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp5b</AttachTo>
+          <Prefix>FC00::25/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp6a</AttachTo>
+          <Prefix>10.0.0.20/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp6a</AttachTo>
+          <Prefix>FC00::29/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp6b</AttachTo>
+          <Prefix>10.0.0.22/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp6b</AttachTo>
+          <Prefix>FC00::2D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp7a</AttachTo>
+          <Prefix>10.0.0.24/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp7a</AttachTo>
+          <Prefix>FC00::31/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp7b</AttachTo>
+          <Prefix>10.0.0.26/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp7b</AttachTo>
+          <Prefix>FC00::35/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp8a</AttachTo>
+          <Prefix>10.0.0.28/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp8a</AttachTo>
+          <Prefix>FC00::39/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp8b</AttachTo>
+          <Prefix>10.0.0.30/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp8b</AttachTo>
+          <Prefix>FC00::3D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp9a</AttachTo>
+          <Prefix>10.0.0.32/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp9a</AttachTo>
+          <Prefix>FC00::41/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp9b</AttachTo>
+          <Prefix>10.0.0.34/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp9b</AttachTo>
+          <Prefix>FC00::45/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp10a</AttachTo>
+          <Prefix>10.0.0.36/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp10a</AttachTo>
+          <Prefix>FC00::49/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp10b</AttachTo>
+          <Prefix>10.0.0.38/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp10b</AttachTo>
+          <Prefix>FC00::4D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp11a</AttachTo>
+          <Prefix>10.0.0.40/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp11a</AttachTo>
+          <Prefix>FC00::51/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp11b</AttachTo>
+          <Prefix>10.0.0.42/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp11b</AttachTo>
+          <Prefix>FC00::55/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp12a</AttachTo>
+          <Prefix>10.0.0.44/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp12a</AttachTo>
+          <Prefix>FC00::59/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp12b</AttachTo>
+          <Prefix>10.0.0.46/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp12b</AttachTo>
+          <Prefix>FC00::5D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp13a</AttachTo>
+          <Prefix>10.0.0.48/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp13a</AttachTo>
+          <Prefix>FC00::61/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp13b</AttachTo>
+          <Prefix>10.0.0.50/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp13b</AttachTo>
+          <Prefix>FC00::65/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp14a</AttachTo>
+          <Prefix>10.0.0.52/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp14a</AttachTo>
+          <Prefix>FC00::69/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp14b</AttachTo>
+          <Prefix>10.0.0.54/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp14b</AttachTo>
+          <Prefix>FC00::6D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp15a</AttachTo>
+          <Prefix>10.0.0.56/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp15a</AttachTo>
+          <Prefix>FC00::71/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp15b</AttachTo>
+          <Prefix>10.0.0.58/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp15b</AttachTo>
+          <Prefix>FC00::75/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp16a</AttachTo>
+          <Prefix>10.0.0.60/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp16a</AttachTo>
+          <Prefix>FC00::79/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp16b</AttachTo>
+          <Prefix>10.0.0.62/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp16b</AttachTo>
+          <Prefix>FC00::7D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Vlan1000</AttachTo>
+          <Prefix>192.168.0.1/21</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Vlan1000</AttachTo>
+          <Prefix>fc02:1000::1/64</Prefix>
+        </IPInterface>
+      </IPInterfaces>
+      <DataAcls/>
+      <AclInterfaces>
+        <AclInterface>
+          <InAcl>NTP_ACL</InAcl>
+          <AttachTo>NTP</AttachTo>
+          <Type>NTP</Type>
+        </AclInterface>
+        <AclInterface>
+          <InAcl>SNMP_ACL</InAcl>
+          <AttachTo>SNMP</AttachTo>
+          <Type>SNMP</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>VTY_LINE</AttachTo>
+          <InAcl>ssh-only</InAcl>
+          <Type>SSH</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPAN</AttachTo>
+          <InAcl>Everflow</InAcl>
+          <Type>Everflow</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPANV6</AttachTo>
+          <InAcl>EverflowV6</InAcl>
+          <Type>EverflowV6</Type>
+        </AclInterface>
+<AclInterface>
+          <AttachTo>etp25a;etp1a;etp25b;etp1b;etp2a;etp2b;etp3a;etp3b;etp4a;etp4b;etp5a;etp5b;etp6a;etp6b;etp7a;etp7b;etp8a;etp8b;etp9a;etp9b;etp10a;etp10b;etp11a;etp11b;etp12a;etp12b;etp13a;etp13b;etp14a;etp14b;etp15a;etp15b;etp16a;etp16b</AttachTo>
+          <InAcl>DataAcl</InAcl>
+          <Type>DataPlane</Type>
+        </AclInterface>
+      </AclInterfaces>
+      <DownstreamSummaries/>
+      <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    </DeviceDataPlaneInfo>
+  </DpgDec>  <PngDec>
+    <DeviceInterfaceLinks>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA01PT0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp25a</StartPort>
+        <Bandwidth>10000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA01T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp1a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA02PT0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp25b</StartPort>
+        <Bandwidth>10000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA02T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp1b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA03T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp2a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA04T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp2b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA05T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp3a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA06T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp3b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA07T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp4a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA08T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp4b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA09T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp5a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA10T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp5b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA11T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp6a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA12T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp6b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA13T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp7a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA14T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp7b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA15T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp8a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA16T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp8b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA17T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp9a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA18T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp9b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA19T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp10a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA20T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp10b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA21T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp11a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA22T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp11b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA23T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp12a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA24T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp12b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA25T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp13a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA26T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp13b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA27T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp14a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA28T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp14b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA29T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp15a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA30T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp15b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA31T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp16a</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA32T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str5-7060x6-moby-512-2</StartDevice>
+        <StartPort>etp16b</StartPort>
+        <Bandwidth>400000</Bandwidth>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp17a</EndPort>
+        <StartDevice>Servers0</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp17b</EndPort>
+        <StartDevice>Servers1</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp17c</EndPort>
+        <StartDevice>Servers2</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp17d</EndPort>
+        <StartDevice>Servers3</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp17e</EndPort>
+        <StartDevice>Servers4</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp17f</EndPort>
+        <StartDevice>Servers5</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp17g</EndPort>
+        <StartDevice>Servers6</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp17h</EndPort>
+        <StartDevice>Servers7</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp17i</EndPort>
+        <StartDevice>Servers8</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp17j</EndPort>
+        <StartDevice>Servers9</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp17k</EndPort>
+        <StartDevice>Servers10</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp17l</EndPort>
+        <StartDevice>Servers11</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp18a</EndPort>
+        <StartDevice>Servers12</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp18b</EndPort>
+        <StartDevice>Servers13</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp18c</EndPort>
+        <StartDevice>Servers14</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp18d</EndPort>
+        <StartDevice>Servers15</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp18e</EndPort>
+        <StartDevice>Servers16</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp18f</EndPort>
+        <StartDevice>Servers17</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp18g</EndPort>
+        <StartDevice>Servers18</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp18h</EndPort>
+        <StartDevice>Servers19</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp18i</EndPort>
+        <StartDevice>Servers20</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp18j</EndPort>
+        <StartDevice>Servers21</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp18k</EndPort>
+        <StartDevice>Servers22</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp18l</EndPort>
+        <StartDevice>Servers23</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp19a</EndPort>
+        <StartDevice>Servers24</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp19b</EndPort>
+        <StartDevice>Servers25</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp19c</EndPort>
+        <StartDevice>Servers26</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp19d</EndPort>
+        <StartDevice>Servers27</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp19e</EndPort>
+        <StartDevice>Servers28</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp19f</EndPort>
+        <StartDevice>Servers29</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp19g</EndPort>
+        <StartDevice>Servers30</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp19h</EndPort>
+        <StartDevice>Servers31</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp19i</EndPort>
+        <StartDevice>Servers32</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp19j</EndPort>
+        <StartDevice>Servers33</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp19k</EndPort>
+        <StartDevice>Servers34</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp19l</EndPort>
+        <StartDevice>Servers35</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp20a</EndPort>
+        <StartDevice>Servers36</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp20b</EndPort>
+        <StartDevice>Servers37</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp20c</EndPort>
+        <StartDevice>Servers38</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp20d</EndPort>
+        <StartDevice>Servers39</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp20e</EndPort>
+        <StartDevice>Servers40</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp20f</EndPort>
+        <StartDevice>Servers41</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp20g</EndPort>
+        <StartDevice>Servers42</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp20h</EndPort>
+        <StartDevice>Servers43</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp20i</EndPort>
+        <StartDevice>Servers44</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp20j</EndPort>
+        <StartDevice>Servers45</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp20k</EndPort>
+        <StartDevice>Servers46</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp20l</EndPort>
+        <StartDevice>Servers47</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp21a</EndPort>
+        <StartDevice>Servers48</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp21b</EndPort>
+        <StartDevice>Servers49</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp21c</EndPort>
+        <StartDevice>Servers50</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp21d</EndPort>
+        <StartDevice>Servers51</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp21e</EndPort>
+        <StartDevice>Servers52</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp21f</EndPort>
+        <StartDevice>Servers53</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp21g</EndPort>
+        <StartDevice>Servers54</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp21h</EndPort>
+        <StartDevice>Servers55</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp21i</EndPort>
+        <StartDevice>Servers56</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp21j</EndPort>
+        <StartDevice>Servers57</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp21k</EndPort>
+        <StartDevice>Servers58</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp21l</EndPort>
+        <StartDevice>Servers59</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp22a</EndPort>
+        <StartDevice>Servers60</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp22b</EndPort>
+        <StartDevice>Servers61</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp22c</EndPort>
+        <StartDevice>Servers62</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp22d</EndPort>
+        <StartDevice>Servers63</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp22e</EndPort>
+        <StartDevice>Servers64</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp22f</EndPort>
+        <StartDevice>Servers65</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp22g</EndPort>
+        <StartDevice>Servers66</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp22h</EndPort>
+        <StartDevice>Servers67</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp22i</EndPort>
+        <StartDevice>Servers68</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp22j</EndPort>
+        <StartDevice>Servers69</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp22k</EndPort>
+        <StartDevice>Servers70</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp22l</EndPort>
+        <StartDevice>Servers71</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp23a</EndPort>
+        <StartDevice>Servers72</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp23b</EndPort>
+        <StartDevice>Servers73</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp23c</EndPort>
+        <StartDevice>Servers74</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp23d</EndPort>
+        <StartDevice>Servers75</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp23e</EndPort>
+        <StartDevice>Servers76</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp23f</EndPort>
+        <StartDevice>Servers77</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp23g</EndPort>
+        <StartDevice>Servers78</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp23h</EndPort>
+        <StartDevice>Servers79</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp23i</EndPort>
+        <StartDevice>Servers80</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp23j</EndPort>
+        <StartDevice>Servers81</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp23k</EndPort>
+        <StartDevice>Servers82</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp23l</EndPort>
+        <StartDevice>Servers83</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp24a</EndPort>
+        <StartDevice>Servers84</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp24b</EndPort>
+        <StartDevice>Servers85</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp24c</EndPort>
+        <StartDevice>Servers86</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp24d</EndPort>
+        <StartDevice>Servers87</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp24e</EndPort>
+        <StartDevice>Servers88</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp24f</EndPort>
+        <StartDevice>Servers89</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp24g</EndPort>
+        <StartDevice>Servers90</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp24h</EndPort>
+        <StartDevice>Servers91</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp24i</EndPort>
+        <StartDevice>Servers92</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp24j</EndPort>
+        <StartDevice>Servers93</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp24k</EndPort>
+        <StartDevice>Servers94</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>str5-7060x6-moby-512-2</EndDevice>
+        <EndPort>etp24l</EndPort>
+        <StartDevice>Servers95</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+    </DeviceInterfaceLinks>
+    <Devices>
+          <Device i:type="BackEndToRRouter">
+            <Hostname>str5-7060x6-moby-512-2</Hostname>
+        <HwSku>Arista-7060X6-16PE-384C-B-O128S2</HwSku>
+        <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.64.247.158</a:IPPrefix>
+        </ManagementAddress>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA01T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.200</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA02T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.201</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA03T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.202</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA04T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.203</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA05T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.204</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA06T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.205</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA07T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.206</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA08T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.207</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA09T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.208</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA10T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.209</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA11T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.210</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA12T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.211</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA13T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.212</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA14T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.213</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA15T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.214</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA16T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.215</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA17T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.216</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA18T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.217</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA19T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.218</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA20T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.219</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA21T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.220</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA22T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.221</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA23T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.222</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA24T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.223</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA25T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.224</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA26T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.225</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA27T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.226</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA28T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.227</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA29T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.228</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA30T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.229</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA31T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.230</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="BackEndLeafRouter">
+         <Hostname>ARISTA32T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.231</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA01PT0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.232</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA02PT0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.182.233</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+    </Devices>
+  </PngDec>  <DeviceInfos>
+    <DeviceInfo>
+      <EthernetInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp1a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp1b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp2a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp2b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp3a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp3b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp4a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp4b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp5a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp5b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp6a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp6b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp7a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp7b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp8a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp8b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp9a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp9b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp10a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp10b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp11a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp11b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp12a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp12b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp13a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp13b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp14a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp14b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp15a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp15b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp16a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp16b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp17a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp17b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp17c</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp17d</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp17e</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp17f</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp17g</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp17h</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp17i</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp17j</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp17k</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp17l</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp18a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp18b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp18c</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp18d</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp18e</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp18f</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp18g</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp18h</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp18i</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp18j</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp18k</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp18l</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp19a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp19b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp19c</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp19d</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp19e</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp19f</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp19g</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp19h</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp19i</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp19j</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp19k</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp19l</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp20a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp20b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp20c</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp20d</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp20e</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp20f</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp20g</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp20h</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp20i</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp20j</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp20k</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp20l</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp21a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp21b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp21c</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp21d</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp21e</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp21f</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp21g</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp21h</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp21i</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp21j</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp21k</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp21l</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp22a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp22b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp22c</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp22d</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp22e</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp22f</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp22g</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp22h</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp22i</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp22j</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp22k</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp22l</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp23a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp23b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp23c</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp23d</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp23e</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp23f</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp23g</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp23h</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp23i</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp23j</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp23k</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp23l</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp24a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp24b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp24c</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp24d</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp24e</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp24f</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp24g</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp24h</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp24i</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp24j</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp24k</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp24l</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp25a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>10000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp25b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>10000</Speed>
+        </a:EthernetInterface>
+      </EthernetInterfaces>
+      <FlowControl>true</FlowControl>
+      <Height>0</Height>
+      <HwSku>Arista-7060X6-16PE-384C-B-O128S2</HwSku>
+      <ManagementInterfaces/>
+    </DeviceInfo>
+  </DeviceInfos>  <MetadataDeclaration>
+    <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:DeviceMetadata>
+        <a:Name>str5-7060x6-moby-512-2</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>DeploymentId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>1</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>CloudType</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Public</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>QosProfile</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Profile0</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SonicQosProfile</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>BALANCED</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>ResourceType</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>ComputeAI</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>DhcpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>192.0.0.1;192.0.0.2;192.0.0.3;192.0.0.4;192.0.0.5;192.0.0.6;192.0.0.7;192.0.0.8;192.0.0.9;192.0.0.10;192.0.0.11;192.0.0.12;192.0.0.13;192.0.0.14;192.0.0.15;192.0.0.16;192.0.0.17;192.0.0.18;192.0.0.19;192.0.0.20;192.0.0.21;192.0.0.22;192.0.0.23;192.0.0.24;192.0.0.25;192.0.0.26;192.0.0.27;192.0.0.28;192.0.0.29;192.0.0.30;192.0.0.31;192.0.0.32;192.0.0.33;192.0.0.34;192.0.0.35;192.0.0.36;192.0.0.37;192.0.0.38;192.0.0.39;192.0.0.40;192.0.0.41;192.0.0.42;192.0.0.43;192.0.0.44;192.0.0.45;192.0.0.46;192.0.0.47;192.0.0.48</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>NtpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.20.8.129;10.20.8.130</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SnmpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.3.145.98</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SyslogResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.64.246.95</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>TacacsGroup</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Starlab</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>TacacsServer</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.64.247.175</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>ForcedMgmtRoutes</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.3.145.98/31;10.3.145.8;100.127.20.16/28;10.3.149.170/31;40.122.216.24;13.91.48.226;10.64.246.0/23;10.3.146.0/24;10.64.5.5;10.201.148.32/28;2603:10b0:11d:1::400/118;2603:10b0:b17:18::400/118;2a01:111:e210:b000::1/64;2a01:111:e210:3000::1/64</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>ErspanDestinationIpv4</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.20.6.16</a:Value>
+         </a:DeviceProperty>
+        </a:Properties>
+      </a:DeviceMetadata>
+    </Devices>
+    <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+  </MetadataDeclaration>
+  <LinkMetadataDeclaration>
+    <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet0;str5-7060x6-moby-512-2:etp1a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet4;str5-7060x6-moby-512-2:etp1b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet8;str5-7060x6-moby-512-2:etp2a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet12;str5-7060x6-moby-512-2:etp2b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet16;str5-7060x6-moby-512-2:etp3a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet20;str5-7060x6-moby-512-2:etp3b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet24;str5-7060x6-moby-512-2:etp4a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet28;str5-7060x6-moby-512-2:etp4b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet32;str5-7060x6-moby-512-2:etp5a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet36;str5-7060x6-moby-512-2:etp5b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet40;str5-7060x6-moby-512-2:etp6a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet44;str5-7060x6-moby-512-2:etp6b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet48;str5-7060x6-moby-512-2:etp7a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet52;str5-7060x6-moby-512-2:etp7b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet56;str5-7060x6-moby-512-2:etp8a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet60;str5-7060x6-moby-512-2:etp8b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet64;str5-7060x6-moby-512-2:etp9a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet68;str5-7060x6-moby-512-2:etp9b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet72;str5-7060x6-moby-512-2:etp10a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet76;str5-7060x6-moby-512-2:etp10b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet80;str5-7060x6-moby-512-2:etp11a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet84;str5-7060x6-moby-512-2:etp11b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet88;str5-7060x6-moby-512-2:etp12a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet92;str5-7060x6-moby-512-2:etp12b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet96;str5-7060x6-moby-512-2:etp13a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet100;str5-7060x6-moby-512-2:etp13b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet104;str5-7060x6-moby-512-2:etp14a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet108;str5-7060x6-moby-512-2:etp14b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet112;str5-7060x6-moby-512-2:etp15a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet116;str5-7060x6-moby-512-2:etp15b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>False</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-64pe-shared-fan-1:Ethernet176;str5-7060x6-moby-512-2:etp16a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>False</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-64pe-shared-fan-1:Ethernet180;str5-7060x6-moby-512-2:etp16b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet184;str5-7060x6-moby-512-2:etp17a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet188;str5-7060x6-moby-512-2:etp17b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet176;str5-7060x6-moby-512-2:etp17c</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet180;str5-7060x6-moby-512-2:etp17d</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet200;str5-7060x6-moby-512-2:etp17e</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet204;str5-7060x6-moby-512-2:etp17f</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet192;str5-7060x6-moby-512-2:etp17g</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet196;str5-7060x6-moby-512-2:etp17h</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet216;str5-7060x6-moby-512-2:etp17i</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet220;str5-7060x6-moby-512-2:etp17j</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet208;str5-7060x6-moby-512-2:etp17k</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet212;str5-7060x6-moby-512-2:etp17l</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet136;str5-7060x6-moby-512-2:etp18a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet140;str5-7060x6-moby-512-2:etp18b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet128;str5-7060x6-moby-512-2:etp18c</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet132;str5-7060x6-moby-512-2:etp18d</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet152;str5-7060x6-moby-512-2:etp18e</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet156;str5-7060x6-moby-512-2:etp18f</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet144;str5-7060x6-moby-512-2:etp18g</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet148;str5-7060x6-moby-512-2:etp18h</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet168;str5-7060x6-moby-512-2:etp18i</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet172;str5-7060x6-moby-512-2:etp18j</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet160;str5-7060x6-moby-512-2:etp18k</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet164;str5-7060x6-moby-512-2:etp18l</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet280;str5-7060x6-moby-512-2:etp19a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet284;str5-7060x6-moby-512-2:etp19b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet272;str5-7060x6-moby-512-2:etp19c</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet276;str5-7060x6-moby-512-2:etp19d</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet296;str5-7060x6-moby-512-2:etp19e</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet300;str5-7060x6-moby-512-2:etp19f</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet288;str5-7060x6-moby-512-2:etp19g</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet292;str5-7060x6-moby-512-2:etp19h</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet312;str5-7060x6-moby-512-2:etp19i</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet316;str5-7060x6-moby-512-2:etp19j</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet304;str5-7060x6-moby-512-2:etp19k</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet308;str5-7060x6-moby-512-2:etp19l</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet232;str5-7060x6-moby-512-2:etp20a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet236;str5-7060x6-moby-512-2:etp20b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet224;str5-7060x6-moby-512-2:etp20c</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet228;str5-7060x6-moby-512-2:etp20d</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet248;str5-7060x6-moby-512-2:etp20e</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet252;str5-7060x6-moby-512-2:etp20f</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet240;str5-7060x6-moby-512-2:etp20g</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet244;str5-7060x6-moby-512-2:etp20h</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet264;str5-7060x6-moby-512-2:etp20i</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet268;str5-7060x6-moby-512-2:etp20j</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet256;str5-7060x6-moby-512-2:etp20k</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet260;str5-7060x6-moby-512-2:etp20l</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet376;str5-7060x6-moby-512-2:etp21a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet380;str5-7060x6-moby-512-2:etp21b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet368;str5-7060x6-moby-512-2:etp21c</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet372;str5-7060x6-moby-512-2:etp21d</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet392;str5-7060x6-moby-512-2:etp21e</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet396;str5-7060x6-moby-512-2:etp21f</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet384;str5-7060x6-moby-512-2:etp21g</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet388;str5-7060x6-moby-512-2:etp21h</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet408;str5-7060x6-moby-512-2:etp21i</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet412;str5-7060x6-moby-512-2:etp21j</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet400;str5-7060x6-moby-512-2:etp21k</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet404;str5-7060x6-moby-512-2:etp21l</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet328;str5-7060x6-moby-512-2:etp22a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet332;str5-7060x6-moby-512-2:etp22b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet320;str5-7060x6-moby-512-2:etp22c</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet324;str5-7060x6-moby-512-2:etp22d</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet344;str5-7060x6-moby-512-2:etp22e</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet348;str5-7060x6-moby-512-2:etp22f</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet336;str5-7060x6-moby-512-2:etp22g</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet340;str5-7060x6-moby-512-2:etp22h</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet360;str5-7060x6-moby-512-2:etp22i</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet364;str5-7060x6-moby-512-2:etp22j</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet352;str5-7060x6-moby-512-2:etp22k</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet356;str5-7060x6-moby-512-2:etp22l</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet472;str5-7060x6-moby-512-2:etp23a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet476;str5-7060x6-moby-512-2:etp23b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet464;str5-7060x6-moby-512-2:etp23c</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet468;str5-7060x6-moby-512-2:etp23d</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet488;str5-7060x6-moby-512-2:etp23e</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet492;str5-7060x6-moby-512-2:etp23f</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet480;str5-7060x6-moby-512-2:etp23g</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet484;str5-7060x6-moby-512-2:etp23h</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet504;str5-7060x6-moby-512-2:etp23i</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet508;str5-7060x6-moby-512-2:etp23j</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet496;str5-7060x6-moby-512-2:etp23k</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet500;str5-7060x6-moby-512-2:etp23l</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet424;str5-7060x6-moby-512-2:etp24a</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet428;str5-7060x6-moby-512-2:etp24b</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet416;str5-7060x6-moby-512-2:etp24c</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet420;str5-7060x6-moby-512-2:etp24d</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet440;str5-7060x6-moby-512-2:etp24e</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet444;str5-7060x6-moby-512-2:etp24f</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet432;str5-7060x6-moby-512-2:etp24g</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet436;str5-7060x6-moby-512-2:etp24h</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet456;str5-7060x6-moby-512-2:etp24i</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet460;str5-7060x6-moby-512-2:etp24j</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet448;str5-7060x6-moby-512-2:etp24k</a:Key>
+            </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>str5-7060x6-moby-512-fan-2:Ethernet452;str5-7060x6-moby-512-2:etp24l</a:Key>
+            </a:LinkMetadata>
+  </Link>
+</LinkMetadataDeclaration>
+  <Hostname>str5-7060x6-moby-512-2</Hostname>
+  <HwSku>Arista-7060X6-16PE-384C-B-O128S2</HwSku>
+</DeviceMiniGraph>

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-arista7060x6.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-arista7060x6.json
@@ -1,0 +1,4457 @@
+{
+    "TC_TO_PRIORITY_GROUP_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "0",
+            "2": "0",
+            "3": "3",
+            "4": "4",
+            "5": "0",
+            "6": "0",
+            "7": "7"
+        }
+    },
+    "MAP_PFC_PRIORITY_TO_QUEUE": {
+        "AZURE": {
+            "0": "0",
+            "1": "1",
+            "2": "2",
+            "3": "3",
+            "4": "4",
+            "5": "5",
+            "6": "6",
+            "7": "7"
+        }
+    },
+    "TC_TO_QUEUE_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "1",
+            "2": "2",
+            "3": "3",
+            "4": "4",
+            "5": "5",
+            "6": "6",
+            "7": "7"
+        }
+    },
+    "DSCP_TO_TC_MAP": {
+        "AZURE": {
+            "0" : "0",
+            "1" : "0",
+            "2" : "0",
+            "3" : "3",
+            "4" : "4",
+            "5" : "0",
+            "6" : "0",
+            "7" : "0",
+            "8" : "0",
+            "9" : "0",
+            "10": "0",
+            "11": "0",
+            "12": "0",
+            "13": "0",
+            "14": "0",
+            "15": "0",
+            "16": "0",
+            "17": "0",
+            "18": "0",
+            "19": "0",
+            "20": "0",
+            "21": "0",
+            "22": "0",
+            "23": "0",
+            "24": "0",
+            "25": "0",
+            "26": "0",
+            "27": "0",
+            "28": "0",
+            "29": "0",
+            "30": "0",
+            "31": "0",
+            "32": "0",
+            "33": "0",
+            "34": "0",
+            "35": "0",
+            "36": "0",
+            "37": "0",
+            "38": "0",
+            "39": "0",
+            "40": "0",
+            "41": "0",
+            "42": "0",
+            "43": "0",
+            "44": "6",
+            "45": "0",
+            "46": "5",
+            "47": "1",
+            "48": "0",
+            "49": "0",
+            "50": "0",
+            "51": "0",
+            "52": "0",
+            "53": "0",
+            "54": "0",
+            "55": "0",
+            "56": "0",
+            "57": "0",
+            "58": "0",
+            "59": "0",
+            "60": "0",
+            "61": "0",
+            "62": "0",
+            "63": "0"
+        }
+    },
+    "SCHEDULER": {
+        "SCHEDULER_Q1": {
+            "type"  : "DWRR",
+            "weight": "10"
+        },
+        "SCHEDULER_Q3": {
+            "type"  : "DWRR",
+            "weight": "20"
+        },
+        "SCHEDULER_Q4": {
+            "type"  : "DWRR",
+            "weight": "10"
+        },
+        "SCHEDULER_Q6": {
+            "type"  : "DWRR",
+            "weight": "70"
+        },
+        "SCHEDULER_DEFAULT": {
+            "type"  : "DWRR",
+            "weight": "10"
+        }
+    },
+    "PORT_QOS_MAP": {
+        "global": {
+            "dscp_to_tc_map"  : "AZURE"
+        },
+        "Ethernet0": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet4": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet8": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet12": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet16": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet20": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet24": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet28": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet32": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet36": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet40": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet44": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet48": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet52": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet56": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet60": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet64": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet68": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet72": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet76": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet80": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet84": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet88": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet92": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet96": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet100": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet104": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet108": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet112": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet116": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet120": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet124": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet128": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet132": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet136": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet140": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet144": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet148": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet152": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet156": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet160": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet164": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet168": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet172": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet176": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet180": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet184": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet188": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet192": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet196": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet200": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet204": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet208": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet212": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet216": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet220": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet224": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet228": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet232": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet236": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet240": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet244": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet248": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet252": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet256": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet260": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet264": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet268": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet272": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet276": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet280": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet284": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet288": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet292": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet296": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet300": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet304": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet308": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet312": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet316": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet320": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet324": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet328": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet332": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet336": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet340": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet344": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet348": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet352": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet356": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet360": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet364": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet368": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet372": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet376": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet380": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet384": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet388": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet392": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet396": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet400": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet404": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet408": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet412": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet416": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet420": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet424": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet428": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet432": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet436": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet440": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet444": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet448": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet452": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet456": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet460": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet464": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet468": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet472": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet476": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet480": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet484": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet488": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet492": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet496": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet500": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet504": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet508": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "3,4",
+            "pfcwd_sw_enable" : "3,4",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE"
+        },
+        "Ethernet512": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "",
+            "pfcwd_sw_enable" : "",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": ""
+        },
+        "Ethernet513": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "",
+            "pfcwd_sw_enable" : "",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": ""
+        }
+    },
+"WRED_PROFILE": {
+        "WRED_LOSSLESS_Q3": {
+            "ecn": "ecn_all",
+            "green_drop_probability": "5",
+            "green_max_threshold": "262144",
+            "green_min_threshold": "131072",
+            "red_drop_probability": "5",
+            "red_max_threshold": "262144",
+            "red_min_threshold": "131072",
+            "wred_green_enable": "true",
+            "wred_red_enable": "true",
+            "wred_yellow_enable": "true",
+            "yellow_drop_probability": "5",
+            "yellow_max_threshold": "262144",
+            "yellow_min_threshold": "131072"
+        },
+        "WRED_LOSSLESS_Q4": {
+            "ecn": "ecn_all",
+            "green_drop_probability": "5",
+            "green_max_threshold": "262144",
+            "green_min_threshold": "131072",
+            "red_drop_probability": "5",
+            "red_max_threshold": "262144",
+            "red_min_threshold": "131072",
+            "wred_green_enable": "true",
+            "wred_red_enable": "true",
+            "wred_yellow_enable": "true",
+            "yellow_drop_probability": "5",
+            "yellow_max_threshold": "262144",
+            "yellow_min_threshold": "131072"
+        }
+    },
+    "QUEUE": {
+        "Ethernet0|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet0|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet0|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet0|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet0|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet0|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet0|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet0|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet4|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet4|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet4|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet4|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet4|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet4|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet4|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet4|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet8|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet8|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet8|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet8|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet8|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet8|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet8|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet8|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet12|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet12|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet12|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet12|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet12|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet12|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet12|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet12|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet16|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet16|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet16|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet16|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet16|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet16|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet16|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet16|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet20|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet20|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet20|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet20|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet20|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet20|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet20|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet20|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet24|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet24|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet24|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet24|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet24|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet24|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet24|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet24|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet28|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet28|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet28|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet28|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet28|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet28|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet28|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet28|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet32|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet32|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet32|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet32|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet32|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet32|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet32|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet32|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet36|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet36|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet36|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet36|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet36|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet36|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet36|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet36|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet40|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet40|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet40|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet40|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet40|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet40|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet40|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet40|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet44|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet44|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet44|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet44|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet44|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet44|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet44|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet44|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet48|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet48|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet48|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet48|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet48|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet48|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet48|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet48|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet52|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet52|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet52|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet52|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet52|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet52|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet52|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet52|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet56|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet56|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet56|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet56|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet56|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet56|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet56|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet56|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet60|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet60|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet60|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet60|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet60|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet60|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet60|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet60|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet64|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet64|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet64|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet64|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet64|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet64|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet64|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet64|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet68|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet68|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet68|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet68|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet68|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet68|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet68|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet68|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet72|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet72|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet72|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet72|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet72|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet72|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet72|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet72|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet76|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet76|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet76|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet76|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet76|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet76|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet76|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet76|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet80|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet80|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet80|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet80|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet80|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet80|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet80|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet80|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet84|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet84|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet84|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet84|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet84|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet84|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet84|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet84|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet88|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet88|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet88|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet88|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet88|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet88|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet88|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet88|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet92|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet92|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet92|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet92|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet92|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet92|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet92|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet92|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet96|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet96|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet96|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet96|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet96|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet96|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet96|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet96|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet100|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet100|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet100|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet100|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet100|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet100|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet100|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet100|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet104|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet104|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet104|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet104|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet104|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet104|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet104|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet104|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet108|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet108|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet108|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet108|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet108|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet108|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet108|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet108|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet112|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet112|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet112|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet112|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet112|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet112|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet112|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet112|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet116|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet116|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet116|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet116|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet116|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet116|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet116|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet116|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet120|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet120|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet120|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet120|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet120|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet120|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet120|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet120|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet124|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet124|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet124|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet124|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet124|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet124|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet124|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet124|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet128|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet128|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet128|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet128|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet128|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet128|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet128|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet128|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet132|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet132|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet132|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet132|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet132|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet132|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet132|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet132|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet136|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet136|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet136|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet136|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet136|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet136|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet136|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet136|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet140|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet140|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet140|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet140|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet140|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet140|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet140|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet140|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet144|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet144|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet144|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet144|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet144|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet144|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet144|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet144|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet148|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet148|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet148|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet148|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet148|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet148|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet148|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet148|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet152|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet152|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet152|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet152|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet152|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet152|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet152|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet152|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet156|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet156|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet156|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet156|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet156|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet156|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet156|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet156|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet160|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet160|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet160|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet160|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet160|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet160|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet160|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet160|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet164|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet164|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet164|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet164|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet164|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet164|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet164|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet164|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet168|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet168|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet168|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet168|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet168|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet168|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet168|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet168|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet172|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet172|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet172|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet172|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet172|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet172|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet172|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet172|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet176|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet176|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet176|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet176|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet176|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet176|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet176|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet176|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet180|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet180|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet180|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet180|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet180|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet180|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet180|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet180|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet184|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet184|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet184|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet184|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet184|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet184|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet184|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet184|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet188|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet188|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet188|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet188|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet188|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet188|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet188|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet188|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet192|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet192|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet192|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet192|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet192|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet192|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet192|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet192|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet196|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet196|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet196|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet196|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet196|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet196|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet196|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet196|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet200|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet200|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet200|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet200|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet200|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet200|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet200|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet200|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet204|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet204|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet204|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet204|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet204|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet204|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet204|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet204|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet208|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet208|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet208|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet208|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet208|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet208|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet208|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet208|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet212|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet212|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet212|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet212|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet212|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet212|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet212|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet212|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet216|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet216|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet216|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet216|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet216|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet216|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet216|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet216|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet220|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet220|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet220|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet220|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet220|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet220|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet220|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet220|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet224|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet224|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet224|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet224|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet224|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet224|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet224|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet224|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet228|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet228|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet228|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet228|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet228|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet228|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet228|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet228|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet232|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet232|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet232|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet232|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet232|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet232|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet232|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet232|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet236|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet236|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet236|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet236|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet236|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet236|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet236|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet236|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet240|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet240|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet240|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet240|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet240|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet240|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet240|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet240|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet244|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet244|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet244|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet244|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet244|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet244|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet244|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet244|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet248|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet248|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet248|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet248|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet248|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet248|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet248|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet248|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet252|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet252|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet252|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet252|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet252|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet252|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet252|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet252|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet256|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet256|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet256|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet256|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet256|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet256|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet256|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet256|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet260|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet260|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet260|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet260|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet260|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet260|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet260|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet260|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet264|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet264|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet264|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet264|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet264|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet264|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet264|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet264|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet268|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet268|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet268|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet268|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet268|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet268|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet268|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet268|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet272|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet272|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet272|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet272|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet272|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet272|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet272|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet272|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet276|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet276|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet276|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet276|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet276|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet276|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet276|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet276|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet280|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet280|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet280|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet280|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet280|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet280|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet280|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet280|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet284|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet284|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet284|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet284|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet284|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet284|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet284|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet284|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet288|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet288|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet288|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet288|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet288|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet288|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet288|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet288|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet292|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet292|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet292|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet292|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet292|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet292|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet292|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet292|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet296|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet296|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet296|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet296|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet296|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet296|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet296|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet296|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet300|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet300|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet300|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet300|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet300|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet300|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet300|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet300|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet304|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet304|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet304|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet304|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet304|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet304|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet304|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet304|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet308|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet308|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet308|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet308|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet308|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet308|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet308|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet308|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet312|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet312|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet312|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet312|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet312|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet312|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet312|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet312|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet316|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet316|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet316|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet316|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet316|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet316|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet316|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet316|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet320|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet320|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet320|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet320|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet320|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet320|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet320|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet320|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet324|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet324|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet324|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet324|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet324|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet324|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet324|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet324|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet328|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet328|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet328|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet328|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet328|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet328|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet328|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet328|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet332|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet332|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet332|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet332|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet332|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet332|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet332|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet332|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet336|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet336|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet336|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet336|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet336|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet336|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet336|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet336|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet340|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet340|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet340|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet340|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet340|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet340|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet340|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet340|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet344|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet344|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet344|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet344|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet344|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet344|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet344|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet344|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet348|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet348|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet348|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet348|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet348|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet348|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet348|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet348|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet352|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet352|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet352|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet352|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet352|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet352|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet352|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet352|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet356|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet356|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet356|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet356|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet356|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet356|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet356|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet356|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet360|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet360|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet360|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet360|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet360|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet360|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet360|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet360|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet364|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet364|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet364|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet364|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet364|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet364|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet364|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet364|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet368|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet368|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet368|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet368|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet368|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet368|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet368|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet368|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet372|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet372|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet372|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet372|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet372|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet372|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet372|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet372|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet376|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet376|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet376|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet376|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet376|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet376|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet376|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet376|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet380|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet380|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet380|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet380|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet380|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet380|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet380|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet380|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet384|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet384|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet384|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet384|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet384|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet384|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet384|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet384|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet388|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet388|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet388|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet388|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet388|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet388|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet388|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet388|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet392|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet392|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet392|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet392|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet392|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet392|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet392|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet392|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet396|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet396|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet396|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet396|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet396|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet396|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet396|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet396|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet400|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet400|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet400|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet400|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet400|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet400|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet400|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet400|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet404|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet404|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet404|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet404|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet404|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet404|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet404|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet404|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet408|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet408|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet408|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet408|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet408|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet408|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet408|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet408|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet412|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet412|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet412|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet412|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet412|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet412|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet412|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet412|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet416|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet416|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet416|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet416|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet416|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet416|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet416|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet416|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet420|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet420|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet420|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet420|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet420|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet420|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet420|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet420|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet424|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet424|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet424|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet424|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet424|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet424|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet424|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet424|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet428|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet428|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet428|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet428|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet428|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet428|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet428|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet428|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet432|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet432|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet432|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet432|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet432|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet432|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet432|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet432|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet436|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet436|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet436|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet436|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet436|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet436|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet436|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet436|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet440|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet440|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet440|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet440|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet440|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet440|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet440|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet440|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet444|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet444|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet444|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet444|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet444|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet444|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet444|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet444|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet448|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet448|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet448|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet448|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet448|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet448|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet448|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet448|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet452|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet452|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet452|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet452|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet452|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet452|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet452|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet452|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet456|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet456|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet456|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet456|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet456|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet456|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet456|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet456|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet460|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet460|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet460|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet460|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet460|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet460|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet460|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet460|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet464|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet464|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet464|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet464|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet464|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet464|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet464|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet464|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet468|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet468|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet468|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet468|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet468|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet468|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet468|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet468|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet472|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet472|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet472|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet472|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet472|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet472|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet472|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet472|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet476|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet476|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet476|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet476|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet476|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet476|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet476|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet476|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet480|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet480|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet480|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet480|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet480|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet480|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet480|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet480|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet484|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet484|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet484|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet484|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet484|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet484|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet484|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet484|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet488|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet488|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet488|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet488|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet488|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet488|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet488|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet488|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet492|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet492|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet492|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet492|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet492|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet492|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet492|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet492|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet496|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet496|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet496|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet496|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet496|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet496|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet496|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet496|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet500|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet500|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet500|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet500|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet500|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet500|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet500|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet500|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet504|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet504|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet504|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet504|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet504|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet504|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet504|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet504|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet508|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet508|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet508|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet508|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet508|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet508|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet508|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet508|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet512|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet512|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet512|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet512|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet512|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet512|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet512|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet512|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },        "Ethernet513|0": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet513|1": {
+            "scheduler": "SCHEDULER_Q1"
+        },
+        "Ethernet513|2": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet513|3": {
+            "scheduler": "SCHEDULER_Q3",
+            "wred_profile": "WRED_LOSSLESS_Q3"
+        },
+        "Ethernet513|4": {
+            "scheduler": "SCHEDULER_Q4",
+            "wred_profile": "WRED_LOSSLESS_Q4"
+        },
+        "Ethernet513|5": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        },
+        "Ethernet513|6": {
+            "scheduler": "SCHEDULER_Q6"
+        },
+        "Ethernet513|7": {
+            "scheduler": "SCHEDULER_DEFAULT"
+        }    }
+}

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -420,6 +420,9 @@ class TestJ2Files(TestCase):
     def test_qos_arista7260_render_template(self):
         self._test_qos_render_template('arista', 'x86_64-arista_7260cx3_64', 'Arista-7260CX3-D96C16', 'sample-arista-7260-t1-minigraph-remap-disabled.xml', 'qos-arista7260.json')
 
+    def test_qos_arista7060x6_render_template(self):
+        self._test_qos_render_template('arista', 'x86_64-arista_7060x6_16pe_384c_b', 'Arista-7060X6-16PE-384C-B-O128S2', 'sample-arista-7060x6-t0-minigraph.xml', 'qos-arista7060x6.json')
+
     def test_qos_arista7260t0_render_template(self):
         self._test_qos_render_template('arista', 'x86_64-arista_7260cx3_64', 'Arista-7260CX3-D92C16', 'sample-arista-7260-t0-minigraph.xml', 'qos-arista7260-t0.json')
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Disable pfc and pfcwd on service ports since they carry lossy traffic and do not require any pfc config

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Finetune buffer and qos configs
#### How to verify it
Copy templates onto switch, reload the config and see the new config db
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Disable PFC and PFCWD on service ports
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

All unit tests pass 

```
collected 312 items

tests/test_cfggen.py ....................................................................................                                                            [ 26%]
tests/test_cfggen_from_yang.py ..................                                                                                                                    [ 32%]
tests/test_cfggen_pfx_filter.py .                                                                                                                                    [ 33%]
tests/test_cfggen_platformJson.py ......                                                                                                                             [ 34%]
tests/test_cfggen_t2_chassis_fe.py ......                                                                                                                            [ 36%]
tests/test_chassis_cfggen.py .........................................................                                                                               [ 55%]
tests/test_frr.py ......                                                                                                                                             [ 57%]
tests/test_j2files.py ................................................                                                                                               [ 72%]
tests/test_j2files_t2_chassis_fe.py ...                                                                                                                              [ 73%]
tests/test_minigraph_case.py ...........................................                                                                                             [ 87%]
tests/test_multinpu_cfggen.py ........................................                                                                                               [100%]

===================================================================== 312 passed in 321.99s (0:05:21) ==================================
```

#### A picture of a cute animal (not mandatory but encouraged)

