### PR TITLE
docker-rs uses logging instead of printing to stderr

### DIFF
--- a/src/sonic-ctrmgrd-rs/Cargo.lock
+++ b/src/sonic-ctrmgrd-rs/Cargo.lock
@@ -319,8 +319,11 @@ dependencies = [
  "enumset",
  "futures-util",
  "serde_json",
+ "syslog-tracing",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src/sonic-ctrmgrd-rs/crates/docker-rs/Cargo.toml
+++ b/src/sonic-ctrmgrd-rs/crates/docker-rs/Cargo.toml
@@ -17,6 +17,9 @@ clap = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+syslog-tracing = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
#### Why I did it
Current docker-rs implementation will generate error message on stderr, and it will be collected by script such as lldp.sh, then by syslog.
```
2025 Sep 24 19:25:19.582082 sonic INFO lldp.sh[355442]: Unable to wait on container: Docker error
2025 Sep 24 19:25:19.582396 sonic INFO container: docker cmd: stop for lldp
2025 Sep 24 19:25:19.582454 sonic DEBUG container: container_stop: END
2025 Sep 24 19:25:19.582568 sonic INFO lldp.sh[355442]: Error: Docker(DockerContainerWaitError { error: "", code: 137 })
2025 Sep 24 19:25:19.584359 sonic NOTICE systemd[1]: lldp.service: Main process exited, code=exited, status=1/FAILURE
2025 Sep 24 19:25:19.605423 sonic NOTICE admin: Stopped lldp service...
2025 Sep 24 19:25:19.610182 sonic INFO systemd[1]: Stopped lldp.service - LLDP container.
2025 Sep 24 19:25:19.610668 sonic NOTICE rsyslog_plugin: :- publish: EVENT_PUBLISHED: {"sonic-events-host:event-stopped-ctr":{"ctr_name":"LLDP","timestamp":"2025-09-24T19:25:19.610276Z"}}
```

Instead, docker-rs should uses logging instead of printing to stderr.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

