### PR TITLE
[7060] add missing configuration to 7060 T0 bcm config file

### DIFF
--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
@@ -447,5 +447,7 @@ serdes_preemphasis_108=0x145c00
 serdes_driver_current_109=0x4
 serdes_preemphasis_109=0x145c00
 
+sai_interface_type_auto_detect=0
+
 mmu_init_config="MSFT-TH-Tier0"
 phy_an_lt_msft=1


### PR DESCRIPTION
#### Why I did it
Fix https://github.com/sonic-net/sonic-buildimage/issues/23943

https://github.com/sonic-net/sonic-buildimage/pull/17652/ missed this one line change in the T0 config.bcm file.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Adding the missing line to the t0 config bcm file.

#### How to verify it
Added this line and confirmed that the crash in #23943 no longer happening.
Further test to make sure 40G link come up is pending.

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

