### PR TITLE
[DPU] Fix regression in smartswitch DPU midplane IP assignment via DHCP

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -667,7 +667,12 @@ sudo cp $IMAGE_CONFIGS/midplane-network/bridge-midplane.network $FILESYSTEM_ROOT
 sudo cp $IMAGE_CONFIGS/midplane-network/dummy-midplane.netdev $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_NETWORK/dummy-midplane.netdev
 sudo cp $IMAGE_CONFIGS/midplane-network/dummy-midplane.network $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_NETWORK/dummy-midplane.network
 sudo cp $IMAGE_CONFIGS/midplane-network/midplane-network-npu.network $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_NETWORK/midplane-network-npu.network
+if [ -f platform/{{ sonic_asic_platform }}/midplane-network-dpu.network ]
+then
+sudo cp platform/{{ sonic_asic_platform }}/midplane-network-dpu.network $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_NETWORK/midplane-network-dpu.network
+else
 sudo cp $IMAGE_CONFIGS/midplane-network/midplane-network-dpu.network $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_NETWORK/midplane-network-dpu.network
+fi
 sudo cp $IMAGE_CONFIGS/midplane-network/midplane-network-npu.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/midplane-network-npu.service
 sudo cp $IMAGE_CONFIGS/midplane-network/midplane-network-dpu.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/midplane-network-dpu.service
 

--- a/platform/pensando/midplane-network-dpu.network
+++ b/platform/pensando/midplane-network-dpu.network
@@ -3,3 +3,6 @@ Name=eth0-midplane
 
 [Network]
 DHCP=yes
+
+[DHCPv4]
+ClientIdentifier=mac


### PR DESCRIPTION
#### Why I did it
To fix https://github.com/sonic-net/sonic-buildimage/issues/24086
where the Smartswitch DPU midplane IP is not getting assigned via DHCP because of change in DHCP client config to handle subtle difference in DHCP request sent by different DPU vendors.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Reverted the earlier change that broke common DHCP client config yaml. Moved vendor specific customization to vendor-specific platform folder.
 
#### How to verify it
Build  successful

#### Which release branch to backport (provide reason below if selected)
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)
- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

