### PR TITLE
[Mellanox][Smartswitch] Set default reboot type as DPU reboot

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -334,13 +334,8 @@ class DpuModule(ModuleBase):
         Returns:
             bool: True if the request has been issued successfully, False if not
         """
-        # Skip pre shutdown and Post startup, handled by pci_detach and pci_reattach
-        if reboot_type == ModuleBase.MODULE_REBOOT_DPU:
-            return self.dpuctl_obj.dpu_reboot(skip_pre_post=True)
-        elif reboot_type == ModuleBase.MODULE_REBOOT_SMARTSWITCH:
-            # Do not wait for result if we are rebooting NPU + DPUs
-            return self.dpuctl_obj.dpu_reboot(no_wait=True, skip_pre_post=True)
-        raise RuntimeError(f"Invalid Reboot Type provided for {self._name}: {reboot_type}")
+        # no_wait=True is not supported at this point, because of race conditions with other drivers
+        return self.dpuctl_obj.dpu_reboot(skip_pre_post=True)
 
     def set_admin_state(self, up):
         """

--- a/platform/mellanox/mlnx-platform-api/tests/test_module.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_module.py
@@ -253,9 +253,7 @@ class TestModule:
             mock_obj.assert_called_once_with(skip_pre_post=True)
             mock_obj.reset_mock()
             m.reboot(reboot_type=ModuleBase.MODULE_REBOOT_SMARTSWITCH)
-            mock_obj.assert_called_once_with(no_wait=True, skip_pre_post=True)
-            with pytest.raises(RuntimeError):
-                m.reboot("None")
+            mock_obj.assert_called_once_with(skip_pre_post=True)
         with patch('sonic_py_common.syslogger.SysLogger.log_error') as mock_method:
             m.dpuctl_obj.dpu_power_on = mock.MagicMock(return_value=True)
             assert m.set_admin_state(True)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This change is added in order to remove the smartswitch reboot type from the module implementatoin, which was used to improve reboot time by not waiting for the DPU reboot to complete, this method improves reboot time, but causes race conditions with stop command of MFT driver. So at this point we complete the DPU reboot each time

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Remove the check whether the type of reboot is `MODULE_REBOOT_DPU` or `MODULE_REBOOT_SMARTSWITCH` and perform complete DPU reboot each time we call the module based reboot

#### How to verify it

Manually verified to check if the reboot of the DPU is complete after execution of `reboot` on DPU on 202506 image

`tests/test_module.py::TestModule::test_dpu_module PASSED                 [ 52%]`


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

