### PR TITLE
[202505][FRR] send EOR during GR only when fib install complete

### DIFF
--- a/src/sonic-frr/patch/0060-bgpd-send-EOR-during-GR-only-when-fib-install-comepl.patch
+++ b/src/sonic-frr/patch/0060-bgpd-send-EOR-during-GR-only-when-fib-install-comepl.patch
@@ -1,0 +1,335 @@
+From dbe634798bca661732672480c65c811581304588 Mon Sep 17 00:00:00 2001
+From: Vijayalaxmi Basavaraj <vbasavaraj@vbasavaraj-mlt.client.nvidia.com>
+Date: Tue, 2 Sep 2025 15:01:55 -0700
+Subject: [PATCH] bgpd:send EOR during GR only when fib install comeplete for
+ suppress fib enabled
+
+Currently during GR, EOR is sent to neighbor prematurely for suppress fib enabled
+case. below fix has be implemented.
+  keep a counter to track the routes installed in FIB.Increamnet
+   counter when bgp send route install to zebra, decreamnet counter when
+   fib install ack to received from zebra in bgp.when this count reaches
+   zero and route deferred count is 0 ad gr route syn pending is set, then
+   do further processing of sending EOR and zebra gr update complete.
+   This will send EOR as soon as last route fib install ack is received.
+
+Testing:
+before:
+2020:2025/08/19 21:23:53.786402 BGP: [ZP3RE-J4Q8C] send End-of-RIB for IPv4 Unicast to swp1s1.3
+2021:2025/08/19 21:23:53.786412 BGP: [ZP3RE-J4Q8C] send End-of-RIB for IPv6 Unicast to swp1s0.3
+2022:2025/08/19 21:23:53.786415 BGP: [ZP3RE-J4Q8C] send End-of-RIB for IPv4 Unicast to swp1s0.3
+2511:2025/08/19 21:23:54.162310 BGP: [TN0HX-6G1RR] u1:s5 send UPDATE w/ attr: , origin ?, mp_nexthop ::(::), path 64900 56000
+2512:2025/08/19 21:23:54.162314 BGP: [H06SA-0JAPR] u1:s5 send MP_REACH for afi/safi IPv4/unicast
+2513:2025/08/19 21:23:54.162316 BGP: [HVRWP-5R9NQ] u1:s5 send UPDATE 91.0.0.49/32 IPv4 unicast
+
+after:
+4270:2025/08/22 17:41:41.631993 BGP: [HVRWP-5R9NQ] u2:s2 send UPDATE 2003:1::/125 IPv6 unicast
+4271:2025/08/22 17:41:41.631998 BGP: [HVRWP-5R9NQ] u2:s2 send UPDATE 2003:7:2::/125 IPv6 unicast
+4272:2025/08/22 17:41:41.632003 BGP: [WEV7K-2GAQ5] u2:s2 send UPDATE len 116 (max message len: 65535) numpfx 2
+4273:2025/08/22 17:41:41.632008 BGP: [JJ5V1-EZ0XX] u2:s2 swp1s1 send UPDATE w/ mp_nexthops 2003:0:1::1, fe80::1e34:daff:febe:4169
+4274:2025/08/22 17:41:41.632041 BGP: [ZP3RE-J4Q8C] send End-of-RIB for IPv4 Unicast to swp1s1
+4275:2025/08/22 17:41:41.632054 BGP: [ZP3RE-J4Q8C] send End-of-RIB for IPv6 Unicast to swp1s1
+
+Signed-off-by: Vijayalaxmi Basavaraj <vbasavaraj@nvidia.com>
+Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>
+---
+ bgpd/bgp_fsm.c    |  13 +++++
+ bgpd/bgp_packet.c |  12 +++--
+ bgpd/bgp_route.c  | 122 ++++++++++++++++++++++++++++++++++++++--------
+ bgpd/bgp_route.h  |   3 ++
+ bgpd/bgp_zebra.c  |   8 ++-
+ bgpd/bgpd.h       |  11 +++--
+ 6 files changed, 139 insertions(+), 30 deletions(-)
+
+diff --git a/bgpd/bgp_fsm.c b/bgpd/bgp_fsm.c
+index 6bcbd30386..d5968547f6 100644
+--- a/bgpd/bgp_fsm.c
++++ b/bgpd/bgp_fsm.c
+@@ -849,6 +849,19 @@ static void bgp_graceful_deferral_timer_expire(struct event *thread)
+ 	safi = info->safi;
+ 	bgp = info->bgp;
+ 
++	/* Check if graceful restart deferral completion is needed */
++	if (BGP_SUPPRESS_FIB_ENABLED(bgp) && (bgp->gr_info[afi][safi].eor_required == bgp->gr_info[afi][safi].eor_received) &&
++		!bgp->gr_info[afi][safi].gr_deferred && bgp->gr_route_sync_pending) {
++			if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
++					zlog_debug("%s: Triggering GR deferral completion from timer expiry for %s",
++							bgp->name_pretty, get_afi_safi_str(afi, safi, false));
++			bgp->gr_info[afi][safi].eor_required = 0;
++			bgp->gr_info[afi][safi].eor_received = 0;
++			XFREE(MTYPE_TMP, info);
++			bgp_process_gr_deferral_complete(bgp, afi, safi);
++			return;
++	}
++
+ 	if (BGP_DEBUG(update, UPDATE_OUT))
+ 		zlog_debug(
+ 			"afi %d, safi %d : graceful restart deferral timer expired",
+diff --git a/bgpd/bgp_packet.c b/bgpd/bgp_packet.c
+index 32df883422..83ca1b2c19 100644
+--- a/bgpd/bgp_packet.c
++++ b/bgpd/bgp_packet.c
+@@ -2511,12 +2511,14 @@ static int bgp_update_receive(struct peer_connection *connection,
+ 							gr_info->eor_required,
+ 							"EOR RCV",
+ 							gr_info->eor_received);
+-					if (gr_info->t_select_deferral) {
+-						void *info = EVENT_ARG(
+-							gr_info->t_select_deferral);
+-						XFREE(MTYPE_TMP, info);
++					if (!BGP_SUPPRESS_FIB_ENABLED(peer->bgp)) {
++						if (gr_info->t_select_deferral) {
++							void *info = EVENT_ARG(
++								gr_info->t_select_deferral);
++							XFREE(MTYPE_TMP, info);
++						}
++						EVENT_OFF(gr_info->t_select_deferral);
+ 					}
+-					EVENT_OFF(gr_info->t_select_deferral);
+ 					gr_info->eor_required = 0;
+ 					gr_info->eor_received = 0;
+ 					/* Best path selection */
+diff --git a/bgpd/bgp_route.c b/bgpd/bgp_route.c
+index 4ba2c68c0c..f50ce52c91 100644
+--- a/bgpd/bgp_route.c
++++ b/bgpd/bgp_route.c
+@@ -3879,6 +3879,7 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
+ 		 * Ensure that on uninstall that the INSTALL_PENDING
+ 		 * is no longer set
+ 		 */
++		bgp_dest_decrement_gr_fib_install_pending_count(dest);
+ 		UNSET_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING);
+ 	}
+ 
+@@ -3963,13 +3964,108 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
+ 	return;
+ }
+ 
++void bgp_process_gr_deferral_complete(struct bgp *bgp, afi_t afi, safi_t safi)
++{
++	bool route_sync_pending = false;
++
++	bgp_send_delayed_eor(bgp);
++	/* Send route processing complete message to RIB */
++	bgp_zebra_update(bgp, afi, safi, ZEBRA_CLIENT_ROUTE_UPDATE_COMPLETE);
++	bgp->gr_info[afi][safi].route_sync = true;
++
++	/* If this instance is all done, check for GR completion overall */
++	FOREACH_AFI_SAFI_NSF (afi, safi) {
++		if (bgp->gr_info[afi][safi].af_enabled && !bgp->gr_info[afi][safi].route_sync) {
++			route_sync_pending = true;
++			break;
++		}
++	}
++
++	if (!route_sync_pending) {
++		bgp->gr_route_sync_pending = false;
++		bgp_update_gr_completion();
++	}
++}
++
++/* This function increments gr_route_fib_install_pending_cnt if needed based on BGP_NODE_FIB_INSTALL_PENDING flag */
++void bgp_dest_increment_gr_fib_install_pending_count(struct bgp_dest *dest)
++{
++	struct bgp_table *table = NULL;
++	struct bgp *bgp = NULL;
++	afi_t afi = AFI_UNSPEC;
++	safi_t safi = SAFI_UNSPEC;
++
++	table = bgp_dest_table(dest);
++	if (!table)
++		return;
++
++	bgp = table->bgp;
++	afi = table->afi;
++	safi = table->safi;
++
++	if (BGP_SUPPRESS_FIB_ENABLED(bgp) && bgp->gr_route_sync_pending &&
++	    !CHECK_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING)) {
++		bgp->gr_info[afi][safi].gr_route_fib_install_pending_cnt++;
++		if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
++			zlog_debug("%s: GR route FIB install count incremented to %u for %s (prefix: %pBD)",
++				   bgp->name_pretty,
++				   bgp->gr_info[afi][safi].gr_route_fib_install_pending_cnt,
++				   get_afi_safi_str(afi, safi, false), dest);
++	}
++}
++
++/* This function decrements gr_route_fib_install_pending_cnt if needed based on BGP_NODE_FIB_INSTALL_PENDING flag */
++void bgp_dest_decrement_gr_fib_install_pending_count(struct bgp_dest *dest)
++{
++	struct bgp_table *table = NULL;
++	struct bgp *bgp = NULL;
++	afi_t afi = 0;
++	safi_t safi = 0;
++
++	table = bgp_dest_table(dest);
++	if (!table)
++		return;
++
++	bgp = table->bgp;
++	afi = table->afi;
++	safi = table->safi;
++
++	if (BGP_SUPPRESS_FIB_ENABLED(bgp) && bgp->gr_route_sync_pending &&
++	    CHECK_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING) &&
++	    bgp->gr_info[afi][safi].gr_route_fib_install_pending_cnt > 0) {
++		bgp->gr_info[afi][safi].gr_route_fib_install_pending_cnt--;
++		if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
++			zlog_debug("%s: GR route FIB install count decremented to %u for %s (prefix: %pBD)",
++				   bgp->name_pretty,
++				   bgp->gr_info[afi][safi].gr_route_fib_install_pending_cnt,
++				   get_afi_safi_str(afi, safi, false), dest);
++	}
++
++	/* Check if graceful restart deferral completion is needed */
++	if (!bgp->gr_info[afi][safi].gr_deferred &&
++	    !bgp->gr_info[afi][safi].gr_route_fib_install_pending_cnt &&
++	    bgp->gr_route_sync_pending) {
++		struct graceful_restart_info *gr_info = &(bgp->gr_info[afi][safi]);
++
++		if (gr_info->t_select_deferral) {
++			void *info = EVENT_ARG(gr_info->t_select_deferral);
++
++			XFREE(MTYPE_TMP, info);
++		}
++		event_cancel(&gr_info->t_select_deferral);
++		if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
++			zlog_debug("%s: Triggering GR deferral completion from FIB notification for %s",
++				   bgp->name_pretty, get_afi_safi_str(afi, safi, false));
++		bgp_process_gr_deferral_complete(bgp, afi, safi);
++	}
++}
++
+ /* Process the routes with the flag BGP_NODE_SELECT_DEFER set */
+ void bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi)
+ {
+ 	struct bgp_dest *dest;
+ 	int cnt = 0;
+ 	struct afi_safi_info *thread_info;
+-	bool route_sync_pending = false;
+ 
+ 	if (bgp->gr_info[afi][safi].t_route_select) {
+ 		struct event *t = bgp->gr_info[afi][safi].t_route_select;
+@@ -4008,25 +4104,11 @@ void bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi)
+ 
+ 	/* Send EOR message when all routes are processed */
+ 	if (!bgp->gr_info[afi][safi].gr_deferred) {
+-		bgp_send_delayed_eor(bgp);
+-		/* Send route processing complete message to RIB */
+-		bgp_zebra_update(bgp, afi, safi,
+-				 ZEBRA_CLIENT_ROUTE_UPDATE_COMPLETE);
+-		bgp->gr_info[afi][safi].route_sync = true;
+-
+-		/* If this instance is all done, check for GR completion overall */
+-		FOREACH_AFI_SAFI_NSF (afi, safi) {
+-			if (bgp->gr_info[afi][safi].af_enabled &&
+-			    !bgp->gr_info[afi][safi].route_sync) {
+-				route_sync_pending = true;
+-				break;
+-			}
+-		}
+-
+-		if (!route_sync_pending) {
+-			bgp->gr_route_sync_pending = false;
+-			bgp_update_gr_completion();
+-		}
++		/* t_select_deferral will be NULL when either gr_route_fib_install_pending_cnt is 0
++		 * or deferral timer for fib install expires
++		 */
++		if (!BGP_SUPPRESS_FIB_ENABLED(bgp) || !bgp->gr_info[afi][safi].t_select_deferral)
++			bgp_process_gr_deferral_complete(bgp, afi, safi);
+ 		return;
+ 	}
+ 
+diff --git a/bgpd/bgp_route.h b/bgpd/bgp_route.h
+index 391890d733..e7fc6e00cd 100644
+--- a/bgpd/bgp_route.h
++++ b/bgpd/bgp_route.h
+@@ -975,6 +975,9 @@ extern int bgp_show_table_rd(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t
+ 			     enum bgp_show_type type, void *output_arg,
+ 			     uint16_t show_flags);
+ extern void bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi);
++extern void bgp_dest_increment_gr_fib_install_pending_count(struct bgp_dest *dest);
++extern void bgp_dest_decrement_gr_fib_install_pending_count(struct bgp_dest *dest);
++extern void bgp_process_gr_deferral_complete(struct bgp *bgp, afi_t afi, safi_t safi);
+ extern bool bgp_update_martian_nexthop(struct bgp *bgp, afi_t afi, safi_t safi,
+ 				       uint8_t type, uint8_t stype,
+ 				       struct attr *attr, struct bgp_dest *dest);
+diff --git a/bgpd/bgp_zebra.c b/bgpd/bgp_zebra.c
+index 84ff88be16..ec7e9e8b0c 100644
+--- a/bgpd/bgp_zebra.c
++++ b/bgpd/bgp_zebra.c
+@@ -1907,12 +1907,15 @@ void bgp_zebra_route_install(struct bgp_dest *dest, struct bgp_path_info *info,
+ 	 * let's set the fact that we expect this route to be installed
+ 	 */
+ 	if (install) {
+-		if (BGP_SUPPRESS_FIB_ENABLED(bgp))
++		if (BGP_SUPPRESS_FIB_ENABLED(bgp)) {
++			bgp_dest_increment_gr_fib_install_pending_count(dest);
+ 			SET_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING);
++		}
+ 
+ 		if (bgp->main_zebra_update_hold && !is_evpn)
+ 			return;
+ 	} else {
++		bgp_dest_decrement_gr_fib_install_pending_count(dest);
+ 		UNSET_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING);
+ 	}
+ 
+@@ -2855,6 +2858,7 @@ static int bgp_zebra_route_notify_owner(int command, struct zclient *zclient,
+ 	case ZAPI_ROUTE_INSTALLED:
+ 		new_select = NULL;
+ 		/* Clear the flags so that route can be processed */
++		bgp_dest_decrement_gr_fib_install_pending_count(dest);
+ 		UNSET_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING);
+ 		SET_FLAG(dest->flags, BGP_NODE_FIB_INSTALLED);
+ 		if (BGP_DEBUG(zebra, ZEBRA))
+@@ -2891,6 +2895,7 @@ static int bgp_zebra_route_notify_owner(int command, struct zclient *zclient,
+ 		if (BGP_DEBUG(zebra, ZEBRA))
+ 			zlog_debug("route: %pBD Failed to Install into Fib",
+ 				   dest);
++		bgp_dest_decrement_gr_fib_install_pending_count(dest);
+ 		UNSET_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING);
+ 		UNSET_FLAG(dest->flags, BGP_NODE_FIB_INSTALLED);
+ 		for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next) {
+@@ -2906,6 +2911,7 @@ static int bgp_zebra_route_notify_owner(int command, struct zclient *zclient,
+ 			zlog_debug("route: %pBD removed due to better admin won",
+ 				   dest);
+ 		new_select = NULL;
++		bgp_dest_decrement_gr_fib_install_pending_count(dest);
+ 		UNSET_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING);
+ 		UNSET_FLAG(dest->flags, BGP_NODE_FIB_INSTALLED);
+ 		for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next) {
+diff --git a/bgpd/bgpd.h b/bgpd/bgpd.h
+index 9340584e79..9729e2fcf3 100644
+--- a/bgpd/bgpd.h
++++ b/bgpd/bgpd.h
+@@ -324,10 +324,11 @@ enum bgp_instance_type {
+ };
+ 
+ #define BGP_SEND_EOR(bgp, afi, safi)                                           \
+-	(!CHECK_FLAG(bgp->flags, BGP_FLAG_GR_DISABLE_EOR)                      \
+-	 && ((bgp->gr_info[afi][safi].t_select_deferral == NULL)               \
+-	     || (bgp->gr_info[afi][safi].eor_required                          \
+-		 == bgp->gr_info[afi][safi].eor_received)))
++	(!CHECK_FLAG(bgp->flags, BGP_FLAG_GR_DISABLE_EOR)                          \
++	 && ((bgp->gr_info[afi][safi].t_select_deferral == NULL)                   \
++	     || (bgp->gr_info[afi][safi].eor_required                              \
++		 == bgp->gr_info[afi][safi].eor_received)) 						       \
++	 && (!BGP_SUPPRESS_FIB_ENABLED(bgp) || !bgp->gr_info[afi][safi].t_select_deferral))
+ 
+ /* BGP GR Global ds */
+ 
+@@ -344,6 +345,8 @@ struct graceful_restart_info {
+ 	struct event *t_select_deferral;
+ 	/* Routes Deferred */
+ 	uint32_t gr_deferred;
++	/* Routes waiting for FIB install */
++	uint32_t gr_route_fib_install_pending_cnt;
+ 	/* Best route select */
+ 	struct event *t_route_select;
+ 	/* AFI, SAFI enabled */
+-- 
+2.39.5
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -57,3 +57,4 @@
 0057-mgmtd-remove-bogus-hedge-code-which-corrupted-active.patch
 0058-mgmtd-normalize-argument-order-to-copy-dst-src.patch
 0059-zebra-Ensure-that-the-dplane-can-send-the-full-packe.patch
+0060-bgpd-send-EOR-during-GR-only-when-fib-install-comepl.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

EOR was sent before all routes are advertised when suppress-fib-pending is enabled, this leads to packet loss, due to peer doing route reconciliation for incomplete RIB.

BACKPORT of upstream FRR fix - `https://github.com/FRRouting/frr/pull/19522`

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Backport FRR fix.

#### How to verify it

Setup topogy like this, setup a regular router interaface between DUT and AUX and setup BGP session between them as well as between switches and IXIA. Run bidirectional traffic towards the prefix advertised by IXIA1. Observe no packet loss during warm-reboot.

```
IXIA1 <-> DUT <-> AUX <-> IXIA2
```

Relevant logs:

```
2025/09/30 12:19:05 BGP: [M67YY-FW795] VRF default: GR route FIB install count incremented to 1 for IPv6 Unicast (prefix: 2000:2:3::/64)
2025/09/30 12:19:05 BGP: [M67YY-FW795] VRF default: GR route FIB install count incremented to 2 for IPv6 Unicast (prefix: 3000:2:3::/64)
2025/09/30 12:19:05 BGP: [M67YY-FW795] VRF default: GR route FIB install count incremented to 3 for IPv6 Unicast (prefix: 3000:2:4::/64)
2025/09/30 12:19:05 BGP: [M67YY-FW795] VRF default: GR route FIB install count incremented to 4 for IPv6 Unicast (prefix: 3000:2:5::/64)
2025/09/30 12:19:05 BGP: [M67YY-FW795] VRF default: GR route FIB install count incremented to 5 for IPv6 Unicast (prefix: 3000:2:6::/64)
2025/09/30 12:19:05 BGP: [M59KS-A3ZXZ] bgp_update_receive: rcvd End-of-RIB for IPv6 Unicast from 2000:1::2 in vrf default


2025/09/30 12:19:05 BGP: [M67YY-FW795] VRF default: GR route FIB install count incremented to 1 for IPv4 Unicast (prefix: 23.23.23.0/24)
2025/09/30 12:19:05 BGP: [M67YY-FW795] VRF default: GR route FIB install count incremented to 2 for IPv4 Unicast (prefix: 24.24.24.0/24)
2025/09/30 12:19:05 BGP: [M67YY-FW795] VRF default: GR route FIB install count incremented to 3 for IPv4 Unicast (prefix: 25.25.25.0/24)
2025/09/30 12:19:05 BGP: [M67YY-FW795] VRF default: GR route FIB install count incremented to 4 for IPv4 Unicast (prefix: 26.26.26.0/24)
2025/09/30 12:19:05 BGP: [M67YY-FW795] VRF default: GR route FIB install count incremented to 5 for IPv4 Unicast (prefix: 100.2.3.0/24)
2025/09/30 12:19:05 BGP: [M59KS-A3ZXZ] bgp_update_receive: rcvd End-of-RIB for IPv4 Unicast from 10.0.2.2 in vrf default


2025/09/30 12:20:10 BGP: [P6D1N-F7T05] VRF default: GR route FIB install count decremented to 4 for IPv4 Unicast (prefix: 100.2.3.0/24)
2025/09/30 12:20:10 BGP: [P6D1N-F7T05] VRF default: GR route FIB install count decremented to 4 for IPv6 Unicast (prefix: 2000:2:3::/64)
2025/09/30 12:20:10 BGP: [P6D1N-F7T05] VRF default: GR route FIB install count decremented to 3 for IPv4 Unicast (prefix: 23.23.23.0/24)
2025/09/30 12:20:10 BGP: [P6D1N-F7T05] VRF default: GR route FIB install count decremented to 2 for IPv4 Unicast (prefix: 24.24.24.0/24)
2025/09/30 12:20:10 BGP: [P6D1N-F7T05] VRF default: GR route FIB install count decremented to 1 for IPv4 Unicast (prefix: 25.25.25.0/24)
2025/09/30 12:20:10 BGP: [P6D1N-F7T05] VRF default: GR route FIB install count decremented to 0 for IPv4 Unicast (prefix: 26.26.26.0/24)
2025/09/30 12:20:10 BGP: [KWWZB-VM9GP] VRF default: Triggering GR deferral completion from FIB notification for IPv4 Unicast
2025/09/30 12:20:10 BGP: [ZP3RE-J4Q8C] send End-of-RIB for IPv4 Unicast to 100.2.6.2
2025/09/30 12:20:10 BGP: [ZP3RE-J4Q8C] send End-of-RIB for IPv4 Unicast to 100.2.5.2
2025/09/30 12:20:10 BGP: [ZP3RE-J4Q8C] send End-of-RIB for IPv4 Unicast to 10.0.2.2
2025/09/30 12:20:10 BGP: [ZP3RE-J4Q8C] send End-of-RIB for IPv4 Unicast to 10.0.1.2


2025/09/30 12:20:10 BGP: [P6D1N-F7T05] VRF default: GR route FIB install count decremented to 3 for IPv6 Unicast (prefix: 3000:2:3::/64)
2025/09/30 12:20:10 BGP: [P6D1N-F7T05] VRF default: GR route FIB install count decremented to 2 for IPv6 Unicast (prefix: 3000:2:4::/64)
2025/09/30 12:20:10 BGP: [P6D1N-F7T05] VRF default: GR route FIB install count decremented to 1 for IPv6 Unicast (prefix: 3000:2:5::/64)
2025/09/30 12:20:10 BGP: [P6D1N-F7T05] VRF default: GR route FIB install count decremented to 0 for IPv6 Unicast (prefix: 3000:2:6::/64)
2025/09/30 12:20:10 BGP: [KWWZB-VM9GP] VRF default: Triggering GR deferral completion from FIB notification for IPv6 Unicast
2025/09/30 12:20:10 BGP: [ZP3RE-J4Q8C] send End-of-RIB for IPv6 Unicast to 2000:2:5::2
2025/09/30 12:20:10 BGP: [ZP3RE-J4Q8C] send End-of-RIB for IPv6 Unicast to 2000:2::2
2025/09/30 12:20:10 BGP: [ZP3RE-J4Q8C] send End-of-RIB for IPv6 Unicast to 2000:1::2
2025/09/30 12:20:10 BGP: [ZP3RE-J4Q8C] send End-of-RIB for IPv6 Unicast to 2000:2:6::2
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

