### PR TITLE
[build] Refine docker build hanging and dpkg install hanging.

### DIFF
--- a/.azure-pipelines/template-daemon.yml
+++ b/.azure-pipelines/template-daemon.yml
@@ -5,14 +5,18 @@ steps:
       do
         sleep 120
         now=$(date +%s)
-        pids=$(ps -C docker-buildx -o pid,etime,args | grep "docker-buildx buildx build" | cut -d" " -f2)
+        pids=$(ps -C docker-buildx -o pid,etime,args | grep "docker-buildx buildx build" | awk '{print $1}')
         for pid in $pids
         do
-          start=$(date --date="$(ls -dl /proc/$pid --time-style full-iso | awk '{print$6,$7}')" +%s)
-          time_s=$(($now-$start))
-          if [[ $time_s -gt $(DOCKER_BUILD_TIMEOUT) ]]; then
+          start_ticks=$(awk '{print $22}' /proc/$pid/stat)
+          boot_time=$(awk '/btime/ {print $2}' /proc/stat)
+          hertz=$(getconf CLK_TCK)
+          start_time=$((boot_time + start_ticks / hertz))
+          ts=$(date -d "@$((now - start_time))" +%s)
+
+          if [[ $ts -gt $(DOCKER_BUILD_TIMEOUT) ]]; then
             echo =========== $(date +%F%T) $time_s &>> target/daemon.log
-            ps $pid &>> target/daemon.log
+            ps -p $pid -o pid,etime,args ww &>> target/daemon.log
             sudo kill $pid
           fi
         done

--- a/slave.mk
+++ b/slave.mk
@@ -866,7 +866,7 @@ SONIC_INSTALL_DEBS = $(addsuffix -install,$(addprefix $(DEBS_PATH)/, \
 $(SONIC_INSTALL_DEBS) : $(DEBS_PATH)/%-install : .platform $$(addsuffix -install,$$(addprefix $(DEBS_PATH)/,$$($$*_DEPENDS))) $(DEBS_PATH)/$$*
 	$(HEADER)
 	[ -f $(DEBS_PATH)/$* ] || { echo $(DEBS_PATH)/$* does not exist $(LOG) && false $(LOG) }
-	while true; do
+	for i in {1..360}; do
 		# wait for conflicted packages to be uninstalled
 		$(foreach deb, $($*_CONFLICT_DEBS), \
 			{ while dpkg -s $(firstword $(subst _, ,$(basename $(deb)))) | grep "^Version: $(word 2, $(subst _, ,$(basename $(deb))))" &> /dev/null; do echo "waiting for $(deb) to be uninstalled" $(LOG); sleep 1; done } )


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In some cases builds maybe stuck.
Some hangs on docker build and some hangs on dpkg install.

##### Work item tracking
- Microsoft ADO **(number only)**:  35240457

#### How I did it
Update pipeline daemon step to avoid docker build stuck.
Add retry limit when dpkg install.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

