### PR TITLE
disable pfc_to_queue_map for service port

### DIFF
--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -459,9 +459,7 @@
 {% else %}
             "tc_to_pg_map"    : "AZURE_DPC",
 {% endif %}
-{% if port in PORT_SERVICE %}
-            "pfc_to_queue_map": ""
-{% else %}
+{% if port not in PORT_SERVICE %}
             "pfc_to_queue_map": "AZURE"
 {% endif %}
         }{% if not loop.last %},{% endif %}

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-arista7060x6.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-arista7060x6.json
@@ -1156,14 +1156,12 @@
         "Ethernet512": {
             "dscp_to_tc_map"  : "AZURE",
             "tc_to_queue_map" : "AZURE",
-            "tc_to_pg_map"    : "AZURE",
-            "pfc_to_queue_map": ""
+            "tc_to_pg_map"    : "AZURE"
         },
         "Ethernet513": {
             "dscp_to_tc_map"  : "AZURE",
             "tc_to_queue_map" : "AZURE",
-            "tc_to_pg_map"    : "AZURE",
-            "pfc_to_queue_map": ""
+            "tc_to_pg_map"    : "AZURE"
         }
     },
 "WRED_PROFILE": {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the following error in test:

```
    |   File "/usr/local/lib/python3.8/dist-packages/_pytest/outcomes.py", line 198, in fail
    |     raise Failed(msg=reason, pytrace=pytrace)
    | Failed: Yang validation failed after config_reload
    +------------------------------------
```
```
29/09/2025 11:38:25 base._run                                L0108 DEBUG  | /var/src/sonic-mgmt_vms91-t0-7060x6-moby-512-3/tests/common/devices/multi_asic.py::_run_on_asics#144: [str5-7060x6-moby-512-3] AnsibleModule::shell Result => {"failed": true, "changed": true, "stdout": "sonic_yang(3):Data Loading Failed:Invalid length for map name.", "stderr": "libyang[0]: Value \"\" does not satisfy the constraint \"1..32\" (range, length, or pattern). (path: /sonic-port-qos-map:sonic-port-qos-map/PORT_QOS_MAP/PORT_QOS_MAP_LIST[ifname='Ethernet512']/pfc_to_queue_map)\nlibyang[0]: Invalid length for map name. (path: /sonic-port-qos-map:sonic-port-qos-map/PORT_QOS_MAP/PORT_QOS_MAP_LIST[ifname='Ethernet512']/pfc_to_queue_map)\nFailed to apply patch due to: Validate json patch: [] failed due to:Data Loading Failed\nInvalid length for map name.\nUsage: config apply-patch [OPTIONS] PATCH_FILE_PATH\nTry \"config apply-patch -h\" for help.\n\nError: Validate json patch: [] failed due to:Data Loading Failed\nInvalid length for map name.", "rc": 2, "cmd": "echo '[]' | sudo config apply-patch /dev/stdin", "start": "2025-09-29 11:38:24.042745", "end": "2025-09-29 11:38:25.165511", "delta": "0:00:01.122766", "msg": "non-zero return code", "invocation": {"module_args": {"_raw_params": "echo '[]' | sudo config apply-patch /dev/stdin", "_uses_shell": true, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": ["sonic_yang(3):Data Loading Failed:Invalid length for map name."], "stderr_lines": ["libyang[0]: Value \"\" does not satisfy the constraint \"1..32\" (range, length, or pattern). (path: /sonic-port-qos-map:sonic-port-qos-map/PORT_QOS_MAP/PORT_QOS_MAP_LIST[ifname='Ethernet512']/pfc_to_queue_map)", "libyang[0]: Invalid length for map name. (path: /sonic-port-qos-map:sonic-port-qos-map/PORT_QOS_MAP/PORT_QOS_MAP_LIST[ifname='Ethernet512']/pfc_to_queue_map)", "Failed to apply patch due to: Validate json patch: [] failed due to:Data Loading Failed", "Invalid length for map name.", "Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH", "Try \"config apply-patch -h\" for help.", "", "Error: Validate json patch: [] failed due to:Data Loading Failed", "Invalid length for map name."], "_ansible_no_log": null}
29/09/2025 11:38:25 utilities.wait_until                     L0163 DEBUG  | yang_validate is False, wait 30 seconds and check again
29/09/2025 11:38:55 utilities.wait_until                     L0168 DEBUG  | yang_validate is still False after 120 seconds, exit with False
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Remove `pfc_to_queue_map` for service port.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

