### PR TITLE
[DPU] Perform explicit DHCP request to work around Client ID mismatch

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -207,6 +207,17 @@ program_console_speed()
     systemctl daemon-reload
 }
 
+request_dpu_midplane_ip()
+{
+    INTERFACE="eth0-midplane"
+    if ip link show "$INTERFACE" &> /dev/null; then
+        echo "dhclient -r $INTERFACE"
+        /usr/sbin/dhclient -r "$INTERFACE"
+        sleep 1
+        echo "dhclient $INTERFACE"
+        /usr/sbin/dhclient "$INTERFACE"
+    fi
+}
 
 #### Begin Main Body ####
 
@@ -240,16 +251,26 @@ fi
 
 program_console_speed
 
+platform=""
+if [ -n "$aboot_platform" ]; then
+    platform=$aboot_platform
+elif [ -n "$onie_platform" ]; then
+    platform=$onie_platform
+else
+    echo "Unknown SONiC platform"
+fi
+
+# W/A for https://github.com/sonic-net/sonic-buildimage/issues/24086
+if /usr/bin/jq -e 'has("DPU")' /usr/share/sonic/device/$platform/platform.json 2>/dev/null; then
+    echo "DPU type detected. Requesting IP ..."
+    request_dpu_midplane_ip
+fi
+
 if [ -f $FIRST_BOOT_FILE ]; then
 
     echo "First boot detected. Performing first boot tasks..."
 
-    if [ -n "$aboot_platform" ]; then
-        platform=$aboot_platform
-    elif [ -n "$onie_platform" ]; then
-        platform=$onie_platform
-    else
-        echo "Unknown SONiC platform"
+    if [ -z "$platform" ]; then
         firsttime_exit
     fi
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix https://github.com/sonic-net/sonic-buildimage/issues/24086

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

1. Install image and setup smartswitch config NPU
2. Boot 202505 image on DPU (Client ID  = DUID)

```
INFO  EVAL_RESULT Expression mtvr-bobcat-03:dpu0 evaluated to 1
INFO  DHCP4_LEASE_ALLOC [hwtype=1 b0:cf:0e:20:ac:e3], cid=[ff:87:be:63:49:00:02:00:00:ab:11:82:02:99:5f:d6:69:f8:a8], tid=0xb1d8e420: lease 169.254.200.1 has been allocated for 3600 seconds
```

3. Install 202506 image on DPU (Client ID = MAC)
4. Perform remote reboot on DPU
```
INFO  EVAL_RESULT Expression mtvr-bobcat-03:dpu0 evaluated to 1
WARN  ALLOC_ENGINE_V4_ALLOC_FAIL_SUBNET [hwtype=1 b0:cf:0e:20:ac:e3], cid=[01:b0:cf:0e:20:ac:e3], tid=0x6a7c428f: failed to allocate an IPv4 lease in the subnet 169.254.200.0/24, subnet-id 10000, shared network (none)
WARN  ALLOC_ENGINE_V4_ALLOC_FAIL [hwtype=1 b0:cf:0e:20:ac:e3], cid=[01:b0:cf:0e:20:ac:e3], tid=0x6a7c428f: failed to allocate an IPv4 address after 1 attempt(s)
WARN  ALLOC_ENGINE_V4_ALLOC_FAIL_CLASSES [hwtype=1 b0:cf:0e:20:ac:e3], cid=[01:b0:cf:0e:20:ac:e3], tid=0x6a7c428f: Failed to allocate an IPv4 address for client with classes: ALL, mtvr-bobcat-03:dpu0, UNKNOWN
INFO  EVAL_RESULT Expression mtvr-bobcat-03:dpu0 evaluated to 1
INFO  DHCP4_LEASE_ADVERT [hwtype=1 b0:cf:0e:20:ac:e3], cid=[no info], tid=0xbc675619: lease 169.254.200.1 will be advertised
INFO  EVAL_RESULT Expression mtvr-bobcat-03:dpu0 evaluated to 1
INFO  DHCP4_LEASE_ALLOC [hwtype=1 b0:cf:0e:20:ac:e3], cid=[no info], tid=0xbc675619: lease 169.254.200.1 has been allocated for 3600 seconds
INFO  EVAL_RESULT Expression mtvr-bobcat-03:dpu0 evaluated to 1
INFO  DHCP4_LEASE_ADVERT [hwtype=1 b0:cf:0e:20:ac:e3], cid=[01:b0:cf:0e:20:ac:e3], tid=0x6a7c428f: lease 169.254.200.1 will be advertised
INFO  EVAL_RESULT Expression mtvr-bobcat-03:dpu0 evaluated to 1
INFO  DHCP4_LEASE_ALLOC [hwtype=1 b0:cf:0e:20:ac:e3], cid=[01:b0:cf:0e:20:ac:e3], tid=0x6a7c428f: lease 169.254.200.1 has been allocated for 3600 seconds
```

5. Install another 202506 image (Client ID = MAC)
6. remote reboot on DPU
```
INFO  EVAL_RESULT Expression mtvr-bobcat-03:dpu0 evaluated to 1
INFO  DHCP4_LEASE_ADVERT [hwtype=1 b0:cf:0e:20:ac:e3], cid=[01:b0:cf:0e:20:ac:e3], tid=0x15ca9721: lease 169.254.200.1 will be advertised
INFO  EVAL_RESULT Expression mtvr-bobcat-03:dpu0 evaluated to 1
INFO  DHCP4_LEASE_ALLOC [hwtype=1 b0:cf:0e:20:ac:e3], cid=[01:b0:cf:0e:20:ac:e3], tid=0x15ca9721: lease 169.254.200.1 has been allocated for 3600 seconds
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

