### PR TITLE
iccpd: Trim trailing blanks

### DIFF
--- a/src/iccpd/src/mlacp_link_handler.c
+++ b/src/iccpd/src/mlacp_link_handler.c
@@ -1131,7 +1131,7 @@ void update_peerlink_isolate_from_all_csm_lif(
         if (lif->isolate_to_peer_link == 1)
         {
             //The return value of the snprintf function is the length of the source string.
-            if ((sizeof(mlag_po_buf) - dst_len) > 
+            if ((sizeof(mlag_po_buf) - dst_len) >
                 (strlen(lif->name) + strlen(lif->portchannel_member_buf) + 2))
             {
                 /* need to isolate port,  get it's member name */
@@ -1145,7 +1145,7 @@ void update_peerlink_isolate_from_all_csm_lif(
             }
             else
             {
-                ICCPD_LOG_WARN(__FUNCTION__, "the remaining length %d is not enough to store:%s%s%s", 
+                ICCPD_LOG_WARN(__FUNCTION__, "the remaining length %d is not enough to store:%s%s%s",
                     sizeof(mlag_po_buf) - dst_len, lif->name, lif->portchannel_member_buf[0] == 0 ? "" : ",", lif->portchannel_member_buf);
             }
         }


### PR DESCRIPTION
Trim some trailing blanks in iccpd.

#### Why I did it

##### Work item tracking

#### How I did it
Run `sed -i 's/\s\s*$//'` over the source files in the iccpd directory.

#### How to verify it

Simple compilation. No change in output will occur.

#### Which release branch to backport (provide reason below if selected)

No backport required.

#### Tested branch (Please provide the tested image version)

master

#### Description for the changelog

- Trim some trailing blanks in iccpd.

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
 _____________
< Hello SONiC! >
 -------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```