### PR TITLE
[QoS] Remove config keys for pfc and pfcwd on service ports

### DIFF
--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -445,10 +445,7 @@
 {% endif %}
 {% endif %}
 {% if port not in PORT_DPC %}
-{% if port in PORT_SERVICE %}
-            "pfc_enable"      : "",
-            "pfcwd_sw_enable" : "",
-{% else %}
+{% if port not in PORT_SERVICE %}
 {% if port in port_names_list_extra_queues %}
             "pfc_enable"      : "2,3,4,6",
 {% else %}

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-arista7060x6.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-arista7060x6.json
@@ -1156,16 +1156,12 @@
         "Ethernet512": {
             "dscp_to_tc_map"  : "AZURE",
             "tc_to_queue_map" : "AZURE",
-            "pfc_enable"      : "",
-            "pfcwd_sw_enable" : "",
             "tc_to_pg_map"    : "AZURE",
             "pfc_to_queue_map": ""
         },
         "Ethernet513": {
             "dscp_to_tc_map"  : "AZURE",
             "tc_to_queue_map" : "AZURE",
-            "pfc_enable"      : "",
-            "pfcwd_sw_enable" : "",
             "tc_to_pg_map"    : "AZURE",
             "pfc_to_queue_map": ""
         }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Remove config keys for pfc and pfcwd on service ports
#### Why I did it
By setting the keys to an empty string "" for `pfcwd_sw_enable`, the buffermgrd still creates corresponding entries in the `PFC_WD` table. This in turn misleads the pfcwd orch to check for TCs where PFCWD is enabled on those service ports which it cannot find since it's an empty string resulting in this constant error stream:

```
2025 Sep 27 12:56:29.631650 str5-7060x6-moby-512-2 NOTICE swss#orchagent: :- registerInWdDb: No lossless TC found on port Ethernet512 
2025 Sep 27 12:56:29.631650 str5-7060x6-moby-512-2 ERR swss#orchagent: :- createEntry: Failed to start PFC Watchdog on port Ethernet512 
2025 Sep 27 12:56:29.631650 str5-7060x6-moby-512-2 NOTICE swss#orchagent: :- registerInWdDb: No lossless TC found on port Ethernet513 
2025 Sep 27 12:56:29.631680 str5-7060x6-moby-512-2 ERR swss#orchagent: :- createEntry: Failed to start PFC Watchdog on port Ethernet513 
2025 Sep 27 12:56:29.969523 str5-7060x6-moby-512-2 NOTICE swss#orchagent: :- registerInWdDb: No lossless TC found on port Ethernet512 
2025 Sep 27 12:56:29.969523 str5-7060x6-moby-512-2 ERR swss#orchagent: :- createEntry: Failed to start PFC Watchdog on port Ethernet512 
2025 Sep 27 12:56:29.969523 str5-7060x6-moby-512-2 NOTICE swss#orchagent: :- registerInWdDb: No lossless TC found on port Ethernet513 
2025 Sep 27 12:56:29.969523 str5-7060x6-moby-512-2 ERR swss#orchagent: :- createEntry: Failed to start PFC Watchdog on port Ethernet513
```

Fix here is to completely remove the key config to prevent buffermgrd in creating PFCWD entries for those service ports.

Issue was not found earlier since the error messages take about 15 minutes to show up from a reload.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Completely remove config keys for pfc and pfcwd on service ports
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

